### PR TITLE
fix: harden storage path transactions

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -381,6 +381,38 @@ function getAccountsBackupRecoveryCandidates(path: string): string[] {
 	return candidates;
 }
 
+async function normalizeStorageComparisonPath(path: string): Promise<string> {
+	let resolved = resolvePath(path);
+	try {
+		resolved = await fs.realpath(resolved);
+	} catch (error: unknown) {
+		// Fall back to the normalized input when the path does not exist yet.
+		if (
+			!error ||
+			typeof error !== "object" ||
+			!("code" in error) ||
+			error.code !== "ENOENT"
+		) {
+			throw error;
+		}
+	}
+	if (process.platform !== "win32") {
+		return resolved;
+	}
+	return resolved.replaceAll("\\", "/").toLowerCase();
+}
+
+async function areEquivalentStoragePaths(
+	left: string,
+	right: string,
+): Promise<boolean> {
+	const [normalizedLeft, normalizedRight] = await Promise.all([
+		normalizeStorageComparisonPath(left),
+		normalizeStorageComparisonPath(right),
+	]);
+	return normalizedLeft === normalizedRight;
+}
+
 async function getAccountsBackupRecoveryCandidatesWithDiscovery(
 	path: string,
 ): Promise<string[]> {
@@ -1761,8 +1793,9 @@ async function loadAccountsFromJournal(
 
 async function loadAccountsInternal(
 	persistMigration: ((storage: AccountStorageV3) => Promise<void>) | null,
+	storagePath = getStoragePath(),
 ): Promise<AccountStorageV3 | null> {
-	const path = getStoragePath();
+	const path = storagePath;
 	const resetMarkerPath = getIntentionalResetMarkerPath(path);
 	await cleanupStaleRotatingBackupArtifacts(path);
 	const migratedLegacyStorage = persistMigration
@@ -1926,8 +1959,11 @@ async function loadAccountsInternal(
 	}
 }
 
-async function saveAccountsUnlocked(storage: AccountStorageV3): Promise<void> {
-	const path = getStoragePath();
+async function saveAccountsUnlocked(
+	storage: AccountStorageV3,
+	storagePath = getStoragePath(),
+): Promise<void> {
+	const path = storagePath;
 	const resetMarkerPath = getIntentionalResetMarkerPath(path);
 	const uniqueSuffix = `${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
 	const tempPath = `${path}.${uniqueSuffix}.tmp`;
@@ -2078,18 +2114,25 @@ export async function withAccountStorageTransaction<T>(
 	return withStorageLock(async () => {
 		const storagePath = getStoragePath();
 		const state = {
-			snapshot: await loadAccountsInternal(saveAccountsUnlocked),
-			storagePath,
+			snapshot: await loadAccountsInternal(
+				(storage) => saveAccountsUnlocked(storage, storagePath),
+				storagePath,
+			),
 			active: true,
+			storagePath,
 		};
 		const current = state.snapshot;
 		const persist = async (storage: AccountStorageV3): Promise<void> => {
-			await saveAccountsUnlocked(storage);
+			await saveAccountsUnlocked(storage, storagePath);
 			state.snapshot = storage;
 		};
-		return transactionSnapshotContext.run(state, () =>
-			handler(current, persist),
-		);
+		return transactionSnapshotContext.run(state, async () => {
+			try {
+				return await handler(current, persist);
+			} finally {
+				state.active = false;
+			}
+		});
 	});
 }
 
@@ -2104,10 +2147,14 @@ export async function withAccountAndFlaggedStorageTransaction<T>(
 ): Promise<T> {
 	return withStorageLock(async () => {
 		const storagePath = getStoragePath();
+		const flaggedStoragePath = getFlaggedAccountsPath();
 		const state = {
-			snapshot: await loadAccountsInternal(saveAccountsUnlocked),
-			storagePath,
+			snapshot: await loadAccountsInternal(
+				(storage) => saveAccountsUnlocked(storage, storagePath),
+				storagePath,
+			),
 			active: true,
+			storagePath,
 		};
 		const current = state.snapshot;
 		const persist = async (
@@ -2116,13 +2163,13 @@ export async function withAccountAndFlaggedStorageTransaction<T>(
 		): Promise<void> => {
 			const previousAccounts = cloneAccountStorageForPersistence(state.snapshot);
 			const nextAccounts = cloneAccountStorageForPersistence(accountStorage);
-			await saveAccountsUnlocked(nextAccounts);
+			await saveAccountsUnlocked(nextAccounts, storagePath);
 			try {
-				await saveFlaggedAccountsUnlocked(flaggedStorage);
+				await saveFlaggedAccountsUnlocked(flaggedStorage, flaggedStoragePath);
 				state.snapshot = nextAccounts;
 			} catch (error) {
 				try {
-					await saveAccountsUnlocked(previousAccounts);
+					await saveAccountsUnlocked(previousAccounts, storagePath);
 					state.snapshot = previousAccounts;
 				} catch (rollbackError) {
 					const combinedError = new AggregateError(
@@ -2141,9 +2188,13 @@ export async function withAccountAndFlaggedStorageTransaction<T>(
 				throw error;
 			}
 		};
-		return transactionSnapshotContext.run(state, () =>
-			handler(current, persist),
-		);
+		return transactionSnapshotContext.run(state, async () => {
+			try {
+				return await handler(current, persist);
+			} finally {
+				state.active = false;
+			}
+		});
 	});
 }
 
@@ -2377,8 +2428,9 @@ export async function loadFlaggedAccounts(): Promise<FlaggedAccountStorageV1> {
 
 async function saveFlaggedAccountsUnlocked(
 	storage: FlaggedAccountStorageV1,
+	storagePath = getFlaggedAccountsPath(),
 ): Promise<void> {
-	const path = getFlaggedAccountsPath();
+	const path = storagePath;
 	const markerPath = getIntentionalResetMarkerPath(path);
 	const uniqueSuffix = `${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
 	const tempPath = `${path}.${uniqueSuffix}.tmp`;
@@ -2477,22 +2529,32 @@ export async function exportAccounts(
 	beforeCommit?: (resolvedPath: string) => Promise<void> | void,
 ): Promise<void> {
 	const resolvedPath = resolvePath(filePath);
-	const currentStoragePath = getStoragePath();
+	const activeStoragePath = getStoragePath();
 
 	if (!force && existsSync(resolvedPath)) {
 		throw new Error(`File already exists: ${resolvedPath}`);
 	}
 
 	const transactionState = transactionSnapshotContext.getStore();
-	const storage =
+	if (
 		transactionState?.active &&
-		transactionState.storagePath === currentStoragePath
-			? transactionState.snapshot
-			: transactionState?.active
-				? await loadAccountsInternal(saveAccountsUnlocked)
-				: await withAccountStorageTransaction((current) =>
-						Promise.resolve(current),
-					);
+		!(await areEquivalentStoragePaths(
+			transactionState.storagePath,
+			activeStoragePath,
+		))
+	) {
+		// A fresh load here can silently export from the wrong storage file while a
+		// different transaction still owns the current snapshot.
+		throw new Error(
+			`Export blocked by storage path mismatch: transaction path is ` +
+				`${transactionState.storagePath}, active path is ${activeStoragePath}`,
+		);
+	}
+	const storage = transactionState?.active
+		? transactionState.snapshot
+		: await withAccountStorageTransaction((current) =>
+				Promise.resolve(current),
+			);
 	if (!storage || storage.accounts.length === 0) {
 		throw new Error("No accounts to export");
 	}

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -718,6 +718,167 @@ describe("storage", () => {
 			);
 		});
 
+		it("keeps combined account and flagged writes pinned to the original storage root after path drift", async () => {
+			const now = Date.now();
+			const primaryStoragePath = getStoragePath();
+			expect(primaryStoragePath).toBeTruthy();
+			const primaryFlaggedStoragePath = getFlaggedAccountsPath();
+			const secondaryStoragePath = join(
+				testWorkDir,
+				"secondary-root",
+				"accounts.json",
+			);
+
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{
+						accountId: "acct-primary",
+						email: "primary@example.com",
+						refreshToken: "refresh-primary",
+						addedAt: now - 10_000,
+						lastUsed: now - 10_000,
+					},
+				],
+			});
+			await saveFlaggedAccounts({
+				version: 1,
+				accounts: [
+					{
+						accountId: "flagged-primary",
+						email: "flagged-primary@example.com",
+						refreshToken: "flagged-refresh-primary",
+						addedAt: now - 9_000,
+						lastUsed: now - 9_000,
+						flaggedAt: now - 9_000,
+					},
+				],
+			});
+
+			setStoragePathDirect(secondaryStoragePath);
+			const secondaryFlaggedStoragePath = getFlaggedAccountsPath();
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{
+						accountId: "acct-secondary",
+						email: "secondary@example.com",
+						refreshToken: "refresh-secondary",
+						addedAt: now - 8_000,
+						lastUsed: now - 8_000,
+					},
+				],
+			});
+			await saveFlaggedAccounts({
+				version: 1,
+				accounts: [
+					{
+						accountId: "flagged-secondary",
+						email: "flagged-secondary@example.com",
+						refreshToken: "flagged-refresh-secondary",
+						addedAt: now - 7_000,
+						lastUsed: now - 7_000,
+						flaggedAt: now - 7_000,
+					},
+				],
+			});
+
+			setStoragePathDirect(primaryStoragePath);
+			const originalRename = fs.rename.bind(fs);
+			let flaggedRenameAttempts = 0;
+			const renameSpy = vi.spyOn(fs, "rename").mockImplementation(
+				async (from, to) => {
+					if (String(to) === primaryFlaggedStoragePath) {
+						flaggedRenameAttempts += 1;
+						throw Object.assign(new Error("flagged storage busy"), {
+							code: "EBUSY",
+						});
+					}
+					return originalRename(from, to);
+				},
+			);
+
+			try {
+				await expect(
+					withAccountAndFlaggedStorageTransaction(async (current, persist) => {
+						setStoragePathDirect(secondaryStoragePath);
+						await persist(
+							{
+								...(current ?? {
+									version: 3,
+									activeIndex: 0,
+									activeIndexByFamily: { codex: 0 },
+									accounts: [],
+								}),
+								accounts: [
+									{
+										accountId: "acct-primary-updated",
+										email: "primary-updated@example.com",
+										refreshToken: "refresh-primary-updated",
+										addedAt: now,
+										lastUsed: now,
+									},
+								],
+							},
+							{
+								version: 1,
+								accounts: [
+									{
+										accountId: "flagged-primary-updated",
+										email: "flagged-primary-updated@example.com",
+										refreshToken: "flagged-refresh-primary-updated",
+										addedAt: now,
+										lastUsed: now,
+										flaggedAt: now,
+									},
+								],
+							},
+						);
+					}),
+				).rejects.toThrow("flagged storage busy");
+				expect(flaggedRenameAttempts).toBe(5);
+			} finally {
+				renameSpy.mockRestore();
+			}
+
+			setStoragePathDirect(primaryStoragePath);
+			const primaryAccounts = await loadAccounts();
+			expect(primaryAccounts?.accounts[0]).toEqual(
+				expect.objectContaining({
+					accountId: "acct-primary",
+					refreshToken: "refresh-primary",
+				}),
+			);
+			const primaryFlagged = await loadFlaggedAccounts();
+			expect(primaryFlagged.accounts[0]).toEqual(
+				expect.objectContaining({
+					accountId: "flagged-primary",
+					refreshToken: "flagged-refresh-primary",
+				}),
+			);
+
+			setStoragePathDirect(secondaryStoragePath);
+			const secondaryAccounts = await loadAccounts();
+			expect(secondaryAccounts?.accounts[0]).toEqual(
+				expect.objectContaining({
+					accountId: "acct-secondary",
+					refreshToken: "refresh-secondary",
+				}),
+			);
+			const secondaryFlagged = await loadFlaggedAccounts();
+			expect(secondaryFlagged.accounts[0]).toEqual(
+				expect.objectContaining({
+					accountId: "flagged-secondary",
+					refreshToken: "flagged-refresh-secondary",
+				}),
+			);
+			expect(secondaryFlaggedStoragePath).not.toBe(primaryFlaggedStoragePath);
+		});
+
 		it("surfaces rollback failure when flagged persistence and account rollback both fail", async () => {
 			const now = Date.now();
 			const storagePath = getStoragePath();
@@ -951,8 +1112,428 @@ describe("storage", () => {
 		it("should fail export when no accounts exist", async () => {
 			const { exportAccounts } = await import("../lib/storage.js");
 			setStoragePathDirect(testStoragePath);
+			await saveAccounts({ version: 3, activeIndex: 0, accounts: [] });
 			await expect(exportAccounts(exportPath)).rejects.toThrow(
 				/No accounts to export/,
+			);
+		});
+
+		it("fails fast when export is called from an active transaction after the storage path changes", async () => {
+			const secondaryStoragePath = join(testWorkDir, "accounts-secondary.json");
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-primary",
+						refreshToken: "refresh-primary",
+						addedAt: 1,
+						lastUsed: 2,
+					},
+				],
+			});
+			setStoragePathDirect(secondaryStoragePath);
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-secondary",
+						refreshToken: "refresh-secondary",
+						addedAt: 3,
+						lastUsed: 4,
+					},
+				],
+			});
+			setStoragePathDirect(testStoragePath);
+
+			await expect(
+				withAccountStorageTransaction(async () => {
+					setStoragePathDirect(secondaryStoragePath);
+					await exportAccounts(exportPath);
+				}),
+			).rejects.toThrow(
+				`Export blocked by storage path mismatch: transaction path is ${testStoragePath}, active path is ${secondaryStoragePath}`,
+			);
+			expect(existsSync(exportPath)).toBe(false);
+		});
+
+		it("allows equivalent Windows-style storage paths during export from an active transaction", async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", {
+				value: "win32",
+				configurable: true,
+			});
+
+			try {
+				await saveAccounts({
+					version: 3,
+					activeIndex: 0,
+					accounts: [
+						{
+							accountId: "acct-primary",
+							refreshToken: "refresh-primary",
+							addedAt: 1,
+							lastUsed: 2,
+						},
+					],
+				});
+
+				await expect(
+					withAccountStorageTransaction(async () => {
+						setStoragePathDirect(
+							testStoragePath.replaceAll("/", "\\").toUpperCase(),
+						);
+						await exportAccounts(exportPath);
+					}),
+				).resolves.toBeUndefined();
+
+				const exported = JSON.parse(await fs.readFile(exportPath, "utf-8"));
+				expect(exported.accounts[0].accountId).toBe("acct-primary");
+			} finally {
+				Object.defineProperty(process, "platform", {
+					value: originalPlatform,
+					configurable: true,
+				});
+			}
+		});
+
+		it("allows symlink-resolved storage paths during export from an active transaction", async () => {
+			if (process.platform === "win32") {
+				return;
+			}
+
+			const realStorageDir = join(testWorkDir, "real-storage");
+			const aliasStorageDir = join(testWorkDir, "alias-storage");
+			const realStoragePath = join(realStorageDir, "accounts.json");
+			const aliasStoragePath = join(aliasStorageDir, "accounts.json");
+
+			await fs.mkdir(realStorageDir, { recursive: true });
+			await fs.symlink(realStorageDir, aliasStorageDir, "dir");
+
+			setStoragePathDirect(realStoragePath);
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-primary",
+						refreshToken: "refresh-primary",
+						addedAt: 1,
+						lastUsed: 2,
+					},
+				],
+			});
+
+			await expect(
+				withAccountStorageTransaction(async () => {
+					setStoragePathDirect(aliasStoragePath);
+					await exportAccounts(exportPath);
+				}),
+			).resolves.toBeUndefined();
+
+			const exported = JSON.parse(await fs.readFile(exportPath, "utf-8"));
+			expect(exported.accounts[0].accountId).toBe("acct-primary");
+		});
+
+		it("reloads fresh storage after a transaction handler throws", async () => {
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-before-throw",
+						refreshToken: "refresh-before-throw",
+						addedAt: 1,
+						lastUsed: 2,
+					},
+				],
+			});
+
+			await expect(
+				withAccountStorageTransaction(async (current, persist) => {
+					await persist({
+						...(current ?? { version: 3, activeIndex: 0, accounts: [] }),
+						accounts: [
+							{
+								accountId: "acct-thrown",
+								refreshToken: "refresh-thrown",
+								addedAt: 3,
+								lastUsed: 4,
+							},
+						],
+					});
+					throw new Error("boom");
+				}),
+			).rejects.toThrow("boom");
+
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-after-throw",
+						refreshToken: "refresh-after-throw",
+						addedAt: 5,
+						lastUsed: 6,
+					},
+				],
+			});
+
+			await exportAccounts(exportPath);
+			const exported = JSON.parse(await fs.readFile(exportPath, "utf-8"));
+			expect(exported.accounts[0].accountId).toBe("acct-after-throw");
+		});
+
+		it("persists transaction updates to the original storage path after path drift", async () => {
+			const secondaryExportPath = join(testWorkDir, "secondary-export.json");
+			const secondaryStoragePath = join(testWorkDir, "secondary-storage.json");
+
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-primary-before-drift",
+						refreshToken: "refresh-primary-before-drift",
+						addedAt: 1,
+						lastUsed: 2,
+					},
+				],
+			});
+			setStoragePathDirect(secondaryStoragePath);
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-secondary-before-drift",
+						refreshToken: "refresh-secondary-before-drift",
+						addedAt: 3,
+						lastUsed: 4,
+					},
+				],
+			});
+			setStoragePathDirect(testStoragePath);
+
+			await withAccountStorageTransaction(async (current, persist) => {
+				setStoragePathDirect(secondaryStoragePath);
+				await persist({
+					...(current ?? { version: 3, activeIndex: 0, accounts: [] }),
+					accounts: [
+						{
+							accountId: "acct-primary-after-drift",
+							refreshToken: "refresh-primary-after-drift",
+							addedAt: 5,
+							lastUsed: 6,
+						},
+					],
+				});
+			});
+
+			setStoragePathDirect(testStoragePath);
+			await exportAccounts(exportPath);
+			const primaryExport = JSON.parse(await fs.readFile(exportPath, "utf-8"));
+			expect(primaryExport.accounts[0].accountId).toBe("acct-primary-after-drift");
+
+			setStoragePathDirect(secondaryStoragePath);
+			await exportAccounts(secondaryExportPath);
+			const secondaryExport = JSON.parse(
+				await fs.readFile(secondaryExportPath, "utf-8"),
+			);
+			expect(secondaryExport.accounts[0].accountId).toBe(
+				"acct-secondary-before-drift",
+			);
+		});
+
+		it("reloads fresh storage after a transaction handler returns successfully", async () => {
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-before-success",
+						refreshToken: "refresh-before-success",
+						addedAt: 1,
+						lastUsed: 2,
+					},
+				],
+			});
+
+			await withAccountStorageTransaction(async (current, persist) => {
+				await persist({
+					...(current ?? { version: 3, activeIndex: 0, accounts: [] }),
+					accounts: [
+						{
+							accountId: "acct-success",
+							refreshToken: "refresh-success",
+							addedAt: 3,
+							lastUsed: 4,
+						},
+					],
+				});
+			});
+
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-after-success",
+						refreshToken: "refresh-after-success",
+						addedAt: 5,
+						lastUsed: 6,
+					},
+				],
+			});
+
+			await exportAccounts(exportPath);
+			const exported = JSON.parse(await fs.readFile(exportPath, "utf-8"));
+			expect(exported.accounts[0].accountId).toBe("acct-after-success");
+		});
+
+		it("reloads fresh storage after a combined transaction handler throws", async () => {
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-before-combined-throw",
+						refreshToken: "refresh-before-combined-throw",
+						addedAt: 1,
+						lastUsed: 2,
+					},
+				],
+			});
+			await saveFlaggedAccounts({ version: 1, accounts: [] });
+
+			await expect(
+				withAccountAndFlaggedStorageTransaction(async (current, persist) => {
+					await persist(
+						{
+							...(current ?? { version: 3, activeIndex: 0, accounts: [] }),
+							accounts: [
+								{
+									accountId: "acct-combined-thrown",
+									refreshToken: "refresh-combined-thrown",
+									addedAt: 3,
+									lastUsed: 4,
+								},
+							],
+						},
+						{ version: 1, accounts: [] },
+					);
+					throw new Error("combined boom");
+				}),
+			).rejects.toThrow("combined boom");
+
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-after-combined-throw",
+						refreshToken: "refresh-after-combined-throw",
+						addedAt: 5,
+						lastUsed: 6,
+					},
+				],
+			});
+
+			await exportAccounts(exportPath);
+			const exported = JSON.parse(await fs.readFile(exportPath, "utf-8"));
+			expect(exported.accounts[0].accountId).toBe("acct-after-combined-throw");
+			await saveFlaggedAccounts({
+				version: 1,
+				accounts: [
+					{
+						accountId: "acct-flagged-after-combined-throw",
+						email: "flagged-after-combined-throw@example.com",
+						refreshToken: "refresh-flagged-after-combined-throw",
+						addedAt: 7,
+						lastUsed: 8,
+						flaggedAt: 9,
+					},
+				],
+			});
+			const loadedFlagged = await loadFlaggedAccounts();
+			expect(loadedFlagged.accounts[0]).toEqual(
+				expect.objectContaining({
+					accountId: "acct-flagged-after-combined-throw",
+					refreshToken: "refresh-flagged-after-combined-throw",
+				}),
+			);
+		});
+
+		it("reloads fresh storage after a combined transaction handler returns successfully", async () => {
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-before-combined-success",
+						refreshToken: "refresh-before-combined-success",
+						addedAt: 1,
+						lastUsed: 2,
+					},
+				],
+			});
+			await saveFlaggedAccounts({ version: 1, accounts: [] });
+
+			await withAccountAndFlaggedStorageTransaction(async (current, persist) => {
+				await persist(
+					{
+						...(current ?? { version: 3, activeIndex: 0, accounts: [] }),
+						accounts: [
+							{
+								accountId: "acct-combined-success",
+								refreshToken: "refresh-combined-success",
+								addedAt: 3,
+								lastUsed: 4,
+							},
+						],
+					},
+					{ version: 1, accounts: [] },
+				);
+			});
+
+			await saveAccounts({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "acct-after-combined-success",
+						refreshToken: "refresh-after-combined-success",
+						addedAt: 5,
+						lastUsed: 6,
+					},
+				],
+			});
+
+			await exportAccounts(exportPath);
+			const exported = JSON.parse(await fs.readFile(exportPath, "utf-8"));
+			expect(exported.accounts[0].accountId).toBe(
+				"acct-after-combined-success",
+			);
+			await saveFlaggedAccounts({
+				version: 1,
+				accounts: [
+					{
+						accountId: "acct-flagged-after-combined-success",
+						email: "flagged-after-combined-success@example.com",
+						refreshToken: "refresh-flagged-after-combined-success",
+						addedAt: 7,
+						lastUsed: 8,
+						flaggedAt: 9,
+					},
+				],
+			});
+			const loadedFlagged = await loadFlaggedAccounts();
+			expect(loadedFlagged.accounts[0]).toEqual(
+				expect.objectContaining({
+					accountId: "acct-flagged-after-combined-success",
+					refreshToken: "refresh-flagged-after-combined-success",
+				}),
 			);
 		});
 
@@ -3069,6 +3650,7 @@ describe("storage", () => {
 			expect(historicalBackup.accounts?.[0]?.refreshToken).toBe("token-2");
 			expect(oldestBackup.accounts?.[0]?.refreshToken).toBe("token-1");
 		});
+
 	});
 
 	describe("clearAccounts edge cases", () => {


### PR DESCRIPTION
## Summary
- pin transactional account writes to the storage path captured at transaction start
- pin flagged-account writes to the matching flagged path so rollback restores the same storage root
- fail fast when `exportAccounts` is called from an active transaction after the storage path drifts
- allow equivalent Windows and symlink-resolved paths during that guard
- mark transaction snapshots inactive once the handler exits so later exports reload fresh state

## Validation
- `npm exec vitest run test/storage.test.ts`
- `npm run typecheck`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr hardens the storage transaction layer against a class of silent data-corruption bugs where `getStoragePath()` drifts mid-transaction (common in multi-worktree and test scenarios). it pins all reads and writes in `withAccountStorageTransaction` and `withAccountAndFlaggedStorageTransaction` — including the migration-persist callback and the rollback write — to the path captured at transaction start. it also marks the transaction snapshot inactive in a `finally` block so `exportAccounts` called after the handler exits reloads fresh state rather than re-using a stale snapshot. on the `exportAccounts` side, the old silent "load from wrong file" fallback is replaced with a fail-fast error when the active path has drifted away from the transaction path, with symlink and windows case-folding equivalence handled via `areEquivalentStoragePaths`.

key changes:
- `loadAccountsInternal` and `saveAccountsUnlocked` now accept an explicit `storagePath` parameter (defaulting to `getStoragePath()`) so callers can pin writes to a specific root
- `saveFlaggedAccountsUnlocked` similarly pinned; `flaggedStoragePath` captured at combined-transaction start and passed through rollback too
- `state.active = false` in `finally` in both transaction functions; subsequent `exportAccounts` calls outside the transaction context reload from disk
- `exportAccounts` throws with a descriptive error when called from an active transaction whose storage path no longer matches the active path
- `normalizeStorageComparisonPath` resolves symlinks and folds case/slashes on win32 for the equivalence check
- one test is potentially broken on linux ci: "allows equivalent Windows-style storage paths during export from an active transaction" patches `process.platform` but not Node's `path.resolve` semantics, so `areEquivalentStoragePaths` will return `false` for backslash paths on posix runners, causing the guard to throw instead of pass

<h3>Confidence Score: 4/5</h3>

- implementation is correct and well-tested; one test is likely broken on linux ci due to a platform-mock gap that needs a one-liner fix before merge
- the core storage pinning, rollback hardening, and fail-fast export guard are all sound. the windows-path equivalence test patches process.platform without patching Node's path.resolve semantics, which means areEquivalentStoragePaths returns false on linux runners and the test fails instead of passes. fixing it is a one-line skip guard (matching the pattern already used in the symlink test). no token safety or concurrency regressions introduced.
- test/storage.test.ts — the windows-style path equivalence test needs a platform guard or the implementation needs path.win32.resolve

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage.ts | core changes are correct: storagePath pinned at transaction start, flaggedStoragePath pinned for combined transaction, active flag torn down in finally, exportAccounts fails fast on path drift. normalizeStorageComparisonPath ENOENT guard and win32 branch are sound for production (both sides of the comparison use the same code path). no token/credential exposure introduced. |
| test/storage.test.ts | good breadth: path-drift pinning, rollback, active-flag teardown, symlink resolution, and export-mismatch guard are all tested. one test ("allows equivalent Windows-style storage paths") is broken on Linux CI because it mocks process.platform without mocking Node's path.resolve semantics — areEquivalentStoragePaths returns false for backslash paths on POSIX, causing the test to throw instead of resolving. combined-transaction export-mismatch path also lacks coverage. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant T as withAccountStorageTransaction
    participant L as loadAccountsInternal(storagePath)
    participant S as saveAccountsUnlocked(storagePath)
    participant E as exportAccounts
    participant CTX as transactionSnapshotContext

    C->>T: call handler
    T->>T: storagePath = getStoragePath() [pinned]
    T->>L: load(persistMigration pinned, storagePath)
    L-->>T: snapshot
    T->>CTX: run(state{snapshot, storagePath, active:true})
    CTX->>C: handler(current, persist)
    C->>S: persist(storage) → saveAccountsUnlocked(storage, storagePath)
    S-->>C: ok
    C->>E: exportAccounts(path)
    E->>E: activeStoragePath = getStoragePath()
    E->>E: areEquivalentStoragePaths(state.storagePath, activeStoragePath)?
    alt paths differ
        E-->>C: throws "Export blocked by storage path mismatch"
    else paths equivalent
        E->>E: use state.snapshot (no extra load)
        E-->>C: ok
    end
    CTX-->>T: handler returns/throws
    T->>T: finally: state.active = false
    T-->>C: result / rethrow
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fstorage.test.ts%3A1183-1240%0A**Windows%20test%20broken%20on%20Linux%20CI**%0A%0A%60normalizeStorageComparisonPath%60%20calls%20%60resolvePath%28path%29%60%20%28which%20uses%20Node's%20platform-native%20%60path.resolve%60%29%20*before*%20converting%20backslashes%20to%20forward%20slashes.%20On%20Linux%2C%20%60path.resolve%60%20does%20not%20treat%20%60%5C%60%20as%20a%20path%20separator%2C%20so%20%60%5CTMP%5CTEST%5CACCOUNTS.JSON%60%20gets%20resolved%20as%20a%20relative%20path%20component%3A%20%60%24%7Bcwd%7D%2F%5CTMP%5CTEST%5CACCOUNTS.JSON%60.%20The%20subsequent%20%60.replaceAll%28%22%5C%5C%22%2C%20%22%2F%22%29.toLowerCase%28%29%60%20then%20produces%20%60%24%7Bcwd%7D%2F%2Ftmp%2Ftest%2Faccounts.json%60%2C%20which%20is%20never%20equal%20to%20the%20canonical%20%60%2Ftmp%2Ftest%2Faccounts.json%60.%0A%0AConcretely%2C%20patching%20%60process.platform%20%3D%20%22win32%22%60%20does%20not%20patch%20Node's%20%60path.resolve%60%20semantics%2C%20so%20%60areEquivalentStoragePaths%60%20returns%20%60false%60%20for%20the%20backslash-upper%20version%20even%20with%20the%20win32%20branch%20active.%20The%20guard%20throws%20and%20the%20test%20fails%20on%20any%20Linux%20CI%20runner.%0A%0AThe%20symlink%20test%20already%20handles%20this%20correctly%20with%20a%20platform%20guard%3A%0A%60%60%60suggestion%0A%09%09it%28%22allows%20equivalent%20Windows-style%20storage%20paths%20during%20export%20from%20an%20active%20transaction%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%09%09%09if%20%28process.platform%20!%3D%3D%20%22win32%22%29%20%7B%0A%09%09%09%09return%3B%0A%09%09%09%7D%0A%09%09%09const%20originalPlatform%20%3D%20process.platform%3B%0A%60%60%60%0AThis%20test%20should%20be%20restricted%20to%20actual%20win32%20runs%2C%20or%20the%20implementation%20in%20%60normalizeStorageComparisonPath%60%20needs%20to%20use%20%60path.win32.resolve%60%20when%20on%20win32%20instead%20of%20relying%20on%20the%20ambient%20%60path.resolve%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fstorage.test.ts%3A1112-1140%0A**Missing%20coverage%3A%20path-drift%20mismatch%20inside%20%60withAccountAndFlaggedStorageTransaction%60**%0A%0Athe%20test%20%22fails%20fast%20when%20export%20is%20called%20from%20an%20active%20transaction%20after%20the%20storage%20path%20changes%22%20covers%20the%20single-storage%20%60withAccountStorageTransaction%60%20path.%20there's%20no%20parallel%20test%20for%20%60withAccountAndFlaggedStorageTransaction%60%20%2B%20storage-path%20drift%20%E2%86%92%20%60exportAccounts%60%20throw.%20both%20functions%20use%20the%20same%20%60transactionSnapshotContext%60%2C%20so%20the%20guard%20behaviour%20is%20identical%2C%20but%20the%20combined-transaction%20code%20path%20through%20%60exportAccounts%60%20remains%20uncovered.%20also%20worth%20adding%20a%20test%20that%20a%20non-%60ENOENT%60%20error%20from%20%60fs.realpath%60%20inside%20%60normalizeStorageComparisonPath%60%20is%20re-thrown%20%28e.g.%20%60EPERM%60%20on%20a%20locked%20directory%29.%20both%20are%20small%20gaps%20against%20the%2080%25%20coverage%20threshold.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/storage.test.ts
Line: 1183-1240

Comment:
**Windows test broken on Linux CI**

`normalizeStorageComparisonPath` calls `resolvePath(path)` (which uses Node's platform-native `path.resolve`) *before* converting backslashes to forward slashes. On Linux, `path.resolve` does not treat `\` as a path separator, so `\TMP\TEST\ACCOUNTS.JSON` gets resolved as a relative path component: `${cwd}/\TMP\TEST\ACCOUNTS.JSON`. The subsequent `.replaceAll("\\", "/").toLowerCase()` then produces `${cwd}//tmp/test/accounts.json`, which is never equal to the canonical `/tmp/test/accounts.json`.

Concretely, patching `process.platform = "win32"` does not patch Node's `path.resolve` semantics, so `areEquivalentStoragePaths` returns `false` for the backslash-upper version even with the win32 branch active. The guard throws and the test fails on any Linux CI runner.

The symlink test already handles this correctly with a platform guard:
```suggestion
		it("allows equivalent Windows-style storage paths during export from an active transaction", async () => {
			if (process.platform !== "win32") {
				return;
			}
			const originalPlatform = process.platform;
```
This test should be restricted to actual win32 runs, or the implementation in `normalizeStorageComparisonPath` needs to use `path.win32.resolve` when on win32 instead of relying on the ambient `path.resolve`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/storage.test.ts
Line: 1112-1140

Comment:
**Missing coverage: path-drift mismatch inside `withAccountAndFlaggedStorageTransaction`**

the test "fails fast when export is called from an active transaction after the storage path changes" covers the single-storage `withAccountStorageTransaction` path. there's no parallel test for `withAccountAndFlaggedStorageTransaction` + storage-path drift → `exportAccounts` throw. both functions use the same `transactionSnapshotContext`, so the guard behaviour is identical, but the combined-transaction code path through `exportAccounts` remains uncovered. also worth adding a test that a non-`ENOENT` error from `fs.realpath` inside `normalizeStorageComparisonPath` is re-thrown (e.g. `EPERM` on a locked directory). both are small gaps against the 80% coverage threshold.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: harden storage path transactions"](https://github.com/ndycode/codex-multi-auth/commit/30a46d2300b00e620d61bf76e962726d57bedaf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25915493)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->