### PR TITLE
fix: reconcile guardian refresh outcomes by stable identity

### DIFF
--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -25,28 +25,78 @@ export interface RefreshGuardianStats {
 
 const DEFAULT_INTERVAL_MS = 60_000;
 
+function findMatchingLiveAccountIndexes(
+	liveAccounts: ManagedAccount[],
+	predicate: (candidate: ManagedAccount) => boolean,
+): number[] {
+	const matches: number[] = [];
+	for (const [index, candidate] of liveAccounts.entries()) {
+		if (predicate(candidate)) {
+			matches.push(index);
+		}
+	}
+	return matches;
+}
+
 function resolveLiveAccountIndex(
 	liveAccounts: ManagedAccount[],
 	sourceAccount: ManagedAccount,
 ): number {
 	if (sourceAccount.accountId) {
-		const byAccountId = liveAccounts.findIndex(
+		const accountIdMatches = findMatchingLiveAccountIndexes(
+			liveAccounts,
 			(candidate) => candidate.accountId === sourceAccount.accountId,
 		);
-		if (byAccountId >= 0) return byAccountId;
+		const resolvedIndex = accountIdMatches[0];
+		if (resolvedIndex !== undefined) {
+			log.debug("Resolved refreshed account by accountId", {
+				sourceIndex: sourceAccount.index,
+				resolvedIndex,
+				matchCount: accountIdMatches.length,
+			});
+			if (accountIdMatches.length > 1) {
+				log.warn("Duplicate live accountId matches during refresh reconciliation", {
+					sourceIndex: sourceAccount.index,
+					resolvedIndex,
+					matchCount: accountIdMatches.length,
+				});
+			}
+			return resolvedIndex;
+		}
 	}
 
 	const sourceEmail = sanitizeEmail(sourceAccount.email);
 	if (sourceEmail) {
-		const byEmail = liveAccounts.findIndex(
+		const emailMatches = findMatchingLiveAccountIndexes(
+			liveAccounts,
 			(candidate) => sanitizeEmail(candidate.email) === sourceEmail,
 		);
-		if (byEmail >= 0) return byEmail;
+		const resolvedIndex = emailMatches[0];
+		if (resolvedIndex !== undefined) {
+			log.debug("Resolved refreshed account by email", {
+				sourceIndex: sourceAccount.index,
+				resolvedIndex,
+				matchCount: emailMatches.length,
+			});
+			if (emailMatches.length > 1) {
+				log.warn("Duplicate live email matches during refresh reconciliation", {
+					sourceIndex: sourceAccount.index,
+					resolvedIndex,
+					matchCount: emailMatches.length,
+				});
+			}
+			return resolvedIndex;
+		}
 	}
 
-	return liveAccounts.findIndex(
+	const byToken = liveAccounts.findIndex(
 		(candidate) => candidate.refreshToken === sourceAccount.refreshToken,
 	);
+	log.debug("Resolved refreshed account by refresh token fallback", {
+		sourceIndex: sourceAccount.index,
+		resolvedIndex: byToken,
+	});
+	return byToken;
 }
 
 export class RefreshGuardian {
@@ -141,11 +191,11 @@ export class RefreshGuardian {
 			for (const candidate of snapshot) {
 				snapshotByIndex.set(candidate.index, candidate);
 			}
+			const liveAccounts = manager.getAccountsSnapshot();
 
 			for (const [accountIndex, result] of refreshResults.entries()) {
 				const sourceAccount = snapshotByIndex.get(accountIndex);
 				if (!sourceAccount) continue;
-				const liveAccounts = manager.getAccountsSnapshot();
 				const resolvedIndex = resolveLiveAccountIndex(liveAccounts, sourceAccount);
 				const account = resolvedIndex >= 0 ? manager.getAccountByIndex(resolvedIndex) : null;
 				if (!account) continue;

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "./logger.js";
 import { applyRefreshResult, refreshExpiringAccounts } from "./proactive-refresh.js";
-import type { AccountManager } from "./accounts.js";
+import { sanitizeEmail, type AccountManager, type ManagedAccount } from "./accounts.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
 
@@ -24,6 +24,30 @@ export interface RefreshGuardianStats {
 }
 
 const DEFAULT_INTERVAL_MS = 60_000;
+
+function resolveLiveAccountIndex(
+	liveAccounts: ManagedAccount[],
+	sourceAccount: ManagedAccount,
+): number {
+	if (sourceAccount.accountId) {
+		const byAccountId = liveAccounts.findIndex(
+			(candidate) => candidate.accountId === sourceAccount.accountId,
+		);
+		if (byAccountId >= 0) return byAccountId;
+	}
+
+	const sourceEmail = sanitizeEmail(sourceAccount.email);
+	if (sourceEmail) {
+		const byEmail = liveAccounts.findIndex(
+			(candidate) => sanitizeEmail(candidate.email) === sourceEmail,
+		);
+		if (byEmail >= 0) return byEmail;
+	}
+
+	return liveAccounts.findIndex(
+		(candidate) => candidate.refreshToken === sourceAccount.refreshToken,
+	);
+}
 
 export class RefreshGuardian {
 	private readonly getAccountManager: () => AccountManager | null;
@@ -122,9 +146,7 @@ export class RefreshGuardian {
 				const sourceAccount = snapshotByIndex.get(accountIndex);
 				if (!sourceAccount) continue;
 				const liveAccounts = manager.getAccountsSnapshot();
-				const resolvedIndex = liveAccounts.findIndex(
-					(candidate) => candidate.refreshToken === sourceAccount.refreshToken,
-				);
+				const resolvedIndex = resolveLiveAccountIndex(liveAccounts, sourceAccount);
 				const account = resolvedIndex >= 0 ? manager.getAccountByIndex(resolvedIndex) : null;
 				if (!account) continue;
 

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -216,7 +216,7 @@ describe("refresh-guardian", () => {
     expect(tickSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves refreshed account using stable refresh token when indices shift", async () => {
+  it("resolves refreshed account by accountId when indices shift", async () => {
     const originalA = createManagedAccount(0);
     const originalB = createManagedAccount(1);
     const liveB = { ...originalB, index: 0 };
@@ -336,8 +336,73 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledWith(liveA);
   });
 
-  it("falls back to normalized email when accountId is unavailable", async () => {
-    const originalA = { ...createManagedAccount(0), accountId: undefined, email: " User0@Example.com " };
+  it("falls back to refreshToken when accountId is unavailable and email is invalid", async () => {
+    const originalA = {
+      ...createManagedAccount(0),
+      accountId: undefined,
+      email: "invalid-no-at",
+    };
+    const originalB = createManagedAccount(1);
+    const liveA = {
+      ...originalA,
+      index: 1,
+    };
+    const liveB = { ...originalB, index: 0 };
+    const snapshots = [
+      [originalA, originalB],
+      [liveB, liveA],
+    ];
+    let readCount = 0;
+    const manager = {
+      getAccountsSnapshot: vi.fn(
+        () => snapshots[Math.min(readCount++, snapshots.length - 1)],
+      ),
+      getAccountByIndex: vi.fn(
+        (index: number) =>
+          [liveB, liveA].find((account) => account.index === index) ?? null,
+      ),
+      clearAuthFailures: vi.fn(),
+      markAccountCoolingDown: vi.fn(),
+      setAccountEnabled: vi.fn(),
+      saveToDiskDebounced: vi.fn(),
+    } as unknown as AccountManager;
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-token",
+              refresh: "refresh-token",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).toHaveBeenCalledWith(
+      liveA,
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA);
+  });
+
+  it("treats empty string accountId the same as undefined by using normalized email", async () => {
+    const originalA = { ...createManagedAccount(0), accountId: "", email: " User0@Example.com " };
     const originalB = createManagedAccount(1);
     const liveA = {
       ...originalA,
@@ -642,6 +707,9 @@ describe("refresh-guardian", () => {
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
+    expect(
+      manager.getAccountsSnapshot as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledTimes(2);
 
     const stats = guardian.getStats();
     expect(stats.runs).toBe(1);

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -12,6 +12,8 @@ vi.mock("../lib/proactive-refresh.js", () => ({
 function createManagedAccount(index: number): ManagedAccount {
   return {
     index,
+    accountId: `acct-${index}`,
+    email: `user${index}@example.com`,
     refreshToken: `refresh-${index}`,
     addedAt: Date.now() - 10_000,
     lastUsed: Date.now() - 5_000,
@@ -270,6 +272,131 @@ describe("refresh-guardian", () => {
     expect(
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(liveB);
+  });
+
+  it("resolves refreshed account by accountId after refresh token rotation", async () => {
+    const originalA = createManagedAccount(0);
+    const originalB = createManagedAccount(1);
+    const liveA = {
+      ...originalA,
+      index: 1,
+      refreshToken: "refresh-0-rotated",
+    };
+    const liveB = { ...originalB, index: 0 };
+    const snapshots = [
+      [originalA, originalB],
+      [liveB, liveA],
+    ];
+    let readCount = 0;
+    const manager = {
+      getAccountsSnapshot: vi.fn(
+        () => snapshots[Math.min(readCount++, snapshots.length - 1)],
+      ),
+      getAccountByIndex: vi.fn(
+        (index: number) =>
+          [liveB, liveA].find((account) => account.index === index) ?? null,
+      ),
+      clearAuthFailures: vi.fn(),
+      markAccountCoolingDown: vi.fn(),
+      setAccountEnabled: vi.fn(),
+      saveToDiskDebounced: vi.fn(),
+    } as unknown as AccountManager;
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-account-id",
+              refresh: "refresh-account-id",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).toHaveBeenCalledWith(
+      liveA,
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA);
+  });
+
+  it("falls back to normalized email when accountId is unavailable", async () => {
+    const originalA = { ...createManagedAccount(0), accountId: undefined, email: " User0@Example.com " };
+    const originalB = createManagedAccount(1);
+    const liveA = {
+      ...originalA,
+      index: 1,
+      refreshToken: "refresh-0-rotated",
+      email: "user0@example.com",
+    };
+    const liveB = { ...originalB, index: 0 };
+    const snapshots = [
+      [originalA, originalB],
+      [liveB, liveA],
+    ];
+    let readCount = 0;
+    const manager = {
+      getAccountsSnapshot: vi.fn(
+        () => snapshots[Math.min(readCount++, snapshots.length - 1)],
+      ),
+      getAccountByIndex: vi.fn(
+        (index: number) =>
+          [liveB, liveA].find((account) => account.index === index) ?? null,
+      ),
+      clearAuthFailures: vi.fn(),
+      markAccountCoolingDown: vi.fn(),
+      setAccountEnabled: vi.fn(),
+      saveToDiskDebounced: vi.fn(),
+    } as unknown as AccountManager;
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-email",
+              refresh: "refresh-email",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).toHaveBeenCalledWith(
+      liveA,
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA);
   });
 
   it("classifies failure reasons and handles no-op branches", async () => {


### PR DESCRIPTION
## Summary

- reconcile refresh-guardian outcomes against the live account row using stable account identity before falling back to the stored refresh token

## What Changed

- added identity-based live-account resolution in `lib/refresh-guardian.ts` that prefers `accountId`, then normalized email, then refresh token
- kept the existing refresh-token path as the last fallback so index shifts still work
- added regression coverage in `test/refresh-guardian.test.ts` for rotated-refresh-token cases resolved by `accountId` and normalized email

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low; limited to refresh-guardian account reconciliation after proactive refresh results return
- Rollback plan: revert commit `27a0d1e`

## Additional Notes

- targeted test run: `npm test -- test/refresh-guardian.test.ts`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes a real bug: after a proactive refresh completes, the guardian was resolving the live account to update using only the refresh token, which fails when the token was rotated during the refresh. the fix adds a stable-identity lookup chain (`accountId` → normalized email → refresh token fallback) in `resolveLiveAccountIndex`, and hoists the `liveAccounts` snapshot outside the result loop for consistency and efficiency. the logic is sound and fits cleanly into the existing accounts/guardian architecture.

key points:
- `resolveLiveAccountIndex` correctly handles empty-string `accountId` as falsy, delegates email normalization to the existing `sanitizeEmail` helper, and logs a warning on duplicate matches.
- moving `liveAccounts = getAccountsSnapshot()` before the loop is strictly better — the old per-iteration snapshot could observe partial token mutations from earlier iterations; the single snapshot avoids that.
- new tests cover accountId-based resolution after token rotation, empty-accountId → email fallback, and no-accountId/invalid-email → token fallback. the pre-existing index-shift test is correctly renamed to reflect accountId primacy.
- `npm test` (full suite) is unchecked in the pr; only the targeted `test/refresh-guardian.test.ts` run is confirmed. the email-fallback branch when `accountId` is truthy but unmatched in live accounts has no vitest coverage.

<h3>Confidence Score: 5/5</h3>

safe to merge — the fix is targeted, logic is correct, and remaining findings are coverage/documentation gaps only.

no p0/p1 issues found. the two comments are p2: one is a vitest coverage gap for an exotic fallback path, the other is an informational note on snapshot timing. the core bug fix (accountId → email → token chain) is correctly implemented and the key rotation scenario is well-tested.

test/refresh-guardian.test.ts — missing coverage for accountId-truthy-but-unmatched → email-fallback branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/refresh-guardian.ts | adds resolveLiveAccountIndex with accountId → normalized-email → refresh-token fallback chain; hoists liveAccounts snapshot before the loop for consistency and efficiency. logic is sound. |
| test/refresh-guardian.test.ts | adds accountId-rotation, email-fallback (empty/undefined accountId), and token-fallback tests; renames existing index-shift test to reflect accountId primacy. missing coverage for accountId-present-but-unmatched → email-fallback path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tick: take pre-refresh snapshot] --> B[await refreshExpiringAccounts]
    B --> C{any results?}
    C -- no --> D[update stats, return]
    C -- yes --> E[build snapshotByIndex map]
    E --> F[getAccountsSnapshot once → liveAccounts]
    F --> G[for each result entry]
    G --> H{sourceAccount in snapshot?}
    H -- no --> G
    H -- yes --> I[resolveLiveAccountIndex]
    I --> J{accountId truthy?}
    J -- yes --> K[findMatchingLiveAccountIndexes by accountId]
    K --> L{match found?}
    L -- yes --> M[return array position]
    L -- no --> N[try email]
    J -- no --> N
    N --> O{sanitizeEmail valid?}
    O -- yes --> P[findMatchingLiveAccountIndexes by email]
    P --> Q{match found?}
    Q -- yes --> M
    Q -- no --> R[findIndex by refreshToken]
    O -- no --> R
    R --> M
    M --> S[getAccountByIndex resolvedIndex]
    S --> T{account null?}
    T -- yes --> G
    T -- no --> U[apply result / mark cooldown]
    U --> G
    G -- done --> V[saveToDiskDebounced, update stats]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Frefresh-guardian.ts%3A194%0A**snapshot%20now%20shared%20across%20all%20loop%20iterations%20%E2%80%94%20note%20for%20reviewers**%0A%0Amoving%20%60liveAccounts%60%20outside%20the%20loop%20is%20correct%20and%20more%20efficient.%20one%20thing%20to%20be%20aware%20of%3A%20if%20%60applyRefreshResult%60%20updates%20%60refreshToken%60%20on%20the%20live%20account%20object%20in%20%60this.accounts%60%2C%20the%20token-fallback%20path%20of%20%60resolveLiveAccountIndex%60%20for%20a%20*subsequent*%20iteration%20compares%20%60sourceAccount.refreshToken%60%20%28pre-refresh%20snapshot%29%20against%20%60liveAccounts%60%20values%20%28also%20pre-refresh%20snapshot%29.%20this%20is%20actually%20more%20consistent%20than%20the%20old%20per-iteration%20fetch%2C%20since%20it%20avoids%20observing%20partial%20mutation%20mid-loop.%20no%20action%20required%20%E2%80%94%20just%20flagging%20the%20intentional%20trade-off%20so%20it's%20explicit.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Frefresh-guardian.test.ts%3A277-337%0A**missing%20vitest%20path%3A%20accountId%20truthy%20but%20absent%20from%20live%20accounts%20%E2%86%92%20email%20fallback**%0A%0Aall%20three%20new%20tests%20exercise%20the%20email%20path%20only%20when%20%60accountId%60%20is%20falsy%20%28%60undefined%60%20or%20%60%22%22%60%29.%20the%20branch%20where%20%60sourceAccount.accountId%60%20is%20truthy%2C%20%60findMatchingLiveAccountIndexes%60%20returns%20empty%20%28no%20live%20account%20carries%20that%20id%20%E2%80%94%20e.g.%20cleared%20after%20forced%20re-auth%29%2C%20and%20execution%20falls%20through%20to%20the%20email%20matcher%20is%20never%20hit.%0A%0Aa%20test%20covering%3A%20%60sourceAccount%60%20has%20a%20truthy%20%60accountId%60%2C%20no%20live%20account%20matches%20that%20id%2C%20but%20one%20live%20account%20matches%20%60sanitizeEmail%28sourceAccount.email%29%60%2C%20so%20the%20email%20branch%20resolves%20it.%0A%0Awithout%20this%2C%20the%20%60accountId-present-but-unmatched%20%E2%86%92%20email%60%20code%20path%20in%20%60resolveLiveAccountIndex%60%20is%20unreachable%20by%20the%20current%20test%20suite.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/refresh-guardian.ts
Line: 194

Comment:
**snapshot now shared across all loop iterations — note for reviewers**

moving `liveAccounts` outside the loop is correct and more efficient. one thing to be aware of: if `applyRefreshResult` updates `refreshToken` on the live account object in `this.accounts`, the token-fallback path of `resolveLiveAccountIndex` for a *subsequent* iteration compares `sourceAccount.refreshToken` (pre-refresh snapshot) against `liveAccounts` values (also pre-refresh snapshot). this is actually more consistent than the old per-iteration fetch, since it avoids observing partial mutation mid-loop. no action required — just flagging the intentional trade-off so it's explicit.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/refresh-guardian.test.ts
Line: 277-337

Comment:
**missing vitest path: accountId truthy but absent from live accounts → email fallback**

all three new tests exercise the email path only when `accountId` is falsy (`undefined` or `""`). the branch where `sourceAccount.accountId` is truthy, `findMatchingLiveAccountIndexes` returns empty (no live account carries that id — e.g. cleared after forced re-auth), and execution falls through to the email matcher is never hit.

a test covering: `sourceAccount` has a truthy `accountId`, no live account matches that id, but one live account matches `sanitizeEmail(sourceAccount.email)`, so the email branch resolves it.

without this, the `accountId-present-but-unmatched → email` code path in `resolveLiveAccountIndex` is unreachable by the current test suite.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: harden guardian identity reconcilia..."](https://github.com/ndycode/codex-multi-auth/commit/c97350c9235e40ed2df5879e6634bb25c0c9da2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26967903)</sub>

<!-- /greptile_comment -->