### PR TITLE
fix fast-expiry token refresh persistence in account pool

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -177,6 +177,7 @@ import {
 import { applyFastSessionDefaults } from "./lib/request/request-transformer.js";
 import { applyResponseCompaction } from "./lib/request/response-compaction.js";
 import { isEmptyResponse } from "./lib/request/response-handler.js";
+import { CodexAuthError } from "./lib/errors.js";
 import {
 	parseRetryAfterHintMs,
 	sanitizeResponseHeadersForLog,
@@ -997,9 +998,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 													accountAuth,
 													client,
 												)) as OAuthAuthDetails;
-												accountManager.updateFromAuth(account, accountAuth);
-												accountManager.clearAuthFailures(account);
-												accountManager.saveToDiskDebounced();
+												await accountManager.commitRefreshedAuth(
+													account,
+													accountAuth,
+												);
 											}
 										} catch (err) {
 											logDebug(
@@ -1010,18 +1012,48 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 											runtimeMetrics.accountRotations++;
 											runtimeMetrics.lastError =
 												(err as Error)?.message ?? String(err);
-											const failures =
-												accountManager.incrementAuthFailures(account);
+											const isRetryableRefreshError =
+												err instanceof CodexAuthError && err.retryable;
 											const accountLabel = formatAccountLabel(
 												account,
 												account.index,
 											);
 
+											sessionAffinityStore?.forgetSession(sessionAffinityKey);
+
+											if (isRetryableRefreshError) {
+												runtimeMetrics.networkErrors++;
+												const retryableRefreshPolicy = evaluateFailurePolicy(
+													{ kind: "network", failoverMode },
+													{ networkCooldownMs: networkErrorCooldownMs },
+												);
+												if (retryableRefreshPolicy.recordFailure) {
+													accountManager.recordFailure(
+														account,
+														modelFamily,
+														model,
+													);
+												}
+												if (
+													typeof retryableRefreshPolicy.cooldownMs === "number" &&
+													retryableRefreshPolicy.cooldownReason
+												) {
+													accountManager.markAccountCoolingDown(
+														account,
+														retryableRefreshPolicy.cooldownMs,
+														retryableRefreshPolicy.cooldownReason,
+													);
+													accountManager.saveToDiskDebounced();
+												}
+												continue;
+											}
+
+											const failures =
+												accountManager.incrementAuthFailures(account);
 											const authFailurePolicy = evaluateFailurePolicy({
 												kind: "auth-refresh",
 												consecutiveAuthFailures: failures,
 											});
-											sessionAffinityStore?.forgetSession(sessionAffinityKey);
 
 											if (authFailurePolicy.removeAccount) {
 												const removedIndex = account.index;
@@ -1945,14 +1977,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 																		fallbackAuth,
 																		client,
 																	)) as OAuthAuthDetails;
-																	accountManager.updateFromAuth(
+																	await accountManager.commitRefreshedAuth(
 																		fallbackAccount,
 																		fallbackAuth,
 																	);
-																	accountManager.clearAuthFailures(
-																		fallbackAccount,
-																	);
-																	accountManager.saveToDiskDebounced();
 																}
 															} catch (refreshError) {
 																logWarn(

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -19,6 +19,8 @@ import {
 	type HybridSelectionOptions,
 } from "./rotation.js";
 import { nowMs } from "./utils.js";
+import { ERROR_MESSAGES } from "./constants.js";
+import { CodexAuthError } from "./errors.js";
 import {
 	loadCodexCliState,
 	type CodexCliTokenCacheEntry,
@@ -801,66 +803,70 @@ export class AccountManager {
 	): Promise<ManagedAccount | null> {
 		const nextAccountId = extractAccountId(auth.access)?.trim() || undefined;
 		const nextEmail = sanitizeEmail(extractAccountEmail(auth.access));
+		try {
+			return await withAccountStorageTransaction(async (current, persist) => {
+				const nextStorage = structuredClone(
+					current ?? this.buildStorageSnapshot(),
+				) as AccountStorageV3;
+				const storageIndex = findAccountIndexByIdentity(
+					nextStorage.accounts,
+					source,
+					auth,
+				);
+				if (storageIndex === undefined) {
+					log.warn("Unable to resolve refreshed account for persistence", {
+						sourceIndex: source.index,
+					});
+					return null;
+				}
 
-		await withAccountStorageTransaction(async (current, persist) => {
-			const nextStorage = structuredClone(
-				current ?? this.buildStorageSnapshot(),
-			) as AccountStorageV3;
-			const storageIndex = findAccountIndexByIdentity(
-				nextStorage.accounts,
-				source,
-				auth,
-			);
-			if (storageIndex === undefined) {
-				log.warn("Unable to resolve refreshed account for persistence", {
-					sourceIndex: source.index,
-					email: source.email,
-				});
-				return;
-			}
+				const storedAccount = nextStorage.accounts[storageIndex];
+				if (!storedAccount) {
+					return null;
+				}
 
-			const storedAccount = nextStorage.accounts[storageIndex];
-			if (!storedAccount) {
-				return;
-			}
+				storedAccount.refreshToken = auth.refresh;
+				storedAccount.accessToken = auth.access;
+				storedAccount.expiresAt = auth.expires;
+				if (
+					nextAccountId &&
+					shouldUpdateAccountIdFromToken(
+						storedAccount.accountIdSource,
+						storedAccount.accountId,
+					)
+				) {
+					storedAccount.accountId = nextAccountId;
+					storedAccount.accountIdSource = "token";
+				}
+				if (nextEmail) {
+					storedAccount.email = nextEmail;
+				}
+				storedAccount.enabled = undefined;
+				delete storedAccount.coolingDownUntil;
+				delete storedAccount.cooldownReason;
 
-			storedAccount.refreshToken = auth.refresh;
-			storedAccount.accessToken = auth.access;
-			storedAccount.expiresAt = auth.expires;
-			if (
-				nextAccountId &&
-				shouldUpdateAccountIdFromToken(
-					storedAccount.accountIdSource,
-					storedAccount.accountId,
-				)
-			) {
-				storedAccount.accountId = nextAccountId;
-				storedAccount.accountIdSource = "token";
-			}
-			if (nextEmail) {
-				storedAccount.email = nextEmail;
-			}
-			storedAccount.enabled = undefined;
-			delete storedAccount.coolingDownUntil;
-			delete storedAccount.cooldownReason;
+				await persist(nextStorage);
 
-			await persist(nextStorage);
-		});
+				const liveAccount = this.getAccountByIdentity(source, auth);
+				if (!liveAccount) {
+					log.warn("Unable to resolve refreshed live account after persistence", {
+						sourceIndex: source.index,
+					});
+					return null;
+				}
 
-		const liveAccount = this.getAccountByIdentity(source, auth);
-		if (!liveAccount) {
-			log.warn("Unable to resolve refreshed live account after persistence", {
-				sourceIndex: source.index,
-				email: source.email,
+				this.updateFromAuth(liveAccount, auth);
+				liveAccount.enabled = true;
+				this.clearAccountCooldown(liveAccount);
+				this.clearAuthFailures(liveAccount);
+				return liveAccount;
 			});
-			return null;
+		} catch (error) {
+			throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+				retryable: true,
+				cause: error,
+			});
 		}
-
-		this.updateFromAuth(liveAccount, auth);
-		liveAccount.enabled = true;
-		this.clearAccountCooldown(liveAccount);
-		this.clearAuthFailures(liveAccount);
-		return liveAccount;
 	}
 
 	toAuthDetails(account: ManagedAccount): Auth {
@@ -973,7 +979,9 @@ export class AccountManager {
 	}
 
 	async saveToDisk(): Promise<void> {
-		await saveAccounts(this.buildStorageSnapshot());
+		await withAccountStorageTransaction(async (_current, persist) => {
+			await persist(this.buildStorageSnapshot());
+		});
 	}
 
 	saveToDiskDebounced(delayMs = 500): void {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -19,7 +19,7 @@ import {
 	type HybridSelectionOptions,
 } from "./rotation.js";
 import { nowMs } from "./utils.js";
-import { ERROR_MESSAGES } from "./constants.js";
+import { ERROR_MESSAGES, HTTP_STATUS } from "./constants.js";
 import { CodexAuthError } from "./errors.js";
 import {
 	loadCodexCliState,
@@ -157,6 +157,37 @@ function findAccountIndexByIdentity<
 		}
 	}
 	return undefined;
+}
+
+const RETRYABLE_AUTH_PERSISTENCE_CODES = new Set(["EAGAIN", "EBUSY", "EPERM"]);
+
+function isRetryableAuthPersistenceError(error: unknown): boolean {
+	if (!error || typeof error !== "object") {
+		return false;
+	}
+
+	const candidate = error as {
+		code?: unknown;
+		status?: unknown;
+		cause?: unknown;
+	};
+	const code =
+		typeof candidate.code === "string"
+			? candidate.code.toUpperCase()
+			: undefined;
+	if (code && RETRYABLE_AUTH_PERSISTENCE_CODES.has(code)) {
+		return true;
+	}
+
+	if (candidate.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
+		return true;
+	}
+
+	if (candidate.cause && candidate.cause !== error) {
+		return isRetryableAuthPersistenceError(candidate.cause);
+	}
+
+	return false;
 }
 
 export interface Workspace {
@@ -845,25 +876,68 @@ export class AccountManager {
 				delete storedAccount.coolingDownUntil;
 				delete storedAccount.cooldownReason;
 
-				await persist(nextStorage);
-
 				const liveAccount = this.getAccountByIdentity(source, auth);
-				if (!liveAccount) {
-					log.warn("Unable to resolve refreshed live account after persistence", {
-						sourceIndex: source.index,
-					});
-					return null;
+				if (liveAccount) {
+					const previousLiveAccountState = {
+						access: liveAccount.access,
+						refreshToken: liveAccount.refreshToken,
+						expires: liveAccount.expires,
+						accountId: liveAccount.accountId,
+						accountIdSource: liveAccount.accountIdSource,
+						email: liveAccount.email,
+						enabled: liveAccount.enabled,
+						coolingDownUntil: liveAccount.coolingDownUntil,
+						cooldownReason: liveAccount.cooldownReason,
+						consecutiveAuthFailures: liveAccount.consecutiveAuthFailures,
+					};
+
+					this.updateFromAuth(liveAccount, auth);
+					liveAccount.enabled = true;
+					this.clearAccountCooldown(liveAccount);
+					this.clearAuthFailures(liveAccount);
+
+					try {
+						await persist(nextStorage);
+					} catch (error) {
+						liveAccount.access = previousLiveAccountState.access;
+						liveAccount.refreshToken = previousLiveAccountState.refreshToken;
+						liveAccount.expires = previousLiveAccountState.expires;
+						liveAccount.accountId = previousLiveAccountState.accountId;
+						liveAccount.accountIdSource =
+							previousLiveAccountState.accountIdSource;
+						liveAccount.email = previousLiveAccountState.email;
+						liveAccount.enabled = previousLiveAccountState.enabled;
+						liveAccount.consecutiveAuthFailures =
+							previousLiveAccountState.consecutiveAuthFailures;
+						if (
+							previousLiveAccountState.coolingDownUntil === undefined
+						) {
+							delete liveAccount.coolingDownUntil;
+						} else {
+							liveAccount.coolingDownUntil =
+								previousLiveAccountState.coolingDownUntil;
+						}
+						if (previousLiveAccountState.cooldownReason === undefined) {
+							delete liveAccount.cooldownReason;
+						} else {
+							liveAccount.cooldownReason =
+								previousLiveAccountState.cooldownReason;
+						}
+						throw error;
+					}
+
+					return liveAccount;
 				}
 
-				this.updateFromAuth(liveAccount, auth);
-				liveAccount.enabled = true;
-				this.clearAccountCooldown(liveAccount);
-				this.clearAuthFailures(liveAccount);
-				return liveAccount;
+				await persist(nextStorage);
+				log.warn("Unable to resolve refreshed live account after persistence", {
+					sourceIndex: source.index,
+				});
+				return null;
 			});
 		} catch (error) {
 			throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-				retryable: true,
+				retryable: isRetryableAuthPersistenceError(error),
 				cause: error,
 			});
 		}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -804,9 +804,9 @@ export class AccountManager {
 		const nextAccountId = extractAccountId(auth.access)?.trim() || undefined;
 		const nextEmail = sanitizeEmail(extractAccountEmail(auth.access));
 		try {
-			return await withAccountStorageTransaction(async (current, persist) => {
+			return await withAccountStorageTransaction(async (_current, persist) => {
 				const nextStorage = structuredClone(
-					current ?? this.buildStorageSnapshot(),
+					this.buildStorageSnapshot(),
 				) as AccountStorageV3;
 				const storageIndex = findAccountIndexByIdentity(
 					nextStorage.accounts,

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -7,6 +7,7 @@ import {
 	type CooldownReason,
 	type RateLimitStateV3,
 	findMatchingAccountIndex,
+	withAccountStorageTransaction,
 } from "./storage.js";
 import type { AccountIdSource, OAuthAuthDetails } from "./types.js";
 import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
@@ -79,6 +80,81 @@ function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
 	return Object.fromEntries(
 		MODEL_FAMILIES.map((family) => [family, defaultValue]),
 	) as Record<ModelFamily, number>;
+}
+
+type AccountIdentityCandidate = Pick<
+	ManagedAccount,
+	"accountId" | "email" | "refreshToken"
+> & {
+	index?: number;
+};
+
+function getAuthIdentityCandidate(
+	auth: OAuthAuthDetails | undefined,
+): AccountIdentityCandidate {
+	const accountId = extractAccountId(auth?.access)?.trim() || undefined;
+	const email = sanitizeEmail(extractAccountEmail(auth?.access));
+	return {
+		accountId,
+		email,
+		refreshToken: auth?.refresh,
+	};
+}
+
+function buildAccountIdentityCandidates(
+	source: AccountIdentityCandidate,
+	auth?: OAuthAuthDetails,
+): AccountIdentityCandidate[] {
+	const derived = getAuthIdentityCandidate(auth);
+	const candidates: AccountIdentityCandidate[] = [];
+	const seen = new Set<string>();
+
+	const pushCandidate = (candidate: AccountIdentityCandidate): void => {
+		const key = `${candidate.accountId ?? ""}|${candidate.email ?? ""}|${candidate.refreshToken ?? ""}`;
+		if (seen.has(key)) return;
+		seen.add(key);
+		candidates.push(candidate);
+	};
+
+	pushCandidate(source);
+	pushCandidate({
+		accountId: source.accountId ?? derived.accountId,
+		email: source.email ?? derived.email,
+		refreshToken: source.refreshToken,
+		index: source.index,
+	});
+	pushCandidate({
+		accountId: derived.accountId ?? source.accountId,
+		email: derived.email ?? source.email,
+		refreshToken: source.refreshToken,
+		index: source.index,
+	});
+	pushCandidate({
+		accountId: derived.accountId ?? source.accountId,
+		email: derived.email ?? source.email,
+		refreshToken: derived.refreshToken ?? source.refreshToken,
+		index: source.index,
+	});
+
+	return candidates;
+}
+
+function findAccountIndexByIdentity<
+	T extends Pick<AccountIdentityCandidate, "accountId" | "email" | "refreshToken">,
+>(
+	accounts: readonly T[],
+	source: AccountIdentityCandidate,
+	auth?: OAuthAuthDetails,
+): number | undefined {
+	for (const candidate of buildAccountIdentityCandidates(source, auth)) {
+		const matchIndex = findMatchingAccountIndex(accounts, candidate, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		});
+		if (matchIndex !== undefined) {
+			return matchIndex;
+		}
+	}
+	return undefined;
 }
 
 export interface Workspace {
@@ -642,6 +718,17 @@ export class AccountManager {
 		account.consecutiveAuthFailures = 0;
 	}
 
+	getAccountByIdentity(
+		candidate: AccountIdentityCandidate,
+		auth?: OAuthAuthDetails,
+	): ManagedAccount | null {
+		const index = findAccountIndexByIdentity(this.accounts, candidate, auth);
+		if (index === undefined) {
+			return null;
+		}
+		return this.accounts[index] ?? null;
+	}
+
 	shouldShowAccountToast(accountIndex: number, debounceMs = 30000): boolean {
 		const now = nowMs();
 		if (accountIndex === this.lastToastAccountIndex && now - this.lastToastTime < debounceMs) {
@@ -668,6 +755,112 @@ export class AccountManager {
 			account.accountIdSource = "token";
 		}
 		account.email = sanitizeEmail(extractAccountEmail(auth.access)) ?? account.email;
+	}
+
+	private buildStorageSnapshot(): AccountStorageV3 {
+		const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
+		for (const family of MODEL_FAMILIES) {
+			const raw = this.currentAccountIndexByFamily[family];
+			activeIndexByFamily[family] = clampNonNegativeInt(raw, 0);
+		}
+
+		const activeIndex = clampNonNegativeInt(activeIndexByFamily.codex, 0);
+
+		return {
+			version: 3,
+			accounts: this.accounts.map((account) => ({
+				accountId: account.accountId,
+				accountIdSource: account.accountIdSource,
+				accountLabel: account.accountLabel,
+				email: account.email,
+				refreshToken: account.refreshToken,
+				accessToken: account.access,
+				expiresAt: account.expires,
+				enabled: account.enabled === false ? false : undefined,
+				addedAt: account.addedAt,
+				lastUsed: account.lastUsed,
+				lastSwitchReason: account.lastSwitchReason,
+				rateLimitResetTimes:
+					Object.keys(account.rateLimitResetTimes).length > 0 ? account.rateLimitResetTimes : undefined,
+				coolingDownUntil: account.coolingDownUntil,
+				cooldownReason: account.cooldownReason,
+				workspaces: account.workspaces,
+				currentWorkspaceIndex: account.currentWorkspaceIndex,
+			})),
+			activeIndex,
+			activeIndexByFamily,
+		};
+	}
+
+	async commitRefreshedAuth(
+		source: Pick<
+			ManagedAccount,
+			"index" | "accountId" | "email" | "refreshToken"
+		>,
+		auth: OAuthAuthDetails,
+	): Promise<ManagedAccount | null> {
+		const nextAccountId = extractAccountId(auth.access)?.trim() || undefined;
+		const nextEmail = sanitizeEmail(extractAccountEmail(auth.access));
+
+		await withAccountStorageTransaction(async (current, persist) => {
+			const nextStorage = structuredClone(
+				current ?? this.buildStorageSnapshot(),
+			) as AccountStorageV3;
+			const storageIndex = findAccountIndexByIdentity(
+				nextStorage.accounts,
+				source,
+				auth,
+			);
+			if (storageIndex === undefined) {
+				log.warn("Unable to resolve refreshed account for persistence", {
+					sourceIndex: source.index,
+					email: source.email,
+				});
+				return;
+			}
+
+			const storedAccount = nextStorage.accounts[storageIndex];
+			if (!storedAccount) {
+				return;
+			}
+
+			storedAccount.refreshToken = auth.refresh;
+			storedAccount.accessToken = auth.access;
+			storedAccount.expiresAt = auth.expires;
+			if (
+				nextAccountId &&
+				shouldUpdateAccountIdFromToken(
+					storedAccount.accountIdSource,
+					storedAccount.accountId,
+				)
+			) {
+				storedAccount.accountId = nextAccountId;
+				storedAccount.accountIdSource = "token";
+			}
+			if (nextEmail) {
+				storedAccount.email = nextEmail;
+			}
+			storedAccount.enabled = undefined;
+			delete storedAccount.coolingDownUntil;
+			delete storedAccount.cooldownReason;
+
+			await persist(nextStorage);
+		});
+
+		const liveAccount = this.getAccountByIdentity(source, auth);
+		if (!liveAccount) {
+			log.warn("Unable to resolve refreshed live account after persistence", {
+				sourceIndex: source.index,
+				email: source.email,
+			});
+			return null;
+		}
+
+		this.updateFromAuth(liveAccount, auth);
+		liveAccount.enabled = true;
+		this.clearAccountCooldown(liveAccount);
+		this.clearAuthFailures(liveAccount);
+		return liveAccount;
 	}
 
 	toAuthDetails(account: ManagedAccount): Auth {
@@ -780,40 +973,7 @@ export class AccountManager {
 	}
 
 	async saveToDisk(): Promise<void> {
-		const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
-		for (const family of MODEL_FAMILIES) {
-			const raw = this.currentAccountIndexByFamily[family];
-			activeIndexByFamily[family] = clampNonNegativeInt(raw, 0);
-		}
-
-		const activeIndex = clampNonNegativeInt(activeIndexByFamily.codex, 0);
-
-		const storage: AccountStorageV3 = {
-			version: 3,
-			accounts: this.accounts.map((account) => ({
-				accountId: account.accountId,
-				accountIdSource: account.accountIdSource,
-				accountLabel: account.accountLabel,
-				email: account.email,
-				refreshToken: account.refreshToken,
-				accessToken: account.access,
-				expiresAt: account.expires,
-				enabled: account.enabled === false ? false : undefined,
-				addedAt: account.addedAt,
-				lastUsed: account.lastUsed,
-				lastSwitchReason: account.lastSwitchReason,
-				rateLimitResetTimes:
-					Object.keys(account.rateLimitResetTimes).length > 0 ? account.rateLimitResetTimes : undefined,
-				coolingDownUntil: account.coolingDownUntil,
-				cooldownReason: account.cooldownReason,
-				workspaces: account.workspaces,
-				currentWorkspaceIndex: account.currentWorkspaceIndex,
-			})),
-			activeIndex,
-			activeIndexByFamily,
-		};
-
-		await saveAccounts(storage);
+		await saveAccounts(this.buildStorageSnapshot());
 	}
 
 	saveToDiskDebounced(delayMs = 500): void {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -779,7 +779,7 @@ export class AccountManager {
 		account.refreshToken = auth.refresh;
 		account.access = auth.access;
 		account.expires = auth.expires;
-		const tokenAccountId = extractAccountId(auth.access);
+		const tokenAccountId = extractAccountId(auth.access)?.trim() || undefined;
 		if (
 			tokenAccountId &&
 			(shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId))
@@ -836,6 +836,8 @@ export class AccountManager {
 		const nextEmail = sanitizeEmail(extractAccountEmail(auth.access));
 		try {
 			return await withAccountStorageTransaction(async (_current, persist) => {
+				// Snapshot the live in-memory pool under the storage lock so refresh
+				// persistence merges against the latest account state.
 				const nextStorage = structuredClone(
 					this.buildStorageSnapshot(),
 				) as AccountStorageV3;

--- a/lib/proactive-refresh.ts
+++ b/lib/proactive-refresh.ts
@@ -14,6 +14,12 @@ import { queuedRefresh } from "./refresh-queue.js";
 import { createLogger } from "./logger.js";
 import type { ManagedAccount } from "./accounts.js";
 import type { TokenResult } from "./types.js";
+import {
+	extractAccountEmail,
+	extractAccountId,
+	sanitizeEmail,
+	shouldUpdateAccountIdFromToken,
+} from "./auth/token-utils.js";
 
 const log = createLogger("proactive-refresh");
 
@@ -43,14 +49,14 @@ export function shouldRefreshProactively(
 	account: ManagedAccount,
 	bufferMs: number = DEFAULT_PROACTIVE_BUFFER_MS,
 ): boolean {
-	// No expiry set - can't determine if refresh is needed
-	if (account.expires === undefined) {
-		return false;
-	}
-
 	// No access token - definitely needs refresh
 	if (!account.access) {
 		return true;
+	}
+
+	// No expiry set - can't determine if refresh is needed
+	if (account.expires === undefined) {
+		return false;
 	}
 
 	// Clamp buffer to minimum
@@ -135,6 +141,10 @@ export async function proactiveRefreshAccount(
 export async function refreshExpiringAccounts(
 	accounts: ManagedAccount[],
 	bufferMs: number = DEFAULT_PROACTIVE_BUFFER_MS,
+	onResult?: (
+		account: ManagedAccount,
+		result: ProactiveRefreshResult,
+	) => Promise<void> | void,
 ): Promise<Map<number, ProactiveRefreshResult>> {
 	const results = new Map<number, ProactiveRefreshResult>();
 	const accountsToRefresh = accounts.filter((a) =>
@@ -151,6 +161,7 @@ export async function refreshExpiringAccounts(
 	// Refresh in parallel for efficiency
 	const refreshPromises = accountsToRefresh.map(async (account) => {
 		const result = await proactiveRefreshAccount(account, bufferMs);
+		await onResult?.(account, result);
 		return { index: account.index, result };
 	});
 
@@ -194,4 +205,13 @@ export function applyRefreshResult(
 	if (result.refresh !== account.refreshToken) {
 		account.refreshToken = result.refresh;
 	}
+	const tokenAccountId = extractAccountId(result.access)?.trim() || undefined;
+	if (
+		tokenAccountId &&
+		shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId)
+	) {
+		account.accountId = tokenAccountId;
+		account.accountIdSource = "token";
+	}
+	account.email = sanitizeEmail(extractAccountEmail(result.access)) ?? account.email;
 }

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -95,6 +95,70 @@ export class RefreshGuardian {
 		return "network-error";
 	}
 
+	private async applyRefreshOutcome(
+		manager: AccountManager,
+		sourceAccount: ReturnType<AccountManager["getAccountsSnapshot"]>[number],
+		result: Awaited<ReturnType<typeof refreshExpiringAccounts>> extends Map<
+			number,
+			infer TValue
+		>
+			? TValue
+			: never,
+	): Promise<boolean> {
+		switch (result.reason) {
+			case "success": {
+				if (result.tokenResult?.type !== "success") {
+					const account = manager.getAccountByIdentity(sourceAccount);
+					if (!account) return false;
+					manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+					this.stats.failed += 1;
+					this.stats.networkFailed += 1;
+					return true;
+				}
+
+				const refreshedAuth = {
+					type: "oauth" as const,
+					access: result.tokenResult.access,
+					refresh: result.tokenResult.refresh,
+					expires: result.tokenResult.expires,
+					multiAccount: true,
+				};
+				const account = manager.getAccountByIdentity(sourceAccount, refreshedAuth);
+				if (account) {
+					applyRefreshResult(account, result.tokenResult);
+					manager.clearAuthFailures(account);
+				}
+				await manager.commitRefreshedAuth(sourceAccount, refreshedAuth);
+				this.stats.refreshed += 1;
+				return false;
+			}
+			case "failed": {
+				const account = manager.getAccountByIdentity(sourceAccount);
+				if (!account) return false;
+				const cooldownReason = this.classifyFailureReason(result.tokenResult);
+				manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
+				this.stats.failed += 1;
+				if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
+				else if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
+				else this.stats.networkFailed += 1;
+				return true;
+			}
+			case "not_needed":
+				this.stats.notNeeded += 1;
+				return false;
+			case "no_refresh_token": {
+				const account = manager.getAccountByIdentity(sourceAccount);
+				if (!account) return false;
+				manager.markAccountCoolingDown(account, this.bufferMs, "auth-failure");
+				manager.setAccountEnabled(account.index, false);
+				this.stats.noRefreshToken += 1;
+				this.stats.failed += 1;
+				this.stats.authFailed += 1;
+				return true;
+			}
+		}
+	}
+
 	async tick(): Promise<void> {
 		if (this.running) return;
 		const manager = this.getAccountManager();
@@ -106,7 +170,30 @@ export class RefreshGuardian {
 				return;
 			}
 
-			const refreshResults = await refreshExpiringAccounts(snapshot, this.bufferMs);
+			const eligibleSnapshot = snapshot.filter((account) => !manager.isAccountCoolingDown(account));
+			if (eligibleSnapshot.length === 0) {
+				this.stats.runs += 1;
+				this.stats.lastRunAt = Date.now();
+				return;
+			}
+
+			let requiresSave = false;
+			const processed = new Set<number>();
+			const refreshResults = await refreshExpiringAccounts(
+				eligibleSnapshot,
+				this.bufferMs,
+				async (sourceAccount, result) => {
+					const saveNeeded = await this.applyRefreshOutcome(
+						manager,
+						sourceAccount,
+						result,
+					);
+					if (saveNeeded) {
+						requiresSave = true;
+					}
+					processed.add(sourceAccount.index);
+				},
+			);
 			if (refreshResults.size === 0) {
 				this.stats.runs += 1;
 				this.stats.lastRunAt = Date.now();
@@ -114,55 +201,29 @@ export class RefreshGuardian {
 			}
 
 			const snapshotByIndex = new Map<number, (typeof snapshot)[number]>();
-			for (const candidate of snapshot) {
+			for (const candidate of eligibleSnapshot) {
 				snapshotByIndex.set(candidate.index, candidate);
 			}
 
 			for (const [accountIndex, result] of refreshResults.entries()) {
+				if (processed.has(accountIndex)) {
+					continue;
+				}
 				const sourceAccount = snapshotByIndex.get(accountIndex);
 				if (!sourceAccount) continue;
-				const liveAccounts = manager.getAccountsSnapshot();
-				const resolvedIndex = liveAccounts.findIndex(
-					(candidate) => candidate.refreshToken === sourceAccount.refreshToken,
+				const saveNeeded = await this.applyRefreshOutcome(
+					manager,
+					sourceAccount,
+					result,
 				);
-				const account = resolvedIndex >= 0 ? manager.getAccountByIndex(resolvedIndex) : null;
-				if (!account) continue;
-
-				switch (result.reason) {
-					case "success":
-						if (result.tokenResult?.type === "success") {
-							applyRefreshResult(account, result.tokenResult);
-							manager.clearAuthFailures(account);
-							this.stats.refreshed += 1;
-						} else {
-							manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
-							this.stats.failed += 1;
-							this.stats.networkFailed += 1;
-						}
-						break;
-					case "failed": {
-						const cooldownReason = this.classifyFailureReason(result.tokenResult);
-						manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
-						this.stats.failed += 1;
-						if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
-						else if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
-						else this.stats.networkFailed += 1;
-						break;
-					}
-					case "not_needed":
-						this.stats.notNeeded += 1;
-						break;
-					case "no_refresh_token":
-						manager.markAccountCoolingDown(account, this.bufferMs, "auth-failure");
-						manager.setAccountEnabled(account.index, false);
-						this.stats.noRefreshToken += 1;
-						this.stats.failed += 1;
-						this.stats.authFailed += 1;
-						break;
+				if (saveNeeded) {
+					requiresSave = true;
 				}
 			}
 
-			manager.saveToDiskDebounced();
+			if (requiresSave) {
+				manager.saveToDiskDebounced();
+			}
 			this.stats.runs += 1;
 			this.stats.lastRunAt = Date.now();
 		} catch (error) {

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -124,7 +124,25 @@ export class RefreshGuardian {
 					multiAccount: true,
 				};
 				try {
-					await manager.commitRefreshedAuth(sourceAccount, refreshedAuth);
+					const committedAccount = await manager.commitRefreshedAuth(
+						sourceAccount,
+						refreshedAuth,
+					);
+					if (!committedAccount) {
+						const account =
+							manager.getAccountByIdentity(sourceAccount, refreshedAuth) ??
+							manager.getAccountByIdentity(sourceAccount);
+						if (account) {
+							manager.markAccountCoolingDown(
+								account,
+								this.bufferMs,
+								"network-error",
+							);
+						}
+						this.stats.failed += 1;
+						this.stats.networkFailed += 1;
+						return !!account;
+					}
 				} catch (error) {
 					log.warn("Refresh guardian commit failed", {
 						sourceIndex: sourceAccount.index,

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "./logger.js";
-import { applyRefreshResult, refreshExpiringAccounts } from "./proactive-refresh.js";
+import { refreshExpiringAccounts } from "./proactive-refresh.js";
 import type { AccountManager } from "./accounts.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
@@ -123,12 +123,21 @@ export class RefreshGuardian {
 					expires: result.tokenResult.expires,
 					multiAccount: true,
 				};
-				const account = manager.getAccountByIdentity(sourceAccount, refreshedAuth);
-				if (account) {
-					applyRefreshResult(account, result.tokenResult);
-					manager.clearAuthFailures(account);
+				try {
+					await manager.commitRefreshedAuth(sourceAccount, refreshedAuth);
+				} catch (error) {
+					log.warn("Refresh guardian commit failed", {
+						sourceIndex: sourceAccount.index,
+						error: error instanceof Error ? error.message : String(error),
+					});
+					const account = manager.getAccountByIdentity(sourceAccount, refreshedAuth);
+					if (account) {
+						manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+					}
+					this.stats.failed += 1;
+					this.stats.networkFailed += 1;
+					return !!account;
 				}
-				await manager.commitRefreshedAuth(sourceAccount, refreshedAuth);
 				this.stats.refreshed += 1;
 				return false;
 			}

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -205,7 +205,6 @@ export class RefreshGuardian {
 			}
 
 			let requiresSave = false;
-			const processed = new Set<number>();
 			const refreshResults = await refreshExpiringAccounts(
 				eligibleSnapshot,
 				this.bufferMs,
@@ -218,34 +217,12 @@ export class RefreshGuardian {
 					if (saveNeeded) {
 						requiresSave = true;
 					}
-					processed.add(sourceAccount.index);
 				},
 			);
 			if (refreshResults.size === 0) {
 				this.stats.runs += 1;
 				this.stats.lastRunAt = Date.now();
 				return;
-			}
-
-			const snapshotByIndex = new Map<number, (typeof snapshot)[number]>();
-			for (const candidate of eligibleSnapshot) {
-				snapshotByIndex.set(candidate.index, candidate);
-			}
-
-			for (const [accountIndex, result] of refreshResults.entries()) {
-				if (processed.has(accountIndex)) {
-					continue;
-				}
-				const sourceAccount = snapshotByIndex.get(accountIndex);
-				if (!sourceAccount) continue;
-				const saveNeeded = await this.applyRefreshOutcome(
-					manager,
-					sourceAccount,
-					result,
-				);
-				if (saveNeeded) {
-					requiresSave = true;
-				}
 			}
 
 			if (requiresSave) {

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "./logger.js";
 import { refreshExpiringAccounts } from "./proactive-refresh.js";
 import type { AccountManager } from "./accounts.js";
+import { CodexAuthError } from "./errors.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
 
@@ -148,12 +149,19 @@ export class RefreshGuardian {
 						sourceIndex: sourceAccount.index,
 						error: error instanceof Error ? error.message : String(error),
 					});
-					const account = manager.getAccountByIdentity(sourceAccount, refreshedAuth);
+					const account =
+						manager.getAccountByIdentity(sourceAccount, refreshedAuth) ??
+						manager.getAccountByIdentity(sourceAccount);
+					const cooldownReason: CooldownReason =
+						error instanceof CodexAuthError && !error.retryable
+							? "auth-failure"
+							: "network-error";
 					if (account) {
-						manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+						manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
 					}
 					this.stats.failed += 1;
-					this.stats.networkFailed += 1;
+					if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
+					else this.stats.networkFailed += 1;
 					return !!account;
 				}
 				this.stats.refreshed += 1;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -19,7 +19,7 @@ import {
 	convertSseToJson,
 	ensureContentType,
 } from "./response-handler.js";
-import type { UserConfig, RequestBody } from "../types.js";
+import type { UserConfig, RequestBody, TokenResult } from "../types.js";
 import { registerCleanup } from "../shutdown.js";
 import { CodexAuthError } from "../errors.js";
 import { isRecord } from "../utils.js";
@@ -428,6 +428,26 @@ export function shouldRefreshToken(auth: Auth, skewMs = 0): boolean {
 	return auth.expires <= Date.now() + safeSkewMs;
 }
 
+function isRetryableRefreshFailure(
+	result: Extract<TokenResult, { type: "failed" }>,
+): boolean {
+	switch (result.reason) {
+		case "network_error":
+		case "unknown":
+		case "invalid_response":
+		case "missing_refresh":
+			return true;
+		case "http_error":
+			return !(
+				result.statusCode === HTTP_STATUS.BAD_REQUEST ||
+				result.statusCode === HTTP_STATUS.UNAUTHORIZED ||
+				result.statusCode === HTTP_STATUS.FORBIDDEN
+			);
+		default:
+			return false;
+	}
+}
+
 /**
  * Refreshes the OAuth token and updates stored credentials
  * @param currentAuth - Current auth state
@@ -440,26 +460,39 @@ export async function refreshAndUpdateToken(
 ): Promise<Auth> {
 	const authSetter = (client as Partial<CodexAuthSetter>).auth;
 	if (!authSetter || typeof authSetter.set !== "function") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, { retryable: false });
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, { retryable: true });
 	}
 
 	const refreshToken = currentAuth.type === "oauth" ? currentAuth.refresh : "";
 	const refreshResult = await queuedRefresh(refreshToken);
 
 	if (refreshResult.type === "failed") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, { retryable: false });
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: isRetryableRefreshFailure(refreshResult),
+			context: {
+				refreshFailureReason: refreshResult.reason,
+				statusCode: refreshResult.statusCode,
+			},
+		});
 	}
 
-	await authSetter.set({
-		path: { id: "openai" },
-		body: {
-			type: "oauth",
-			access: refreshResult.access,
-			refresh: refreshResult.refresh,
-			expires: refreshResult.expires,
-			multiAccount: true,
-		},
-	});
+	try {
+		await authSetter.set({
+			path: { id: "openai" },
+			body: {
+				type: "oauth",
+				access: refreshResult.access,
+				refresh: refreshResult.refresh,
+				expires: refreshResult.expires,
+				multiAccount: true,
+			},
+		});
+	} catch (error) {
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: true,
+			cause: error,
+		});
+	}
 
 	// Update current auth reference if it's OAuth type
 	if (currentAuth.type === "oauth") {

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -435,8 +435,9 @@ function isRetryableRefreshFailure(
 		case "network_error":
 		case "unknown":
 		case "invalid_response":
-		case "missing_refresh":
 			return true;
+		case "missing_refresh":
+			return false;
 		case "http_error":
 			return !(
 				result.statusCode === HTTP_STATUS.BAD_REQUEST ||

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -461,7 +461,9 @@ export async function refreshAndUpdateToken(
 ): Promise<Auth> {
 	const authSetter = (client as Partial<CodexAuthSetter>).auth;
 	if (!authSetter || typeof authSetter.set !== "function") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, { retryable: true });
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: false,
+		});
 	}
 
 	const refreshToken = currentAuth.type === "oauth" ? currentAuth.refresh : "";

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -449,6 +449,35 @@ function isRetryableRefreshFailure(
 	}
 }
 
+function isRetryableAuthSetterError(error: unknown): boolean {
+	if (!error || typeof error !== "object") {
+		return false;
+	}
+
+	const candidate = error as {
+		code?: unknown;
+		status?: unknown;
+		cause?: unknown;
+	};
+	const code =
+		typeof candidate.code === "string"
+			? candidate.code.toUpperCase()
+			: undefined;
+	if (code === "EAGAIN" || code === "EBUSY" || code === "EPERM") {
+		return true;
+	}
+
+	if (candidate.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
+		return true;
+	}
+
+	if (candidate.cause && candidate.cause !== error) {
+		return isRetryableAuthSetterError(candidate.cause);
+	}
+
+	return false;
+}
+
 /**
  * Refreshes the OAuth token and updates stored credentials
  * @param currentAuth - Current auth state
@@ -492,7 +521,7 @@ export async function refreshAndUpdateToken(
 		});
 	} catch (error) {
 		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-			retryable: true,
+			retryable: isRetryableAuthSetterError(error),
 			cause: error,
 		});
 	}

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -3,6 +3,7 @@ import type { OAuthAuthDetails } from "../lib/types.js";
 
 const mockLoadAccounts = vi.fn();
 const mockSaveAccounts = vi.fn();
+const mockWithAccountStorageTransaction = vi.fn();
 const mockLoadCodexCliState = vi.fn();
 const mockSyncAccountStorageFromCodexCli = vi.fn();
 const mockSetCodexCliActiveSelection = vi.fn();
@@ -14,6 +15,7 @@ vi.mock("../lib/storage.js", async (importOriginal) => {
     ...actual,
     loadAccounts: mockLoadAccounts,
     saveAccounts: mockSaveAccounts,
+    withAccountStorageTransaction: mockWithAccountStorageTransaction,
   };
 });
 
@@ -81,6 +83,11 @@ describe("accounts edge branches", () => {
     vi.clearAllMocks();
     mockLoadAccounts.mockResolvedValue(null);
     mockSaveAccounts.mockResolvedValue(undefined);
+    mockWithAccountStorageTransaction.mockImplementation(async (handler) =>
+      handler(null, async (storage) => {
+        await mockSaveAccounts(storage);
+      }),
+    );
     mockLoadCodexCliState.mockResolvedValue(null);
     mockSyncAccountStorageFromCodexCli.mockImplementation(async (storage) => ({
       storage,

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -1,12 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AccountManager } from "../lib/accounts.js";
 
+const {
+  mockLoadAccounts,
+  mockSaveAccounts,
+  mockWithAccountStorageTransaction,
+} = vi.hoisted(() => ({
+  mockLoadAccounts: vi.fn(),
+  mockSaveAccounts: vi.fn(),
+  mockWithAccountStorageTransaction: vi.fn(),
+}));
+
 vi.mock("../lib/storage.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/storage.js")>();
   return {
     ...actual,
-    loadAccounts: vi.fn(),
-    saveAccounts: vi.fn().mockResolvedValue(undefined),
+    loadAccounts: mockLoadAccounts,
+    saveAccounts: mockSaveAccounts,
+    withAccountStorageTransaction: mockWithAccountStorageTransaction,
   };
 });
 
@@ -22,7 +33,6 @@ vi.mock("../lib/codex-cli/writer.js", () => ({
   setCodexCliActiveSelection: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { loadAccounts, saveAccounts } from "../lib/storage.js";
 import { syncAccountStorageFromCodexCli } from "../lib/codex-cli/sync.js";
 import { loadCodexCliState } from "../lib/codex-cli/state.js";
 import { setCodexCliActiveSelection } from "../lib/codex-cli/writer.js";
@@ -30,8 +40,13 @@ import { setCodexCliActiveSelection } from "../lib/codex-cli/writer.js";
 describe("AccountManager loadFromDisk", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(loadAccounts).mockResolvedValue(null);
-    vi.mocked(saveAccounts).mockResolvedValue(undefined);
+    mockLoadAccounts.mockResolvedValue(null);
+    mockSaveAccounts.mockResolvedValue(undefined);
+    mockWithAccountStorageTransaction.mockImplementation(async (handler) =>
+      handler(null, async (storage) => {
+        await mockSaveAccounts(storage);
+      }),
+    );
     vi.mocked(syncAccountStorageFromCodexCli).mockResolvedValue({
       changed: false,
       storage: null,
@@ -56,7 +71,7 @@ describe("AccountManager loadFromDisk", () => {
       ],
     };
 
-    vi.mocked(loadAccounts).mockResolvedValue(stored);
+    mockLoadAccounts.mockResolvedValue(stored);
     vi.mocked(syncAccountStorageFromCodexCli).mockResolvedValue({
       changed: true,
       storage: synced,
@@ -64,7 +79,7 @@ describe("AccountManager loadFromDisk", () => {
 
     const manager = await AccountManager.loadFromDisk();
 
-    expect(saveAccounts).toHaveBeenCalledWith(synced);
+    expect(mockSaveAccounts).toHaveBeenCalledWith(synced);
     expect(manager.getAccountCount()).toBe(2);
     expect(manager.getCurrentAccount()?.refreshToken).toBe("stored-refresh");
   });
@@ -81,7 +96,7 @@ describe("AccountManager loadFromDisk", () => {
       changed: true,
       storage: synced,
     });
-    vi.mocked(saveAccounts).mockRejectedValueOnce(new Error("forced persist failure"));
+    mockSaveAccounts.mockRejectedValueOnce(new Error("forced persist failure"));
 
     const manager = await AccountManager.loadFromDisk();
 
@@ -91,7 +106,7 @@ describe("AccountManager loadFromDisk", () => {
 
   it("hydrates missing access/accountId fields from Codex CLI token cache", async () => {
     const now = Date.now();
-    vi.mocked(loadAccounts).mockResolvedValue({
+    mockLoadAccounts.mockResolvedValue({
       version: 3 as const,
       activeIndex: 0,
       accounts: [
@@ -122,12 +137,12 @@ describe("AccountManager loadFromDisk", () => {
     expect(account?.expires).toBe(now + 120_000);
     expect(account?.accountId).toBe("acct-123");
     expect(account?.accountIdSource).toBe("token");
-    expect(saveAccounts).toHaveBeenCalledTimes(1);
+    expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
   });
 
   it("skips expired Codex CLI cache entries and does not persist", async () => {
     const now = Date.now();
-    vi.mocked(loadAccounts).mockResolvedValue({
+    mockLoadAccounts.mockResolvedValue({
       version: 3 as const,
       activeIndex: 0,
       accounts: [
@@ -156,7 +171,7 @@ describe("AccountManager loadFromDisk", () => {
 
     expect(account?.access).toBeUndefined();
     expect(account?.accountId).toBeUndefined();
-    expect(saveAccounts).not.toHaveBeenCalled();
+    expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
   it("syncCodexCliActiveSelectionForIndex ignores invalid indices and syncs a valid one", async () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -18,6 +18,7 @@ vi.mock("../lib/storage.js", async (importOriginal) => {
   return {
     ...actual,
     saveAccounts: vi.fn().mockResolvedValue(undefined),
+    withAccountStorageTransaction: vi.fn(),
   };
 });
 
@@ -1046,6 +1047,92 @@ describe("AccountManager", () => {
       
       expect(account.accountId).toBe("org-selected-id");
       expect(account.accountIdSource).toBe("org");
+    });
+  });
+
+  describe("commitRefreshedAuth", () => {
+    it("persists refreshed auth transactionally and updates the live account", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "old-refresh",
+            accessToken: "old-access",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+            email: "old@example.com",
+            accountId: "old-account-id",
+            accountIdSource: "token" as const,
+            enabled: false,
+            coolingDownUntil: now + 30_000,
+            cooldownReason: "auth-failure" as const,
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const account = manager.getAccountByIndex(0)!;
+      account.enabled = false;
+      manager.markAccountCoolingDown(account, 30_000, "auth-failure");
+      manager.incrementAuthFailures(account);
+
+      const payload = Buffer.from(
+        JSON.stringify({
+          email: "new@example.com",
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "new-account-id",
+          },
+        }),
+      ).toString("base64url");
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: `header.${payload}.signature`,
+        refresh: "new-refresh",
+        expires: now + 3_600_000,
+      };
+
+      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
+        const persist = vi.fn().mockResolvedValue(undefined);
+        const result = await handler(stored as any, persist);
+
+        expect(persist).toHaveBeenCalledTimes(1);
+        const persistedStorage = persist.mock.calls[0]?.[0];
+        expect(persistedStorage?.accounts[0]?.refreshToken).toBe("new-refresh");
+        expect(persistedStorage?.accounts[0]?.accessToken).toBe(
+          refreshedAuth.access,
+        );
+        expect(persistedStorage?.accounts[0]?.expiresAt).toBe(
+          refreshedAuth.expires,
+        );
+        expect(persistedStorage?.accounts[0]?.accountId).toBe("new-account-id");
+        expect(persistedStorage?.accounts[0]?.accountIdSource).toBe("token");
+        expect(persistedStorage?.accounts[0]?.email).toBe("new@example.com");
+        expect(persistedStorage?.accounts[0]?.enabled).toBeUndefined();
+        expect(persistedStorage?.accounts[0]?.coolingDownUntil).toBeUndefined();
+        expect(persistedStorage?.accounts[0]?.cooldownReason).toBeUndefined();
+
+        return result;
+      });
+
+      const updated = await manager.commitRefreshedAuth(account, refreshedAuth);
+
+      expect(updated).toBe(account);
+      expect(account.refreshToken).toBe("new-refresh");
+      expect(account.access).toBe(refreshedAuth.access);
+      expect(account.expires).toBe(refreshedAuth.expires);
+      expect(account.accountId).toBe("new-account-id");
+      expect(account.accountIdSource).toBe("token");
+      expect(account.email).toBe("new@example.com");
+      expect(account.enabled).toBe(true);
+      expect(account.coolingDownUntil).toBeUndefined();
+      expect(account.cooldownReason).toBeUndefined();
+      expect(account.consecutiveAuthFailures).toBe(0);
     });
   });
 

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1159,6 +1159,76 @@ describe("AccountManager", () => {
       expect(account.consecutiveAuthFailures).toBe(0);
     });
 
+    it("preserves unsaved live pool state when persisting refreshed auth", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        activeIndexByFamily: {
+          codex: 0,
+        },
+        accounts: [
+          {
+            refreshToken: "old-refresh-a",
+            accessToken: "old-access-a",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+            email: "a@example.com",
+          },
+          {
+            refreshToken: "old-refresh-b",
+            accessToken: "old-access-b",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+            email: "b@example.com",
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const accountA = manager.getAccountByIndex(0)!;
+      const accountB = manager.getAccountByIndex(1)!;
+      manager.markSwitched(accountB, "rotation", "codex");
+      manager.markRateLimited(accountB, 45_000, "codex");
+      manager.markAccountCoolingDown(accountB, 30_000, "network-error");
+
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: "header.payload.signature",
+        refresh: "new-refresh-a",
+        expires: now + 3_600_000,
+      };
+
+      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
+        const persist = vi.fn().mockResolvedValue(undefined);
+        const result = await handler(stored as any, persist);
+
+        expect(persist).toHaveBeenCalledTimes(1);
+        const persistedStorage = persist.mock.calls[0]?.[0];
+        expect(persistedStorage?.activeIndex).toBe(1);
+        expect(persistedStorage?.activeIndexByFamily?.codex).toBe(1);
+        expect(persistedStorage?.accounts[0]?.refreshToken).toBe("new-refresh-a");
+        expect(persistedStorage?.accounts[1]?.rateLimitResetTimes?.codex).toBeGreaterThan(
+          now,
+        );
+        expect(persistedStorage?.accounts[1]?.cooldownReason).toBe(
+          "network-error",
+        );
+        expect(persistedStorage?.accounts[1]?.coolingDownUntil).toBeGreaterThan(
+          now,
+        );
+
+        return result;
+      });
+
+      await manager.commitRefreshedAuth(accountA, refreshedAuth);
+    });
+
     it("propagates storage write failure as retryable CodexAuthError", async () => {
       const { withAccountStorageTransaction } = await import("../lib/storage.js");
       const mockWithAccountStorageTransaction = vi.mocked(

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -11,6 +11,7 @@ import {
   getAccountIdCandidates,
 } from "../lib/accounts.js";
 import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
+import { CodexAuthError } from "../lib/errors.js";
 import type { OAuthAuthDetails } from "../lib/types.js";
 
 vi.mock("../lib/storage.js", async (importOriginal) => {
@@ -20,6 +21,29 @@ vi.mock("../lib/storage.js", async (importOriginal) => {
     saveAccounts: vi.fn().mockResolvedValue(undefined),
     withAccountStorageTransaction: vi.fn(),
   };
+});
+
+beforeEach(async () => {
+  resetTrackers();
+  const { saveAccounts, withAccountStorageTransaction } = await import(
+    "../lib/storage.js"
+  );
+  const mockSaveAccounts = vi.mocked(saveAccounts);
+  const mockWithAccountStorageTransaction = vi.mocked(
+    withAccountStorageTransaction,
+  );
+
+  mockSaveAccounts.mockReset();
+  mockSaveAccounts.mockResolvedValue(undefined);
+  mockWithAccountStorageTransaction.mockReset();
+  mockWithAccountStorageTransaction.mockImplementation(async (handler) => {
+    let current = null;
+    const persist = async (storage: Parameters<typeof saveAccounts>[0]) => {
+      current = structuredClone(storage);
+      await mockSaveAccounts(storage);
+    };
+    return handler(current as never, persist);
+  });
 });
 
 describe("parseRateLimitReason", () => {
@@ -1133,6 +1157,144 @@ describe("AccountManager", () => {
       expect(account.coolingDownUntil).toBeUndefined();
       expect(account.cooldownReason).toBeUndefined();
       expect(account.consecutiveAuthFailures).toBe(0);
+    });
+
+    it("propagates storage write failure as retryable CodexAuthError", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      mockWithAccountStorageTransaction.mockRejectedValueOnce(
+        Object.assign(new Error("EBUSY"), { code: "EBUSY" }),
+      );
+
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "old-refresh",
+            accessToken: "old-access",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const account = manager.getAccountByIndex(0)!;
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: "header.payload.signature",
+        refresh: "new-refresh",
+        expires: now + 3_600_000,
+      };
+
+      const error = await manager.commitRefreshedAuth(account, refreshedAuth).catch(
+        (err) => err as CodexAuthError,
+      );
+
+      expect(error).toBeInstanceOf(CodexAuthError);
+      expect(error.retryable).toBe(true);
+      expect(account.refreshToken).toBe("old-refresh");
+    });
+
+    it("prevents debounced saves from writing stale auth during refresh persistence", async () => {
+      vi.useFakeTimers();
+      try {
+        const { saveAccounts, withAccountStorageTransaction } = await import(
+          "../lib/storage.js"
+        );
+        const mockSaveAccounts = vi.mocked(saveAccounts);
+        const mockWithAccountStorageTransaction = vi.mocked(
+          withAccountStorageTransaction,
+        );
+
+        const now = Date.now();
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            {
+              refreshToken: "old-refresh",
+              accessToken: "old-access",
+              expiresAt: now,
+              addedAt: now,
+              lastUsed: now,
+            },
+          ],
+        };
+        const manager = new AccountManager(undefined, stored as any);
+        const account = manager.getAccountByIndex(0)!;
+        const refreshedAuth: OAuthAuthDetails = {
+          type: "oauth",
+          access: "new-access",
+          refresh: "new-refresh",
+          expires: now + 3_600_000,
+        };
+
+        let storageState = structuredClone(stored) as typeof stored;
+        let lock = Promise.resolve();
+        let releasePersist!: () => void;
+        const persistBlocked = new Promise<void>((resolve) => {
+          releasePersist = resolve;
+        });
+        let notifyPersistStarted!: () => void;
+        const persistStarted = new Promise<void>((resolve) => {
+          notifyPersistStarted = resolve;
+        });
+
+        mockWithAccountStorageTransaction.mockImplementation((handler) => {
+          const run = async () => {
+            const current = structuredClone(storageState) as typeof storageState;
+            const persist = async (
+              nextStorage: Parameters<typeof saveAccounts>[0],
+            ) => {
+              if (
+                nextStorage.accounts[0]?.refreshToken === "new-refresh" &&
+                nextStorage.accounts[0]?.accessToken === "new-access"
+              ) {
+                notifyPersistStarted();
+                await persistBlocked;
+              }
+              storageState = structuredClone(nextStorage) as typeof storageState;
+              await mockSaveAccounts(nextStorage);
+            };
+            return handler(current as never, persist);
+          };
+
+          const result = lock.then(run, run);
+          lock = result.then(
+            () => undefined,
+            () => undefined,
+          );
+          return result;
+        });
+
+        const commitPromise = manager.commitRefreshedAuth(account, refreshedAuth);
+        await persistStarted;
+
+        manager.saveToDiskDebounced(0);
+        await vi.advanceTimersByTimeAsync(0);
+
+        releasePersist();
+        await commitPromise;
+        await manager.flushPendingSave();
+
+        expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
+        expect(mockSaveAccounts.mock.calls[0]?.[0]?.accounts[0]?.refreshToken).toBe(
+          "new-refresh",
+        );
+        expect(mockSaveAccounts.mock.calls[1]?.[0]?.accounts[0]?.refreshToken).toBe(
+          "new-refresh",
+        );
+        expect(mockSaveAccounts.mock.calls[1]?.[0]?.accounts[0]?.accessToken).toBe(
+          "new-access",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1270,6 +1270,47 @@ describe("AccountManager", () => {
       expect(account.refreshToken).toBe("old-refresh");
     });
 
+    it("propagates non-transient storage write failure as terminal CodexAuthError", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      mockWithAccountStorageTransaction.mockRejectedValueOnce(
+        Object.assign(new Error("EACCES"), { code: "EACCES" }),
+      );
+
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "old-refresh",
+            accessToken: "old-access",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const account = manager.getAccountByIndex(0)!;
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: "header.payload.signature",
+        refresh: "new-refresh",
+        expires: now + 3_600_000,
+      };
+
+      const error = await manager.commitRefreshedAuth(account, refreshedAuth).catch(
+        (err) => err as CodexAuthError,
+      );
+
+      expect(error).toBeInstanceOf(CodexAuthError);
+      expect(error.retryable).toBe(false);
+      expect(account.refreshToken).toBe("old-refresh");
+    });
+
     it("prevents debounced saves from writing stale auth during refresh persistence", async () => {
       vi.useFakeTimers();
       try {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1229,6 +1229,59 @@ describe("AccountManager", () => {
       await manager.commitRefreshedAuth(accountA, refreshedAuth);
     });
 
+    it("keeps trimmed token accountId identical in memory and persisted storage", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      const now = Date.now();
+      const payload = Buffer.from(
+        JSON.stringify({
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "  matching-account-id  ",
+          },
+        }),
+      ).toString("base64url");
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "old-refresh",
+            accessToken: "old-access",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+            accountId: "matching-account-id",
+            accountIdSource: "token" as const,
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const account = manager.getAccountByIndex(0)!;
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: `header.${payload}.signature`,
+        refresh: "new-refresh",
+        expires: now + 3_600_000,
+      };
+
+      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
+        const persist = vi.fn().mockResolvedValue(undefined);
+        const result = await handler(stored as any, persist);
+
+        expect(persist).toHaveBeenCalledTimes(1);
+        const persistedStorage = persist.mock.calls[0]?.[0];
+        expect(persistedStorage?.accounts[0]?.accountId).toBe("matching-account-id");
+
+        return result;
+      });
+
+      await manager.commitRefreshedAuth(account, refreshedAuth);
+
+      expect(account.accountId).toBe("matching-account-id");
+    });
+
     it("propagates storage write failure as retryable CodexAuthError", async () => {
       const { withAccountStorageTransaction } = await import("../lib/storage.js");
       const mockWithAccountStorageTransaction = vi.mocked(

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -183,7 +183,9 @@ describe('Fetch Helpers Module', () => {
 			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'oldr', expires: 0 };
 			const client = {
 				auth: {
-					set: vi.fn().mockRejectedValue(new Error('persist failed')),
+					set: vi.fn().mockRejectedValue(
+						Object.assign(new Error('persist failed'), { code: 'EBUSY' }),
+					),
 				},
 			} as any;
 			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
@@ -198,6 +200,29 @@ describe('Fetch Helpers Module', () => {
 			);
 			expect(error).toBeInstanceOf(CodexAuthError);
 			expect(error.retryable).toBe(true);
+		});
+
+		it('throws terminal auth errors when auth persistence fails permanently', async () => {
+			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'oldr', expires: 0 };
+			const client = {
+				auth: {
+					set: vi.fn().mockRejectedValue(
+						Object.assign(new Error('persist failed'), { code: 'EACCES' }),
+					),
+				},
+			} as any;
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'success',
+				access: 'new',
+				refresh: 'newr',
+				expires: 123,
+			} as any);
+
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(false);
 		});
 	});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -86,7 +86,7 @@ describe('Fetch Helpers Module', () => {
 				(err) => err as CodexAuthError,
 			);
 			expect(error).toBeInstanceOf(CodexAuthError);
-			expect(error.retryable).toBe(true);
+			expect(error.retryable).toBe(false);
 			expect(refreshSpy).not.toHaveBeenCalled();
 		});
 
@@ -99,7 +99,7 @@ describe('Fetch Helpers Module', () => {
 				(err) => err as CodexAuthError,
 			);
 			expect(error).toBeInstanceOf(CodexAuthError);
-			expect(error.retryable).toBe(true);
+			expect(error.retryable).toBe(false);
 			expect(refreshSpy).not.toHaveBeenCalled();
 		});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -23,6 +23,7 @@ import * as loggerModule from '../lib/logger.js';
 import type { Auth } from '../lib/types.js';
 import type { CreateCodexHeadersParams } from '../lib/request/fetch-helpers.js';
 import { URL_PATHS, OPENAI_HEADERS, OPENAI_HEADER_VALUES, CODEX_BASE_URL } from '../lib/constants.js';
+import { CodexAuthError } from '../lib/errors.js';
 
 describe('Fetch Helpers Module', () => {
         afterEach(async () => {
@@ -81,7 +82,11 @@ describe('Fetch Helpers Module', () => {
 			const client = {} as any;
 			const refreshSpy = vi.spyOn(refreshQueueModule, 'queuedRefresh');
 
-			await expect(refreshAndUpdateToken(auth, client)).rejects.toThrow();
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
 			expect(refreshSpy).not.toHaveBeenCalled();
 		});
 
@@ -90,16 +95,45 @@ describe('Fetch Helpers Module', () => {
 			const client = { auth: { set: 'bad' } } as any;
 			const refreshSpy = vi.spyOn(refreshQueueModule, 'queuedRefresh');
 
-			await expect(refreshAndUpdateToken(auth, client)).rejects.toThrow();
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
 			expect(refreshSpy).not.toHaveBeenCalled();
 		});
 
-		it('throws when refresh fails', async () => {
+		it('throws retryable auth errors for transient refresh failures', async () => {
 			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'bad', expires: 0 };
 			const client = { auth: { set: vi.fn() } } as any;
-			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({ type: 'failed' } as any);
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'failed',
+				reason: 'network_error',
+				message: 'temporary network issue',
+			} as any);
 
-			await expect(refreshAndUpdateToken(auth, client)).rejects.toThrow();
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
+		});
+
+		it('throws terminal auth errors for explicit invalid-refresh responses', async () => {
+			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'bad', expires: 0 };
+			const client = { auth: { set: vi.fn() } } as any;
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'failed',
+				reason: 'http_error',
+				statusCode: 401,
+				message: 'refresh token rejected',
+			} as any);
+
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(false);
 		});
 
 		it('updates stored auth on success', async () => {
@@ -127,6 +161,27 @@ describe('Fetch Helpers Module', () => {
 			expect(updated.access).toBe('new');
 			expect(updated.refresh).toBe('newr');
 			expect(updated.expires).toBe(123);
+		});
+
+		it('throws retryable auth errors when auth persistence fails', async () => {
+			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'oldr', expires: 0 };
+			const client = {
+				auth: {
+					set: vi.fn().mockRejectedValue(new Error('persist failed')),
+				},
+			} as any;
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'success',
+				access: 'new',
+				refresh: 'newr',
+				expires: 123,
+			} as any);
+
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
 		});
 	});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -136,6 +136,22 @@ describe('Fetch Helpers Module', () => {
 			expect(error.retryable).toBe(false);
 		});
 
+		it('treats missing refresh tokens as terminal auth errors', async () => {
+			const auth: Auth = { type: 'oauth', access: 'old', refresh: '', expires: 0 };
+			const client = { auth: { set: vi.fn() } } as any;
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'failed',
+				reason: 'missing_refresh',
+				message: 'missing refresh token',
+			} as any);
+
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(false);
+		});
+
 		it('updates stored auth on success', async () => {
 			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'oldr', expires: 0 };
 			const client = { auth: { set: vi.fn() } } as any;

--- a/test/proactive-refresh.test.ts
+++ b/test/proactive-refresh.test.ts
@@ -39,7 +39,10 @@ describe("proactive-refresh", () => {
 
 	describe("shouldRefreshProactively", () => {
 		it("returns false when no expiry is set", () => {
-			const account = createMockAccount({ expires: undefined });
+			const account = createMockAccount({
+				access: "test-access",
+				expires: undefined,
+			});
 			expect(shouldRefreshProactively(account)).toBe(false);
 		});
 
@@ -47,6 +50,14 @@ describe("proactive-refresh", () => {
 			const account = createMockAccount({
 				access: undefined,
 				expires: Date.now() + 600000,
+			});
+			expect(shouldRefreshProactively(account)).toBe(true);
+		});
+
+		it("returns true when access token is missing even if expiry is undefined", () => {
+			const account = createMockAccount({
+				access: undefined,
+				expires: undefined,
 			});
 			expect(shouldRefreshProactively(account)).toBe(true);
 		});
@@ -360,6 +371,47 @@ describe("proactive-refresh", () => {
 			expect(results.get(0)?.reason).toBe("success");
 			expect(results.get(1)?.reason).toBe("failed");
 		});
+
+		it("invokes onResult for each refreshed account", async () => {
+			const accounts = [
+				createMockAccount({
+					index: 0,
+					access: "access-0",
+					expires: Date.now() + 60_000,
+					refreshToken: "refresh-0",
+				}),
+				createMockAccount({
+					index: 1,
+					access: "access-1",
+					expires: Date.now() + 10 * 60 * 1000,
+					refreshToken: "refresh-1",
+				}),
+			];
+			const onResult = vi.fn();
+
+			vi.mocked(refreshQueue.queuedRefresh).mockResolvedValue({
+				type: "success" as const,
+				access: "new-access",
+				refresh: "new-refresh",
+				expires: Date.now() + 3_600_000,
+			});
+
+			const results = await refreshExpiringAccounts(
+				accounts,
+				DEFAULT_PROACTIVE_BUFFER_MS,
+				onResult,
+			);
+
+			expect(results.size).toBe(1);
+			expect(onResult).toHaveBeenCalledTimes(1);
+			expect(onResult).toHaveBeenCalledWith(
+				accounts[0],
+				expect.objectContaining({
+					refreshed: true,
+					reason: "success",
+				}),
+			);
+		});
 	});
 
 	describe("applyRefreshResult", () => {
@@ -398,6 +450,36 @@ describe("proactive-refresh", () => {
 			});
 
 			expect(account.refreshToken).toBe("same-refresh");
+		});
+
+		it("updates account identity fields from refreshed access tokens", () => {
+			const account = createMockAccount({
+				access: "old-access",
+				expires: Date.now(),
+				refreshToken: "old-refresh",
+				accountId: "old-account-id",
+				accountIdSource: "token",
+				email: "old@example.com",
+			});
+			const payload = Buffer.from(
+				JSON.stringify({
+					email: "new@example.com",
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "new-account-id",
+					},
+				}),
+			).toString("base64url");
+
+			applyRefreshResult(account, {
+				type: "success",
+				access: `header.${payload}.signature`,
+				refresh: "new-refresh",
+				expires: Date.now() + 3_600_000,
+			});
+
+			expect(account.accountId).toBe("new-account-id");
+			expect(account.accountIdSource).toBe("token");
+			expect(account.email).toBe("new@example.com");
 		});
 	});
 

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import type { AccountManager, ManagedAccount } from "../lib/accounts.js";
+import type { AccountManager, ManagedAccount, OAuthAuthDetails } from "../lib/accounts.js";
 
 const refreshExpiringAccountsMock = vi.fn();
 const applyRefreshResultMock = vi.fn();
@@ -218,14 +218,10 @@ describe("refresh-guardian", () => {
     await guardian.tick();
 
     expect(refreshExpiringAccountsMock).toHaveBeenCalledTimes(1);
-    expect(applyRefreshResultMock).toHaveBeenCalledTimes(1);
-    expect(applyRefreshResultMock).toHaveBeenCalledWith(
-      accountA,
-      expect.objectContaining({ type: "success" }),
-    );
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
     expect(
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(accountA);
+    ).not.toHaveBeenCalled();
     expect(
       manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(
@@ -346,14 +342,17 @@ describe("refresh-guardian", () => {
 
     await guardian.tick();
 
-    expect(applyRefreshResultMock).toHaveBeenCalledTimes(1);
-    expect(applyRefreshResultMock).toHaveBeenCalledWith(
-      liveB,
-      expect.objectContaining({ type: "success" }),
-    );
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
     expect(
-      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(liveB);
+      manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      originalB,
+      expect.objectContaining({
+        type: "oauth",
+        access: "access-shifted",
+        refresh: "refresh-shifted",
+      }),
+    );
   });
 
   it("classifies failure reasons and handles no-op branches", async () => {
@@ -702,10 +701,7 @@ describe("refresh-guardian", () => {
     );
 
     await expect(guardian.tick()).resolves.toBeUndefined();
-    expect(applyRefreshResultMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ refreshToken: originalA.refreshToken }),
-      expect.anything(),
-    );
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(
@@ -713,5 +709,79 @@ describe("refresh-guardian", () => {
       60_000,
       "rate-limit",
     );
+  });
+
+  it("treats commit failures as retryable network cooldowns and continues the batch", async () => {
+    const accountA = createManagedAccount(0);
+    const accountB = createManagedAccount(1);
+    const manager = createManagerMock([accountA, accountB]);
+    const commitRefreshedAuthMock = manager
+      .commitRefreshedAuth as ReturnType<typeof vi.fn>;
+    commitRefreshedAuthMock.mockImplementation(
+      async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) => {
+        if (candidate.refreshToken === accountA.refreshToken) {
+          throw Object.assign(new Error("EBUSY"), { code: "EBUSY" });
+        }
+        return manager.getAccountByIdentity(candidate, auth);
+      },
+    );
+
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-0",
+              refresh: "refresh-0-new",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+        [
+          1,
+          {
+            refreshed: true,
+            reason: "failed",
+            tokenResult: {
+              type: "failed",
+              reason: "http_error",
+              statusCode: 429,
+              message: "rate limited",
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
+    expect(commitRefreshedAuthMock).toHaveBeenCalledTimes(1);
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA, 60_000, "network-error");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB, 60_000, "rate-limit");
+    expect(
+      manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledTimes(1);
+
+    const stats = guardian.getStats();
+    expect(stats.runs).toBe(1);
+    expect(stats.refreshed).toBe(0);
+    expect(stats.failed).toBe(2);
+    expect(stats.networkFailed).toBe(1);
+    expect(stats.rateLimited).toBe(1);
   });
 });

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -20,12 +20,52 @@ function createManagedAccount(index: number): ManagedAccount {
   };
 }
 
+function findAccountByIdentity(
+  accounts: ManagedAccount[],
+  candidate: Partial<ManagedAccount>,
+): ManagedAccount | null {
+  return (
+    accounts.find((account) => {
+      if (
+        typeof candidate.index === "number" &&
+        account.index === candidate.index
+      ) {
+        return true;
+      }
+      if (
+        candidate.refreshToken &&
+        account.refreshToken === candidate.refreshToken
+      ) {
+        return true;
+      }
+      if (candidate.accountId && account.accountId === candidate.accountId) {
+        return true;
+      }
+      if (candidate.email && account.email === candidate.email) {
+        return true;
+      }
+      return false;
+    }) ?? null
+  );
+}
+
 function createManagerMock(accounts: ManagedAccount[]): AccountManager {
   return {
     getAccountsSnapshot: vi.fn(() => accounts),
     getAccountByIndex: vi.fn(
       (index: number) =>
         accounts.find((account) => account.index === index) ?? null,
+    ),
+    isAccountCoolingDown: vi.fn(
+      (account: ManagedAccount) =>
+        typeof account.coolingDownUntil === "number" &&
+        account.coolingDownUntil > Date.now(),
+    ),
+    getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
+      findAccountByIdentity(accounts, candidate),
+    ),
+    commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
+      findAccountByIdentity(accounts, candidate),
     ),
     clearAuthFailures: vi.fn(),
     markAccountCoolingDown: vi.fn(),
@@ -108,6 +148,33 @@ describe("refresh-guardian", () => {
     expect(stats.lastRunAt).not.toBeNull();
   });
 
+  it("skips accounts that are already cooling down", async () => {
+    const coolingAccount = {
+      ...createManagedAccount(0),
+      coolingDownUntil: Date.now() + 60_000,
+      cooldownReason: "auth-failure" as const,
+    };
+    const readyAccount = createManagedAccount(1);
+    const manager = createManagerMock([coolingAccount, readyAccount]);
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      intervalMs: 5_000,
+      bufferMs: 60_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(new Map());
+
+    await guardian.tick();
+
+    expect(refreshExpiringAccountsMock).toHaveBeenCalledWith(
+      [readyAccount],
+      60_000,
+      expect.any(Function),
+    );
+    expect(manager.markAccountCoolingDown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(guardian.getStats().runs).toBe(1);
+  });
+
   it("applies refresh outcomes and updates stats", async () => {
     const accountA = createManagedAccount(0);
     const accountB = createManagedAccount(1);
@@ -159,6 +226,16 @@ describe("refresh-guardian", () => {
     expect(
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountA);
+    expect(
+      manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      accountA,
+      expect.objectContaining({
+        type: "oauth",
+        access: "access-0",
+        refresh: "refresh-0-new",
+      }),
+    );
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountB, 60_000, "auth-failure");
@@ -231,6 +308,13 @@ describe("refresh-guardian", () => {
       getAccountByIndex: vi.fn(
         (index: number) =>
           [liveB, liveA].find((account) => account.index === index) ?? null,
+      ),
+      isAccountCoolingDown: vi.fn(() => false),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity([liveB, liveA], candidate),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity([liveB, liveA], candidate),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
@@ -394,6 +478,13 @@ describe("refresh-guardian", () => {
       getAccountByIndex: vi.fn(
         (index: number) =>
           liveSnapshot.find((account) => account.index === index) ?? null,
+      ),
+      isAccountCoolingDown: vi.fn(() => false),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity(liveSnapshot, candidate),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity(liveSnapshot, candidate),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
@@ -559,6 +650,13 @@ describe("refresh-guardian", () => {
       }),
       getAccountByIndex: vi.fn(
         (index: number) => liveAfterRemoval[index] ?? null,
+      ),
+      isAccountCoolingDown: vi.fn(() => false),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity(liveAfterRemoval, candidate),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity(liveAfterRemoval, candidate),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import type { AccountManager, ManagedAccount, OAuthAuthDetails } from "../lib/accounts.js";
+import {
+  extractAccountEmail,
+  extractAccountId,
+  sanitizeEmail,
+} from "../lib/auth/token-utils.js";
+import { findMatchingAccountIndex } from "../lib/storage.js";
 
 const refreshExpiringAccountsMock = vi.fn();
 const applyRefreshResultMock = vi.fn();
 
 vi.mock("../lib/proactive-refresh.js", () => ({
-  refreshExpiringAccounts: refreshExpiringAccountsMock,
+  refreshExpiringAccounts: vi.fn(async (accounts, bufferMs, onResult) => {
+    const results = await refreshExpiringAccountsMock(accounts, bufferMs, onResult);
+    if (results instanceof Map && typeof onResult === "function") {
+      for (const [accountIndex, result] of results.entries()) {
+        const sourceAccount = accounts.find(
+          (account) => account.index === accountIndex,
+        );
+        if (!sourceAccount) {
+          continue;
+        }
+        await onResult(sourceAccount, result);
+      }
+    }
+    return results;
+  }),
   applyRefreshResult: applyRefreshResultMock,
 }));
 
@@ -23,30 +43,52 @@ function createManagedAccount(index: number): ManagedAccount {
 function findAccountByIdentity(
   accounts: ManagedAccount[],
   candidate: Partial<ManagedAccount>,
+  auth?: OAuthAuthDetails,
 ): ManagedAccount | null {
-  return (
-    accounts.find((account) => {
-      if (
-        typeof candidate.index === "number" &&
-        account.index === candidate.index
-      ) {
-        return true;
-      }
-      if (
-        candidate.refreshToken &&
-        account.refreshToken === candidate.refreshToken
-      ) {
-        return true;
-      }
-      if (candidate.accountId && account.accountId === candidate.accountId) {
-        return true;
-      }
-      if (candidate.email && account.email === candidate.email) {
-        return true;
-      }
-      return false;
-    }) ?? null
-  );
+  const derived = {
+    accountId: extractAccountId(auth?.access)?.trim() || undefined,
+    email: sanitizeEmail(extractAccountEmail(auth?.access)),
+    refreshToken: auth?.refresh,
+  };
+  const lookupCandidates = [
+    candidate,
+    {
+      accountId: candidate.accountId ?? derived.accountId,
+      email: candidate.email ?? derived.email,
+      refreshToken: candidate.refreshToken,
+    },
+    {
+      accountId: derived.accountId ?? candidate.accountId,
+      email: derived.email ?? candidate.email,
+      refreshToken: candidate.refreshToken,
+    },
+    {
+      accountId: derived.accountId ?? candidate.accountId,
+      email: derived.email ?? candidate.email,
+      refreshToken: derived.refreshToken ?? candidate.refreshToken,
+    },
+  ];
+
+  const seen = new Set<string>();
+  for (const lookupCandidate of lookupCandidates) {
+    const key = `${lookupCandidate.accountId ?? ""}|${lookupCandidate.email ?? ""}|${lookupCandidate.refreshToken ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const matchIndex = findMatchingAccountIndex(accounts, {
+      accountId: lookupCandidate.accountId,
+      email: lookupCandidate.email,
+      refreshToken: lookupCandidate.refreshToken,
+    }, {
+      allowUniqueAccountIdFallbackWithoutEmail: true,
+    });
+    if (matchIndex !== undefined) {
+      return accounts[matchIndex] ?? null;
+    }
+  }
+
+  return null;
 }
 
 function createManagerMock(accounts: ManagedAccount[]): AccountManager {
@@ -61,11 +103,11 @@ function createManagerMock(accounts: ManagedAccount[]): AccountManager {
         typeof account.coolingDownUntil === "number" &&
         account.coolingDownUntil > Date.now(),
     ),
-    getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
-      findAccountByIdentity(accounts, candidate),
+    getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+      findAccountByIdentity(accounts, candidate, auth),
     ),
-    commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
-      findAccountByIdentity(accounts, candidate),
+    commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+      findAccountByIdentity(accounts, candidate, auth),
     ),
     clearAuthFailures: vi.fn(),
     markAccountCoolingDown: vi.fn(),
@@ -306,11 +348,11 @@ describe("refresh-guardian", () => {
           [liveB, liveA].find((account) => account.index === index) ?? null,
       ),
       isAccountCoolingDown: vi.fn(() => false),
-      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity([liveB, liveA], candidate),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity([liveB, liveA], candidate, auth),
       ),
-      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity([liveB, liveA], candidate),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity([liveB, liveA], candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
@@ -479,11 +521,11 @@ describe("refresh-guardian", () => {
           liveSnapshot.find((account) => account.index === index) ?? null,
       ),
       isAccountCoolingDown: vi.fn(() => false),
-      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity(liveSnapshot, candidate),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveSnapshot, candidate, auth),
       ),
-      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity(liveSnapshot, candidate),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveSnapshot, candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
@@ -651,11 +693,11 @@ describe("refresh-guardian", () => {
         (index: number) => liveAfterRemoval[index] ?? null,
       ),
       isAccountCoolingDown: vi.fn(() => false),
-      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity(liveAfterRemoval, candidate),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAfterRemoval, candidate, auth),
       ),
-      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity(liveAfterRemoval, candidate),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAfterRemoval, candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -711,6 +711,52 @@ describe("refresh-guardian", () => {
     );
   });
 
+  it("treats null commit results as retryable network cooldowns", async () => {
+    const accountA = createManagedAccount(0);
+    const manager = createManagerMock([accountA]);
+    const commitRefreshedAuthMock = manager
+      .commitRefreshedAuth as ReturnType<typeof vi.fn>;
+    commitRefreshedAuthMock.mockResolvedValueOnce(null);
+
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-0",
+              refresh: "refresh-0-new",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
+    expect(commitRefreshedAuthMock).toHaveBeenCalledTimes(1);
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountA, 60_000, "network-error");
+
+    const stats = guardian.getStats();
+    expect(stats.runs).toBe(1);
+    expect(stats.refreshed).toBe(0);
+    expect(stats.failed).toBe(1);
+    expect(stats.networkFailed).toBe(1);
+  });
+
   it("treats commit failures as retryable network cooldowns and continues the batch", async () => {
     const accountA = createManagedAccount(0);
     const accountB = createManagedAccount(1);

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import type { AccountManager, ManagedAccount, OAuthAuthDetails } from "../lib/accounts.js";
+import type { AccountManager, ManagedAccount } from "../lib/accounts.js";
 import {
   extractAccountEmail,
   extractAccountId,
   sanitizeEmail,
 } from "../lib/auth/token-utils.js";
+import { CodexAuthError } from "../lib/errors.js";
 import { findMatchingAccountIndex } from "../lib/storage.js";
+import type { OAuthAuthDetails } from "../lib/types.js";
 
 const refreshExpiringAccountsMock = vi.fn();
 const applyRefreshResultMock = vi.fn();
@@ -871,5 +873,49 @@ describe("refresh-guardian", () => {
     expect(stats.failed).toBe(2);
     expect(stats.networkFailed).toBe(1);
     expect(stats.rateLimited).toBe(1);
+  });
+
+  it("treats non-retryable commit failures as auth cooldowns", async () => {
+    const accountA = createManagedAccount(0);
+    const manager = createManagerMock([accountA]);
+    const commitRefreshedAuthMock = manager
+      .commitRefreshedAuth as ReturnType<typeof vi.fn>;
+    commitRefreshedAuthMock.mockRejectedValueOnce(
+      new CodexAuthError("refresh persistence failed", { retryable: false }),
+    );
+
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-0",
+              refresh: "refresh-0-new",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountA, 60_000, "auth-failure");
+    const stats = guardian.getStats();
+    expect(stats.failed).toBe(1);
+    expect(stats.authFailed).toBe(1);
+    expect(stats.networkFailed).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- persist refreshed auth transactionally so fast-expiry refreshes do not get overwritten by stale pool snapshots

## What Changed

- added `AccountManager.commitRefreshedAuth(...)` and identity-based account matching so refresh results update the correct stored row before any later pool snapshot save
- updated the runtime refresh paths to use transactional persistence for both the main request loop and stream failover refreshes
- treated transient refresh and auth-store write failures as retryable refresh errors instead of terminal auth-invalid failures, and extended the proactive refresh / guardian coverage around fast-expiry cases

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: moderate; this changes how refreshed auth is persisted and how transient refresh failures are classified in the runtime account loop
- Rollback plan: revert commit `9cbc72a` on `fix/fast-expiry-refresh-persistence` or revert the PR if the new persistence path causes account rotation regressions

## Additional Notes

- rebased onto current `main` and re-ran the full validation gate on the rebased branch

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr fixes fast-expiry token refresh persistence by replacing the ad-hoc `updateFromAuth` + `clearAuthFailures` + `saveToDiskDebounced` triple with a single `commitRefreshedAuth` call that runs under `withStorageLock`, builds a fresh pool snapshot, updates both the on-disk record and the live in-memory account atomically, and rolls back in-memory changes if the write fails.

**key changes:**
- `AccountManager.commitRefreshedAuth` — transactional persist with in-memory rollback on storage failure; identity-based account matching so the correct row is updated even if the index has shifted
- `index.ts` — main loop and stream failover paths use `commitRefreshedAuth`; transient refresh/persistence errors (`EAGAIN`, `EBUSY`, `EPERM`, `network_error`) now trigger a network-class cooldown+continue instead of `incrementAuthFailures`
- `lib/proactive-refresh.ts` — `refreshExpiringAccounts` gains an `onResult` callback so the guardian can commit each refresh transactionally as results arrive in parallel; `shouldRefreshProactively` now correctly returns `true` when the access token is missing even if `expires` is undefined
- `lib/refresh-guardian.ts` — pre-filters cooling-down accounts, routes success results through `commitRefreshedAuth`, and only triggers `saveToDiskDebounced` for failure-cooldown writes (not for already-persisted successes)
- `lib/request/fetch-helpers.ts` — `isRetryableRefreshFailure` classifies `network_error`/`unknown`/`invalid_response` as retryable and 400/401/403 `http_error` as terminal; `missing_refresh` stays terminal
- tests updated across all six affected files with strong coverage of the transactional commit, rollback, retryable vs terminal error paths, and the cooling-down skip

<h3>Confidence Score: 4/5</h3>

solid approach with one P1 data-integrity edge case in `commitRefreshedAuth` where tokens are written to disk without in-memory update when `liveAccount` lookup fails post-snapshot

the lock-based transactional commit, retryable error classification, and rollback logic are all well-designed and well-tested. previous P1 concerns (missing_refresh as retryable, storage write triggering incrementAuthFailures on healthy accounts) are resolved. the remaining P1 is the "disk write proceeds but live pool not updated" path in `commitRefreshedAuth` when `getAccountByIdentity` returns null after `storageIndex` was found — this leaves the guardian in a perpetual refresh loop for the affected account until restart. the duplicate retryable helper (P2) and missing concurrent-commit test (P2) don't block merge.

`lib/accounts.ts` — specifically the `await persist(nextStorage)` call at line ~401 in the "liveAccount not found" branch of `commitRefreshedAuth`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/accounts.ts | core change: adds `commitRefreshedAuth` with transactional disk write, in-memory rollback on persist failure, and identity-based account matching; one P1 issue (disk write proceeds without in-memory update when `liveAccount` lookup fails post-snapshot) and one P2 (duplicate retryable error checker) |
| index.ts | main request loop and stream failover now use `commitRefreshedAuth`; retryable vs terminal refresh errors classified correctly; `sessionAffinityStore` forget moved before the retryable branch — looks correct |
| lib/proactive-refresh.ts | adds optional `onResult` callback to `refreshExpiringAccounts`, reorders `shouldRefreshProactively` checks so missing access-token triggers refresh even without expiry, extends `applyRefreshResult` with identity-field updates — all changes look correct |
| lib/refresh-guardian.ts | replaces inline `applyRefreshResult`+`clearAuthFailures` with `commitRefreshedAuth` via new `applyRefreshOutcome` helper; pre-filters cooling-down accounts before passing to `refreshExpiringAccounts`; `requiresSave` flag correctly distinguishes failure cooldowns (debounced save) from successful commits (already persisted) |
| lib/request/fetch-helpers.ts | adds `isRetryableRefreshFailure` and `isRetryableAuthSetterError`; wraps `authSetter.set` failure in `CodexAuthError`; `missing_refresh` correctly returns `false` (terminal) — logic is sound but `isRetryableAuthSetterError` duplicates `isRetryableAuthPersistenceError` in accounts.ts |
| test/accounts.test.ts | new `commitRefreshedAuth` suite covers transactional write, rollback on EBUSY, terminal EACCES, pool-state preservation, and debounced-save race; missing test for two concurrent commits on different accounts |
| test/refresh-guardian.test.ts | updated to use `commitRefreshedAuth` mock instead of `applyRefreshResult`; adds cooling-down skip test, null-commit cooldown test, and commit error classification; coverage looks solid |
| test/fetch-helpers.test.ts | adds tests for retryable network errors, terminal 401 and missing_refresh, EBUSY and EACCES auth persistence failures — comprehensive coverage of the new error classification |
| test/proactive-refresh.test.ts | adds `onResult` invocation test and identity-field update test for `applyRefreshResult`; also adds the access-missing-without-expiry path for `shouldRefreshProactively` — good coverage |
| test/accounts-edge.test.ts | plumbs `withAccountStorageTransaction` mock into edge-case setup; no functional change to test logic |
| test/accounts-load-from-disk.test.ts | migrates to `vi.hoisted` mocks and plumbs `withAccountStorageTransaction`; assertions updated to use named mocks — cleaner setup, no logic change |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant RL as RequestLoop / Guardian
    participant CM as commitRefreshedAuth
    participant Lock as withStorageLock
    participant Mem as LivePool (in-memory)
    participant Disk as Storage (disk)

    RL->>CM: commitRefreshedAuth(source, auth)
    CM->>Lock: acquire lock
    Lock-->>CM: lock held
    CM->>CM: buildStorageSnapshot() → nextStorage
    CM->>CM: findAccountIndexByIdentity(nextStorage, source, auth)
    CM->>CM: update storedAccount in nextStorage (tokens, identity)
    CM->>Mem: getAccountByIdentity(source, auth) → liveAccount
    CM->>Mem: updateFromAuth(liveAccount, auth)
    CM->>Mem: clearAuthFailures / clearCooldown / enabled=true
    CM->>Disk: persist(nextStorage)
    alt persist succeeds
        Disk-->>CM: ok
        CM->>Lock: release lock
        CM-->>RL: return liveAccount
    else persist fails (EBUSY/EPERM)
        Disk-->>CM: error
        CM->>Mem: rollback liveAccount to previousState
        CM->>Lock: release lock
        CM-->>RL: throw CodexAuthError(retryable=true)
    else persist fails (EACCES/other)
        Disk-->>CM: error
        CM->>Mem: rollback liveAccount to previousState
        CM->>Lock: release lock
        CM-->>RL: throw CodexAuthError(retryable=false)
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `lib/refresh-guardian.ts`, line 463-477 ([link](https://github.com/ndycode/codex-multi-auth/blob/9cbc72aaed4590f452fbffbf4e1f21f27bae5ae0/lib/refresh-guardian.ts#L463-L477)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **redundant double update on the same live account object**

   in the `"success"` branch of `applyRefreshOutcome`, the code:

   1. calls `applyRefreshResult(account, result.tokenResult)` which writes `access`, `refresh`, `expires`, `accountId`, `email` to the live account
   2. calls `manager.clearAuthFailures(account)` on the live account
   3. then calls `await manager.commitRefreshedAuth(sourceAccount, refreshedAuth)` which calls `this.updateFromAuth(liveAccount, auth)` + `this.clearAuthFailures(liveAccount)` + `this.clearAccountCooldown(liveAccount)` on the **same** account object

   steps 1-2 are fully superseded by step 3's internal calls. consider removing the pre-commit `applyRefreshResult` / `clearAuthFailures` lines and relying solely on `commitRefreshedAuth` for consistency.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/refresh-guardian.ts
   Line: 463-477

   Comment:
   **redundant double update on the same live account object**

   in the `"success"` branch of `applyRefreshOutcome`, the code:

   1. calls `applyRefreshResult(account, result.tokenResult)` which writes `access`, `refresh`, `expires`, `accountId`, `email` to the live account
   2. calls `manager.clearAuthFailures(account)` on the live account
   3. then calls `await manager.commitRefreshedAuth(sourceAccount, refreshedAuth)` which calls `this.updateFromAuth(liveAccount, auth)` + `this.clearAuthFailures(liveAccount)` + `this.clearAccountCooldown(liveAccount)` on the **same** account object

   steps 1-2 are fully superseded by step 3's internal calls. consider removing the pre-commit `applyRefreshResult` / `clearAuthFailures` lines and relying solely on `commitRefreshedAuth` for consistency.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Frefresh-guardian.ts%0ALine%3A%20463-477%0A%0AComment%3A%0A**redundant%20double%20update%20on%20the%20same%20live%20account%20object**%0A%0Ain%20the%20%60%22success%22%60%20branch%20of%20%60applyRefreshOutcome%60%2C%20the%20code%3A%0A%0A1.%20calls%20%60applyRefreshResult%28account%2C%20result.tokenResult%29%60%20which%20writes%20%60access%60%2C%20%60refresh%60%2C%20%60expires%60%2C%20%60accountId%60%2C%20%60email%60%20to%20the%20live%20account%0A2.%20calls%20%60manager.clearAuthFailures%28account%29%60%20on%20the%20live%20account%0A3.%20then%20calls%20%60await%20manager.commitRefreshedAuth%28sourceAccount%2C%20refreshedAuth%29%60%20which%20calls%20%60this.updateFromAuth%28liveAccount%2C%20auth%29%60%20%2B%20%60this.clearAuthFailures%28liveAccount%29%60%20%2B%20%60this.clearAccountCooldown%28liveAccount%29%60%20on%20the%20**same**%20account%20object%0A%0Asteps%201-2%20are%20fully%20superseded%20by%20step%203's%20internal%20calls.%20consider%20removing%20the%20pre-commit%20%60applyRefreshResult%60%20%2F%20%60clearAuthFailures%60%20lines%20and%20relying%20solely%20on%20%60commitRefreshedAuth%60%20for%20consistency.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

2. `test/accounts.test.ts`, line 718-802 ([link](https://github.com/ndycode/codex-multi-auth/blob/9cbc72aaed4590f452fbffbf4e1f21f27bae5ae0/test/accounts.test.ts#L718-L802)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **missing vitest coverage for `commitRefreshedAuth` storage write failure path**

   the test suite covers the happy path but has no case where `withAccountStorageTransaction` rejects. given the windows EBUSY concern and the p1 issue where a storage throw incorrectly routes through `incrementAuthFailures`, a test verifying the error propagation (and the expected type/retryable flag once the fix is applied) would close the gap. add a case like:

   ```ts
   it("propagates storage write failure as retryable CodexAuthError", async () => {
     mockWithAccountStorageTransaction.mockRejectedValueOnce(
       Object.assign(new Error("EBUSY"), { code: "EBUSY" }),
     );
     await expect(manager.commitRefreshedAuth(account, refreshedAuth))
       .rejects.toMatchObject({ retryable: true });
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/accounts.test.ts
   Line: 718-802

   Comment:
   **missing vitest coverage for `commitRefreshedAuth` storage write failure path**

   the test suite covers the happy path but has no case where `withAccountStorageTransaction` rejects. given the windows EBUSY concern and the p1 issue where a storage throw incorrectly routes through `incrementAuthFailures`, a test verifying the error propagation (and the expected type/retryable flag once the fix is applied) would close the gap. add a case like:

   ```ts
   it("propagates storage write failure as retryable CodexAuthError", async () => {
     mockWithAccountStorageTransaction.mockRejectedValueOnce(
       Object.assign(new Error("EBUSY"), { code: "EBUSY" }),
     );
     await expect(manager.commitRefreshedAuth(account, refreshedAuth))
       .rejects.toMatchObject({ retryable: true });
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Faccounts.test.ts%0ALine%3A%20718-802%0A%0AComment%3A%0A**missing%20vitest%20coverage%20for%20%60commitRefreshedAuth%60%20storage%20write%20failure%20path**%0A%0Athe%20test%20suite%20covers%20the%20happy%20path%20but%20has%20no%20case%20where%20%60withAccountStorageTransaction%60%20rejects.%20given%20the%20windows%20EBUSY%20concern%20and%20the%20p1%20issue%20where%20a%20storage%20throw%20incorrectly%20routes%20through%20%60incrementAuthFailures%60%2C%20a%20test%20verifying%20the%20error%20propagation%20%28and%20the%20expected%20type%2Fretryable%20flag%20once%20the%20fix%20is%20applied%29%20would%20close%20the%20gap.%20add%20a%20case%20like%3A%0A%0A%60%60%60ts%0Ait%28%22propagates%20storage%20write%20failure%20as%20retryable%20CodexAuthError%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20mockWithAccountStorageTransaction.mockRejectedValueOnce%28%0A%20%20%20%20Object.assign%28new%20Error%28%22EBUSY%22%29%2C%20%7B%20code%3A%20%22EBUSY%22%20%7D%29%2C%0A%20%20%29%3B%0A%20%20await%20expect%28manager.commitRefreshedAuth%28account%2C%20refreshedAuth%29%29%0A%20%20%20%20.rejects.toMatchObject%28%7B%20retryable%3A%20true%20%7D%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

3. `lib/accounts.ts`, line 400-406 ([link](https://github.com/ndycode/codex-multi-auth/blob/77922ec0e647be188f30242d3000ce4c69c42169/lib/accounts.ts#L400-L406)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **disk write with stale in-memory when liveAccount lookup fails**

   when `storageIndex` is found in the snapshot but `getAccountByIdentity` returns `null` (account removed from live pool between snapshot and lookup), `persist(nextStorage)` is still called — writing the new tokens to disk — but in-memory `this.accounts` is never updated. the live pool carries the old expiry/access token for the remainder of the process lifetime; the account will keep triggering proactive refresh on every guardian tick until restart.

   the warning log covers observability, but the correct action here is to skip the write (or roll back), not silently persist tokens that can't be applied in-memory. at minimum, the `persist` on the "no live account" path should be gated the same way as the guarded path, or the caller should be notified the commit was a no-op.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/accounts.ts
   Line: 400-406

   Comment:
   **disk write with stale in-memory when liveAccount lookup fails**

   when `storageIndex` is found in the snapshot but `getAccountByIdentity` returns `null` (account removed from live pool between snapshot and lookup), `persist(nextStorage)` is still called — writing the new tokens to disk — but in-memory `this.accounts` is never updated. the live pool carries the old expiry/access token for the remainder of the process lifetime; the account will keep triggering proactive refresh on every guardian tick until restart.

   the warning log covers observability, but the correct action here is to skip the write (or roll back), not silently persist tokens that can't be applied in-memory. at minimum, the `persist` on the "no live account" path should be gated the same way as the guarded path, or the caller should be notified the commit was a no-op.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Faccounts.ts%0ALine%3A%20400-406%0A%0AComment%3A%0A**disk%20write%20with%20stale%20in-memory%20when%20liveAccount%20lookup%20fails**%0A%0Awhen%20%60storageIndex%60%20is%20found%20in%20the%20snapshot%20but%20%60getAccountByIdentity%60%20returns%20%60null%60%20%28account%20removed%20from%20live%20pool%20between%20snapshot%20and%20lookup%29%2C%20%60persist%28nextStorage%29%60%20is%20still%20called%20%E2%80%94%20writing%20the%20new%20tokens%20to%20disk%20%E2%80%94%20but%20in-memory%20%60this.accounts%60%20is%20never%20updated.%20the%20live%20pool%20carries%20the%20old%20expiry%2Faccess%20token%20for%20the%20remainder%20of%20the%20process%20lifetime%3B%20the%20account%20will%20keep%20triggering%20proactive%20refresh%20on%20every%20guardian%20tick%20until%20restart.%0A%0Athe%20warning%20log%20covers%20observability%2C%20but%20the%20correct%20action%20here%20is%20to%20skip%20the%20write%20%28or%20roll%20back%29%2C%20not%20silently%20persist%20tokens%20that%20can't%20be%20applied%20in-memory.%20at%20minimum%2C%20the%20%60persist%60%20on%20the%20%22no%20live%20account%22%20path%20should%20be%20gated%20the%20same%20way%20as%20the%20guarded%20path%2C%20or%20the%20caller%20should%20be%20notified%20the%20commit%20was%20a%20no-op.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Faccounts.ts%3A164-194%0A**duplicate%20retryable%20error%20checker%20vs%20%60isRetryableAuthSetterError%60%20in%20%60fetch-helpers.ts%60**%0A%0A%60isRetryableAuthPersistenceError%60%20%28here%29%20and%20%60isRetryableAuthSetterError%60%20%28%60lib%2Frequest%2Ffetch-helpers.ts%3A452-478%60%29%20are%20functionally%20identical%20%E2%80%94%20both%20check%20%60EAGAIN%2FEBUSY%2FEPERM%60%2C%20%60HTTP%20429%60%2C%20and%20recurse%20into%20%60.cause%60.%20having%20two%20copies%20risks%20the%20sets%20diverging%20silently%20%28e.g.%20a%20new%20code%20added%20to%20one%20but%20not%20the%20other%29.%0A%0Aextract%20to%20a%20shared%20helper%20in%20%60lib%2Ferrors.ts%60%20or%20%60lib%2Futils.ts%60%20and%20import%20from%20both%20call%20sites%20%E2%80%94%20consistent%20with%20the%20project's%20existing%20pattern%20of%20centralising%20storage%20error%20logic%20there.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Faccounts.ts%3A400-406%0A**disk%20write%20with%20stale%20in-memory%20when%20liveAccount%20lookup%20fails**%0A%0Awhen%20%60storageIndex%60%20is%20found%20in%20the%20snapshot%20but%20%60getAccountByIdentity%60%20returns%20%60null%60%20%28account%20removed%20from%20live%20pool%20between%20snapshot%20and%20lookup%29%2C%20%60persist%28nextStorage%29%60%20is%20still%20called%20%E2%80%94%20writing%20the%20new%20tokens%20to%20disk%20%E2%80%94%20but%20in-memory%20%60this.accounts%60%20is%20never%20updated.%20the%20live%20pool%20carries%20the%20old%20expiry%2Faccess%20token%20for%20the%20remainder%20of%20the%20process%20lifetime%3B%20the%20account%20will%20keep%20triggering%20proactive%20refresh%20on%20every%20guardian%20tick%20until%20restart.%0A%0Athe%20warning%20log%20covers%20observability%2C%20but%20the%20correct%20action%20here%20is%20to%20skip%20the%20write%20%28or%20roll%20back%29%2C%20not%20silently%20persist%20tokens%20that%20can't%20be%20applied%20in-memory.%20at%20minimum%2C%20the%20%60persist%60%20on%20the%20%22no%20live%20account%22%20path%20should%20be%20gated%20the%20same%20way%20as%20the%20guarded%20path%2C%20or%20the%20caller%20should%20be%20notified%20the%20commit%20was%20a%20no-op.%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Faccounts.test.ts%3A1059-1142%0A**missing%20vitest%20coverage%3A%20two%20concurrent%20%60commitRefreshedAuth%60%20calls%20on%20different%20accounts**%0A%0Athe%20debounced-save%20race%20test%20%28%60%22prevents%20debounced%20saves%20from%20writing%20stale%20auth%20during%20refresh%20persistence%22%60%29%20covers%20%60commitRefreshedAuth%60%20vs%20%60saveToDiskDebounced%60%20interleaving%20under%20the%20lock.%20there's%20no%20test%20that%20launches%20%60commitRefreshedAuth%60%20for%20accounts%20A%20and%20B%20concurrently%20and%20asserts%20that%3A%0A%0A1.%20B's%20snapshot%20captures%20A's%20already-committed%20token%20updates%20%28because%20A%20runs%20first%20under%20the%20lock%29%0A2.%20neither%20account's%20tokens%20overwrite%20the%20other's%20on%20disk%0A%0Athis%20is%20the%20core%20serialisation%20guarantee%20of%20%60withStorageLock%60%20%E2%80%94%20given%20the%20windows%20filesystem%20EBUSY%20risk%20and%20the%20fact%20that%20the%20guardian%20now%20fires%20all%20account%20refreshes%20in%20parallel%20via%20%60Promise.all%60%2C%20this%20scenario%20is%20realistic%20and%20the%20lock%20ordering%20should%20be%20vitest-covered.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/accounts.ts
Line: 164-194

Comment:
**duplicate retryable error checker vs `isRetryableAuthSetterError` in `fetch-helpers.ts`**

`isRetryableAuthPersistenceError` (here) and `isRetryableAuthSetterError` (`lib/request/fetch-helpers.ts:452-478`) are functionally identical — both check `EAGAIN/EBUSY/EPERM`, `HTTP 429`, and recurse into `.cause`. having two copies risks the sets diverging silently (e.g. a new code added to one but not the other).

extract to a shared helper in `lib/errors.ts` or `lib/utils.ts` and import from both call sites — consistent with the project's existing pattern of centralising storage error logic there.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts.ts
Line: 400-406

Comment:
**disk write with stale in-memory when liveAccount lookup fails**

when `storageIndex` is found in the snapshot but `getAccountByIdentity` returns `null` (account removed from live pool between snapshot and lookup), `persist(nextStorage)` is still called — writing the new tokens to disk — but in-memory `this.accounts` is never updated. the live pool carries the old expiry/access token for the remainder of the process lifetime; the account will keep triggering proactive refresh on every guardian tick until restart.

the warning log covers observability, but the correct action here is to skip the write (or roll back), not silently persist tokens that can't be applied in-memory. at minimum, the `persist` on the "no live account" path should be gated the same way as the guarded path, or the caller should be notified the commit was a no-op.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/accounts.test.ts
Line: 1059-1142

Comment:
**missing vitest coverage: two concurrent `commitRefreshedAuth` calls on different accounts**

the debounced-save race test (`"prevents debounced saves from writing stale auth during refresh persistence"`) covers `commitRefreshedAuth` vs `saveToDiskDebounced` interleaving under the lock. there's no test that launches `commitRefreshedAuth` for accounts A and B concurrently and asserts that:

1. B's snapshot captures A's already-committed token updates (because A runs first under the lock)
2. neither account's tokens overwrite the other's on disk

this is the core serialisation guarantee of `withStorageLock` — given the windows filesystem EBUSY risk and the fact that the guardian now fires all account refreshes in parallel via `Promise.all`, this scenario is realistic and the lock ordering should be vitest-covered.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["test: cover trimmed refreshed account id..."](https://github.com/ndycode/codex-multi-auth/commit/77922ec0e647be188f30242d3000ce4c69c42169) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26963315)</sub>

<!-- /greptile_comment -->