### PR TITLE
fix stale account pool penalties after successful requests

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -550,6 +550,24 @@ export class AccountManager {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		healthTracker.recordSuccess(account.index, quotaKey);
+		const hadCooldownMetadata =
+			account.coolingDownUntil !== undefined || account.cooldownReason !== undefined;
+		const hadAuthFailures = (account.consecutiveAuthFailures ?? 0) > 0;
+		const isCoolingDown = this.isAccountCoolingDown(account);
+		let healed = false;
+
+		if (!isCoolingDown && hadCooldownMetadata) {
+			healed = true;
+		}
+
+		if (!isCoolingDown && hadAuthFailures) {
+			this.clearAuthFailures(account);
+			healed = true;
+		}
+
+		if (healed) {
+			this.saveToDiskDebounced();
+		}
 	}
 
 	recordRateLimit(account: ManagedAccount, family: ModelFamily, model?: string | null): void {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -557,6 +557,7 @@ export class AccountManager {
 		let healed = false;
 
 		if (!isCoolingDown && hadCooldownMetadata) {
+			this.clearAccountCooldown(account);
 			healed = true;
 		}
 

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1903,7 +1903,11 @@ describe("AccountManager", () => {
       expect(score).toBe(100);
     });
 
-    it("recordSuccess clears stale auth failure state and persists the healed account", () => {
+    it("recordSuccess clears stale auth failure state and persists the healed account", async () => {
+      const { saveAccounts } = await import("../lib/storage.js");
+      const mockSaveAccounts = vi.mocked(saveAccounts);
+      mockSaveAccounts.mockClear();
+
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -1923,19 +1927,58 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       account.consecutiveAuthFailures = 2;
-      const saveSpy = vi
-        .spyOn(manager, "saveToDiskDebounced")
-        .mockImplementation(() => {});
 
       manager.recordSuccess(account, "codex", "gpt-5.1");
+      await manager.flushPendingSave();
 
       expect(account.consecutiveAuthFailures).toBe(0);
       expect(account.coolingDownUntil).toBeUndefined();
       expect(account.cooldownReason).toBeUndefined();
-      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+      const persisted = mockSaveAccounts.mock.calls[0]?.[0];
+      expect(persisted?.accounts[0]?.consecutiveAuthFailures ?? 0).toBe(0);
+      expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
+      expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
     });
 
-    it("recordSuccess does not clear an active cooldown from a newer concurrent failure", () => {
+    it("recordSuccess clears stale cooldown metadata when only the reason remains", async () => {
+      const { saveAccounts } = await import("../lib/storage.js");
+      const mockSaveAccounts = vi.mocked(saveAccounts);
+      mockSaveAccounts.mockClear();
+
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            addedAt: now,
+            lastUsed: now,
+            cooldownReason: "network-error" as const,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+
+      manager.recordSuccess(account, "codex", "gpt-5.1");
+      await manager.flushPendingSave();
+
+      expect(account.coolingDownUntil).toBeUndefined();
+      expect(account.cooldownReason).toBeUndefined();
+      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+      const persisted = mockSaveAccounts.mock.calls[0]?.[0];
+      expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
+      expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
+    });
+
+    it("recordSuccess does not clear an active cooldown from a newer concurrent failure", async () => {
+      const { saveAccounts } = await import("../lib/storage.js");
+      const mockSaveAccounts = vi.mocked(saveAccounts);
+      mockSaveAccounts.mockClear();
+
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -1955,16 +1998,14 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       account.consecutiveAuthFailures = 2;
-      const saveSpy = vi
-        .spyOn(manager, "saveToDiskDebounced")
-        .mockImplementation(() => {});
 
       manager.recordSuccess(account, "codex", "gpt-5.1");
+      await manager.flushPendingSave();
 
       expect(account.consecutiveAuthFailures).toBe(2);
       expect(account.coolingDownUntil).toBe(now + 60_000);
       expect(account.cooldownReason).toBe("auth-failure");
-      expect(saveSpy).not.toHaveBeenCalled();
+      expect(mockSaveAccounts).not.toHaveBeenCalled();
     });
 
     it("recordRateLimit updates health and drains token bucket", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1903,6 +1903,70 @@ describe("AccountManager", () => {
       expect(score).toBe(100);
     });
 
+    it("recordSuccess clears stale auth failure state and persists the healed account", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            addedAt: now,
+            lastUsed: now,
+            consecutiveAuthFailures: 2,
+            coolingDownUntil: now - 1000,
+            cooldownReason: "network-error" as const,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      account.consecutiveAuthFailures = 2;
+      const saveSpy = vi
+        .spyOn(manager, "saveToDiskDebounced")
+        .mockImplementation(() => {});
+
+      manager.recordSuccess(account, "codex", "gpt-5.1");
+
+      expect(account.consecutiveAuthFailures).toBe(0);
+      expect(account.coolingDownUntil).toBeUndefined();
+      expect(account.cooldownReason).toBeUndefined();
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("recordSuccess does not clear an active cooldown from a newer concurrent failure", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            addedAt: now,
+            lastUsed: now,
+            consecutiveAuthFailures: 2,
+            coolingDownUntil: now + 60_000,
+            cooldownReason: "auth-failure" as const,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      account.consecutiveAuthFailures = 2;
+      const saveSpy = vi
+        .spyOn(manager, "saveToDiskDebounced")
+        .mockImplementation(() => {});
+
+      manager.recordSuccess(account, "codex", "gpt-5.1");
+
+      expect(account.consecutiveAuthFailures).toBe(2);
+      expect(account.coolingDownUntil).toBe(now + 60_000);
+      expect(account.cooldownReason).toBe("auth-failure");
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
     it("recordRateLimit updates health and drains token bucket", () => {
       const now = Date.now();
       const stored = {


### PR DESCRIPTION
## Summary

- heal stale account-pool penalties after a real successful request so healthy accounts do not carry expired auth-failure state forward

## What Changed

- updated `AccountManager.recordSuccess(...)` in `lib/accounts.ts` to clear stale auth-failure counters and expired cooldown metadata when an account succeeds again
- persist the healed state with `saveToDiskDebounced()`
- added regression coverage in `test/accounts.test.ts` to prove success heals stale state without clearing an active newer cooldown

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low to moderate; limited to success-path healing of persisted account state
- Rollback plan: revert commit `adbf49a`

## Additional Notes

- implemented from an isolated worktree based on current `origin/main`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr heals stale account-pool penalty state (expired cooldown metadata and `consecutiveAuthFailures`) on the success path in `AccountManager.recordSuccess`, then persists the cleaned state via `saveToDiskDebounced`. the previous orphaned-`cooldownReason` concern is resolved: the new code calls `clearAccountCooldown` explicitly in the `hadCooldownMetadata` branch rather than relying on `isAccountCoolingDown`'s internal side effect, so a stored account with only `cooldownReason` set (and `coolingDownUntil` absent) will also be cleaned correctly.

- `lib/accounts.ts`: snapshots `hadCooldownMetadata` and `hadAuthFailures` before calling `isAccountCoolingDown`; both healing branches are guarded by `!isCoolingDown` to preserve an active newer cooldown
- `test/accounts.test.ts`: three new regression cases — full heal, orphaned-reason-only heal, and active-cooldown guard; all verify persist behavior via `flushPendingSave` + `mockSaveAccounts`
- minor: post-construction `account.consecutiveAuthFailures = 2` mutation in test cases 1 and 3 is redundant since the value is already present in the `stored` fixture; no isolated test exists for the `consecutiveAuthFailures > 0` / no-cooldown-metadata-at-all path, though the risk is low given the branches are independent

<h3>Confidence Score: 5/5</h3>

safe to merge — logic is correct, previous concern is addressed, no P0/P1 issues found

all remaining findings are P2 style/test-hygiene only. core healing logic is sound, guard against active cooldowns is correct, debounced persist coalesces concurrent heals safely, and the orphaned-cooldownReason gap from the prior review thread is explicitly closed by the direct clearAccountCooldown call.

test/accounts.test.ts — redundant post-construction mutation on lines 1929 and 2000, and missing isolated test for pure auth-failure healing path

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds stale-penalty healing to recordSuccess: explicit clearAccountCooldown + clearAuthFailures guarded by isCoolingDown, then debounced persist. orphaned-cooldownReason concern from previous review is resolved by the direct clearAccountCooldown call in the hadCooldownMetadata branch. |
| test/accounts.test.ts | three new cases cover: full heal (expired cooldown + auth failures), orphaned-reason-only heal, and active-cooldown guard. minor: post-construction consecutiveAuthFailures mutation in cases 1 and 3 is redundant since the value is already present in stored; no isolated test for auth-failure-only healing with zero cooldown metadata. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[recordSuccess called] --> B[snapshot hadCooldownMetadata\nhadAuthFailures]
    B --> C[isAccountCoolingDown]
    C -->|coolingDownUntil future| D[isCoolingDown = true]
    C -->|coolingDownUntil expired\nside-effect: clearAccountCooldown| E[isCoolingDown = false]
    C -->|coolingDownUntil undefined| E
    D --> F[skip all healing\nhealed = false]
    E --> G{hadCooldownMetadata?}
    G -->|yes| H[clearAccountCooldown\nhealed = true]
    G -->|no| I{hadAuthFailures?}
    H --> I
    I -->|yes| J[clearAuthFailures\nhealed = true]
    I -->|no| K{healed?}
    J --> K
    K -->|yes| L[saveToDiskDebounced]
    K -->|no| M[no persist]
    F --> M
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Faccounts.test.ts%3A1929%0A**redundant%20post-construction%20mutation**%0A%0A%60stored.accounts%5B0%5D.consecutiveAuthFailures%60%20is%20already%20%602%60%2C%20so%20%60AccountManager%60%20will%20deserialize%20that%20value%20onto%20the%20live%20account%20object.%20the%20assignment%20on%20line%201929%20is%20a%20no-op%20and%20could%20mislead%20a%20future%20reader%20into%20thinking%20the%20value%20isn't%20inherited%20from%20storage.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20consecutiveAuthFailures%3A%202%20already%20comes%20from%20stored%20%E2%80%94%20no%20override%20needed%0A%60%60%60%0A%0Asame%20pattern%20appears%20on%20line%202000%20in%20the%20active-cooldown%20test.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/accounts.test.ts
Line: 1929

Comment:
**redundant post-construction mutation**

`stored.accounts[0].consecutiveAuthFailures` is already `2`, so `AccountManager` will deserialize that value onto the live account object. the assignment on line 1929 is a no-op and could mislead a future reader into thinking the value isn't inherited from storage.

```suggestion
      // consecutiveAuthFailures: 2 already comes from stored — no override needed
```

same pattern appears on line 2000 in the active-cooldown test.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: heal stale cooldown metadata on suc..."](https://github.com/ndycode/codex-multi-auth/commit/7f512c39e4fc558e08be4167565247dc600a6dfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26965215)</sub>

<!-- /greptile_comment -->