### PR TITLE
fix: prefer fresh access tokens during account selection

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -74,6 +74,7 @@ import {
 } from "./accounts/rate-limits.js";
 
 const log = createLogger("accounts");
+const ACCOUNT_SELECTION_FRESH_WINDOW_MS = 5 * 60_000;
 
 function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
 	return Object.fromEntries(
@@ -381,12 +382,45 @@ export class AccountManager {
 		return account ?? null;
 	}
 
+	private hasFreshAccessToken(account: ManagedAccount): boolean {
+		if (!account.access) return false;
+		if (typeof account.expires !== "number" || !Number.isFinite(account.expires)) {
+			return false;
+		}
+		return account.expires > nowMs() + ACCOUNT_SELECTION_FRESH_WINDOW_MS;
+	}
+
+	private isAccountSelectableForFamily(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+		requireFresh = false,
+	): boolean {
+		if (account.enabled === false) return false;
+		clearExpiredRateLimits(account);
+		if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
+			return false;
+		}
+		return !requireFresh || this.hasFreshAccessToken(account);
+	}
+
+	private hasFreshAvailableAccountForFamily(
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		return this.accounts.some(
+			(account) =>
+				Boolean(account) &&
+				this.isAccountSelectableForFamily(account, family, model) &&
+				this.hasFreshAccessToken(account),
+		);
+	}
+
 	isAccountAvailableForFamily(index: number, family: ModelFamily, model?: string | null): boolean {
 		const account = this.getAccountByIndex(index);
 		if (!account) return false;
-		if (account.enabled === false) return false;
-		clearExpiredRateLimits(account);
-		return !isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
+		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
+		return this.isAccountSelectableForFamily(account, family, model, requireFresh);
 	}
 
 	setActiveIndex(index: number): ManagedAccount | null {
@@ -446,15 +480,13 @@ export class AccountManager {
 		if (count === 0) return null;
 
 		const cursor = this.cursorByFamily[family];
+		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
 		
 		for (let i = 0; i < count; i++) {
 			const idx = (cursor + i) % count;
 			const account = this.accounts[idx];
 			if (!account) continue;
-			if (account.enabled === false) continue;
-			
-			clearExpiredRateLimits(account);
-			if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
+			if (!this.isAccountSelectableForFamily(account, family, model, requireFresh)) {
 				continue;
 			}
 			
@@ -472,15 +504,13 @@ export class AccountManager {
 		if (count === 0) return null;
 
 		const cursor = this.cursorByFamily[family];
+		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
 		
 		for (let i = 0; i < count; i++) {
 			const idx = (cursor + i) % count;
 			const account = this.accounts[idx];
 			if (!account) continue;
-			if (account.enabled === false) continue;
-			
-			clearExpiredRateLimits(account);
-			if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
+			if (!this.isAccountSelectableForFamily(account, family, model, requireFresh)) {
 				continue;
 			}
 			
@@ -495,6 +525,7 @@ export class AccountManager {
 	getCurrentOrNextForFamilyHybrid(family: ModelFamily, model?: string | null, options?: HybridSelectionOptions): ManagedAccount | null {
 		const count = this.accounts.length;
 		if (count === 0) return null;
+		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
 
 		const currentIndex = this.currentAccountIndexByFamily[family];
 		if (currentIndex >= 0 && currentIndex < count) {
@@ -503,10 +534,13 @@ export class AccountManager {
 				if (currentAccount.enabled === false) {
 					// Fall through to hybrid selection.
 				} else {
-				clearExpiredRateLimits(currentAccount);
 				if (
-					!isRateLimitedForFamily(currentAccount, family, model) &&
-					!this.isAccountCoolingDown(currentAccount)
+					this.isAccountSelectableForFamily(
+						currentAccount,
+						family,
+						model,
+						requireFresh,
+					)
 				) {
 					currentAccount.lastUsed = nowMs();
 					return currentAccount;
@@ -522,13 +556,14 @@ export class AccountManager {
 		const accountsWithMetrics: AccountWithMetrics[] = this.accounts
 			.map((account): AccountWithMetrics | null => {
 				if (!account) return null;
-				if (account.enabled === false) return null;
-				clearExpiredRateLimits(account);
-				const isAvailable =
-					!isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
 				return {
 					index: account.index,
-					isAvailable,
+					isAvailable: this.isAccountSelectableForFamily(
+						account,
+						family,
+						model,
+						requireFresh,
+					),
 					lastUsed: account.lastUsed,
 				};
 			})

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -253,4 +253,31 @@ describe("AccountManager loadFromDisk", () => {
 
     expect(manager.getNextForFamily("codex")).toBeNull();
   });
+
+  it("getNextForFamily falls back to stale accounts when no fresh option exists", () => {
+    const now = Date.now();
+    const manager = new AccountManager(undefined, {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        {
+          refreshToken: "stale-1",
+          accessToken: "access-1",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "stale-2",
+          accessToken: "access-2",
+          expiresAt: now + 120_000,
+          addedAt: now,
+          lastUsed: now - 5_000,
+        },
+      ],
+    } as never);
+
+    const selected = manager.getNextForFamily("codex");
+    expect(selected?.refreshToken).toBe("stale-1");
+  });
 });

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -280,4 +280,32 @@ describe("AccountManager loadFromDisk", () => {
     const selected = manager.getNextForFamily("codex");
     expect(selected?.refreshToken).toBe("stale-1");
   });
+
+  it("getNextForFamily prefers a fresh account when one is available", () => {
+    const now = Date.now();
+    const manager = new AccountManager(undefined, {
+      version: 3 as const,
+      activeIndex: 0,
+      activeIndexByFamily: { codex: 0 },
+      accounts: [
+        {
+          refreshToken: "stale-1",
+          accessToken: "access-1",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "token-fresh",
+          accessToken: "access-fresh",
+          expiresAt: now + 10 * 60_000,
+          addedAt: now,
+          lastUsed: now - 5_000,
+        },
+      ],
+    } as never);
+
+    const selected = manager.getNextForFamily("codex");
+    expect(selected?.refreshToken).toBe("token-fresh");
+  });
 });

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -406,6 +406,62 @@ describe("AccountManager", () => {
     expect(account?.rateLimitResetTimes?.codex).toBeUndefined();
   });
 
+  it("prefers accounts with fresh access tokens in availability checks", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        {
+          refreshToken: "token-stale",
+          accessToken: "access-stale",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "token-fresh",
+          accessToken: "access-fresh",
+          expiresAt: now + 10 * 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+      ],
+    };
+    const manager = new AccountManager(undefined, stored);
+
+    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
+    expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
+  });
+
+  it("keeps stale accounts available when the whole pool is stale", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        {
+          refreshToken: "token-stale-1",
+          accessToken: "access-stale-1",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "token-stale-2",
+          accessToken: "access-stale-2",
+          expiresAt: now + 120_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+      ],
+    };
+    const manager = new AccountManager(undefined, stored);
+
+    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
+    expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
+  });
+
   it("rotates when the active account is rate-limited", () => {
     const now = Date.now();
     const stored = {
@@ -612,6 +668,36 @@ describe("AccountManager", () => {
     expect(gpt51First?.refreshToken).toBe("token-1");
     expect(codexSecond?.refreshToken).toBe("token-2");
     expect(gpt51Second?.refreshToken).toBe("token-2");
+  });
+
+  it("skips a stale active account when a fresher account is available", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      activeIndexByFamily: { codex: 0 },
+      accounts: [
+        {
+          refreshToken: "token-stale",
+          accessToken: "access-stale",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "token-fresh",
+          accessToken: "access-fresh",
+          expiresAt: now + 10 * 60_000,
+          addedAt: now,
+          lastUsed: now - 5_000,
+        },
+      ],
+    };
+
+    const manager = new AccountManager(undefined, stored as never);
+    const selected = manager.getCurrentOrNextForFamily("codex");
+
+    expect(selected?.refreshToken).toBe("token-fresh");
   });
 
   it("hybrid selection prefers active index when available", () => {
@@ -2083,6 +2169,37 @@ describe("AccountManager", () => {
       
       const secondCall = manager.getCurrentOrNextForFamilyHybrid("codex");
       expect(secondCall?.index).toBe(selected?.index);
+    });
+
+    it("prefers a fresh alternate account over a stale current account", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        activeIndexByFamily: { codex: 0 },
+        accounts: [
+          {
+            refreshToken: "token-stale",
+            accessToken: "access-stale",
+            expiresAt: now + 60_000,
+            addedAt: now,
+            lastUsed: now,
+          },
+          {
+            refreshToken: "token-fresh",
+            accessToken: "access-fresh",
+            expiresAt: now + 10 * 60_000,
+            addedAt: now,
+            lastUsed: now - 5_000,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored as never);
+      const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
+
+      expect(selected?.refreshToken).toBe("token-fresh");
+      expect(selected?.index).toBe(1);
     });
 
     it("falls back to least-recently-used when all accounts are rate-limited", () => {


### PR DESCRIPTION
## Summary

- prefer accounts with sufficiently fresh access tokens during runtime selection, while still falling back to stale accounts when the whole pool needs refresh recovery

## What Changed

- added fresh-token-aware selection helpers in `lib/accounts.ts` using a five-minute freshness window
- updated the standard and hybrid family selectors to prioritize fresh accounts when any are available
- kept stale accounts selectable as the fallback path when every available account is near expiry
- added regression coverage in `test/accounts.test.ts` and `test/accounts-load-from-disk.test.ts` for fresh-preference and all-stale fallback behavior

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: moderate; touches request-time account selection, but preserves stale-token fallback when no fresh alternative exists
- Rollback plan: revert commit `66d2d63`

## Additional Notes

- targeted test run: `npm test -- test/accounts.test.ts test/accounts-load-from-disk.test.ts`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr adds fresh-token-aware account selection across all four selection paths (`isAccountAvailableForFamily`, `getCurrentOrNextForFamily`, `getNextForFamily`, `getCurrentOrNextForFamilyHybrid`) using a 5-minute freshness window, with a stale-account fallback when the whole pool is near expiry. the refactor also extracts `isAccountSelectableForFamily` to deduplicate the enabled/rate-limit/cooldown checks.

- `hasFreshAccessToken` and `hasFreshAvailableAccountForFamily` correctly gate fresh preference; the stale-fallback behavior (all accounts stale → allow all) is tested and working
- **P1**: the `accountsWithMetrics` mapping in `getCurrentOrNextForFamilyHybrid` no longer filters `enabled === false` accounts — they're now included with `isAvailable: false`. `selectHybridAccount`'s LRU fallback iterates the full array, so a disabled account can be returned when every other account is rate-limited/cooling down. the old `if (account.enabled === false) return null;` guard must be restored
- test coverage for the new paths is good; the `getNextForFamily` fresh-preference case (previously flagged) is now covered in `accounts-load-from-disk.test.ts`
- `npm test` is unchecked in the validation checklist — full suite should be confirmed green before merge given the scope of the change

<h3>Confidence Score: 4/5</h3>

safe to merge after fixing the disabled-account LRU regression in the hybrid selector

one confirmed P1 regression: disabled accounts are no longer filtered from the accountsWithMetrics array, making them selectable by the LRU fallback path in selectHybridAccount when all enabled accounts are unavailable; the fix is a one-line restore of the existing guard

lib/accounts.ts lines 556-570 (accountsWithMetrics map in getCurrentOrNextForFamilyHybrid)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds fresh-token helpers and wires them into all four selection paths; P1 regression: disabled accounts are no longer filtered from accountsWithMetrics, making them eligible for the LRU fallback in getCurrentOrNextForFamilyHybrid |
| test/accounts.test.ts | adds four new test cases covering fresh-preference and all-stale fallback for isAccountAvailableForFamily, getCurrentOrNextForFamily, and getCurrentOrNextForFamilyHybrid; coverage looks solid for the new paths |
| test/accounts-load-from-disk.test.ts | adds stale-fallback and fresh-preference tests for getNextForFamily loaded from a disk-like storage object; addresses the previously flagged coverage gap |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[selection request] --> B[hasFreshAvailableAccountForFamily\nscan all accounts]
    B -->|any fresh+available| C[requireFresh = true]
    B -->|none fresh or available| D[requireFresh = false]
    C --> E[isAccountSelectableForFamily\nenabled? not rate-limited? not cooling?\nand hasFreshAccessToken?]
    D --> F[isAccountSelectableForFamily\nenabled? not rate-limited? not cooling?]
    E -->|pass| G[return account]
    F -->|pass| G
    E -->|fail for all| H{selection path}
    F -->|fail for all| H
    H -->|getCurrentOrNextForFamily\ngetNextForFamily| I[return null]
    H -->|getCurrentOrNextForFamilyHybrid| J[selectHybridAccount LRU fallback]
    J -->|OLD: disabled accounts filtered out| K[safe LRU pick]
    J -->|NEW: disabled accounts included with isAvailable=false| L[⚠️ may return disabled account]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `index.ts`, line 1914-1926 ([link](https://github.com/ndycode/codex-multi-auth/blob/66d2d63704a10b697c7bbbd1833db1feb2e602bd/index.ts#L1914-L1926)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **O(N²) scan in stream-failover loop**

   `isAccountAvailableForFamily` now does a full O(N) pool scan (via `hasFreshAvailableAccountForFamily`) on every call. the caller at line 1914 is already a loop over `streamFallbackCandidateOrder`, so each failover event now scans the entire account pool once per candidate. for a large pool this degrades unnecessarily.

   pre-compute `requireFresh` once before the loop — or expose a batch-availability helper — to restore O(N) total cost:

   ```typescript
   // before the loop:
   const requireFresh = accountManager.hasFreshAvailableAccountForFamily(modelFamily, model);
   // then in the loop, pass requireFresh through to the check
   ```

   this mirrors the pattern already used inside `getCurrentOrNextForFamily` and the other internal selectors.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: index.ts
   Line: 1914-1926

   Comment:
   **O(N²) scan in stream-failover loop**

   `isAccountAvailableForFamily` now does a full O(N) pool scan (via `hasFreshAvailableAccountForFamily`) on every call. the caller at line 1914 is already a loop over `streamFallbackCandidateOrder`, so each failover event now scans the entire account pool once per candidate. for a large pool this degrades unnecessarily.

   pre-compute `requireFresh` once before the loop — or expose a batch-availability helper — to restore O(N) total cost:

   ```typescript
   // before the loop:
   const requireFresh = accountManager.hasFreshAvailableAccountForFamily(modelFamily, model);
   // then in the loop, pass requireFresh through to the check
   ```

   this mirrors the pattern already used inside `getCurrentOrNextForFamily` and the other internal selectors.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20index.ts%0ALine%3A%201914-1926%0A%0AComment%3A%0A**O%28N%C2%B2%29%20scan%20in%20stream-failover%20loop**%0A%0A%60isAccountAvailableForFamily%60%20now%20does%20a%20full%20O%28N%29%20pool%20scan%20%28via%20%60hasFreshAvailableAccountForFamily%60%29%20on%20every%20call.%20the%20caller%20at%20line%201914%20is%20already%20a%20loop%20over%20%60streamFallbackCandidateOrder%60%2C%20so%20each%20failover%20event%20now%20scans%20the%20entire%20account%20pool%20once%20per%20candidate.%20for%20a%20large%20pool%20this%20degrades%20unnecessarily.%0A%0Apre-compute%20%60requireFresh%60%20once%20before%20the%20loop%20%E2%80%94%20or%20expose%20a%20batch-availability%20helper%20%E2%80%94%20to%20restore%20O%28N%29%20total%20cost%3A%0A%0A%60%60%60typescript%0A%2F%2F%20before%20the%20loop%3A%0Aconst%20requireFresh%20%3D%20accountManager.hasFreshAvailableAccountForFamily%28modelFamily%2C%20model%29%3B%0A%2F%2F%20then%20in%20the%20loop%2C%20pass%20requireFresh%20through%20to%20the%20check%0A%60%60%60%0A%0Athis%20mirrors%20the%20pattern%20already%20used%20inside%20%60getCurrentOrNextForFamily%60%20and%20the%20other%20internal%20selectors.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

2. `lib/accounts.ts`, line 556-570 ([link](https://github.com/ndycode/codex-multi-auth/blob/9b6b8248909ff5d5ae80b862554283390175e358/lib/accounts.ts#L556-L570)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **disabled accounts leak into hybrid LRU fallback**

   the old code had `if (account.enabled === false) return null;` in the `accountsWithMetrics` map, which filtered disabled accounts out entirely. the new code removes that guard and instead relies on `isAccountSelectableForFamily` returning `false`, but that only sets `isAvailable: false` — the account still stays in the `accountsWithMetrics` array.

   in `selectHybridAccount` the LRU fallback path (`if (available.length === 0)`) iterates the **full `resolvedAccounts` array**, not just the available slice. so when every non-disabled account is rate-limited or cooling down, a disabled account can be returned from `selectHybridAccount`, and `getCurrentOrNextForFamilyHybrid` returns it without any `enabled` check.

   fix: restore the early-return null for disabled accounts so they're excluded from the array:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/accounts.ts
   Line: 556-570

   Comment:
   **disabled accounts leak into hybrid LRU fallback**

   the old code had `if (account.enabled === false) return null;` in the `accountsWithMetrics` map, which filtered disabled accounts out entirely. the new code removes that guard and instead relies on `isAccountSelectableForFamily` returning `false`, but that only sets `isAvailable: false` — the account still stays in the `accountsWithMetrics` array.

   in `selectHybridAccount` the LRU fallback path (`if (available.length === 0)`) iterates the **full `resolvedAccounts` array**, not just the available slice. so when every non-disabled account is rate-limited or cooling down, a disabled account can be returned from `selectHybridAccount`, and `getCurrentOrNextForFamilyHybrid` returns it without any `enabled` check.

   fix: restore the early-return null for disabled accounts so they're excluded from the array:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Faccounts.ts%0ALine%3A%20556-570%0A%0AComment%3A%0A**disabled%20accounts%20leak%20into%20hybrid%20LRU%20fallback**%0A%0Athe%20old%20code%20had%20%60if%20%28account.enabled%20%3D%3D%3D%20false%29%20return%20null%3B%60%20in%20the%20%60accountsWithMetrics%60%20map%2C%20which%20filtered%20disabled%20accounts%20out%20entirely.%20the%20new%20code%20removes%20that%20guard%20and%20instead%20relies%20on%20%60isAccountSelectableForFamily%60%20returning%20%60false%60%2C%20but%20that%20only%20sets%20%60isAvailable%3A%20false%60%20%E2%80%94%20the%20account%20still%20stays%20in%20the%20%60accountsWithMetrics%60%20array.%0A%0Ain%20%60selectHybridAccount%60%20the%20LRU%20fallback%20path%20%28%60if%20%28available.length%20%3D%3D%3D%200%29%60%29%20iterates%20the%20**full%20%60resolvedAccounts%60%20array**%2C%20not%20just%20the%20available%20slice.%20so%20when%20every%20non-disabled%20account%20is%20rate-limited%20or%20cooling%20down%2C%20a%20disabled%20account%20can%20be%20returned%20from%20%60selectHybridAccount%60%2C%20and%20%60getCurrentOrNextForFamilyHybrid%60%20returns%20it%20without%20any%20%60enabled%60%20check.%0A%0Afix%3A%20restore%20the%20early-return%20null%20for%20disabled%20accounts%20so%20they're%20excluded%20from%20the%20array%3A%0A%0A%60%60%60suggestion%0A%09%09const%20accountsWithMetrics%3A%20AccountWithMetrics%5B%5D%20%3D%20this.accounts%0A%09%09%09.map%28%28account%29%3A%20AccountWithMetrics%20%7C%20null%20%3D%3E%20%7B%0A%09%09%09%09if%20%28!account%29%20return%20null%3B%0A%09%09%09%09if%20%28account.enabled%20%3D%3D%3D%20false%29%20return%20null%3B%0A%09%09%09%09return%20%7B%0A%09%09%09%09%09index%3A%20account.index%2C%0A%09%09%09%09%09isAvailable%3A%20this.isAccountSelectableForFamily%28%0A%09%09%09%09%09%09account%2C%0A%09%09%09%09%09%09family%2C%0A%09%09%09%09%09%09model%2C%0A%09%09%09%09%09%09requireFresh%2C%0A%09%09%09%09%09%29%2C%0A%09%09%09%09%09lastUsed%3A%20account.lastUsed%2C%0A%09%09%09%09%7D%3B%0A%09%09%09%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Faccounts.ts%3A556-570%0A**disabled%20accounts%20leak%20into%20hybrid%20LRU%20fallback**%0A%0Athe%20old%20code%20had%20%60if%20%28account.enabled%20%3D%3D%3D%20false%29%20return%20null%3B%60%20in%20the%20%60accountsWithMetrics%60%20map%2C%20which%20filtered%20disabled%20accounts%20out%20entirely.%20the%20new%20code%20removes%20that%20guard%20and%20instead%20relies%20on%20%60isAccountSelectableForFamily%60%20returning%20%60false%60%2C%20but%20that%20only%20sets%20%60isAvailable%3A%20false%60%20%E2%80%94%20the%20account%20still%20stays%20in%20the%20%60accountsWithMetrics%60%20array.%0A%0Ain%20%60selectHybridAccount%60%20the%20LRU%20fallback%20path%20%28%60if%20%28available.length%20%3D%3D%3D%200%29%60%29%20iterates%20the%20**full%20%60resolvedAccounts%60%20array**%2C%20not%20just%20the%20available%20slice.%20so%20when%20every%20non-disabled%20account%20is%20rate-limited%20or%20cooling%20down%2C%20a%20disabled%20account%20can%20be%20returned%20from%20%60selectHybridAccount%60%2C%20and%20%60getCurrentOrNextForFamilyHybrid%60%20returns%20it%20without%20any%20%60enabled%60%20check.%0A%0Afix%3A%20restore%20the%20early-return%20null%20for%20disabled%20accounts%20so%20they're%20excluded%20from%20the%20array%3A%0A%0A%60%60%60suggestion%0A%09%09const%20accountsWithMetrics%3A%20AccountWithMetrics%5B%5D%20%3D%20this.accounts%0A%09%09%09.map%28%28account%29%3A%20AccountWithMetrics%20%7C%20null%20%3D%3E%20%7B%0A%09%09%09%09if%20%28!account%29%20return%20null%3B%0A%09%09%09%09if%20%28account.enabled%20%3D%3D%3D%20false%29%20return%20null%3B%0A%09%09%09%09return%20%7B%0A%09%09%09%09%09index%3A%20account.index%2C%0A%09%09%09%09%09isAvailable%3A%20this.isAccountSelectableForFamily%28%0A%09%09%09%09%09%09account%2C%0A%09%09%09%09%09%09family%2C%0A%09%09%09%09%09%09model%2C%0A%09%09%09%09%09%09requireFresh%2C%0A%09%09%09%09%09%29%2C%0A%09%09%09%09%09lastUsed%3A%20account.lastUsed%2C%0A%09%09%09%09%7D%3B%0A%09%09%09%7D%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Faccounts.ts%3A419-424%0A**O%28n%29%20scan%20per%20index%20check**%0A%0A%60isAccountAvailableForFamily%60%20now%20calls%20%60hasFreshAvailableAccountForFamily%60%20on%20every%20invocation%2C%20which%20walks%20all%20accounts%20and%20calls%20%60isAccountSelectableForFamily%60%20%28including%20%60clearExpiredRateLimits%60%29%20for%20each%20one.%20callers%20that%20check%20every%20index%20in%20a%20loop%20%E2%80%94%20e.g.%20a%20UI%20list%20render%20%E2%80%94%20will%20hit%20O%28n%C2%B2%29%20work.%20for%20small%20pools%20this%20is%20fine%2C%20but%20worth%20caching%20%60requireFresh%60%20at%20the%20call%20site%20or%20lifting%20the%20scan%20up%20to%20where%20all%20indexes%20are%20iterated%20together.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/accounts.ts
Line: 556-570

Comment:
**disabled accounts leak into hybrid LRU fallback**

the old code had `if (account.enabled === false) return null;` in the `accountsWithMetrics` map, which filtered disabled accounts out entirely. the new code removes that guard and instead relies on `isAccountSelectableForFamily` returning `false`, but that only sets `isAvailable: false` — the account still stays in the `accountsWithMetrics` array.

in `selectHybridAccount` the LRU fallback path (`if (available.length === 0)`) iterates the **full `resolvedAccounts` array**, not just the available slice. so when every non-disabled account is rate-limited or cooling down, a disabled account can be returned from `selectHybridAccount`, and `getCurrentOrNextForFamilyHybrid` returns it without any `enabled` check.

fix: restore the early-return null for disabled accounts so they're excluded from the array:

```suggestion
		const accountsWithMetrics: AccountWithMetrics[] = this.accounts
			.map((account): AccountWithMetrics | null => {
				if (!account) return null;
				if (account.enabled === false) return null;
				return {
					index: account.index,
					isAvailable: this.isAccountSelectableForFamily(
						account,
						family,
						model,
						requireFresh,
					),
					lastUsed: account.lastUsed,
				};
			})
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts.ts
Line: 419-424

Comment:
**O(n) scan per index check**

`isAccountAvailableForFamily` now calls `hasFreshAvailableAccountForFamily` on every invocation, which walks all accounts and calls `isAccountSelectableForFamily` (including `clearExpiredRateLimits`) for each one. callers that check every index in a loop — e.g. a UI list render — will hit O(n²) work. for small pools this is fine, but worth caching `requireFresh` at the call site or lifting the scan up to where all indexes are iterated together.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover fresh family selection happy..."](https://github.com/ndycode/codex-multi-auth/commit/9b6b8248909ff5d5ae80b862554283390175e358) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26968185)</sub>

<!-- /greptile_comment -->