### PR TITLE
fix: hydrate newer refresh tokens from expired cli cache

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -188,7 +188,11 @@ export class AccountManager {
 				changed = true;
 			}
 
-			if (cached.refreshToken && cached.refreshToken !== account.refreshToken) {
+			if (
+				cachedAccessUsable &&
+				cached.refreshToken &&
+				cached.refreshToken !== account.refreshToken
+			) {
 				account.refreshToken = cached.refreshToken;
 				changed = true;
 			}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -188,11 +188,7 @@ export class AccountManager {
 				changed = true;
 			}
 
-			if (
-				cachedAccessUsable &&
-				cached.refreshToken &&
-				!account.refreshToken
-			) {
+			if (cached.refreshToken && !account.refreshToken) {
 				account.refreshToken = cached.refreshToken;
 				changed = true;
 			}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -191,7 +191,7 @@ export class AccountManager {
 			if (
 				cachedAccessUsable &&
 				cached.refreshToken &&
-				cached.refreshToken !== account.refreshToken
+				!account.refreshToken
 			) {
 				account.refreshToken = cached.refreshToken;
 				changed = true;

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -175,17 +175,21 @@ export class AccountManager {
 			const cached = cache.get(email);
 			if (!cached) continue;
 
-			if (typeof cached.expiresAt === "number" && cached.expiresAt <= now) {
-				continue;
-			}
+			const cachedAccessUsable =
+				typeof cached.expiresAt !== "number" || cached.expiresAt > now;
 
 			const missingOrExpired =
 				!account.access || account.expires === undefined || account.expires <= now;
-			if (missingOrExpired) {
+			if (missingOrExpired && cachedAccessUsable) {
 				account.access = cached.accessToken;
 				if (typeof cached.expiresAt === "number") {
 					account.expires = cached.expiresAt;
 				}
+				changed = true;
+			}
+
+			if (cached.refreshToken && cached.refreshToken !== account.refreshToken) {
+				account.refreshToken = cached.refreshToken;
 				changed = true;
 			}
 

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -188,7 +188,7 @@ describe("accounts edge branches", () => {
 
     const expired = snapshot[1];
     expect(expired?.access).toBe("existing-access");
-    expect(expired?.refreshToken).toBe("expired-refresh-updated");
+    expect(expired?.refreshToken).toBe("refresh-2");
     expect(expired?.accountId).toBe("expired-id");
     expect(expired?.accountIdSource).toBe("token");
   });

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -231,6 +231,47 @@ describe("accounts edge branches", () => {
     expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
+  it("hydrates a missing local refresh token from an expired CLI cache entry", async () => {
+    const now = Date.now();
+    const stored = buildStored([
+      buildStoredAccount({
+        refreshToken: "local-refresh-placeholder",
+        email: "expired@example.com",
+        accessToken: "local-access",
+        expiresAt: now + 120_000,
+      }),
+    ]);
+
+    const { AccountManager } = await importAccountsModule();
+    const manager = new AccountManager(undefined, stored as never);
+    const account = manager.getAccountByIndex(0)!;
+    account.refreshToken = "";
+
+    mockLoadCodexCliState.mockResolvedValue({
+      sourceUpdatedAtMs: now - 60_000,
+      accounts: [
+        {
+          email: "expired@example.com",
+          accessToken: "cached-access-old",
+          expiresAt: now - 1,
+          refreshToken: "cached-refresh-restored",
+          accountId: "expired-account-id",
+        },
+      ],
+    });
+
+    const hydrate = getPrivate<() => Promise<void>>(
+      manager as object,
+      "hydrateFromCodexCli",
+    );
+    await hydrate.call(manager);
+
+    const snapshot = manager.getAccountsSnapshot();
+    expect(snapshot[0]?.refreshToken).toBe("cached-refresh-restored");
+    expect(snapshot[0]?.access).toBe("local-access");
+    expect(snapshot[0]?.accountId).toBe("expired-account-id");
+  });
+
   it("returns early when Codex CLI state has no usable cache entries", async () => {
     const stored = buildStored([
       buildStoredAccount({

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -182,7 +182,7 @@ describe("accounts edge branches", () => {
     const snapshot = manager.getAccountsSnapshot();
     const updated = snapshot[0];
     expect(updated?.access).toBe("refreshed-access");
-    expect(updated?.refreshToken).toBe("refreshed-refresh");
+    expect(updated?.refreshToken).toBe("refresh-1");
     expect(updated?.accountId).toBe("account-from-cache");
     expect(updated?.accountIdSource).toBe("token");
 
@@ -191,6 +191,44 @@ describe("accounts edge branches", () => {
     expect(expired?.refreshToken).toBe("refresh-2");
     expect(expired?.accountId).toBe("expired-id");
     expect(expired?.accountIdSource).toBe("token");
+  });
+
+  it("does not overwrite a local refresh token with a stale usable CLI cache token", async () => {
+    const now = Date.now();
+    const stored = buildStored([
+      buildStoredAccount({
+        refreshToken: "local-refresh-new",
+        email: "match@example.com",
+        accessToken: "local-access",
+        expiresAt: now + 120_000,
+      }),
+    ]);
+
+    const { AccountManager } = await importAccountsModule();
+    const manager = new AccountManager(undefined, stored as never);
+
+    mockLoadCodexCliState.mockResolvedValue({
+      sourceUpdatedAtMs: now - 60_000,
+      accounts: [
+        {
+          email: "match@example.com",
+          accessToken: "cached-access-old",
+          expiresAt: now + 300_000,
+          refreshToken: "cached-refresh-old",
+        },
+      ],
+    });
+
+    const hydrate = getPrivate<() => Promise<void>>(
+      manager as object,
+      "hydrateFromCodexCli",
+    );
+    await hydrate.call(manager);
+
+    const snapshot = manager.getAccountsSnapshot();
+    expect(snapshot[0]?.refreshToken).toBe("local-refresh-new");
+    expect(snapshot[0]?.access).toBe("local-access");
+    expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
   it("returns early when Codex CLI state has no usable cache entries", async () => {

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -154,12 +154,14 @@ describe("accounts edge branches", () => {
           email: "match@example.com",
           accessToken: "refreshed-access",
           expiresAt: now + 300_000,
+          refreshToken: "refreshed-refresh",
           accountId: "account-from-cache",
         },
         {
           email: "expired@example.com",
           accessToken: "expired-access",
           expiresAt: now - 1,
+          refreshToken: "expired-refresh-updated",
           accountId: "expired-id",
         },
         {
@@ -180,12 +182,15 @@ describe("accounts edge branches", () => {
     const snapshot = manager.getAccountsSnapshot();
     const updated = snapshot[0];
     expect(updated?.access).toBe("refreshed-access");
+    expect(updated?.refreshToken).toBe("refreshed-refresh");
     expect(updated?.accountId).toBe("account-from-cache");
     expect(updated?.accountIdSource).toBe("token");
 
     const expired = snapshot[1];
     expect(expired?.access).toBe("existing-access");
-    expect(expired?.accountId).toBeUndefined();
+    expect(expired?.refreshToken).toBe("expired-refresh-updated");
+    expect(expired?.accountId).toBe("expired-id");
+    expect(expired?.accountIdSource).toBe("token");
   });
 
   it("returns early when Codex CLI state has no usable cache entries", async () => {

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -125,7 +125,7 @@ describe("AccountManager loadFromDisk", () => {
     expect(saveAccounts).toHaveBeenCalledTimes(1);
   });
 
-  it("skips expired Codex CLI cache entries and does not persist", async () => {
+  it("skips expired access hydration but backfills missing account identity", async () => {
     const now = Date.now();
     vi.mocked(loadAccounts).mockResolvedValue({
       version: 3 as const,
@@ -155,8 +155,9 @@ describe("AccountManager loadFromDisk", () => {
     const account = manager.getCurrentAccount();
 
     expect(account?.access).toBeUndefined();
-    expect(account?.accountId).toBeUndefined();
-    expect(saveAccounts).not.toHaveBeenCalled();
+    expect(account?.accountId).toBe("acct-expired");
+    expect(account?.accountIdSource).toBe("token");
+    expect(saveAccounts).toHaveBeenCalledTimes(1);
   });
 
   it("syncCodexCliActiveSelectionForIndex ignores invalid indices and syncs a valid one", async () => {


### PR DESCRIPTION
## Summary

- hydrate newer refresh token and account identity data from Codex CLI cache even when the cached access token is already expired

## What Changed

- split CLI cache hydration in `lib/accounts.ts` so expired cache entries can still refresh stored `refreshToken` and `accountId` fields without reviving the expired access token
- added regression coverage in `test/accounts-edge.test.ts` for expired cache entries that should update refresh credentials but keep the existing usable access token

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- test/accounts-edge.test.ts`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low; this only changes how CLI cache hydration updates stored credentials for already-matched accounts.
- Rollback plan: revert commit `45a7ee6` or close the branch if reviewers want to keep the previous hydration gate.

## Additional Notes

- This keeps stale access tokens out of selection while still preserving fresher refresh credentials from the local Codex CLI cache.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr splits `hydrateFromCodexCli` in `lib/accounts.ts` so that expired CLI cache entries can still back-fill a missing `refreshToken` and `accountId` on a matched account, without reviving the stale access token. the access-token block remains gated by `cachedAccessUsable`, while the new refresh-token block uses `!account.refreshToken` as its only guard — meaning it only writes when the account has no existing credential, which safely prevents token downgrades from race conditions (e.g. a post-oauth-refresh process restart where the local store already holds a newer token).

- `lib/accounts.ts`: replaces the early `continue` on expired entries with a `cachedAccessUsable` boolean; adds a separate `refreshToken` hydration block guarded by `cached.refreshToken && !account.refreshToken`; accountId block now reachable for expired entries
- `test/accounts-edge.test.ts`: adds two new vitest scenarios — \"does not overwrite a local refresh token with a stale usable CLI cache token\" and \"hydrates a missing local refresh token from an expired CLI cache entry\"; updates existing multi-account test expectations
- `test/accounts-load-from-disk.test.ts`: updates expired-entry test title and expectations to reflect that `accountId` is now back-filled and `saveAccounts` is called once for expired entries

<h3>Confidence Score: 5/5</h3>

safe to merge — core logic is correct, token downgrade risk is properly contained by the !account.refreshToken guard, and all three changed files have consistent test coverage

only finding is a P2 missing saveAccounts assertion in one new test; no P0/P1 defects remain. prior concerns about freshness guard and cachedAccessUsable contradiction are resolved — the !account.refreshToken guard is the right scope for this fill-in behavior.

test/accounts-edge.test.ts — third new test is missing a mockSaveAccounts assertion

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | splits CLI cache hydration so expired entries still back-fill missing refreshToken and accountId; access token block correctly gated behind cachedAccessUsable — logic is sound and token downgrade risk is contained by !account.refreshToken guard |
| test/accounts-edge.test.ts | adds two new targeted scenarios (no-overwrite guard, expired-entry hydration) plus updates the existing multi-account test; third new test is missing a saveToDisk call assertion |
| test/accounts-load-from-disk.test.ts | updates expired-entry test title and expectations to match new behavior: backfills accountId and now expects one saveAccounts call — consistent with production logic |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[for each account in accounts] --> B{cached entry exists?}
    B -- no --> A
    B -- yes --> C{cachedAccessUsable?\nexpiresAt > now or no expiry}
    C --> D{missingOrExpired AND\ncachedAccessUsable?}
    D -- yes --> E[write access token\nwrite expiresAt\nchanged = true]
    D -- no --> F{cached.refreshToken\nAND !account.refreshToken?}
    E --> F
    F -- yes --> G[write refreshToken\nchanged = true]
    F -- no --> H{!account.accountId\nAND cached.accountId\nAND shouldUpdate?}
    G --> H
    H -- yes --> I[write accountId\nwrite accountIdSource\nchanged = true]
    H -- no --> A
    I --> A
    A --> J{changed?}
    J -- yes --> K[saveToDisk\ncatch and log errors]
    J -- no --> L[return]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Faccounts-edge.test.ts%3A263-275%0A**missing%20%60saveToDisk%60%20persistence%20assertion**%0A%0Athe%20test%20verifies%20in-memory%20state%20%28%60refreshToken%60%2C%20%60access%60%2C%20%60accountId%60%29%20but%20never%20asserts%20that%20%60saveToDisk%60%20was%20actually%20called%20after%20hydrating%20from%20an%20expired%20CLI%20entry.%20%60changed%60%20is%20set%20to%20%60true%60%20here%2C%20so%20%60saveToDisk%60%20should%20fire%20%E2%80%94%20without%20asserting%20it%2C%20a%20future%20regression%20that%20silently%20skips%20the%20save%20call%20would%20pass%20this%20test%20undetected.%20add%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20snapshot%20%3D%20manager.getAccountsSnapshot%28%29%3B%0A%20%20%20%20expect%28snapshot%5B0%5D%3F.refreshToken%29.toBe%28%22cached-refresh-restored%22%29%3B%0A%20%20%20%20expect%28snapshot%5B0%5D%3F.access%29.toBe%28%22local-access%22%29%3B%0A%20%20%20%20expect%28snapshot%5B0%5D%3F.accountId%29.toBe%28%22expired-account-id%22%29%3B%0A%20%20%20%20expect%28mockSaveAccounts%29.toHaveBeenCalledTimes%281%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/accounts-edge.test.ts
Line: 263-275

Comment:
**missing `saveToDisk` persistence assertion**

the test verifies in-memory state (`refreshToken`, `access`, `accountId`) but never asserts that `saveToDisk` was actually called after hydrating from an expired CLI entry. `changed` is set to `true` here, so `saveToDisk` should fire — without asserting it, a future regression that silently skips the save call would pass this test undetected. add:

```suggestion
    const snapshot = manager.getAccountsSnapshot();
    expect(snapshot[0]?.refreshToken).toBe("cached-refresh-restored");
    expect(snapshot[0]?.access).toBe("local-access");
    expect(snapshot[0]?.accountId).toBe("expired-account-id");
    expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix expired cache load regression test"](https://github.com/ndycode/codex-multi-auth/commit/83d934ae17e53c0572bfb180af44bf49819ac97f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26969057)</sub>

<!-- /greptile_comment -->