### PR TITLE
fix: graduate refresh guardian failure penalties

### DIFF
--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "./logger.js";
 import { applyRefreshResult, refreshExpiringAccounts } from "./proactive-refresh.js";
 import type { AccountManager } from "./accounts.js";
+import { ACCOUNT_LIMITS } from "./constants.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
 
@@ -24,6 +25,7 @@ export interface RefreshGuardianStats {
 }
 
 const DEFAULT_INTERVAL_MS = 60_000;
+const NETWORK_FAILURE_COOLDOWN_MS = 6_000;
 
 export class RefreshGuardian {
 	private readonly getAccountManager: () => AccountManager | null;
@@ -95,6 +97,15 @@ export class RefreshGuardian {
 		return "network-error";
 	}
 
+	private getNetworkFailureCooldownMs(): number {
+		return Math.min(this.bufferMs, NETWORK_FAILURE_COOLDOWN_MS);
+	}
+
+	private getAuthFailureCooldownMs(failureCount: number): number {
+		const streak = Math.max(1, Math.floor(failureCount));
+		return Math.min(this.bufferMs, ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS * streak);
+	}
+
 	async tick(): Promise<void> {
 		if (this.running) return;
 		const manager = this.getAccountManager();
@@ -135,14 +146,33 @@ export class RefreshGuardian {
 							manager.clearAuthFailures(account);
 							this.stats.refreshed += 1;
 						} else {
-							manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+							manager.markAccountCoolingDown(
+								account,
+								this.getNetworkFailureCooldownMs(),
+								"network-error",
+							);
 							this.stats.failed += 1;
 							this.stats.networkFailed += 1;
 						}
 						break;
 					case "failed": {
 						const cooldownReason = this.classifyFailureReason(result.tokenResult);
-						manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
+						if (cooldownReason === "rate-limit") {
+							manager.markRateLimited(account, this.bufferMs, "codex");
+						} else if (cooldownReason === "auth-failure") {
+							const failureCount = manager.incrementAuthFailures(account);
+							manager.markAccountCoolingDown(
+								account,
+								this.getAuthFailureCooldownMs(failureCount),
+								cooldownReason,
+							);
+						} else {
+							manager.markAccountCoolingDown(
+								account,
+								this.getNetworkFailureCooldownMs(),
+								cooldownReason,
+							);
+						}
 						this.stats.failed += 1;
 						if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
 						else if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
@@ -153,7 +183,11 @@ export class RefreshGuardian {
 						this.stats.notNeeded += 1;
 						break;
 					case "no_refresh_token":
-						manager.markAccountCoolingDown(account, this.bufferMs, "auth-failure");
+						manager.markAccountCoolingDown(
+							account,
+							ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS,
+							"auth-failure",
+						);
 						manager.setAccountEnabled(account.index, false);
 						this.stats.noRefreshToken += 1;
 						this.stats.failed += 1;

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -146,6 +146,7 @@ export class RefreshGuardian {
 							manager.clearAuthFailures(account);
 							this.stats.refreshed += 1;
 						} else {
+							manager.clearAuthFailures(account);
 							manager.markAccountCoolingDown(
 								account,
 								this.getNetworkFailureCooldownMs(),
@@ -158,6 +159,7 @@ export class RefreshGuardian {
 					case "failed": {
 						const cooldownReason = this.classifyFailureReason(result.tokenResult);
 						if (cooldownReason === "rate-limit") {
+							manager.clearAuthFailures(account);
 							manager.markRateLimited(account, this.bufferMs, "codex");
 						} else if (cooldownReason === "auth-failure") {
 							const failureCount = manager.incrementAuthFailures(account);
@@ -167,6 +169,7 @@ export class RefreshGuardian {
 								cooldownReason,
 							);
 						} else {
+							manager.clearAuthFailures(account);
 							manager.markAccountCoolingDown(
 								account,
 								this.getNetworkFailureCooldownMs(),

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -638,6 +638,149 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledTimes(2);
   });
 
+  it("resets auth failure streaks after network and rate-limit outcomes", async () => {
+    const accountA = createManagedAccount(0);
+    const accountB = createManagedAccount(1);
+    const manager = createManagerMock([accountA, accountB]);
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock
+      .mockResolvedValueOnce(
+        new Map([
+          [
+            0,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 401,
+                message: "expired-a",
+              },
+            },
+          ],
+          [
+            1,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 401,
+                message: "expired-b",
+              },
+            },
+          ],
+        ]),
+      )
+      .mockResolvedValueOnce(
+        new Map([
+          [
+            0,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "network_error",
+                message: "timeout-a",
+              },
+            },
+          ],
+          [
+            1,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 429,
+                message: "rate-limit-b",
+              },
+            },
+          ],
+        ]),
+      )
+      .mockResolvedValueOnce(
+        new Map([
+          [
+            0,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 401,
+                message: "expired-a-again",
+              },
+            },
+          ],
+          [
+            1,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 401,
+                message: "expired-b-again",
+              },
+            },
+          ],
+        ]),
+      );
+
+    await guardian.tick();
+    await guardian.tick();
+    await guardian.tick();
+
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA);
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(3, accountA);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(4, accountB);
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA, 30_000, "auth-failure");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB, 30_000, "auth-failure");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(3, accountA, 6_000, "network-error");
+    expect(
+      manager.markRateLimited as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountB, 60_000, "codex");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(4, accountA, 30_000, "auth-failure");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(5, accountB, 30_000, "auth-failure");
+  });
+
   it("handles account removal during tick without throwing", async () => {
     const originalA = createManagedAccount(0);
     const originalB = createManagedAccount(1);

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -27,9 +27,34 @@ function createManagerMock(accounts: ManagedAccount[]): AccountManager {
       (index: number) =>
         accounts.find((account) => account.index === index) ?? null,
     ),
-    clearAuthFailures: vi.fn(),
-    markAccountCoolingDown: vi.fn(),
-    setAccountEnabled: vi.fn(),
+    clearAuthFailures: vi.fn((account: ManagedAccount) => {
+      account.consecutiveAuthFailures = 0;
+    }),
+    incrementAuthFailures: vi.fn((account: ManagedAccount) => {
+      account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+      return account.consecutiveAuthFailures;
+    }),
+    markAccountCoolingDown: vi.fn(
+      (
+        account: ManagedAccount,
+        cooldownMs: number,
+        reason: "auth-failure" | "network-error" | "rate-limit",
+      ) => {
+        account.coolingDownUntil = Date.now() + cooldownMs;
+        account.cooldownReason = reason;
+      },
+    ),
+    markRateLimited: vi.fn(
+      (account: ManagedAccount, retryAfterMs: number) => {
+        account.rateLimitResetTimes.codex = Date.now() + retryAfterMs;
+      },
+    ),
+    setAccountEnabled: vi.fn((index: number, enabled: boolean) => {
+      const account = accounts.find((candidate) => candidate.index === index);
+      if (account) {
+        account.enabled = enabled;
+      }
+    }),
     saveToDiskDebounced: vi.fn(),
   } as unknown as AccountManager;
 }
@@ -160,8 +185,11 @@ describe("refresh-guardian", () => {
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountA);
     expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountB);
+    expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(accountB, 60_000, "auth-failure");
+    ).toHaveBeenCalledWith(accountB, 30_000, "auth-failure");
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
@@ -232,8 +260,15 @@ describe("refresh-guardian", () => {
         (index: number) =>
           [liveB, liveA].find((account) => account.index === index) ?? null,
       ),
-      clearAuthFailures: vi.fn(),
+      clearAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = 0;
+      }),
+      incrementAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+        return account.consecutiveAuthFailures;
+      }),
       markAccountCoolingDown: vi.fn(),
+      markRateLimited: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
     const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
@@ -343,16 +378,19 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledWith(1, false);
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(1, accountB, 60_000, "auth-failure");
+    ).toHaveBeenNthCalledWith(1, accountB, 30_000, "auth-failure");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(2, accountC, 60_000, "rate-limit");
+    ).toHaveBeenNthCalledWith(2, accountD, 6_000, "network-error");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(3, accountD, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(3, accountE, 30_000, "auth-failure");
     expect(
-      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(4, accountE, 60_000, "auth-failure");
+      manager.markRateLimited as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountC, 60_000, "codex");
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountE);
 
     const stats = guardian.getStats();
     expect(stats.runs).toBe(1);
@@ -395,8 +433,15 @@ describe("refresh-guardian", () => {
         (index: number) =>
           liveSnapshot.find((account) => account.index === index) ?? null,
       ),
-      clearAuthFailures: vi.fn(),
+      clearAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = 0;
+      }),
+      incrementAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+        return account.consecutiveAuthFailures;
+      }),
       markAccountCoolingDown: vi.fn(),
+      markRateLimited: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -499,19 +544,25 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledTimes(5);
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(1, accountA, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(1, accountA, 6_000, "network-error");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(2, accountB, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(2, accountB, 6_000, "network-error");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(3, accountC, 60_000, "auth-failure");
+    ).toHaveBeenNthCalledWith(3, accountC, 30_000, "auth-failure");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(4, accountD, 60_000, "auth-failure");
+    ).toHaveBeenNthCalledWith(4, accountD, 30_000, "auth-failure");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(5, accountE, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(5, accountE, 6_000, "network-error");
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountC);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountD);
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
@@ -545,6 +596,48 @@ describe("refresh-guardian", () => {
     expect(Reflect.get(guardian, "running")).toBe(false);
   });
 
+  it("escalates auth cooldowns across repeated guardian failures", async () => {
+    const account = createManagedAccount(0);
+    const manager = createManagerMock([account]);
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 120_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "failed",
+            tokenResult: {
+              type: "failed",
+              reason: "http_error",
+              statusCode: 401,
+              message: "expired",
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+    await vi.advanceTimersByTimeAsync(30_001);
+    await guardian.tick();
+
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, account, 30_000, "auth-failure");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, account, 60_000, "auth-failure");
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledTimes(2);
+  });
+
   it("handles account removal during tick without throwing", async () => {
     const originalA = createManagedAccount(0);
     const originalB = createManagedAccount(1);
@@ -560,8 +653,15 @@ describe("refresh-guardian", () => {
       getAccountByIndex: vi.fn(
         (index: number) => liveAfterRemoval[index] ?? null,
       ),
-      clearAuthFailures: vi.fn(),
+      clearAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = 0;
+      }),
+      incrementAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+        return account.consecutiveAuthFailures;
+      }),
       markAccountCoolingDown: vi.fn(),
+      markRateLimited: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -609,11 +709,11 @@ describe("refresh-guardian", () => {
       expect.anything(),
     );
     expect(
-      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+      manager.markRateLimited as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(
       expect.objectContaining({ refreshToken: originalB.refreshToken }),
       60_000,
-      "rate-limit",
+      "codex",
     );
   });
 });


### PR DESCRIPTION
## Summary

- graduate refresh guardian penalties so transient refresh misses do not sideline healthy accounts as long as hard auth failures

## What Changed

- updated `lib/refresh-guardian.ts` so `429` refresh failures mark the account rate-limited, network-style failures use a short cooldown, and hard auth failures back off progressively using `consecutiveAuthFailures`
- expanded `test/refresh-guardian.test.ts` to cover the new rate-limit path, the shorter network cooldown path, and repeated auth-failure escalation

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- test/refresh-guardian.test.ts`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low to medium; this only changes guardian penalty timing and state, but it does alter when accounts re-enter the pool after failed refresh attempts.
- Rollback plan: revert commit `bfb6a33` or close the branch if reviewers want the fixed-buffer behavior.

## Additional Notes

- This keeps transient refresh noise from cooling an account for the full guardian buffer while still backing off repeated hard auth failures more aggressively.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr graduates the refresh guardian's penalty system so transient network/rate-limit misses no longer cost the full `bufferMs` cooldown, while hard auth failures now back off progressively using `consecutiveAuthFailures`. the new `getNetworkFailureCooldownMs` (6 s), `getAuthFailureCooldownMs` (30 s × streak, capped at `bufferMs`), and `markRateLimited` delegation are a clean separation of concerns that fit well with the rest of the cooldown machinery in `lib/accounts.ts`.

key changes:
- `429` → delegates to `markRateLimited(account, bufferMs, \"codex\")` and resets failure counter
- `network_error` / other unknown → 6 s short cooldown, failure counter cleared
- `auth-failure` (401/400/403, `missing_refresh`, `invalid_response`) → `incrementAuthFailures` + `30_000 × streak` (capped at `bufferMs`)
- `no_refresh_token` → fixed 30 s cooldown + `setAccountEnabled(false)`; no longer uses `bufferMs` or touches the failure counter
- `success` path with non-success token result → now also calls `clearAuthFailures` before the network-error cooldown (new behaviour)
- `npm test` full suite is unchecked in the pr checklist — only the guardian test file was verified

<h3>Confidence Score: 5/5</h3>

safe to merge; all remaining findings are P2 style/coverage suggestions with no impact on runtime correctness

the core penalty graduation logic is correct and well-tested for the new paths. the P2 findings (redundant Math.floor, missing bufferMs-cap test, undocumented no_refresh_token asymmetry) do not affect correctness or production reliability and don't justify blocking merge.

no files require special attention; the `no_refresh_token` asymmetry in `lib/refresh-guardian.ts` is worth a follow-up comment but not a blocker

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/refresh-guardian.ts | graduated penalty logic is sound; `no_refresh_token` path now uses a fixed 30 s cooldown instead of `bufferMs` and skips `incrementAuthFailures`/`clearAuthFailures` — a deliberate but undocumented asymmetry worth a comment |
| test/refresh-guardian.test.ts | new tests cover rate-limit, network-cooldown, and auth-failure escalation paths well; the `bufferMs` cap in `getAuthFailureCooldownMs` is not exercised by any test |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tick: account result] --> B{result.reason}
    B -- success --> C{tokenResult.type === success?}
    C -- yes --> D[applyRefreshResult\nclearAuthFailures\nstats.refreshed++]
    C -- no --> E[clearAuthFailures\nmarkAccountCoolingDown 6s network-error\nstats.networkFailed++]
    B -- failed --> F{classifyFailureReason}
    F -- rate-limit 429 --> G[clearAuthFailures\nmarkRateLimited bufferMs codex\nstats.rateLimited++]
    F -- auth-failure 401/403/400/missing/invalid --> H[incrementAuthFailures → streak\nmarkAccountCoolingDown 30s×streak capped bufferMs\nstats.authFailed++]
    F -- network-error other --> I[clearAuthFailures\nmarkAccountCoolingDown 6s network-error\nstats.networkFailed++]
    B -- not_needed --> J[stats.notNeeded++]
    B -- no_refresh_token --> K[markAccountCoolingDown 30s auth-failure\nsetAccountEnabled false\nstats.noRefreshToken++]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Frefresh-guardian.ts%3A104-107%0A**%60Math.floor%60%20on%20an%20integer%20return%20value%20is%20redundant**%0A%0A%60incrementAuthFailures%60%20always%20returns%20a%20positive%20integer%20%28%60consecutiveAuthFailures%60%20is%20%60%28...%20%3F%3F%200%29%20%2B%201%60%29%2C%20so%20the%20%60Math.floor%60%20guard%20here%20is%20dead%20code.%20the%20%60Math.max%281%2C%20...%29%60%20is%20still%20useful%20as%20a%20defensive%20floor%20against%20a%20zero%2Fnegative%20value%20arriving%20from%20an%20external%20caller%2C%20but%20flooring%20is%20not.%0A%0A%60%60%60suggestion%0A%09private%20getAuthFailureCooldownMs%28failureCount%3A%20number%29%3A%20number%20%7B%0A%09%09const%20streak%20%3D%20Math.max%281%2C%20failureCount%29%3B%0A%09%09return%20Math.min%28this.bufferMs%2C%20ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS%20*%20streak%29%3B%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Frefresh-guardian.ts%3A188-197%0A**%60no_refresh_token%60%20cooldown%20no%20longer%20respects%20%60bufferMs%60**%0A%0Apreviously%20this%20path%20used%20%60this.bufferMs%60%20%28default%205%20min%29.%20now%20it%20uses%20%60ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS%60%20%2830%20s%29%20hard-coded%2C%20bypassing%20%60getAuthFailureCooldownMs%60%20entirely.%20the%20account%20is%20disabled%20immediately%20after%2C%20so%20the%20cooldown%20is%20mostly%20cosmetic%20%E2%80%94%20but%20there%20are%20two%20edge%20cases%20worth%20considering%3A%0A%0A1.%20if%20%60setAccountEnabled%60%20is%20called%20externally%20%28e.g.%20a%20migration%20or%20admin%20reset%29%20before%20the%20cooldown%20expires%2C%20the%20account%20re-enters%20the%20pool%20after%20only%2030%20s%20regardless%20of%20%60bufferMs%60.%0A2.%20%60incrementAuthFailures%60%20and%20%60clearAuthFailures%60%20are%20not%20called%20here%2C%20so%20the%20%60consecutiveAuthFailures%60%20counter%20is%20left%20at%20whatever%20it%20was%20before.%20if%20the%20account%20is%20later%20re-added%20%28new%20%60ManagedAccount%60%20object%29%2C%20this%20is%20irrelevant%3B%20if%20it%20is%20re-enabled%20in-place%2C%20the%20stale%20counter%20will%20inflate%20the%20first%20cooldown%20from%20%60getAuthFailureCooldownMs%60.%0A%0Aif%20the%2030%20s%20value%20and%20skipped%20counter%20management%20are%20intentional%2C%20a%20brief%20comment%20would%20help%20future%20readers%20understand%20the%20asymmetry.%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Frefresh-guardian.test.ts%3A599-639%0A**missing%20vitest%20coverage%20for%20%60bufferMs%60%20cap%20in%20escalation**%0A%0Athe%20%22escalates%20auth%20cooldowns%22%20test%20verifies%20streaks%201%20%E2%86%92%2030%20s%20and%202%20%E2%86%92%2060%20s%2C%20but%20never%20exercises%20the%20%60Math.min%28this.bufferMs%2C%20...%29%60%20branch%20where%20%60streak%20*%20AUTH_FAILURE_COOLDOWN_MS%60%20exceeds%20%60bufferMs%60.%20with%20%60bufferMs%20%3D%2060_000%60%20and%20%60streak%20%3D%203%60%2C%20the%20cooldown%20should%20cap%20at%2060%20s%20rather%20than%20continuing%20to%2090%20s.%20without%20a%20test%2C%20a%20future%20refactor%20could%20silently%20remove%20the%20cap.%20consider%20adding%20a%20third%20tick%20%28or%20a%20second%20test%20with%20a%20short%20%60bufferMs%60%29%20to%20cover%20this%20path%3A%0A%0A%60%60%60ts%0A%2F%2F%20example%3A%20bufferMs%20%3D%2040_000%2C%20streak%20%3D%202%20%E2%86%92%2030_000%20*%202%20%3D%2060_000%20%E2%86%92%20capped%20at%2040_000%0Aconst%20guardian%20%3D%20new%20RefreshGuardian%28%28%29%20%3D%3E%20manager%2C%20%7B%20bufferMs%3A%2040_000%2C%20intervalMs%3A%205_000%20%7D%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/refresh-guardian.ts
Line: 104-107

Comment:
**`Math.floor` on an integer return value is redundant**

`incrementAuthFailures` always returns a positive integer (`consecutiveAuthFailures` is `(... ?? 0) + 1`), so the `Math.floor` guard here is dead code. the `Math.max(1, ...)` is still useful as a defensive floor against a zero/negative value arriving from an external caller, but flooring is not.

```suggestion
	private getAuthFailureCooldownMs(failureCount: number): number {
		const streak = Math.max(1, failureCount);
		return Math.min(this.bufferMs, ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS * streak);
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/refresh-guardian.ts
Line: 188-197

Comment:
**`no_refresh_token` cooldown no longer respects `bufferMs`**

previously this path used `this.bufferMs` (default 5 min). now it uses `ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS` (30 s) hard-coded, bypassing `getAuthFailureCooldownMs` entirely. the account is disabled immediately after, so the cooldown is mostly cosmetic — but there are two edge cases worth considering:

1. if `setAccountEnabled` is called externally (e.g. a migration or admin reset) before the cooldown expires, the account re-enters the pool after only 30 s regardless of `bufferMs`.
2. `incrementAuthFailures` and `clearAuthFailures` are not called here, so the `consecutiveAuthFailures` counter is left at whatever it was before. if the account is later re-added (new `ManagedAccount` object), this is irrelevant; if it is re-enabled in-place, the stale counter will inflate the first cooldown from `getAuthFailureCooldownMs`.

if the 30 s value and skipped counter management are intentional, a brief comment would help future readers understand the asymmetry.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/refresh-guardian.test.ts
Line: 599-639

Comment:
**missing vitest coverage for `bufferMs` cap in escalation**

the "escalates auth cooldowns" test verifies streaks 1 → 30 s and 2 → 60 s, but never exercises the `Math.min(this.bufferMs, ...)` branch where `streak * AUTH_FAILURE_COOLDOWN_MS` exceeds `bufferMs`. with `bufferMs = 60_000` and `streak = 3`, the cooldown should cap at 60 s rather than continuing to 90 s. without a test, a future refactor could silently remove the cap. consider adding a third tick (or a second test with a short `bufferMs`) to cover this path:

```ts
// example: bufferMs = 40_000, streak = 2 → 30_000 * 2 = 60_000 → capped at 40_000
const guardian = new RefreshGuardian(() => manager, { bufferMs: 40_000, intervalMs: 5_000 });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: clear guardian auth streaks on non-..."](https://github.com/ndycode/codex-multi-auth/commit/6e6781a69d00ee1d732dcf1af074b8e217dbca25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26969667)</sub>

<!-- /greptile_comment -->