### PR TITLE
fix: persist refreshed live-probe tokens in forecast commands

### DIFF
--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -2325,6 +2325,7 @@ async function runForecast(args: string[]): Promise<number> {
 	return runForecastCommand(args, {
 		setStoragePath,
 		loadAccounts,
+		saveAccounts,
 		loadDashboardDisplaySettings,
 		resolveActiveIndex,
 		loadQuotaCache,
@@ -3221,6 +3222,7 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 			setStoragePath,
 			getStoragePath,
 			loadAccounts,
+			saveAccounts,
 			resolveActiveIndex,
 			queuedRefresh,
 			fetchCodexQuotaSnapshot,

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -1,4 +1,5 @@
 import type { DashboardDisplaySettings } from "../../dashboard-settings.js";
+import { extractAccountEmail, sanitizeEmail } from "../../accounts.js";
 import {
 	buildForecastExplanation,
 	type ForecastAccountResult,
@@ -29,6 +30,7 @@ type QuotaEmailFallbackState = ReadonlyMap<
 export interface ForecastCommandDeps {
 	setStoragePath: (path: string | null) => void;
 	loadAccounts: () => Promise<AccountStorageV3 | null>;
+	saveAccounts: (storage: AccountStorageV3) => Promise<void>;
 	loadDashboardDisplaySettings?: () => Promise<DashboardDisplaySettings>;
 	resolveActiveIndex: (storage: AccountStorageV3, family?: "codex") => number;
 	loadQuotaCache: () => Promise<QuotaCacheData | null>;
@@ -266,6 +268,7 @@ export async function runForecastCommand(
 	const refreshFailures = new Map<number, TokenFailure>();
 	const liveQuotaByIndex = new Map<number, CodexQuotaSnapshot>();
 	const probeErrors: string[] = [];
+	let storageChanged = false;
 
 	for (let i = 0; i < storage.accounts.length; i += 1) {
 		const account = storage.accounts[i];
@@ -287,9 +290,34 @@ export async function runForecastCommand(
 				});
 				continue;
 			}
+			const refreshedEmail = sanitizeEmail(
+				extractAccountEmail(refreshResult.access, refreshResult.idToken),
+			);
+			const refreshedAccountId = deps.extractAccountId(refreshResult.access);
+			const previousRefreshToken = account.refreshToken;
+			const previousAccessToken = account.accessToken;
+			const previousExpiresAt = account.expiresAt;
+			const previousEmail = account.email;
+			const previousAccountId = account.accountId;
+			const previousAccountIdSource = account.accountIdSource;
+			account.refreshToken = refreshResult.refresh;
+			account.accessToken = refreshResult.access;
+			account.expiresAt = refreshResult.expires;
+			if (refreshedEmail) account.email = refreshedEmail;
+			if (refreshedAccountId) {
+				account.accountId = refreshedAccountId;
+				account.accountIdSource = "token";
+			}
+			storageChanged =
+				storageChanged ||
+				previousRefreshToken !== account.refreshToken ||
+				previousAccessToken !== account.accessToken ||
+				previousExpiresAt !== account.expiresAt ||
+				previousEmail !== account.email ||
+				previousAccountId !== account.accountId ||
+				previousAccountIdSource !== account.accountIdSource;
 			probeAccessToken = refreshResult.access;
-			probeAccountId =
-				account.accountId ?? deps.extractAccountId(refreshResult.access);
+			probeAccountId = account.accountId ?? refreshedAccountId;
 		}
 
 		if (!probeAccessToken || !probeAccountId) {
@@ -326,6 +354,10 @@ export async function runForecastCommand(
 			);
 			probeErrors.push(`${deps.formatAccountLabel(account, i)}: ${message}`);
 		}
+	}
+
+	if (options.live && storageChanged) {
+		await deps.saveAccounts(storage);
 	}
 
 	const forecastInputs = storage.accounts.map((account, index) => ({

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -7,7 +7,11 @@ import {
 import type { QuotaCacheData } from "../../quota-cache.js";
 import type { CodexQuotaSnapshot } from "../../quota-probe.js";
 import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
-import type { AccountMetadataV3, AccountStorageV3 } from "../../storage.js";
+import {
+	findMatchingAccountIndex,
+	type AccountMetadataV3,
+	type AccountStorageV3,
+} from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 import { sleep } from "../../utils.js";
 
@@ -128,6 +132,57 @@ async function saveAccountsWithRetry(
 			await sleep(10 * 2 ** attempt);
 		}
 	}
+}
+
+type AccountIdentityMatch = Pick<AccountMetadataV3, "accountId" | "email" | "refreshToken">;
+type RefreshedAccountPatch = Pick<
+	AccountMetadataV3,
+	"refreshToken" | "accessToken" | "expiresAt"
+> & {
+	email?: AccountMetadataV3["email"];
+	accountId?: AccountMetadataV3["accountId"];
+	accountIdSource?: AccountMetadataV3["accountIdSource"];
+};
+
+function applyRefreshedAccountPatch(
+	account: AccountMetadataV3,
+	patch: RefreshedAccountPatch,
+): void {
+	account.refreshToken = patch.refreshToken;
+	account.accessToken = patch.accessToken;
+	account.expiresAt = patch.expiresAt;
+	if (patch.email) account.email = patch.email;
+	if (patch.accountId) {
+		account.accountId = patch.accountId;
+		account.accountIdSource = patch.accountIdSource;
+	}
+}
+
+async function persistRefreshedAccountPatch(
+	storage: AccountStorageV3,
+	accountMatch: AccountIdentityMatch,
+	patch: RefreshedAccountPatch,
+	loadAccounts: ForecastCommandDeps["loadAccounts"],
+	saveAccounts: ForecastCommandDeps["saveAccounts"],
+): Promise<void> {
+	const latestStorage = (await loadAccounts()) ?? storage;
+	const nextStorage = structuredClone(latestStorage);
+	const targetIndex =
+		findMatchingAccountIndex(nextStorage.accounts, accountMatch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		}) ??
+		findMatchingAccountIndex(nextStorage.accounts, patch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		});
+	if (targetIndex === undefined) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	const targetAccount = nextStorage.accounts[targetIndex];
+	if (!targetAccount) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	applyRefreshedAccountPatch(targetAccount, patch);
+	await saveAccountsWithRetry(nextStorage, saveAccounts);
 }
 
 function joinStyledSegments(
@@ -323,27 +378,41 @@ export async function runForecastCommand(
 			const previousExpiresAt = account.expiresAt;
 			const previousEmail = account.email;
 			const previousAccountId = account.accountId;
-			const previousAccountIdSource = account.accountIdSource;
-			account.refreshToken = refreshResult.refresh;
-			account.accessToken = refreshResult.access;
-			account.expiresAt = refreshResult.expires;
-			if (refreshedEmail) account.email = refreshedEmail;
-			if (refreshedAccountId) {
-				account.accountId = refreshedAccountId;
-				account.accountIdSource = "token";
+			const refreshPatch: RefreshedAccountPatch = {
+				refreshToken: refreshResult.refresh,
+				accessToken: refreshResult.access,
+				expiresAt: refreshResult.expires,
+			};
+			if (refreshedEmail) {
+				refreshPatch.email = refreshedEmail;
 			}
-			const refreshedStorageChanged =
-				previousRefreshToken !== account.refreshToken ||
-				previousAccessToken !== account.accessToken ||
-				previousExpiresAt !== account.expiresAt ||
-				previousEmail !== account.email ||
-				previousAccountId !== account.accountId ||
-				previousAccountIdSource !== account.accountIdSource;
+			if (refreshedAccountId) {
+				refreshPatch.accountId = refreshedAccountId;
+				refreshPatch.accountIdSource = "token";
+			}
+			const accountMatch: AccountIdentityMatch = {
+				refreshToken: previousRefreshToken,
+				email: previousEmail,
+				accountId: previousAccountId,
+			};
+			applyRefreshedAccountPatch(account, refreshPatch);
 			probeAccessToken = refreshResult.access;
 			probeAccountId = account.accountId ?? refreshedAccountId;
-			if (refreshedStorageChanged) {
+			if (
+				previousRefreshToken !== refreshPatch.refreshToken ||
+				previousAccessToken !== refreshPatch.accessToken ||
+				previousExpiresAt !== refreshPatch.expiresAt ||
+				previousEmail !== account.email ||
+				previousAccountId !== account.accountId
+			) {
 				try {
-					await saveAccountsWithRetry(storage, deps.saveAccounts);
+					await persistRefreshedAccountPatch(
+						storage,
+						accountMatch,
+						refreshPatch,
+						deps.loadAccounts,
+						deps.saveAccounts,
+					);
 				} catch (error) {
 					const message = deps.normalizeFailureDetail(
 						error instanceof Error ? error.message : String(error),

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -9,6 +9,7 @@ import type { CodexQuotaSnapshot } from "../../quota-probe.js";
 import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
 import type { AccountMetadataV3, AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
+import { sleep } from "../../utils.js";
 
 interface ForecastCliOptions {
 	live: boolean;
@@ -26,6 +27,8 @@ type QuotaEmailFallbackState = ReadonlyMap<
 	string,
 	{ matchingCount: number; distinctAccountIds: Set<string> }
 >;
+
+const RETRYABLE_STORAGE_WRITE_CODES = new Set(["EBUSY", "EPERM"]);
 
 export interface ForecastCommandDeps {
 	setStoragePath: (path: string | null) => void;
@@ -103,6 +106,28 @@ export interface ForecastCommandDeps {
 	logInfo?: (message: string) => void;
 	logError?: (message: string) => void;
 	getNow?: () => number;
+}
+
+function isRetryableStorageWriteError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_STORAGE_WRITE_CODES.has(code);
+}
+
+async function saveAccountsWithRetry(
+	storage: AccountStorageV3,
+	saveAccounts: ForecastCommandDeps["saveAccounts"],
+): Promise<void> {
+	for (let attempt = 0; ; attempt += 1) {
+		try {
+			await saveAccounts(storage);
+			return;
+		} catch (error) {
+			if (!isRetryableStorageWriteError(error) || attempt >= 3) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
 }
 
 function joinStyledSegments(
@@ -268,7 +293,6 @@ export async function runForecastCommand(
 	const refreshFailures = new Map<number, TokenFailure>();
 	const liveQuotaByIndex = new Map<number, CodexQuotaSnapshot>();
 	const probeErrors: string[] = [];
-	let storageChanged = false;
 
 	for (let i = 0; i < storage.accounts.length; i += 1) {
 		const account = storage.accounts[i];
@@ -308,8 +332,7 @@ export async function runForecastCommand(
 				account.accountId = refreshedAccountId;
 				account.accountIdSource = "token";
 			}
-			storageChanged =
-				storageChanged ||
+			const refreshedStorageChanged =
 				previousRefreshToken !== account.refreshToken ||
 				previousAccessToken !== account.accessToken ||
 				previousExpiresAt !== account.expiresAt ||
@@ -318,6 +341,18 @@ export async function runForecastCommand(
 				previousAccountIdSource !== account.accountIdSource;
 			probeAccessToken = refreshResult.access;
 			probeAccountId = account.accountId ?? refreshedAccountId;
+			if (refreshedStorageChanged) {
+				try {
+					await saveAccountsWithRetry(storage, deps.saveAccounts);
+				} catch (error) {
+					const message = deps.normalizeFailureDetail(
+						error instanceof Error ? error.message : String(error),
+						undefined,
+					);
+					probeErrors.push(`${deps.formatAccountLabel(account, i)}: ${message}`);
+					continue;
+				}
+			}
 		}
 
 		if (!probeAccessToken || !probeAccountId) {
@@ -354,10 +389,6 @@ export async function runForecastCommand(
 			);
 			probeErrors.push(`${deps.formatAccountLabel(account, i)}: ${message}`);
 		}
-	}
-
-	if (options.live && storageChanged) {
-		await deps.saveAccounts(storage);
 	}
 
 	const forecastInputs = storage.accounts.map((account, index) => ({

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -251,6 +251,23 @@ async function defaultWriteFile(path: string, contents: string): Promise<void> {
 	}
 }
 
+async function saveAccountsWithRetry(
+	storage: AccountStorageV3,
+	saveAccounts: ReportCommandDeps["saveAccounts"],
+): Promise<void> {
+	for (let attempt = 0; ; attempt += 1) {
+		try {
+			await saveAccounts(storage);
+			return;
+		} catch (error) {
+			if (!isRetryableWriteError(error) || attempt >= 3) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+}
+
 export async function runReportCommand(
 	args: string[],
 	deps: ReportCommandDeps,
@@ -281,7 +298,6 @@ export async function runReportCommand(
 	const refreshFailures = new Map<number, TokenFailure>();
 	const liveQuotaByIndex = new Map<number, CodexQuotaSnapshot>();
 	const probeErrors: string[] = [];
-	let storageChanged = false;
 
 	if (storage && options.live) {
 		for (let i = 0; i < storage.accounts.length; i += 1) {
@@ -319,14 +335,25 @@ export async function runReportCommand(
 				account.accountId = tokenDerivedAccountId;
 				account.accountIdSource = "token";
 			}
-			storageChanged =
-				storageChanged ||
+			const refreshedStorageChanged =
 				previousRefreshToken !== account.refreshToken ||
 				previousAccessToken !== account.accessToken ||
 				previousExpiresAt !== account.expiresAt ||
 				previousEmail !== account.email ||
 				previousAccountId !== account.accountId ||
 				previousAccountIdSource !== account.accountIdSource;
+			if (refreshedStorageChanged) {
+				try {
+					await saveAccountsWithRetry(storage, deps.saveAccounts);
+				} catch (error) {
+					const message = deps.normalizeFailureDetail(
+						error instanceof Error ? error.message : String(error),
+						undefined,
+					);
+					probeErrors.push(`${formatAccountLabel(account, i)}: ${message}`);
+					continue;
+				}
+			}
 
 			const accountId = account.accountId ?? refreshedAccountId;
 			if (!accountId) {
@@ -351,10 +378,6 @@ export async function runReportCommand(
 				probeErrors.push(`${formatAccountLabel(account, i)}: ${message}`);
 			}
 		}
-	}
-
-	if (storage && options.live && storageChanged) {
-		await deps.saveAccounts(storage);
 	}
 
 	const forecastResults = storage

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -1,6 +1,11 @@
 import { promises as fs } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { extractAccountId, formatAccountLabel } from "../../accounts.js";
+import {
+	extractAccountEmail,
+	extractAccountId,
+	formatAccountLabel,
+	sanitizeEmail,
+} from "../../accounts.js";
 import {
 	evaluateForecastAccounts,
 	type ForecastAccountResult,
@@ -47,6 +52,7 @@ export interface ReportCommandDeps {
 	setStoragePath: (path: string | null) => void;
 	getStoragePath: () => string;
 	loadAccounts: () => Promise<AccountStorageV3 | null>;
+	saveAccounts: (storage: AccountStorageV3) => Promise<void>;
 	resolveActiveIndex: (storage: AccountStorageV3, family?: "codex") => number;
 	queuedRefresh: (refreshToken: string) => Promise<TokenResult>;
 	fetchCodexQuotaSnapshot: (input: {
@@ -275,6 +281,7 @@ export async function runReportCommand(
 	const refreshFailures = new Map<number, TokenFailure>();
 	const liveQuotaByIndex = new Map<number, CodexQuotaSnapshot>();
 	const probeErrors: string[] = [];
+	let storageChanged = false;
 
 	if (storage && options.live) {
 		for (let i = 0; i < storage.accounts.length; i += 1) {
@@ -293,8 +300,35 @@ export async function runReportCommand(
 				continue;
 			}
 
-			const accountId =
+			const refreshedEmail = sanitizeEmail(
+				extractAccountEmail(refreshResult.access, refreshResult.idToken),
+			);
+			const refreshedAccountId =
 				account.accountId ?? extractAccountId(refreshResult.access);
+			const previousRefreshToken = account.refreshToken;
+			const previousAccessToken = account.accessToken;
+			const previousExpiresAt = account.expiresAt;
+			const previousEmail = account.email;
+			const previousAccountId = account.accountId;
+			const previousAccountIdSource = account.accountIdSource;
+			account.refreshToken = refreshResult.refresh;
+			account.accessToken = refreshResult.access;
+			account.expiresAt = refreshResult.expires;
+			if (refreshedEmail) account.email = refreshedEmail;
+			if (refreshedAccountId) {
+				account.accountId = refreshedAccountId;
+				account.accountIdSource = "token";
+			}
+			storageChanged =
+				storageChanged ||
+				previousRefreshToken !== account.refreshToken ||
+				previousAccessToken !== account.accessToken ||
+				previousExpiresAt !== account.expiresAt ||
+				previousEmail !== account.email ||
+				previousAccountId !== account.accountId ||
+				previousAccountIdSource !== account.accountIdSource;
+
+			const accountId = account.accountId ?? refreshedAccountId;
 			if (!accountId) {
 				probeErrors.push(
 					`${formatAccountLabel(account, i)}: missing accountId for live probe`,
@@ -317,6 +351,10 @@ export async function runReportCommand(
 				probeErrors.push(`${formatAccountLabel(account, i)}: ${message}`);
 			}
 		}
+	}
+
+	if (storage && options.live && storageChanged) {
+		await deps.saveAccounts(storage);
 	}
 
 	const forecastResults = storage

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -303,8 +303,8 @@ export async function runReportCommand(
 			const refreshedEmail = sanitizeEmail(
 				extractAccountEmail(refreshResult.access, refreshResult.idToken),
 			);
-			const refreshedAccountId =
-				account.accountId ?? extractAccountId(refreshResult.access);
+			const tokenDerivedAccountId = extractAccountId(refreshResult.access);
+			const refreshedAccountId = account.accountId ?? tokenDerivedAccountId;
 			const previousRefreshToken = account.refreshToken;
 			const previousAccessToken = account.accessToken;
 			const previousExpiresAt = account.expiresAt;
@@ -315,8 +315,8 @@ export async function runReportCommand(
 			account.accessToken = refreshResult.access;
 			account.expiresAt = refreshResult.expires;
 			if (refreshedEmail) account.email = refreshedEmail;
-			if (refreshedAccountId) {
-				account.accountId = refreshedAccountId;
+			if (tokenDerivedAccountId) {
+				account.accountId = tokenDerivedAccountId;
 				account.accountIdSource = "token";
 			}
 			storageChanged =

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -22,7 +22,11 @@ import {
 	getModelProfile,
 	resolveNormalizedModel,
 } from "../../request/helpers/model-map.js";
-import type { AccountStorageV3 } from "../../storage.js";
+import {
+	findMatchingAccountIndex,
+	type AccountMetadataV3,
+	type AccountStorageV3,
+} from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 import { sleep } from "../../utils.js";
 
@@ -268,6 +272,57 @@ async function saveAccountsWithRetry(
 	}
 }
 
+type AccountIdentityMatch = Pick<AccountMetadataV3, "accountId" | "email" | "refreshToken">;
+type RefreshedAccountPatch = Pick<
+	AccountMetadataV3,
+	"refreshToken" | "accessToken" | "expiresAt"
+> & {
+	email?: AccountMetadataV3["email"];
+	accountId?: AccountMetadataV3["accountId"];
+	accountIdSource?: AccountMetadataV3["accountIdSource"];
+};
+
+function applyRefreshedAccountPatch(
+	account: AccountMetadataV3,
+	patch: RefreshedAccountPatch,
+): void {
+	account.refreshToken = patch.refreshToken;
+	account.accessToken = patch.accessToken;
+	account.expiresAt = patch.expiresAt;
+	if (patch.email) account.email = patch.email;
+	if (patch.accountId) {
+		account.accountId = patch.accountId;
+		account.accountIdSource = patch.accountIdSource;
+	}
+}
+
+async function persistRefreshedAccountPatch(
+	storage: AccountStorageV3,
+	accountMatch: AccountIdentityMatch,
+	patch: RefreshedAccountPatch,
+	loadAccounts: ReportCommandDeps["loadAccounts"],
+	saveAccounts: ReportCommandDeps["saveAccounts"],
+): Promise<void> {
+	const latestStorage = (await loadAccounts()) ?? storage;
+	const nextStorage = structuredClone(latestStorage);
+	const targetIndex =
+		findMatchingAccountIndex(nextStorage.accounts, accountMatch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		}) ??
+		findMatchingAccountIndex(nextStorage.accounts, patch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		});
+	if (targetIndex === undefined) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	const targetAccount = nextStorage.accounts[targetIndex];
+	if (!targetAccount) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	applyRefreshedAccountPatch(targetAccount, patch);
+	await saveAccountsWithRetry(nextStorage, saveAccounts);
+}
+
 export async function runReportCommand(
 	args: string[],
 	deps: ReportCommandDeps,
@@ -326,25 +381,39 @@ export async function runReportCommand(
 			const previousExpiresAt = account.expiresAt;
 			const previousEmail = account.email;
 			const previousAccountId = account.accountId;
-			const previousAccountIdSource = account.accountIdSource;
-			account.refreshToken = refreshResult.refresh;
-			account.accessToken = refreshResult.access;
-			account.expiresAt = refreshResult.expires;
-			if (refreshedEmail) account.email = refreshedEmail;
-			if (tokenDerivedAccountId) {
-				account.accountId = tokenDerivedAccountId;
-				account.accountIdSource = "token";
+			const refreshPatch: RefreshedAccountPatch = {
+				refreshToken: refreshResult.refresh,
+				accessToken: refreshResult.access,
+				expiresAt: refreshResult.expires,
+			};
+			if (refreshedEmail) {
+				refreshPatch.email = refreshedEmail;
 			}
-			const refreshedStorageChanged =
-				previousRefreshToken !== account.refreshToken ||
-				previousAccessToken !== account.accessToken ||
-				previousExpiresAt !== account.expiresAt ||
+			if (tokenDerivedAccountId) {
+				refreshPatch.accountId = tokenDerivedAccountId;
+				refreshPatch.accountIdSource = "token";
+			}
+			const accountMatch: AccountIdentityMatch = {
+				refreshToken: previousRefreshToken,
+				email: previousEmail,
+				accountId: previousAccountId,
+			};
+			applyRefreshedAccountPatch(account, refreshPatch);
+			if (
+				previousRefreshToken !== refreshPatch.refreshToken ||
+				previousAccessToken !== refreshPatch.accessToken ||
+				previousExpiresAt !== refreshPatch.expiresAt ||
 				previousEmail !== account.email ||
-				previousAccountId !== account.accountId ||
-				previousAccountIdSource !== account.accountIdSource;
-			if (refreshedStorageChanged) {
+				previousAccountId !== account.accountId
+			) {
 				try {
-					await saveAccountsWithRetry(storage, deps.saveAccounts);
+					await persistRefreshedAccountPatch(
+						storage,
+						accountMatch,
+						refreshPatch,
+						deps.loadAccounts,
+						deps.saveAccounts,
+					);
 				} catch (error) {
 					const message = deps.normalizeFailureDetail(
 						error instanceof Error ? error.message : String(error),

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -143,8 +143,19 @@ describe("runForecastCommand", () => {
 
 	it("persists refreshed probe tokens before forecasting live quota", async () => {
 		const storage = createStorage();
+		const callLog: string[] = [];
+		let persistedStorage: AccountStorageV3 | null = null;
 		const deps = createDeps({
 			loadAccounts: vi.fn(async () => storage),
+			saveAccounts: vi.fn(async (nextStorage) => {
+				callLog.push(`save-${callLog.filter((entry) => entry.startsWith("save-")).length + 1}`);
+				if (callLog.length === 1) {
+					throw Object.assign(new Error("EBUSY write in progress"), {
+						code: "EBUSY",
+					});
+				}
+				persistedStorage = structuredClone(nextStorage);
+			}),
 			hasUsableAccessToken: vi.fn(() => false),
 			queuedRefresh: vi.fn(async () => ({
 				type: "success",
@@ -154,11 +165,31 @@ describe("runForecastCommand", () => {
 				idToken: "id-token-forecast-updated",
 			})),
 			extractAccountId: vi.fn(() => "account-id-updated"),
+			fetchCodexQuotaSnapshot: vi.fn(async (input) => {
+				callLog.push("fetch");
+				expect(persistedStorage?.accounts[0]?.refreshToken).toBe(
+					"refresh-forecast-updated",
+				);
+				expect(persistedStorage?.accounts[0]?.accessToken).toBe(
+					"access-forecast-updated",
+				);
+				expect(input.accessToken).toBe(
+					persistedStorage?.accounts[0]?.accessToken,
+				);
+				return {
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {},
+					secondary: {},
+				};
+			}),
 		});
 
 		const result = await runForecastCommand(["--json", "--live"], deps);
 
 		expect(result).toBe(0);
+		expect(callLog).toEqual(["save-1", "save-2", "fetch"]);
+		expect(deps.saveAccounts).toHaveBeenCalledTimes(2);
 		expect(deps.saveAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: [

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -143,10 +143,21 @@ describe("runForecastCommand", () => {
 
 	it("persists refreshed probe tokens before forecasting live quota", async () => {
 		const storage = createStorage();
+		const concurrentStorage = createStorage();
+		concurrentStorage.accounts[0] = {
+			...concurrentStorage.accounts[0],
+			currentWorkspaceIndex: 7,
+		};
 		const callLog: string[] = [];
 		let persistedStorage: AccountStorageV3 | null = null;
+		let loadCount = 0;
 		const deps = createDeps({
-			loadAccounts: vi.fn(async () => storage),
+			loadAccounts: vi.fn(async () => {
+				loadCount += 1;
+				return loadCount === 1
+					? storage
+					: structuredClone(concurrentStorage);
+			}),
 			saveAccounts: vi.fn(async (nextStorage) => {
 				callLog.push(`save-${callLog.filter((entry) => entry.startsWith("save-")).length + 1}`);
 				if (callLog.length === 1) {
@@ -173,6 +184,7 @@ describe("runForecastCommand", () => {
 				expect(persistedStorage?.accounts[0]?.accessToken).toBe(
 					"access-forecast-updated",
 				);
+				expect(persistedStorage?.accounts[0]?.currentWorkspaceIndex).toBe(7);
 				expect(input.accessToken).toBe(
 					persistedStorage?.accounts[0]?.accessToken,
 				);
@@ -189,6 +201,7 @@ describe("runForecastCommand", () => {
 
 		expect(result).toBe(0);
 		expect(callLog).toEqual(["save-1", "save-2", "fetch"]);
+		expect(deps.loadAccounts).toHaveBeenCalledTimes(2);
 		expect(deps.saveAccounts).toHaveBeenCalledTimes(2);
 		expect(deps.saveAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -199,6 +212,7 @@ describe("runForecastCommand", () => {
 						expiresAt: 999_999,
 						accountId: "account-id-updated",
 						accountIdSource: "token",
+						currentWorkspaceIndex: 7,
 					}),
 				],
 			}),

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -36,6 +36,7 @@ function createDeps(
 	return {
 		setStoragePath: vi.fn(),
 		loadAccounts: vi.fn(async () => createStorage()),
+		saveAccounts: vi.fn(async () => undefined),
 		resolveActiveIndex: vi.fn(() => 0),
 		loadQuotaCache: vi.fn(async () => ({ byAccountId: {}, byEmail: {} })),
 		saveQuotaCache: vi.fn(async () => undefined),
@@ -137,6 +138,45 @@ describe("runForecastCommand", () => {
 		expect(result).toBe(0);
 		expect(deps.logInfo).toHaveBeenCalledWith(
 			expect.stringContaining('"command": "forecast"'),
+		);
+	});
+
+	it("persists refreshed probe tokens before forecasting live quota", async () => {
+		const storage = createStorage();
+		const deps = createDeps({
+			loadAccounts: vi.fn(async () => storage),
+			hasUsableAccessToken: vi.fn(() => false),
+			queuedRefresh: vi.fn(async () => ({
+				type: "success",
+				access: "access-forecast-updated",
+				refresh: "refresh-forecast-updated",
+				expires: 999_999,
+				idToken: "id-token-forecast-updated",
+			})),
+			extractAccountId: vi.fn(() => "account-id-updated"),
+		});
+
+		const result = await runForecastCommand(["--json", "--live"], deps);
+
+		expect(result).toBe(0);
+		expect(deps.saveAccounts).toHaveBeenCalledWith(
+			expect.objectContaining({
+				accounts: [
+					expect.objectContaining({
+						refreshToken: "refresh-forecast-updated",
+						accessToken: "access-forecast-updated",
+						expiresAt: 999_999,
+						accountId: "account-id-updated",
+						accountIdSource: "token",
+					}),
+				],
+			}),
+		);
+		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				accountId: "account-id-updated",
+				accessToken: "access-forecast-updated",
+			}),
 		);
 	});
 

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -206,8 +206,19 @@ describe("runReportCommand", () => {
 				enabled: true,
 			},
 		]);
+		const callLog: string[] = [];
+		let persistedStorage: AccountStorageV3 | null = null;
 		const deps = createDeps({
 			loadAccounts: vi.fn(async () => storage),
+			saveAccounts: vi.fn(async (nextStorage) => {
+				callLog.push(`save-${callLog.filter((entry) => entry.startsWith("save-")).length + 1}`);
+				if (callLog.length === 1) {
+					throw Object.assign(new Error("EPERM write blocked"), {
+						code: "EPERM",
+					});
+				}
+				persistedStorage = structuredClone(nextStorage);
+			}),
 			queuedRefresh: vi.fn(async () => ({
 				type: "success",
 				access: "access-token-updated",
@@ -215,11 +226,31 @@ describe("runReportCommand", () => {
 				expires: 500,
 				idToken: "id-token-updated",
 			})),
+			fetchCodexQuotaSnapshot: vi.fn(async (input) => {
+				callLog.push("fetch");
+				expect(persistedStorage?.accounts[0]?.refreshToken).toBe(
+					"refresh-token-updated",
+				);
+				expect(persistedStorage?.accounts[0]?.accessToken).toBe(
+					"access-token-updated",
+				);
+				expect(input.accessToken).toBe(
+					persistedStorage?.accounts[0]?.accessToken,
+				);
+				return {
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {},
+					secondary: {},
+				};
+			}),
 		});
 
 		const result = await runReportCommand(["--live", "--json"], deps);
 
 		expect(result).toBe(0);
+		expect(callLog).toEqual(["save-1", "save-2", "fetch"]);
+		expect(deps.saveAccounts).toHaveBeenCalledTimes(2);
 		expect(deps.saveAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: [

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -33,6 +33,7 @@ function createDeps(
 		setStoragePath: vi.fn(),
 		getStoragePath: vi.fn(() => "/mock/openai-codex-accounts.json"),
 		loadAccounts: vi.fn(async () => createStorage()),
+		saveAccounts: vi.fn(async () => undefined),
 		resolveActiveIndex: vi.fn(() => 0),
 		queuedRefresh: vi.fn(async () => ({
 			type: "success",
@@ -189,6 +190,54 @@ describe("runReportCommand", () => {
 			"token expired",
 		);
 		expect(jsonOutput.forecast.accounts[3]?.liveQuota?.planType).toBe("pro");
+	});
+
+	it("persists refreshed probe tokens before report live probes", async () => {
+		const storage = createStorage([
+			{
+				email: "one@example.com",
+				accountId: "acct-report",
+				refreshToken: "refresh-token-1",
+				accessToken: "access-token-1",
+				expiresAt: 10,
+				addedAt: 1,
+				lastUsed: 1,
+				enabled: true,
+			},
+		]);
+		const deps = createDeps({
+			loadAccounts: vi.fn(async () => storage),
+			queuedRefresh: vi.fn(async () => ({
+				type: "success",
+				access: "access-token-updated",
+				refresh: "refresh-token-updated",
+				expires: 500,
+				idToken: "id-token-updated",
+			})),
+		});
+
+		const result = await runReportCommand(["--live", "--json"], deps);
+
+		expect(result).toBe(0);
+		expect(deps.saveAccounts).toHaveBeenCalledWith(
+			expect.objectContaining({
+				accounts: [
+					expect.objectContaining({
+						refreshToken: "refresh-token-updated",
+						accessToken: "access-token-updated",
+						expiresAt: 500,
+						accountId: "acct-report",
+						accountIdSource: "token",
+					}),
+				],
+			}),
+		);
+		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				accountId: "acct-report",
+				accessToken: "access-token-updated",
+			}),
+		);
 	});
 
 	it("prints a human-readable report and announces the output path", async () => {

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -206,10 +206,28 @@ describe("runReportCommand", () => {
 				enabled: true,
 			},
 		]);
+		const concurrentStorage = createStorage([
+			{
+				email: "one@example.com",
+				accountId: "acct-report",
+				accountIdSource: "org",
+				refreshToken: "refresh-token-1",
+				accessToken: "access-token-1",
+				expiresAt: 10,
+				currentWorkspaceIndex: 5,
+				addedAt: 1,
+				lastUsed: 1,
+				enabled: true,
+			},
+		]);
 		const callLog: string[] = [];
 		let persistedStorage: AccountStorageV3 | null = null;
+		let loadCount = 0;
 		const deps = createDeps({
-			loadAccounts: vi.fn(async () => storage),
+			loadAccounts: vi.fn(async () => {
+				loadCount += 1;
+				return loadCount === 1 ? storage : structuredClone(concurrentStorage);
+			}),
 			saveAccounts: vi.fn(async (nextStorage) => {
 				callLog.push(`save-${callLog.filter((entry) => entry.startsWith("save-")).length + 1}`);
 				if (callLog.length === 1) {
@@ -234,6 +252,7 @@ describe("runReportCommand", () => {
 				expect(persistedStorage?.accounts[0]?.accessToken).toBe(
 					"access-token-updated",
 				);
+				expect(persistedStorage?.accounts[0]?.currentWorkspaceIndex).toBe(5);
 				expect(input.accessToken).toBe(
 					persistedStorage?.accounts[0]?.accessToken,
 				);
@@ -250,20 +269,22 @@ describe("runReportCommand", () => {
 
 		expect(result).toBe(0);
 		expect(callLog).toEqual(["save-1", "save-2", "fetch"]);
+		expect(deps.loadAccounts).toHaveBeenCalledTimes(2);
 		expect(deps.saveAccounts).toHaveBeenCalledTimes(2);
 		expect(deps.saveAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: [
 					expect.objectContaining({
-					refreshToken: "refresh-token-updated",
-					accessToken: "access-token-updated",
-					expiresAt: 500,
-					accountId: "acct-report",
-					accountIdSource: "org",
-				}),
-			],
-		}),
-	);
+						refreshToken: "refresh-token-updated",
+						accessToken: "access-token-updated",
+						expiresAt: 500,
+						accountId: "acct-report",
+						accountIdSource: "org",
+						currentWorkspaceIndex: 5,
+					}),
+				],
+			}),
+		);
 		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "acct-report",

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -197,6 +197,7 @@ describe("runReportCommand", () => {
 			{
 				email: "one@example.com",
 				accountId: "acct-report",
+				accountIdSource: "org",
 				refreshToken: "refresh-token-1",
 				accessToken: "access-token-1",
 				expiresAt: 10,
@@ -223,15 +224,15 @@ describe("runReportCommand", () => {
 			expect.objectContaining({
 				accounts: [
 					expect.objectContaining({
-						refreshToken: "refresh-token-updated",
-						accessToken: "access-token-updated",
-						expiresAt: 500,
-						accountId: "acct-report",
-						accountIdSource: "token",
-					}),
-				],
-			}),
-		);
+					refreshToken: "refresh-token-updated",
+					accessToken: "access-token-updated",
+					expiresAt: 500,
+					accountId: "acct-report",
+					accountIdSource: "org",
+				}),
+			],
+		}),
+	);
 		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "acct-report",


### PR DESCRIPTION
## Summary

- persist refreshed auth returned by live probe refreshes so `forecast` and `report` stop reusing stale token state between runs

## What Changed

- added `saveAccounts` wiring to the forecast and report command dependencies
- updated `lib/codex-manager/commands/forecast.ts` to write refreshed access, refresh, expiry, email, and account identity back into storage before probing live quota
- updated `lib/codex-manager/commands/report.ts` with the same persistence path for live report probes
- added regression coverage in `test/codex-manager-forecast-command.test.ts` and `test/codex-manager-report-command.test.ts`

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: moderate; touches live probe command persistence, but only after successful refreshes
- Rollback plan: revert commit `229c9bf`

## Additional Notes

- targeted test run: `npm test -- test/codex-manager-forecast-command.test.ts test/codex-manager-report-command.test.ts`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr wires `saveAccounts` into `forecast` and `report` and adds a load-patch-save cycle after every successful token refresh so stale tokens are no longer re-used across runs. the `accountIdSource` bug flagged in the previous review thread is correctly fixed in `report.ts` — `tokenDerivedAccountId` is now used directly for the patch rather than `account.accountId ?? tokenDerivedAccountId`, so `accountIdSource="token"` is only written when the id genuinely came from the refreshed token.

- `persistRefreshedAccountPatch` re-reads storage from disk before each save, correctly handling external concurrent writers between accounts in the loop
- ebusy/eperm retry is present in both commands with exponential backoff, covering windows filesystem contention
- `saveAccountsWithRetry` retries with a stale `nextStorage` snapshot — if another process writes during the backoff window the retry will overwrite it; low-probability but worth hardening before widespread windows use
- all persistence helpers (`saveAccountsWithRetry`, `persistRefreshedAccountPatch`, `applyRefreshedAccountPatch`, type aliases) are duplicated verbatim between `forecast.ts` and `report.ts`; extracting to a shared module would prevent divergence
- `npm test` (full suite) is unchecked in the pr validation checklist — only the two targeted test files were run
- vitest coverage is missing for the non-retryable error path (account skip via `continue`), multi-account ordering, and the no-change fast path where `saveAccounts` should not be called

<h3>Confidence Score: 5/5</h3>

safe to merge; core persistence logic is correct and the previous accountIdSource bug is properly fixed

all remaining findings are p2 — code duplication, the stale-snapshot retry (low-probability, windows-specific), and missing vitest branches. the happy path, retry behavior, and accountIdSource correctness are all validated by the new tests. no p0/p1 issues remain.

lib/codex-manager/commands/forecast.ts and lib/codex-manager/commands/report.ts — the duplicated persistence helpers and stale-snapshot retry pattern should be addressed as a follow-up

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/forecast.ts | adds token persistence on refresh: reads latest storage from disk, patches the matching account, saves with ebusy/eperm retry; retry reuses stale snapshot rather than re-reading, which is a low-probability data-loss risk on windows; logic and flow are otherwise correct |
| lib/codex-manager/commands/report.ts | adds identical persistence path as forecast.ts; correctly uses tokenDerivedAccountId (not account.accountId ?? tokenDerivedAccountId) so accountIdSource="token" is only written when the id genuinely came from the token — resolves the bug from the previous review thread; same stale-snapshot retry risk applies |
| lib/codex-manager.ts | wires saveAccounts into both runForecast and runReportCommand dep objects; minimal change, correct |
| test/codex-manager-forecast-command.test.ts | adds regression test covering ebusy retry, concurrent-storage reload, and token persistence before the probe; missing coverage for non-retryable error path and multi-account ordering |
| test/codex-manager-report-command.test.ts | adds regression test covering eperm retry and accountIdSource="org" preservation; same coverage gaps as the forecast test |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[forecast/report --live loop
for each enabled account] --> B{hasUsableAccessToken?}
    B -- yes
forecast only --> C[use existing accessToken]
    B -- no --> D[queuedRefresh]
    D --> E{success?}
    E -- no --> F[refreshFailures.set
continue]
    E -- yes --> G[build refreshPatch
token/email/accountId]
    G --> H[applyRefreshedAccountPatch
to in-memory account]
    H --> I{any field changed?}
    I -- no --> C
    I -- yes --> J[persistRefreshedAccountPatch]
    J --> J1[loadAccounts from disk
get latest snapshot]
    J1 --> J2[structuredClone
find matching account]
    J2 --> J3[applyRefreshedAccountPatch
to clone]
    J3 --> J4[saveAccountsWithRetry]
    J4 --> J5{save OK?}
    J5 -- yes --> K[probe fetchCodexQuotaSnapshot]
    J5 -- EBUSY/EPERM
attempt < 3 --> J6[sleep 10x2^n ms
retry with SAME snapshot]
    J6 --> J4
    J5 -- non-retryable
or attempt >= 3 --> L[probeErrors.push
continue]
    K --> M[liveQuotaByIndex.set]
    C --> K
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fcodex-manager%2Fcommands%2Fforecast.ts%3A120-135%0A**persistence%20helpers%20duplicated%20verbatim%20across%20both%20commands**%0A%0A%60saveAccountsWithRetry%60%2C%20%60persistRefreshedAccountPatch%60%2C%20%60applyRefreshedAccountPatch%60%2C%20%60AccountIdentityMatch%60%2C%20and%20%60RefreshedAccountPatch%60%20are%20copy-pasted%20identically%20into%20both%20%60forecast.ts%60%20and%20%60report.ts%60.%20any%20future%20fix%20%28e.g.%20re-reading%20storage%20before%20a%20retry%29%20has%20to%20be%20applied%20twice.%20extract%20these%20to%20a%20shared%20module%2C%20e.g.%20%60lib%2Fcodex-manager%2Frefresh-persistence.ts%60%2C%20and%20import%20from%20both%20commands.%0A%0Asame%20duplication%20appears%20in%20%60lib%2Fcodex-manager%2Fcommands%2Freport.ts%60%20%28lines%20258%E2%80%93328%29.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fcodex-manager%2Fcommands%2Fforecast.ts%3A120-135%0A**stale%20snapshot%20reused%20on%20retry%20%E2%80%94%20windows%20filesystem%20risk**%0A%0A%60persistRefreshedAccountPatch%60%20reloads%20from%20disk%20once%20before%20constructing%20%60nextStorage%60%2C%20then%20hands%20that%20snapshot%20to%20%60saveAccountsWithRetry%60.%20if%20attempt%200%20throws%20%60EBUSY%60%20or%20%60EPERM%60%20%28both%20are%20common%20on%20windows%20while%20antivirus%20%2F%20the%20OS%20indexer%20holds%20the%20file%29%2C%20a%20concurrent%20codex%20process%20can%20write%20its%20own%20changes%20to%20the%20file%20during%20the%2010%20ms%20backoff%20window.%20the%20retry%20will%20then%20save%20the%20pre-backoff%20%60nextStorage%60%2C%20silently%20overwriting%20the%20concurrent%20write.%0A%0Athe%20safest%20fix%20is%20to%20reload%20and%20re-patch%20inside%20the%20retry%20body%20instead%20of%20outside%20it%3A%0A%0A%60%60%60ts%0Aasync%20function%20saveAccountsWithRetry%28%0A%20%20%20%20accountMatch%3A%20AccountIdentityMatch%2C%0A%20%20%20%20patch%3A%20RefreshedAccountPatch%2C%0A%20%20%20%20loadAccounts%3A%20ForecastCommandDeps%5B%22loadAccounts%22%5D%2C%0A%20%20%20%20saveAccounts%3A%20ForecastCommandDeps%5B%22saveAccounts%22%5D%2C%0A%20%20%20%20fallbackStorage%3A%20AccountStorageV3%2C%0A%29%3A%20Promise%3Cvoid%3E%20%7B%0A%20%20%20%20for%20%28let%20attempt%20%3D%200%3B%20%3B%20attempt%20%2B%3D%201%29%20%7B%0A%20%20%20%20%20%20%20%20const%20latestStorage%20%3D%20%28await%20loadAccounts%28%29%29%20%3F%3F%20fallbackStorage%3B%0A%20%20%20%20%20%20%20%20const%20nextStorage%20%3D%20structuredClone%28latestStorage%29%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20resolve%20%2B%20apply%20patch%20...%0A%20%20%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20await%20saveAccounts%28nextStorage%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%28!isRetryableStorageWriteError%28error%29%20%7C%7C%20attempt%20%3E%3D%203%29%20throw%20error%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20await%20sleep%2810%20*%202%20**%20attempt%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0Asame%20issue%20exists%20in%20%60lib%2Fcodex-manager%2Fcommands%2Freport.ts%60%20%60saveAccountsWithRetry%60.%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fcodex-manager-forecast-command.test.ts%3A141-230%0A**vitest%20coverage%20gaps%20in%20the%20new%20persistence%20path**%0A%0Athe%20new%20test%20covers%20the%20happy%20path%20%2B%20ebusy%20retry.%20a%20few%20branches%20in%20the%20persistence%20path%20have%20no%20coverage%3A%0A%0A-%20%60persistRefreshedAccountPatch%60%20throws%20a%20**non-retryable**%20error%20%28e.g.%20%60EACCES%60%29%20%E2%86%92%20the%20%60catch%60%20block%20should%20push%20a%20%60probeErrors%60%20entry%20and%20%60continue%60%20to%20the%20next%20account%3B%20no%20test%20verifies%20the%20account%20is%20skipped%20rather%20than%20crashing%20the%20command.%0A-%20multi-account%20scenario%3A%20verify%20that%20when%20accounts%5B0%5D's%20patch%20is%20saved%20first%2C%20accounts%5B1%5D's%20%60loadAccounts%60%20reload%20sees%20accounts%5B0%5D's%20updated%20token%20rather%20than%20the%20original%20snapshot.%0A-%20no-change%20fast%20path%3A%20when%20%60previousRefreshToken%20%3D%3D%3D%20refreshPatch.refreshToken%60%20etc.%2C%20%60persistRefreshedAccountPatch%60%20should%20not%20be%20called%20at%20all%3B%20no%20test%20asserts%20%60saveAccounts%60%20call%20count%20is%200%20in%20that%20case.%0A%0Asame%20gaps%20apply%20to%20%60test%2Fcodex-manager-report-command.test.ts%60.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager/commands/forecast.ts
Line: 120-135

Comment:
**persistence helpers duplicated verbatim across both commands**

`saveAccountsWithRetry`, `persistRefreshedAccountPatch`, `applyRefreshedAccountPatch`, `AccountIdentityMatch`, and `RefreshedAccountPatch` are copy-pasted identically into both `forecast.ts` and `report.ts`. any future fix (e.g. re-reading storage before a retry) has to be applied twice. extract these to a shared module, e.g. `lib/codex-manager/refresh-persistence.ts`, and import from both commands.

same duplication appears in `lib/codex-manager/commands/report.ts` (lines 258–328).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager/commands/forecast.ts
Line: 120-135

Comment:
**stale snapshot reused on retry — windows filesystem risk**

`persistRefreshedAccountPatch` reloads from disk once before constructing `nextStorage`, then hands that snapshot to `saveAccountsWithRetry`. if attempt 0 throws `EBUSY` or `EPERM` (both are common on windows while antivirus / the OS indexer holds the file), a concurrent codex process can write its own changes to the file during the 10 ms backoff window. the retry will then save the pre-backoff `nextStorage`, silently overwriting the concurrent write.

the safest fix is to reload and re-patch inside the retry body instead of outside it:

```ts
async function saveAccountsWithRetry(
    accountMatch: AccountIdentityMatch,
    patch: RefreshedAccountPatch,
    loadAccounts: ForecastCommandDeps["loadAccounts"],
    saveAccounts: ForecastCommandDeps["saveAccounts"],
    fallbackStorage: AccountStorageV3,
): Promise<void> {
    for (let attempt = 0; ; attempt += 1) {
        const latestStorage = (await loadAccounts()) ?? fallbackStorage;
        const nextStorage = structuredClone(latestStorage);
        // resolve + apply patch ...
        try {
            await saveAccounts(nextStorage);
            return;
        } catch (error) {
            if (!isRetryableStorageWriteError(error) || attempt >= 3) throw error;
            await sleep(10 * 2 ** attempt);
        }
    }
}
```

same issue exists in `lib/codex-manager/commands/report.ts` `saveAccountsWithRetry`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-forecast-command.test.ts
Line: 141-230

Comment:
**vitest coverage gaps in the new persistence path**

the new test covers the happy path + ebusy retry. a few branches in the persistence path have no coverage:

- `persistRefreshedAccountPatch` throws a **non-retryable** error (e.g. `EACCES`) → the `catch` block should push a `probeErrors` entry and `continue` to the next account; no test verifies the account is skipped rather than crashing the command.
- multi-account scenario: verify that when accounts[0]'s patch is saved first, accounts[1]'s `loadAccounts` reload sees accounts[0]'s updated token rather than the original snapshot.
- no-change fast path: when `previousRefreshToken === refreshPatch.refreshToken` etc., `persistRefreshedAccountPatch` should not be called at all; no test asserts `saveAccounts` call count is 0 in that case.

same gaps apply to `test/codex-manager-report-command.test.ts`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix-merge-refreshed-probe-persistence"](https://github.com/ndycode/codex-multi-auth/commit/b4c375ee81d2e11c66788bdcd50acdb84d5c6449) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26968529)</sub>

<!-- /greptile_comment -->