### PR TITLE
feat: add session supervisor config plumbing

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -145,6 +145,7 @@ export const DEFAULT_PLUGIN_CONFIG: PluginConfig = {
 	liveAccountSync: true,
 	liveAccountSyncDebounceMs: 250,
 	liveAccountSyncPollMs: 2_000,
+	codexCliSessionSupervisor: false,
 	sessionAffinity: true,
 	sessionAffinityTtlMs: 20 * 60_000,
 	sessionAffinityMaxEntries: 512,
@@ -854,6 +855,25 @@ export function getLiveAccountSyncPollMs(pluginConfig: PluginConfig): number {
 		pluginConfig.liveAccountSyncPollMs,
 		2_000,
 		{ min: 500 },
+	);
+}
+
+/**
+ * Determines whether the CLI session supervisor wrapper is enabled.
+ *
+ * This accessor is synchronous, side-effect free, and safe for concurrent reads.
+ * It performs no filesystem I/O and does not expose token material.
+ *
+ * @param pluginConfig - The plugin configuration object used as the non-environment fallback
+ * @returns `true` when the session supervisor should wrap interactive Codex sessions
+ */
+export function getCodexCliSessionSupervisor(
+	pluginConfig: PluginConfig,
+): boolean {
+	return resolveBooleanSetting(
+		"CODEX_AUTH_CLI_SESSION_SUPERVISOR",
+		pluginConfig.codexCliSessionSupervisor,
+		false,
 	);
 }
 

--- a/lib/quota-probe.ts
+++ b/lib/quota-probe.ts
@@ -305,6 +305,19 @@ export interface ProbeCodexQuotaOptions {
 	model?: string;
 	fallbackModels?: readonly string[];
 	timeoutMs?: number;
+	signal?: AbortSignal;
+}
+
+function createAbortError(message: string): Error {
+	const error = new Error(message);
+	error.name = "AbortError";
+	return error;
+}
+
+function throwIfQuotaProbeAborted(signal: AbortSignal | undefined): void {
+	if (signal?.aborted) {
+		throw createAbortError("Quota probe aborted");
+	}
 }
 
 /**
@@ -331,8 +344,11 @@ export async function fetchCodexQuotaSnapshot(
 	let lastError: Error | null = null;
 
 	for (const model of models) {
+		throwIfQuotaProbeAborted(options.signal);
 		try {
+			throwIfQuotaProbeAborted(options.signal);
 			const instructions = await getCodexInstructions(model);
+			throwIfQuotaProbeAborted(options.signal);
 			const probeBody: RequestBody = {
 				model,
 				stream: true,
@@ -356,6 +372,12 @@ export async function fetchCodexQuotaSnapshot(
 			headers.set("content-type", "application/json");
 
 			const controller = new AbortController();
+			const onAbort = () => controller.abort(options.signal?.reason);
+			if (options.signal?.aborted) {
+				controller.abort(options.signal.reason);
+			} else {
+				options.signal?.addEventListener("abort", onAbort, { once: true });
+			}
 			const timeout = setTimeout(() => controller.abort(), timeoutMs);
 			let response: Response;
 			try {
@@ -367,6 +389,7 @@ export async function fetchCodexQuotaSnapshot(
 				});
 			} finally {
 				clearTimeout(timeout);
+				options.signal?.removeEventListener("abort", onAbort);
 			}
 
 			const snapshotBase = parseQuotaSnapshotBase(response.headers, response.status);
@@ -390,6 +413,7 @@ export async function fetchCodexQuotaSnapshot(
 
 				const unsupportedInfo = getUnsupportedCodexModelInfo(errorBody);
 				if (unsupportedInfo.isUnsupported) {
+					throwIfQuotaProbeAborted(options.signal);
 					lastError = new Error(
 						unsupportedInfo.message ?? `Model '${model}' unsupported for this account`,
 					);
@@ -406,8 +430,15 @@ export async function fetchCodexQuotaSnapshot(
 			}
 			lastError = new Error("Codex response did not include quota headers");
 		} catch (error) {
+			if (options.signal?.aborted) {
+				throw error instanceof Error ? error : createAbortError("Quota probe aborted");
+			}
 			lastError = error instanceof Error ? error : new Error(String(error));
 		}
+	}
+
+	if (options.signal?.aborted) {
+		throw createAbortError("Quota probe aborted");
 	}
 
 	throw lastError ?? new Error("Failed to fetch quotas");

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -44,6 +44,7 @@ export const PluginConfigSchema = z.object({
 	liveAccountSync: z.boolean().optional(),
 	liveAccountSyncDebounceMs: z.number().min(50).optional(),
 	liveAccountSyncPollMs: z.number().min(500).optional(),
+	codexCliSessionSupervisor: z.boolean().optional(),
 	sessionAffinity: z.boolean().optional(),
 	sessionAffinityTtlMs: z.number().min(1_000).optional(),
 	sessionAffinityMaxEntries: z.number().min(8).optional(),

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -21,6 +21,7 @@ import {
 	getPreemptiveQuotaRemainingPercent5h,
 	getPreemptiveQuotaRemainingPercent7d,
 	getPreemptiveQuotaMaxDeferralMs,
+	getCodexCliSessionSupervisor,
 } from '../lib/config.js';
 import type { PluginConfig } from '../lib/types.js';
 import * as fs from 'node:fs';
@@ -67,6 +68,7 @@ describe('Plugin Configuration', () => {
 		'CODEX_AUTH_PREEMPTIVE_QUOTA_5H_REMAINING_PCT',
 		'CODEX_AUTH_PREEMPTIVE_QUOTA_7D_REMAINING_PCT',
 		'CODEX_AUTH_PREEMPTIVE_QUOTA_MAX_DEFERRAL_MS',
+		'CODEX_AUTH_CLI_SESSION_SUPERVISOR',
 	] as const;
 	const originalEnv: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
 
@@ -139,6 +141,7 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				codexCliSessionSupervisor: false,
 			});
 			// existsSync is called with multiple candidate config paths (primary + legacy fallbacks)
 			expect(mockExistsSync).toHaveBeenCalled();
@@ -197,6 +200,7 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				codexCliSessionSupervisor: false,
 			});
 		});
 
@@ -452,6 +456,7 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				codexCliSessionSupervisor: false,
 			});
 		});
 
@@ -516,6 +521,7 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				codexCliSessionSupervisor: false,
 	});
 		expect(mockLogWarn).toHaveBeenCalled();
 	});
@@ -574,6 +580,7 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				codexCliSessionSupervisor: false,
 		});
 		expect(mockLogWarn).toHaveBeenCalled();
 	});
@@ -978,6 +985,33 @@ describe('Plugin Configuration', () => {
 			expect(getPreemptiveQuotaRemainingPercent5h({ preemptiveQuotaRemainingPercent5h: 1 })).toBe(9);
 			expect(getPreemptiveQuotaRemainingPercent7d({ preemptiveQuotaRemainingPercent7d: 2 })).toBe(11);
 			expect(getPreemptiveQuotaMaxDeferralMs({ preemptiveQuotaMaxDeferralMs: 2_000 })).toBe(123000);
+		});
+	});
+
+	describe('CLI session supervisor setting', () => {
+		it('should default the supervisor wrapper to disabled', () => {
+			expect(getCodexCliSessionSupervisor({})).toBe(false);
+		});
+
+		it('should honor the config value when the env override is unset', () => {
+			delete process.env.CODEX_AUTH_CLI_SESSION_SUPERVISOR;
+			expect(
+				getCodexCliSessionSupervisor({ codexCliSessionSupervisor: true }),
+			).toBe(true);
+		});
+
+		it('should allow the env override to disable the supervisor wrapper', () => {
+			process.env.CODEX_AUTH_CLI_SESSION_SUPERVISOR = '0';
+			expect(
+				getCodexCliSessionSupervisor({ codexCliSessionSupervisor: true }),
+			).toBe(false);
+			delete process.env.CODEX_AUTH_CLI_SESSION_SUPERVISOR;
+		});
+
+		it('should prioritize environment override for the supervisor wrapper', () => {
+			process.env.CODEX_AUTH_CLI_SESSION_SUPERVISOR = '1';
+			expect(getCodexCliSessionSupervisor({ codexCliSessionSupervisor: false })).toBe(true);
+			delete process.env.CODEX_AUTH_CLI_SESSION_SUPERVISOR;
 		});
 	});
 });

--- a/test/quota-probe.test.ts
+++ b/test/quota-probe.test.ts
@@ -170,6 +170,132 @@ describe("quota-probe", () => {
 		await assertion;
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
+
+	it("aborts immediately when the caller abort signal fires", async () => {
+		const controller = new AbortController();
+		let markFetchStarted!: () => void;
+		const fetchStarted = new Promise<void>((resolve) => {
+			markFetchStarted = resolve;
+		});
+		const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+			return new Promise<Response>((_resolve, reject) => {
+				init?.signal?.addEventListener(
+					"abort",
+					() => {
+						const error = new Error("aborted");
+						(error as Error & { name?: string }).name = "AbortError";
+						reject(error);
+					},
+					{ once: true },
+				);
+				markFetchStarted();
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const pending = fetchCodexQuotaSnapshot({
+			accountId: "acc-abort",
+			accessToken: "token-abort",
+			model: "gpt-5-codex",
+			fallbackModels: [],
+			timeoutMs: 30_000,
+			signal: controller.signal,
+		});
+
+		await fetchStarted;
+		controller.abort();
+
+		await expect(pending).rejects.toThrow(/abort/i);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects immediately when the caller signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			fetchCodexQuotaSnapshot({
+				accountId: "acc-pre-aborted",
+				accessToken: "token-pre-aborted",
+				model: "gpt-5-codex",
+				fallbackModels: [],
+				timeoutMs: 30_000,
+				signal: controller.signal,
+			}),
+		).rejects.toThrow(/abort/i);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("re-checks the caller abort signal after loading instructions", async () => {
+		const controller = new AbortController();
+		const instructionsReady = (() => {
+			let resolve!: (value: string) => void;
+			const promise = new Promise<string>((res) => {
+				resolve = res;
+			});
+			return { promise, resolve };
+		})();
+		getCodexInstructionsMock.mockImplementationOnce(() => instructionsReady.promise);
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const pending = fetchCodexQuotaSnapshot({
+			accountId: "acc-post-instructions-abort",
+			accessToken: "token-post-instructions-abort",
+			model: "gpt-5-codex",
+			fallbackModels: [],
+			timeoutMs: 30_000,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		instructionsReady.resolve("instructions:gpt-5-codex");
+
+		await expect(pending).rejects.toThrow(/abort/i);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("does not start probing a fallback model after the caller aborts an unsupported first attempt", async () => {
+		const controller = new AbortController();
+		const unsupported = new Response(
+			JSON.stringify({
+				error: { message: "Model gpt-5.3-codex unsupported", type: "invalid_request_error" },
+			}),
+			{ status: 400, headers: new Headers({ "content-type": "application/json" }) },
+		);
+		const fetchMock = vi.fn(async () => {
+			controller.abort();
+			return unsupported;
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		getUnsupportedCodexModelInfoMock
+			.mockReturnValueOnce({
+				isUnsupported: true,
+				unsupportedModel: "gpt-5.3-codex",
+				message: "unsupported",
+			})
+			.mockReturnValue({
+				isUnsupported: false,
+				unsupportedModel: undefined,
+				message: undefined,
+			});
+
+		await expect(
+			fetchCodexQuotaSnapshot({
+				accountId: "acc-abort-before-fallback",
+				accessToken: "token-abort-before-fallback",
+				model: "gpt-5.3-codex",
+				fallbackModels: ["gpt-5.2-codex"],
+				signal: controller.signal,
+			}),
+		).rejects.toThrow(/abort/i);
+		expect(getCodexInstructionsMock).toHaveBeenCalledTimes(1);
+		expect(getCodexInstructionsMock).toHaveBeenCalledWith("gpt-5.3-codex");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
 	it("parses reset-at values expressed as epoch seconds and epoch milliseconds", async () => {
 		const nowSec = Math.floor(Date.now() / 1000);
 		const primarySeconds = nowSec + 120;


### PR DESCRIPTION
## Summary
- extract the low-risk supervisor plumbing out of #207 into its own PR
- add the config/schema flag and abort-aware quota probe support needed by the supervisor runtime
- cover the new config and quota abort behavior with focused tests

## Validation
- npm exec vitest run test/plugin-config.test.ts test/quota-probe.test.ts
- npm run typecheck

## Notes
- supersedes the plumbing portion of #207 so reviewers can clear the substrate before the runtime wrapper PR

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

clean plumbing PR that wires the `codexCliSessionSupervisor` boolean flag through schema, config default, env override accessor, and snapshot tests, then adds `AbortSignal` support to `fetchCodexQuotaSnapshot` with proper listener cleanup and abort re-checks around every async suspension point.

- `lib/schemas.ts` + `lib/config.ts`: `codexCliSessionSupervisor` added as an optional zod boolean, defaults to `false`, overridable via `CODEX_AUTH_CLI_SESSION_SUPERVISOR`. accessor is synchronous, side-effect free, no token or filesystem exposure — consistent with existing `resolveBooleanSetting` pattern.
- `lib/quota-probe.ts`: `signal?: AbortSignal` added to `ProbeCodexQuotaOptions`. the inner `AbortController` correctly forwards the caller signal via an `{ once: true }` listener, handles the pre-aborted edge case, and cleans up in `finally`. abort guards are placed at every async boundary (before instructions load, after instructions load, after unsupported-model response). no filesystem access or token leak introduced.
- `test/plugin-config.test.ts`: all four supervisor override paths covered; env var lifecycle correctly cleaned up per test. existing config snapshot assertions updated.
- `test/quota-probe.test.ts`: four focused abort scenarios cover pre-aborted signal, mid-fetch abort, post-instructions abort, and abort during unsupported fallback — good vitest coverage for the new behavior.
- one minor redundancy: `throwIfQuotaProbeAborted` at line 349 (inside `try`) is a no-op duplicate of line 347 (outside `try`) — js is single-threaded so the signal cannot flip between two synchronous lines. no runtime impact; see inline comment.

<h3>Confidence Score: 5/5</h3>

- safe to merge — all abort paths are correct and tested, no token or filesystem risk introduced.
- config flag is trivially safe (boolean, env-overridable, no i/o). abort plumbing is mechanically correct: listener cleanup via `finally` + `{ once: true }` prevents leaks, pre-abort detection guards every async suspension point, and the catch correctly re-surfaces AbortErrors. the only finding is a redundant synchronous guard (line 349) that is dead code but harmless. test coverage is solid across all four new abort scenarios.
- no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/config.ts | adds `codexCliSessionSupervisor` boolean flag to `DEFAULT_PLUGIN_CONFIG` and a clean `getCodexCliSessionSupervisor` accessor that delegates to existing `resolveBooleanSetting` with `CODEX_AUTH_CLI_SESSION_SUPERVISOR` env override. no filesystem i/o, no token exposure, side-effect free. |
| lib/quota-probe.ts | adds optional `signal?: AbortSignal` to `ProbeCodexQuotaOptions` and wires abort-awareness throughout `fetchCodexQuotaSnapshot`. abort propagation and listener cleanup are correct. one redundant synchronous guard at line 349 (inside try) duplicates the check at line 347 (outside try) — dead code, no runtime impact. |
| lib/schemas.ts | adds `codexCliSessionSupervisor: z.boolean().optional()` to `PluginConfigSchema` — minimal, consistent with the surrounding schema entries. |
| test/plugin-config.test.ts | correctly adds `codexCliSessionSupervisor: false` to all existing config-snapshot assertions and adds a focused `describe` block with four cases covering default, config override, env disable, and env enable. full env var lifecycle (delete, set, delete) is properly managed to avoid state leakage. |
| test/quota-probe.test.ts | adds four targeted abort tests covering: mid-fetch signal fire, pre-aborted signal, signal abort between instructions load and fetch, and abort during unsupported-model fallback chain. covers all meaningful abort checkpoints in the new code. minor: missing blank line separator before the existing "parses reset-at values" test. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchCodexQuotaSnapshot
    participant AbortController
    participant fetch as fetch(Codex API)

    Caller->>fetchCodexQuotaSnapshot: call({ signal })
    loop for each model
        fetchCodexQuotaSnapshot->>fetchCodexQuotaSnapshot: throwIfAborted(signal) [line 347 – outside try]
        fetchCodexQuotaSnapshot->>fetchCodexQuotaSnapshot: await getCodexInstructions(model)
        fetchCodexQuotaSnapshot->>fetchCodexQuotaSnapshot: throwIfAborted(signal) [post-instructions]
        fetchCodexQuotaSnapshot->>AbortController: new AbortController()
        alt signal already aborted
            fetchCodexQuotaSnapshot->>AbortController: controller.abort(signal.reason)
        else
            Caller-->>fetchCodexQuotaSnapshot: signal "abort" event → onAbort fires
            fetchCodexQuotaSnapshot->>AbortController: controller.abort(signal.reason)
        end
        fetchCodexQuotaSnapshot->>fetch: fetch(..., { signal: controller.signal })
        fetch-->>fetchCodexQuotaSnapshot: response / AbortError
        fetchCodexQuotaSnapshot->>fetchCodexQuotaSnapshot: clearTimeout + removeEventListener
        alt signal aborted in catch
            fetchCodexQuotaSnapshot-->>Caller: throw AbortError
        end
    end
    alt signal aborted after loop
        fetchCodexQuotaSnapshot-->>Caller: throw AbortError
    end
    fetchCodexQuotaSnapshot-->>Caller: CodexQuotaSnapshot | lastError
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fquota-probe.ts%3A347-349%0A**Redundant%20consecutive%20abort%20guard**%0A%0Alines%20347%20and%20349%20both%20call%20%60throwIfQuotaProbeAborted%60%20with%20zero%20async%20work%20between%20them.%20js%20is%20single-threaded%2C%20so%20%60signal.aborted%60%20cannot%20flip%20between%20two%20synchronous%20lines.%20the%20guard%20at%20line%20347%20%28outside%20the%20%60try%60%29%20is%20the%20effective%20early-exit%20point%20%E2%80%94%20it%20propagates%20cleanly%20to%20the%20caller%20without%20being%20swallowed%20by%20the%20catch.%20line%20349%20%28inside%20%60try%60%29%20is%20dead%20code%3A%20if%20the%20signal%20were%20somehow%20aborted%20here%20the%20catch%20would%20re-throw%20it%20anyway%2C%20but%20it%20can%20never%20be%20aborted%20here%20without%20line%20347%20having%20already%20fired.%0A%0A%60%60%60suggestion%0A%09for%20%28const%20model%20of%20models%29%20%7B%0A%09%09throwIfQuotaProbeAborted%28options.signal%29%3B%0A%09%09try%20%7B%0A%09%09%09const%20instructions%20%3D%20await%20getCodexInstructions%28model%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/quota-probe.ts
Line: 347-349

Comment:
**Redundant consecutive abort guard**

lines 347 and 349 both call `throwIfQuotaProbeAborted` with zero async work between them. js is single-threaded, so `signal.aborted` cannot flip between two synchronous lines. the guard at line 347 (outside the `try`) is the effective early-exit point — it propagates cleanly to the caller without being swallowed by the catch. line 349 (inside `try`) is dead code: if the signal were somehow aborted here the catch would re-throw it anyway, but it can never be aborted here without line 347 having already fired.

```suggestion
	for (const model of models) {
		throwIfQuotaProbeAborted(options.signal);
		try {
			const instructions = await getCodexInstructions(model);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add session supervisor config plum..."](https://github.com/ndycode/codex-multi-auth/commit/dd077fff9cd663d0693a03d037b1a42657eef5fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25915813)</sub>

<!-- /greptile_comment -->