### PR TITLE
fix runtime tracker state identity keys

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -76,8 +76,16 @@ import {
 
 const log = createLogger("accounts");
 
-function getRuntimeTrackerKey(account: ManagedAccount): string | number {
-	return getRuntimeAccountIdentityKey(account) ?? account.index;
+export function getRuntimeTrackerKey(
+	account: ManagedAccount,
+): string | number {
+	if (account._runtimeTrackerKey !== undefined) {
+		return account._runtimeTrackerKey;
+	}
+
+	const trackerKey = getRuntimeAccountIdentityKey(account) ?? account.index;
+	account._runtimeTrackerKey = trackerKey;
+	return trackerKey;
 }
 
 function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
@@ -96,6 +104,7 @@ export interface Workspace {
 
 export interface ManagedAccount {
 	index: number;
+	_runtimeTrackerKey?: string | number;
 	accountId?: string;
 	accountIdSource?: AccountIdSource;
 	accountLabel?: string;
@@ -373,10 +382,14 @@ export class AccountManager {
 	}
 
 	getAccountsSnapshot(): ManagedAccount[] {
-		return this.accounts.map((account) => ({
-			...account,
-			rateLimitResetTimes: { ...account.rateLimitResetTimes },
-		}));
+		return this.accounts.map((account) => {
+			const trackerKey = getRuntimeTrackerKey(account);
+			return {
+				...account,
+				_runtimeTrackerKey: trackerKey,
+				rateLimitResetTimes: { ...account.rateLimitResetTimes },
+			};
+		});
 	}
 
 	getAccountByIndex(index: number): ManagedAccount | null {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -24,6 +24,7 @@ import {
 } from "./codex-cli/state.js";
 import { syncAccountStorageFromCodexCli } from "./codex-cli/sync.js";
 import { setCodexCliActiveSelection } from "./codex-cli/writer.js";
+import { getAccountIdentityKey } from "./storage/identity.js";
 
 export {
 	extractAccountId,
@@ -74,6 +75,10 @@ import {
 } from "./accounts/rate-limits.js";
 
 const log = createLogger("accounts");
+
+function getRuntimeTrackerKey(account: ManagedAccount): string | number {
+	return getAccountIdentityKey(account) ?? `index:${account.index}`;
+}
 
 function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
 	return Object.fromEntries(
@@ -528,6 +533,7 @@ export class AccountManager {
 					!isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
 				return {
 					index: account.index,
+					trackerKey: getRuntimeTrackerKey(account),
 					isAvailable,
 					lastUsed: account.lastUsed,
 				};
@@ -549,27 +555,28 @@ export class AccountManager {
 	recordSuccess(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
-		healthTracker.recordSuccess(account.index, quotaKey);
+		healthTracker.recordSuccess(getRuntimeTrackerKey(account), quotaKey);
 	}
 
 	recordRateLimit(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		const tokenTracker = getTokenTracker();
-		healthTracker.recordRateLimit(account.index, quotaKey);
-		tokenTracker.drain(account.index, quotaKey);
+		const trackerKey = getRuntimeTrackerKey(account);
+		healthTracker.recordRateLimit(trackerKey, quotaKey);
+		tokenTracker.drain(trackerKey, quotaKey);
 	}
 
 	recordFailure(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
-		healthTracker.recordFailure(account.index, quotaKey);
+		healthTracker.recordFailure(getRuntimeTrackerKey(account), quotaKey);
 	}
 
 	consumeToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
-		return tokenTracker.tryConsume(account.index, quotaKey);
+		return tokenTracker.tryConsume(getRuntimeTrackerKey(account), quotaKey);
 	}
 
 	/**
@@ -580,7 +587,7 @@ export class AccountManager {
 	refundToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
-		return tokenTracker.refundToken(account.index, quotaKey);
+		return tokenTracker.refundToken(getRuntimeTrackerKey(account), quotaKey);
 	}
 
 	markSwitched(account: ManagedAccount, reason: "rate-limit" | "initial" | "rotation", family: ModelFamily): void {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -24,7 +24,7 @@ import {
 } from "./codex-cli/state.js";
 import { syncAccountStorageFromCodexCli } from "./codex-cli/sync.js";
 import { setCodexCliActiveSelection } from "./codex-cli/writer.js";
-import { getAccountIdentityKey } from "./storage/identity.js";
+import { getRuntimeAccountIdentityKey } from "./storage/identity.js";
 
 export {
 	extractAccountId,
@@ -77,7 +77,7 @@ import {
 const log = createLogger("accounts");
 
 function getRuntimeTrackerKey(account: ManagedAccount): string | number {
-	return getAccountIdentityKey(account) ?? `index:${account.index}`;
+	return getRuntimeAccountIdentityKey(account) ?? account.index;
 }
 
 function initFamilyState(defaultValue: number): Record<ModelFamily, number> {

--- a/lib/parallel-probe.ts
+++ b/lib/parallel-probe.ts
@@ -7,6 +7,7 @@ import {
 	type AccountWithMetrics,
 } from "./rotation.js";
 import { clearExpiredRateLimits, isRateLimitedForFamily } from "./accounts/rate-limits.js";
+import { getRuntimeAccountIdentityKey } from "./storage/identity.js";
 
 const log = createLogger("parallel-probe");
 
@@ -108,6 +109,7 @@ export function getTopCandidates(
 
 		accountsWithMetrics.push({
 			index: account.index,
+			trackerKey: getRuntimeAccountIdentityKey(account),
 			isAvailable,
 			lastUsed: account.lastUsed,
 			account,
@@ -119,8 +121,9 @@ export function getTopCandidates(
 
 	const now = Date.now();
 	const scored = available.map((a) => {
-		const health = healthTracker.getScore(a.index, quotaKey);
-		const tokens = tokenTracker.getTokens(a.index, quotaKey);
+		const trackerKey = a.trackerKey ?? a.index;
+		const health = healthTracker.getScore(trackerKey, quotaKey);
+		const tokens = tokenTracker.getTokens(trackerKey, quotaKey);
 		const hoursSinceUsed = (now - a.lastUsed) / (1000 * 60 * 60);
 		const score = health * 2 + tokens * 5 + hoursSinceUsed * 2.0;
 		return { ...a, score };

--- a/lib/parallel-probe.ts
+++ b/lib/parallel-probe.ts
@@ -1,4 +1,8 @@
-import type { ManagedAccount, AccountManager } from "./accounts.js";
+import {
+	getRuntimeTrackerKey,
+	type ManagedAccount,
+	type AccountManager,
+} from "./accounts.js";
 import type { ModelFamily } from "./prompts/codex.js";
 import { createLogger } from "./logger.js";
 import {
@@ -7,8 +11,6 @@ import {
 	type AccountWithMetrics,
 } from "./rotation.js";
 import { clearExpiredRateLimits, isRateLimitedForFamily } from "./accounts/rate-limits.js";
-import { getRuntimeAccountIdentityKey } from "./storage/identity.js";
-
 const log = createLogger("parallel-probe");
 
 export interface ProbeCandidate {
@@ -109,7 +111,7 @@ export function getTopCandidates(
 
 		accountsWithMetrics.push({
 			index: account.index,
-			trackerKey: getRuntimeAccountIdentityKey(account),
+			trackerKey: getRuntimeTrackerKey(account),
 			isAvailable,
 			lastUsed: account.lastUsed,
 			account,

--- a/lib/rotation.ts
+++ b/lib/rotation.ts
@@ -44,6 +44,8 @@ interface HealthEntry {
   consecutiveFailures: number;
 }
 
+type TrackerKey = number | string;
+
 /**
  * Tracks health scores for accounts to prioritize healthy accounts.
  * Accounts with higher health scores are preferred for selection.
@@ -56,8 +58,10 @@ export class HealthScoreTracker {
     this.config = { ...DEFAULT_HEALTH_SCORE_CONFIG, ...config };
   }
 
-  private getKey(accountIndex: number, quotaKey?: string): string {
-    return quotaKey ? `${accountIndex}:${quotaKey}` : `${accountIndex}`;
+  private getKey(accountKey: TrackerKey, quotaKey?: string): string {
+    const normalizedKey =
+      typeof accountKey === "number" ? `${accountKey}` : accountKey;
+    return quotaKey ? `${normalizedKey}:${quotaKey}` : normalizedKey;
   }
 
   private applyPassiveRecovery(entry: HealthEntry): number {
@@ -67,21 +71,21 @@ export class HealthScoreTracker {
     return Math.min(entry.score + recovery, this.config.maxScore);
   }
 
-  getScore(accountIndex: number, quotaKey?: string): number {
-    const key = this.getKey(accountIndex, quotaKey);
+  getScore(accountKey: TrackerKey, quotaKey?: string): number {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     if (!entry) return this.config.maxScore;
     return this.applyPassiveRecovery(entry);
   }
 
-  getConsecutiveFailures(accountIndex: number, quotaKey?: string): number {
-    const key = this.getKey(accountIndex, quotaKey);
+  getConsecutiveFailures(accountKey: TrackerKey, quotaKey?: string): number {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     return entry?.consecutiveFailures ?? 0;
   }
 
-  recordSuccess(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  recordSuccess(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
     const newScore = Math.min(baseScore + this.config.successDelta, this.config.maxScore);
@@ -92,8 +96,8 @@ export class HealthScoreTracker {
     });
   }
 
-  recordRateLimit(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  recordRateLimit(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
     const newScore = Math.max(baseScore + this.config.rateLimitDelta, this.config.minScore);
@@ -104,8 +108,8 @@ export class HealthScoreTracker {
     });
   }
 
-  recordFailure(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  recordFailure(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
     const newScore = Math.max(baseScore + this.config.failureDelta, this.config.minScore);
@@ -116,8 +120,8 @@ export class HealthScoreTracker {
     });
   }
 
-  reset(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  reset(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     this.entries.delete(key);
   }
 
@@ -162,8 +166,10 @@ export class TokenBucketTracker {
     this.config = { ...DEFAULT_TOKEN_BUCKET_CONFIG, ...config };
   }
 
-  private getKey(accountIndex: number, quotaKey?: string): string {
-    return quotaKey ? `${accountIndex}:${quotaKey}` : `${accountIndex}`;
+  private getKey(accountKey: TrackerKey, quotaKey?: string): string {
+    const normalizedKey =
+      typeof accountKey === "number" ? `${accountKey}` : accountKey;
+    return quotaKey ? `${normalizedKey}:${quotaKey}` : normalizedKey;
   }
 
   private refillTokens(entry: TokenBucketEntry): number {
@@ -173,8 +179,8 @@ export class TokenBucketTracker {
     return Math.min(entry.tokens + tokensToAdd, this.config.maxTokens);
   }
 
-  getTokens(accountIndex: number, quotaKey?: string): number {
-    const key = this.getKey(accountIndex, quotaKey);
+  getTokens(accountKey: TrackerKey, quotaKey?: string): number {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.buckets.get(key);
     if (!entry) return this.config.maxTokens;
     return this.refillTokens(entry);
@@ -183,8 +189,8 @@ export class TokenBucketTracker {
   /**
    * Attempt to consume a token. Returns true if successful, false if bucket is empty.
    */
-  tryConsume(accountIndex: number, quotaKey?: string): boolean {
-    const key = this.getKey(accountIndex, quotaKey);
+  tryConsume(accountKey: TrackerKey, quotaKey?: string): boolean {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.buckets.get(key);
     const currentTokens = entry ? this.refillTokens(entry) : this.config.maxTokens;
 
@@ -212,8 +218,8 @@ export class TokenBucketTracker {
    * Use this when a request fails due to network errors (not rate limits).
    * @returns true if refund was successful, false if no valid consumption found
    */
-  refundToken(accountIndex: number, quotaKey?: string): boolean {
-    const key = this.getKey(accountIndex, quotaKey);
+  refundToken(accountKey: TrackerKey, quotaKey?: string): boolean {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.buckets.get(key);
     if (!entry || entry.consumptions.length === 0) return false;
 
@@ -239,8 +245,8 @@ export class TokenBucketTracker {
   /**
    * Drain tokens on rate limit to prevent immediate retries.
    */
-  drain(accountIndex: number, quotaKey?: string, drainAmount: number = 10): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  drain(accountKey: TrackerKey, quotaKey?: string, drainAmount: number = 10): void {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.buckets.get(key);
     const currentTokens = entry ? this.refillTokens(entry) : this.config.maxTokens;
     this.buckets.set(key, {
@@ -250,8 +256,8 @@ export class TokenBucketTracker {
     });
   }
 
-  reset(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  reset(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     this.buckets.delete(key);
   }
 
@@ -266,6 +272,7 @@ export class TokenBucketTracker {
 
 export interface AccountWithMetrics {
   index: number;
+  trackerKey?: TrackerKey;
   isAvailable: boolean;
   lastUsed: number;
 }
@@ -393,8 +400,9 @@ export function selectHybridAccount(
   const pidBonus = resolvedOptions.pidOffsetEnabled ? (process.pid % 100) * 0.01 : 0;
 
   for (const account of available) {
-    const health = resolvedHealthTracker.getScore(account.index, resolvedQuotaKey);
-    const tokens = resolvedTokenTracker.getTokens(account.index, resolvedQuotaKey);
+    const trackerKey = account.trackerKey ?? account.index;
+    const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
+    const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
     const hoursSinceUsed = (now - account.lastUsed) / (1000 * 60 * 60);
 
     const capabilityBoost =
@@ -421,8 +429,9 @@ export function selectHybridAccount(
   }
 
   if (bestAccount && available.length > 1) {
-    const health = resolvedHealthTracker.getScore(bestAccount.index, resolvedQuotaKey);
-    const tokens = resolvedTokenTracker.getTokens(bestAccount.index, resolvedQuotaKey);
+    const trackerKey = bestAccount.trackerKey ?? bestAccount.index;
+    const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
+    const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
     log.debug("Selected account", {
       index: bestAccount.index,
       health: Math.round(health),

--- a/lib/rotation.ts
+++ b/lib/rotation.ts
@@ -46,6 +46,12 @@ interface HealthEntry {
 
 type TrackerKey = number | string;
 
+function normalizeTrackerKey(accountKey: TrackerKey, quotaKey?: string): string {
+	const normalizedKey =
+		typeof accountKey === "number" ? `${accountKey}` : accountKey;
+	return quotaKey ? `${normalizedKey}:${quotaKey}` : normalizedKey;
+}
+
 /**
  * Tracks health scores for accounts to prioritize healthy accounts.
  * Accounts with higher health scores are preferred for selection.
@@ -59,9 +65,7 @@ export class HealthScoreTracker {
   }
 
   private getKey(accountKey: TrackerKey, quotaKey?: string): string {
-    const normalizedKey =
-      typeof accountKey === "number" ? `${accountKey}` : accountKey;
-    return quotaKey ? `${normalizedKey}:${quotaKey}` : normalizedKey;
+    return normalizeTrackerKey(accountKey, quotaKey);
   }
 
   private applyPassiveRecovery(entry: HealthEntry): number {
@@ -167,9 +171,7 @@ export class TokenBucketTracker {
   }
 
   private getKey(accountKey: TrackerKey, quotaKey?: string): string {
-    const normalizedKey =
-      typeof accountKey === "number" ? `${accountKey}` : accountKey;
-    return quotaKey ? `${normalizedKey}:${quotaKey}` : normalizedKey;
+    return normalizeTrackerKey(accountKey, quotaKey);
   }
 
   private refillTokens(entry: TokenBucketEntry): number {

--- a/lib/rotation.ts
+++ b/lib/rotation.ts
@@ -49,7 +49,7 @@ type TrackerKey = number | string;
 function normalizeTrackerKey(accountKey: TrackerKey, quotaKey?: string): string {
 	const normalizedKey =
 		typeof accountKey === "number" ? `${accountKey}` : accountKey;
-	return quotaKey ? `${normalizedKey}:${quotaKey}` : normalizedKey;
+	return JSON.stringify([normalizedKey, quotaKey ?? null]);
 }
 
 /**

--- a/lib/storage/identity.ts
+++ b/lib/storage/identity.ts
@@ -6,6 +6,12 @@ type AccountLike = {
 	refreshToken?: string;
 };
 
+type RuntimeAccountLike = {
+	accountId?: string;
+	email?: string;
+	index?: number;
+};
+
 export type AccountIdentityRef = {
 	accountId?: string;
 	emailKey?: string;
@@ -52,19 +58,39 @@ export function toAccountIdentityRef(
 	};
 }
 
-export function getAccountIdentityKey(
-	account: Pick<AccountLike, "accountId" | "email" | "refreshToken">,
+function getIdentityKeyFromRef(
+	ref: AccountIdentityRef,
+	options: { allowRefreshFallback: boolean },
 ): string | undefined {
-	const ref = toAccountIdentityRef(account);
 	if (ref.accountId && ref.emailKey) {
 		return `account:${ref.accountId}::email:${ref.emailKey}`;
 	}
 	if (ref.accountId) return `account:${ref.accountId}`;
 	if (ref.emailKey) return `email:${ref.emailKey}`;
-	if (ref.refreshToken) {
+	if (options.allowRefreshFallback && ref.refreshToken) {
 		// Legacy refresh-only identity keys embedded raw tokens. Hashing preserves
 		// deterministic fallback matching without exposing token material in logs.
 		return `refresh:${hashRefreshTokenKey(ref.refreshToken)}`;
 	}
 	return undefined;
+}
+
+export function getAccountIdentityKey(
+	account: Pick<AccountLike, "accountId" | "email" | "refreshToken">,
+): string | undefined {
+	const ref = toAccountIdentityRef(account);
+	return getIdentityKeyFromRef(ref, { allowRefreshFallback: true });
+}
+
+export function getRuntimeAccountIdentityKey(
+	account: Pick<RuntimeAccountLike, "accountId" | "email" | "index">,
+): string | number | undefined {
+	const ref = toAccountIdentityRef({
+		accountId: account.accountId,
+		email: account.email,
+	});
+	return (
+		getIdentityKeyFromRef(ref, { allowRefreshFallback: false }) ??
+		(typeof account.index === "number" ? account.index : undefined)
+	);
 }

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -9,6 +9,7 @@ import {
   formatCooldown,
   shouldUpdateAccountIdFromToken,
   getAccountIdCandidates,
+  getRuntimeTrackerKey,
 } from "../lib/accounts.js";
 import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
 import {
@@ -2062,6 +2063,52 @@ describe("AccountManager", () => {
       const rotatedAccount = manager.getCurrentAccount()!;
       expect(getRuntimeAccountIdentityKey(rotatedAccount)).toBe(trackerKey);
       expect(getAccountIdentityKey(rotatedAccount)).not.toBe(`${trackerKey}`);
+      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBe(degradedScore);
+      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
+    });
+
+    it("keeps pinned runtime tracker state stable after updateFromAuth enriches identity", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          { refreshToken: "token-1", addedAt: now, lastUsed: now },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      const healthTracker = getHealthTracker();
+      const tokenTracker = getTokenTracker();
+      const trackerKey = getRuntimeTrackerKey(account);
+
+      manager.recordFailure(account, "codex", "gpt-5.1");
+      const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+      expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
+
+      const payload = Buffer.from(JSON.stringify({
+        email: "enriched@example.com",
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "account-enriched",
+        },
+        exp: Math.floor((now + 3600000) / 1000),
+      })).toString("base64url");
+      const accessToken = `header.${payload}.signature`;
+
+      manager.updateFromAuth(account, {
+        type: "oauth",
+        access: accessToken,
+        refresh: "token-1-rotated",
+        expires: now + 3600000,
+      });
+
+      expect(account.accountId).toBe("account-enriched");
+      expect(account.email).toBe("enriched@example.com");
+      expect(getRuntimeAccountIdentityKey(account)).toBe(
+        "account:account-enriched::email:enriched@example.com",
+      );
+      expect(getRuntimeTrackerKey(account)).toBe(trackerKey);
       expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBe(degradedScore);
       expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
     });

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -11,7 +11,10 @@ import {
   getAccountIdCandidates,
 } from "../lib/accounts.js";
 import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
-import { getAccountIdentityKey } from "../lib/storage/identity.js";
+import {
+  getAccountIdentityKey,
+  getRuntimeAccountIdentityKey,
+} from "../lib/storage/identity.js";
 import type { OAuthAuthDetails } from "../lib/types.js";
 
 vi.mock("../lib/storage.js", async (importOriginal) => {
@@ -1877,7 +1880,7 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
-      const trackerKey = getAccountIdentityKey(account)!;
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordSuccess(account, "codex", "gpt-5.1");
       
@@ -1898,7 +1901,7 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
-      const trackerKey = getAccountIdentityKey(account)!;
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordSuccess(account, "codex", null);
       
@@ -1920,7 +1923,7 @@ describe("AccountManager", () => {
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
       const tokenTracker = getTokenTracker();
-      const trackerKey = getAccountIdentityKey(account)!;
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordRateLimit(account, "codex", "gpt-5.1");
       
@@ -1943,7 +1946,7 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
-      const trackerKey = getAccountIdentityKey(account)!;
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordRateLimit(account, "gpt-5.2");
       
@@ -1964,7 +1967,7 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
-      const trackerKey = getAccountIdentityKey(account)!;
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordFailure(account, "codex", "gpt-5.2");
       
@@ -1985,7 +1988,7 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
-      const trackerKey = getAccountIdentityKey(account)!;
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordFailure(account, "gpt-5.1", null);
       
@@ -2006,7 +2009,7 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const tokenTracker = getTokenTracker();
-      const trackerKey = getAccountIdentityKey(account)!;
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       const initialTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
       const result = manager.consumeToken(account, "codex", "gpt-5.1");
@@ -2032,6 +2035,35 @@ describe("AccountManager", () => {
       const result = manager.consumeToken(account, "codex");
 
       expect(result).toBe(true);
+    });
+
+    it("keeps refresh-only tracker state stable when the refresh token rotates", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          { refreshToken: "token-1", addedAt: now, lastUsed: now },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      const healthTracker = getHealthTracker();
+      const tokenTracker = getTokenTracker();
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
+
+      manager.recordFailure(account, "codex", "gpt-5.1");
+      const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+      expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
+
+      account.refreshToken = "token-1-rotated";
+
+      const rotatedAccount = manager.getCurrentAccount()!;
+      expect(getRuntimeAccountIdentityKey(rotatedAccount)).toBe(trackerKey);
+      expect(getAccountIdentityKey(rotatedAccount)).not.toBe(`${trackerKey}`);
+      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBe(degradedScore);
+      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
     });
 
     it("preserves tracker state when account indexes shift", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -11,6 +11,7 @@ import {
   getAccountIdCandidates,
 } from "../lib/accounts.js";
 import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
+import { getAccountIdentityKey } from "../lib/storage/identity.js";
 import type { OAuthAuthDetails } from "../lib/types.js";
 
 vi.mock("../lib/storage.js", async (importOriginal) => {
@@ -1876,10 +1877,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getAccountIdentityKey(account)!;
 
       manager.recordSuccess(account, "codex", "gpt-5.1");
       
-      const score = healthTracker.getScore(account.index, "codex:gpt-5.1");
+      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
       expect(score).toBe(100);
     });
 
@@ -1896,10 +1898,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getAccountIdentityKey(account)!;
 
       manager.recordSuccess(account, "codex", null);
       
-      const score = healthTracker.getScore(account.index, "codex");
+      const score = healthTracker.getScore(trackerKey, "codex");
       expect(score).toBe(100);
     });
 
@@ -1917,11 +1920,12 @@ describe("AccountManager", () => {
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
       const tokenTracker = getTokenTracker();
+      const trackerKey = getAccountIdentityKey(account)!;
 
       manager.recordRateLimit(account, "codex", "gpt-5.1");
       
-      const score = healthTracker.getScore(account.index, "codex:gpt-5.1");
-      const tokens = tokenTracker.getTokens(account.index, "codex:gpt-5.1");
+      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+      const tokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
       expect(score).toBeLessThan(100);
       expect(tokens).toBeLessThan(50);
     });
@@ -1939,10 +1943,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getAccountIdentityKey(account)!;
 
       manager.recordRateLimit(account, "gpt-5.2");
       
-      const score = healthTracker.getScore(account.index, "gpt-5.2");
+      const score = healthTracker.getScore(trackerKey, "gpt-5.2");
       expect(score).toBeLessThan(100);
     });
 
@@ -1959,10 +1964,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getAccountIdentityKey(account)!;
 
       manager.recordFailure(account, "codex", "gpt-5.2");
       
-      const score = healthTracker.getScore(account.index, "codex:gpt-5.2");
+      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.2");
       expect(score).toBeLessThan(100);
     });
 
@@ -1979,10 +1985,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getAccountIdentityKey(account)!;
 
       manager.recordFailure(account, "gpt-5.1", null);
       
-      const score = healthTracker.getScore(account.index, "gpt-5.1");
+      const score = healthTracker.getScore(trackerKey, "gpt-5.1");
       expect(score).toBeLessThan(100);
     });
 
@@ -1999,10 +2006,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const tokenTracker = getTokenTracker();
+      const trackerKey = getAccountIdentityKey(account)!;
 
-      const initialTokens = tokenTracker.getTokens(account.index, "codex:gpt-5.1");
+      const initialTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
       const result = manager.consumeToken(account, "codex", "gpt-5.1");
-      const afterTokens = tokenTracker.getTokens(account.index, "codex:gpt-5.1");
+      const afterTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
 
       expect(result).toBe(true);
       expect(afterTokens).toBeLessThan(initialTokens);
@@ -2024,6 +2032,47 @@ describe("AccountManager", () => {
       const result = manager.consumeToken(account, "codex");
 
       expect(result).toBe(true);
+    });
+
+    it("preserves tracker state when account indexes shift", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 1,
+        activeIndexByFamily: { codex: 1 },
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "first@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+          {
+            refreshToken: "token-2",
+            email: "second@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored as never);
+      const trackedAccount = manager.getAccountByIndex(1)!;
+      const trackerKey = getAccountIdentityKey(trackedAccount)!;
+      const healthTracker = getHealthTracker();
+      const tokenTracker = getTokenTracker();
+
+      manager.recordFailure(trackedAccount, "codex", "gpt-5.1");
+      expect(manager.consumeToken(trackedAccount, "codex", "gpt-5.1")).toBe(true);
+
+      expect(manager.removeAccountByIndex(0)).toBe(true);
+
+      const remainingAccount = manager.getAccountByIndex(0)!;
+      expect(remainingAccount.email).toBe("second@example.com");
+      expect(remainingAccount.index).toBe(0);
+      expect(getAccountIdentityKey(remainingAccount)).toBe(trackerKey);
+      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeLessThan(100);
+      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
     });
   });
 

--- a/test/parallel-probe.test.ts
+++ b/test/parallel-probe.test.ts
@@ -5,7 +5,11 @@ import {
 	getTopCandidates,
 	type ProbeCandidate,
 } from "../lib/parallel-probe.js";
-import type { ManagedAccount } from "../lib/accounts.js";
+import {
+	AccountManager,
+	getRuntimeTrackerKey,
+	type ManagedAccount,
+} from "../lib/accounts.js";
 import { getHealthTracker, resetTrackers } from "../lib/rotation.js";
 import { getRuntimeAccountIdentityKey } from "../lib/storage/identity.js";
 
@@ -300,6 +304,91 @@ describe("parallel-probe", () => {
 			expect(candidates).toHaveLength(2);
 			expect(candidates[0]?.email).toBe("second@example.com");
 			expect(candidates[1]?.email).toBe("first@example.com");
+		});
+
+		it("reuses pinned tracker keys after accounts gain identity fields", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{
+						refreshToken: "token-2",
+						email: "healthy@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getAccountByIndex(0)!;
+			const pinnedTrackerKey = getRuntimeTrackerKey(account);
+			getHealthTracker().recordFailure(pinnedTrackerKey, "codex");
+
+			const payload = Buffer.from(JSON.stringify({
+				email: "enriched@example.com",
+				"https://api.openai.com/auth": {
+					chatgpt_account_id: "account-enriched",
+				},
+				exp: Math.floor((now + 3600000) / 1000),
+			})).toString("base64url");
+			const accessToken = `header.${payload}.signature`;
+
+			manager.updateFromAuth(account, {
+				type: "oauth",
+				access: accessToken,
+				refresh: "token-1-rotated",
+				expires: now + 3600000,
+			});
+
+			const candidates = getTopCandidates(manager, "codex", null, 2);
+			const enrichedCandidate = candidates.find(
+				(candidate) => candidate.refreshToken === "token-1-rotated",
+			);
+
+			expect(candidates).toHaveLength(2);
+			expect(candidates[0]?.email).toBe("healthy@example.com");
+			expect(enrichedCandidate?._runtimeTrackerKey).toBe(pinnedTrackerKey);
+		});
+
+		it("does not alias tracker state when tracker and quota keys contain delimiters", () => {
+			const now = Date.now();
+			const collidingWriter = createMockAccount(0, {
+				accountId: "one",
+				lastUsed: now,
+			});
+			const shouldStayHealthy = createMockAccount(1, {
+				accountId: "one:codex",
+				lastUsed: now,
+			});
+			const healthyPeer = createMockAccount(2, {
+				accountId: "peer",
+				lastUsed: now,
+			});
+
+			getHealthTracker().recordFailure(
+				getRuntimeTrackerKey(collidingWriter),
+				"codex:gpt-5.1:three",
+			);
+
+			const mockManager = {
+				getAccountsSnapshot: vi
+					.fn()
+					.mockReturnValue([shouldStayHealthy, healthyPeer]),
+			};
+
+			const candidates = getTopCandidates(
+				mockManager as unknown as Parameters<typeof getTopCandidates>[0],
+				"gpt-5.1",
+				"three",
+				2,
+			);
+
+			expect(candidates).toHaveLength(2);
+			expect(candidates[0]?.accountId).toBe("one:codex");
+			expect(candidates[1]?.accountId).toBe("peer");
 		});
 
 		it("supports named-parameter options form", () => {

--- a/test/parallel-probe.test.ts
+++ b/test/parallel-probe.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	probeAccountsInParallel,
 	createProbeCandidates,
@@ -6,6 +6,8 @@ import {
 	type ProbeCandidate,
 } from "../lib/parallel-probe.js";
 import type { ManagedAccount } from "../lib/accounts.js";
+import { getHealthTracker, resetTrackers } from "../lib/rotation.js";
+import { getRuntimeAccountIdentityKey } from "../lib/storage/identity.js";
 
 function createMockAccount(index: number, overrides: Partial<ManagedAccount> = {}): ManagedAccount {
 	return {
@@ -19,6 +21,14 @@ function createMockAccount(index: number, overrides: Partial<ManagedAccount> = {
 }
 
 describe("parallel-probe", () => {
+	beforeEach(() => {
+		resetTrackers();
+	});
+
+	afterEach(() => {
+		resetTrackers();
+	});
+
 	describe("createProbeCandidates", () => {
 		it("creates candidates with abort controllers", () => {
 			const accounts = [createMockAccount(0), createMockAccount(1)];
@@ -259,6 +269,37 @@ describe("parallel-probe", () => {
 
 			expect(candidates).toHaveLength(2);
 			expect(candidates[0].index).toBe(1);
+		});
+
+		it("uses runtime tracker keys when ranking candidates", () => {
+			const now = Date.now();
+			const penalizedAccount = createMockAccount(0, {
+				email: "first@example.com",
+				lastUsed: now,
+			});
+			const healthyAccount = createMockAccount(1, {
+				email: "second@example.com",
+				lastUsed: now,
+			});
+			const trackerKey = getRuntimeAccountIdentityKey(penalizedAccount)!;
+			getHealthTracker().recordFailure(trackerKey, "codex");
+
+			const mockManager = {
+				getAccountsSnapshot: vi
+					.fn()
+					.mockReturnValue([penalizedAccount, healthyAccount]),
+			};
+
+			const candidates = getTopCandidates(
+				mockManager as unknown as Parameters<typeof getTopCandidates>[0],
+				"codex",
+				null,
+				2,
+			);
+
+			expect(candidates).toHaveLength(2);
+			expect(candidates[0]?.email).toBe("second@example.com");
+			expect(candidates[1]?.email).toBe("first@example.com");
 		});
 
 		it("supports named-parameter options form", () => {

--- a/test/rotation.test.ts
+++ b/test/rotation.test.ts
@@ -362,6 +362,19 @@ describe("selectHybridAccount", () => {
 		expect(result?.index).toBe(1);
 	});
 
+	it("uses trackerKey when runtime state is keyed by stable identity", () => {
+		const now = Date.now();
+		const accounts: AccountWithMetrics[] = [
+			{ index: 0, trackerKey: "email:first@example.com", isAvailable: true, lastUsed: now },
+			{ index: 1, trackerKey: "email:second@example.com", isAvailable: true, lastUsed: now },
+		];
+
+		healthTracker.recordFailure("email:first@example.com");
+
+		const result = selectHybridAccount(accounts, healthTracker, tokenTracker);
+		expect(result?.index).toBe(1);
+	});
+
 	it("considers freshness in selection", () => {
 		const accounts: AccountWithMetrics[] = [
 			{ index: 0, isAvailable: true, lastUsed: Date.now() },

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getConfigDir, getProjectStorageKey } from "../lib/storage/paths.js";
 import { setStoragePathState } from "../lib/storage/path-state.js";
 import { getIntentionalResetMarkerPath } from "../lib/storage/backup-paths.js";
+import { getRuntimeAccountIdentityKey } from "../lib/storage/identity.js";
 import {
 	buildNamedBackupPath,
 	clearAccounts,
@@ -151,6 +152,16 @@ describe("storage", () => {
 
 			expect(identityKey).toBe(`refresh:${expectedHash}`);
 			expect(identityKey).not.toContain(refreshToken.trim());
+		});
+
+		it("uses numeric index as the runtime key for refresh-only accounts", () => {
+			expect(
+				getRuntimeAccountIdentityKey({
+					accountId: " ",
+					email: " ",
+					index: 7,
+				}),
+			).toBe(7);
 		});
 	});
 	describe("deduplication", () => {


### PR DESCRIPTION
## Summary

- keep runtime health and token bucket state pinned to stable account identity keys instead of mutable `account.index` values

## What Changed

- widened the in-memory health/token tracker keys to accept stable string identities as well as numeric indexes
- routed runtime tracker lookups through `getRuntimeAccountIdentityKey(...)` so refresh-token-only accounts fall back to numeric runtime indexes instead of refresh-token hashes
- passed runtime tracker keys through both the account-manager flow and `parallel-probe` candidate scoring so every hybrid-selection path reads the same tracker state
- extracted the shared tracker-key normalization helper in `rotation.ts`
- added regressions covering index churn after account removal, refresh-token rotation for refresh-only accounts, runtime-key scoring in `parallel-probe`, and runtime identity fallback behavior

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/accounts.test.ts test/parallel-probe.test.ts test/rotation.test.ts test/storage.test.ts test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low
- Rollback plan: revert `35707b7` and `6a4b5e2`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR pins in-memory health and token-bucket tracker state to stable account identity keys (email/accountId-based) rather than mutable `account.index` values, fixing a real regression where account removal + re-indexing would silently orphan or cross-contaminate tracker state for accounts that have email or accountId. the change is mechanically sound for the identity-rich path; the refresh-only numeric fallback is intentionally preserved as a known-limited fallback.

**key changes:**
- `normalizeTrackerKey` in `rotation.ts` switches from `\"${idx}:${quotaKey}\"` colon-concat to `JSON.stringify([key, quotaKey])`, closing a delimiter-collision vector
- `getRuntimeTrackerKey` in `accounts.ts` caches the resolved key on the live `ManagedAccount` object; `updateFromAuth` does not clear the cache, so identity enrichment after first access doesn't change the tracker bucket
- `getAccountsSnapshot` now propagates `_runtimeTrackerKey` onto snapshot copies so `parallel-probe` and `selectHybridAccount` all read the same bucket
- new regressions cover: index-churn after account removal, refresh-token rotation for refresh-only accounts, runtime-key-based candidate scoring in `parallel-probe`, and delimiter-collision prevention

**concern:** `removeAccount` re-assigns `acc.index` but does not clear `_runtimeTrackerKey` on surviving refresh-only accounts — if a new refresh-only account fills the same numeric slot, both accounts share tracker state with no test coverage.

<h3>Confidence Score: 4/5</h3>

safe to merge for identity-rich accounts; the refresh-only slot-collision after account removal is a real P1 on an uncommon code path that needs a targeted fix or explicit test + doc before ship

the identity-keyed path is correct, well-tested, and closes the real index-churn bug. the P1 is the `removeAccount` + re-index scenario for refresh-only accounts where `_runtimeTrackerKey` is not cleared: surviving refresh-only accounts keep their old numeric slot key, and any new refresh-only account added at the same slot will share tracker state. this is a present defect on the refresh-only path with no regression coverage.

`lib/accounts.ts` — `removeAccount` and `getRuntimeTrackerKey` interaction for refresh-only accounts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds `getRuntimeTrackerKey` with lazy-cache mutation pattern and routes all tracker ops through stable identity keys; `removeAccount` re-indexes `acc.index` but leaves `_runtimeTrackerKey` stale for refresh-only accounts, enabling slot-collision for newly-added refresh-only accounts at the same numeric slot |
| lib/rotation.ts | widens `HealthScoreTracker` and `TokenBucketTracker` to accept `TrackerKey = number | string`; replaces colon-concatenated key format with `JSON.stringify` array encoding to prevent delimiter-collision; `AccountWithMetrics` gains optional `trackerKey` field used by `selectHybridAccount` |
| lib/storage/identity.ts | refactors `getAccountIdentityKey` into shared `getIdentityKeyFromRef` with `allowRefreshFallback` option; adds `getRuntimeAccountIdentityKey` that skips the refresh-hash path and falls back to numeric `account.index` for refresh-only accounts |
| lib/parallel-probe.ts | adds `trackerKey` to `AccountWithMetrics` push and routes health/token lookups through `a.trackerKey ?? a.index`; the fallback guard is dead code given snapshot always populates `trackerKey` |
| test/accounts.test.ts | updates existing tracker assertions to use identity keys; adds regression tests for refresh-token rotation stability, identity enrichment pinning, and index-churn — but no test for new refresh-only account occupying an already-used numeric slot after removal |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ManagedAccount] --> B{has accountId or email?}
    B -- yes --> C["getRuntimeAccountIdentityKey\n→ stable string key"]
    B -- no --> D["getRuntimeAccountIdentityKey\n→ account.index (numeric)"]
    C --> E[getRuntimeTrackerKey\ncaches on _runtimeTrackerKey]
    D --> E
    E --> F{_runtimeTrackerKey set?}
    F -- yes --> G[TrackerKey]
    F -- no, compute + cache --> G
    G --> H[normalizeTrackerKey\nJSON.stringify array]
    H --> I[HealthScoreTracker / TokenBucketTracker]
    I --> J[selectHybridAccount / getTopCandidates]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Faccounts.ts%3A384-392%0A**%60getAccountsSnapshot%60%20double-writes%20%60_runtimeTrackerKey%60**%0A%0A%60getRuntimeTrackerKey%28account%29%60%20on%20line%20386%20already%20caches%20%60_runtimeTrackerKey%60%20on%20the%20live%20account%20as%20a%20side-effect%2C%20and%20then%20the%20spread%20copy%20on%20line%20389%20writes%20it%20again%20explicitly.%20the%20redundant%20write%20is%20harmless%20but%20the%20implicit%20mutation%20of%20the%20live%20%60ManagedAccount%60%20inside%20a%20%60getAccountsSnapshot%60%20call%20is%20surprising%20%E2%80%94%20callers%20don't%20expect%20a%20%22read%22%20snapshot%20to%20mutate%20the%20underlying%20live%20objects.%0A%0Aconsider%20extracting%20the%20cache-fill%20step%20to%20an%20explicit%20%60initRuntimeTrackerKey%60%20call%20that's%20invoked%20at%20add%2Flogin%20time%20instead%20of%20lazily%20on%20first%20snapshot.%20this%20keeps%20%60getAccountsSnapshot%60%20side-effect-free%20and%20removes%20the%20duplicated%20write.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Faccounts.ts%3A747-750%0A**tracker-key%20slot%20collision%20after%20remove%20%2B%20re-add%20for%20refresh-only%20accounts**%0A%0A%60removeAccount%60%20re-indexes%20surviving%20accounts%20%28%60acc.index%20%3D%20index%60%29%20but%20does%20**not**%20clear%20%60_runtimeTrackerKey%60%20on%20them.%20for%20identity-rich%20accounts%20this%20is%20correct%20%E2%80%94%20their%20cached%20key%20is%20email%2FaccountId-based%20and%20remains%20stable.%20however%20for%20refresh-only%20accounts%20%28no%20%60email%60%2C%20no%20%60accountId%60%29%20the%20cached%20key%20IS%20the%20old%20numeric%20index%20%28e.g.%20%601%60%29.%20after%20removal%20and%20re-index%3A%0A%0A1.%20surviving%20refresh-only%20account%20at%20old%20index%20%601%60%20is%20re-indexed%20to%20%600%60%2C%20but%20%60_runtimeTrackerKey%60%20stays%20%601%60.%0A2.%20a%20new%20refresh-only%20account%20added%20to%20the%20list%20later%20gets%20%60account.index%20%3D%201%60%20with%20no%20cache%20entry%20%E2%86%92%20%60getRuntimeTrackerKey%60%20computes%20%601%60.%0A3.%20both%20accounts%20now%20map%20to%20tracker%20key%20%601%60%20%E2%86%92%20they%20share%20health%2Ftoken-bucket%20state.%0A%0Athis%20is%20a%20real%20slot-collision%20that%20the%20PR's%20email%2FaccountId%20path%20avoids%20but%20the%20refresh-only%20fallback%20path%20re-introduces%20after%20any%20account%20churn.%20there's%20no%20test%20covering%20this%20combination.%20as%20a%20minimum%2C%20consider%20documenting%20the%20invariant%20that%20numeric-fallback%20accounts%20MUST%20be%20the%20last%20shape%20added%20%28or%20asserting%20at%20add-time%20that%20refresh-only%20accounts%20always%20get%20a%20unique%20initial%20slot%29.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fparallel-probe.ts%3A126-128%0A**fallback%20guard%20redundant%20given%20upstream%20snapshot%20guarantee**%0A%0A%60a.trackerKey%20%3F%3F%20a.index%60%20duplicates%20logic%20from%20%60getRuntimeTrackerKey%60.%20since%20%60getAccountsSnapshot%28%29%60%20%28line%2097%29%20already%20calls%20%60getRuntimeTrackerKey%60%20on%20every%20account%20and%20the%20resulting%20snapshot%20always%20carries%20a%20populated%20%60trackerKey%60%2C%20this%20%60%3F%3F%20a.index%60%20branch%20is%20dead.%20removing%20the%20guard%20makes%20the%20intent%20clearer%20and%20avoids%20silently%20re-introducing%20a%20numeric-index%20path%20for%20an%20account%20whose%20%60trackerKey%60%20was%20somehow%20stripped%20between%20snapshot%20and%20scoring.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/accounts.ts
Line: 384-392

Comment:
**`getAccountsSnapshot` double-writes `_runtimeTrackerKey`**

`getRuntimeTrackerKey(account)` on line 386 already caches `_runtimeTrackerKey` on the live account as a side-effect, and then the spread copy on line 389 writes it again explicitly. the redundant write is harmless but the implicit mutation of the live `ManagedAccount` inside a `getAccountsSnapshot` call is surprising — callers don't expect a "read" snapshot to mutate the underlying live objects.

consider extracting the cache-fill step to an explicit `initRuntimeTrackerKey` call that's invoked at add/login time instead of lazily on first snapshot. this keeps `getAccountsSnapshot` side-effect-free and removes the duplicated write.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts.ts
Line: 747-750

Comment:
**tracker-key slot collision after remove + re-add for refresh-only accounts**

`removeAccount` re-indexes surviving accounts (`acc.index = index`) but does **not** clear `_runtimeTrackerKey` on them. for identity-rich accounts this is correct — their cached key is email/accountId-based and remains stable. however for refresh-only accounts (no `email`, no `accountId`) the cached key IS the old numeric index (e.g. `1`). after removal and re-index:

1. surviving refresh-only account at old index `1` is re-indexed to `0`, but `_runtimeTrackerKey` stays `1`.
2. a new refresh-only account added to the list later gets `account.index = 1` with no cache entry → `getRuntimeTrackerKey` computes `1`.
3. both accounts now map to tracker key `1` → they share health/token-bucket state.

this is a real slot-collision that the PR's email/accountId path avoids but the refresh-only fallback path re-introduces after any account churn. there's no test covering this combination. as a minimum, consider documenting the invariant that numeric-fallback accounts MUST be the last shape added (or asserting at add-time that refresh-only accounts always get a unique initial slot).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/parallel-probe.ts
Line: 126-128

Comment:
**fallback guard redundant given upstream snapshot guarantee**

`a.trackerKey ?? a.index` duplicates logic from `getRuntimeTrackerKey`. since `getAccountsSnapshot()` (line 97) already calls `getRuntimeTrackerKey` on every account and the resulting snapshot always carries a populated `trackerKey`, this `?? a.index` branch is dead. removing the guard makes the intent clearer and avoids silently re-introducing a numeric-index path for an account whose `trackerKey` was somehow stripped between snapshot and scoring.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix runtime tracker key stability"](https://github.com/ndycode/codex-multi-auth/commit/497fe8c31b0d14b5fc89885d7346831f3d5f21e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26973341)</sub>

<!-- /greptile_comment -->