### PR TITLE
fix hybrid selection sticky current account

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -496,25 +496,6 @@ export class AccountManager {
 		const count = this.accounts.length;
 		if (count === 0) return null;
 
-		const currentIndex = this.currentAccountIndexByFamily[family];
-		if (currentIndex >= 0 && currentIndex < count) {
-			const currentAccount = this.accounts[currentIndex];
-			if (currentAccount) {
-				if (currentAccount.enabled === false) {
-					// Fall through to hybrid selection.
-				} else {
-				clearExpiredRateLimits(currentAccount);
-				if (
-					!isRateLimitedForFamily(currentAccount, family, model) &&
-					!this.isAccountCoolingDown(currentAccount)
-				) {
-					currentAccount.lastUsed = nowMs();
-					return currentAccount;
-				}
-				}
-			}
-		}
-
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		const tokenTracker = getTokenTracker();

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -614,7 +614,7 @@ describe("AccountManager", () => {
     expect(gpt51Second?.refreshToken).toBe("token-2");
   });
 
-  it("hybrid selection prefers active index when available", () => {
+  it("hybrid selection does not stick to the active index when another account scores better", () => {
     const now = Date.now();
     const stored = {
       version: 3 as const,
@@ -628,10 +628,11 @@ describe("AccountManager", () => {
 
     const manager = new AccountManager(undefined, stored as any);
     
-    // Even though token-1 has better freshness score, token-2 is active and available
+    // token-1 has a materially better freshness score, so hybrid scoring should
+    // beat the current-account sticky preference.
     const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
-    expect(selected?.refreshToken).toBe("token-2");
-    expect(selected?.index).toBe(1);
+    expect(selected?.refreshToken).toBe("token-1");
+    expect(selected?.index).toBe(0);
   });
 
   describe("removeAccount", () => {
@@ -2060,7 +2061,7 @@ describe("AccountManager", () => {
       expect(selected?.index).toBe(1);
     });
 
-    it("updates cursor and family index after hybrid selection", () => {
+    it("re-scores on the next call instead of sticking to the prior hybrid winner", () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -2082,7 +2083,8 @@ describe("AccountManager", () => {
       expect(selected).not.toBeNull();
       
       const secondCall = manager.getCurrentOrNextForFamilyHybrid("codex");
-      expect(secondCall?.index).toBe(selected?.index);
+      expect(secondCall?.index).toBe(1);
+      expect(secondCall?.index).not.toBe(selected?.index);
     });
 
     it("falls back to least-recently-used when all accounts are rate-limited", () => {


### PR DESCRIPTION
## Summary

- remove the current-account fast path from hybrid selection so the next pick is always decided by the hybrid score

## What Changed

- deleted the early return in `getCurrentOrNextForFamilyHybrid(...)` that reused the current account whenever it was merely available
- updated the account-manager regressions to prove hybrid scoring can beat the active index and that the next call re-scores instead of sticking to the previous winner

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low
- Rollback plan: revert `72e1c9e`

## Additional Notes

- Targeted regression run: `npm test -- test/accounts.test.ts`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

removes the sticky current-account fast path from `getCurrentOrNextForFamilyHybrid` so hybrid scoring drives every pick instead of reusing the active account whenever it is merely available. the corresponding tests are correctly inverted to assert that a fresher-scoring account beats the stored active index, and that a second call re-scores rather than repeating the prior winner.

- **`lib/accounts.ts`**: deleted the early-return block (~19 lines) inside `getCurrentOrNextForFamilyHybrid`; the downstream state writes (`currentAccountIndexByFamily`, `cursorByFamily`, `lastUsed`) are untouched and still correct
- **`test/accounts.test.ts`**: two test names and their assertions flipped to prove the new non-sticky behaviour; setup data unchanged so the new expectations are deterministically driven by freshness score
- `npm test` checkbox is unchecked in the PR — for a change to the core rotation path, the full suite should be green before merge; the targeted run (`accounts.test.ts`) is a good start but doesn't exercise call-sites in other suites
- no property tests in `test/property/rotation.property.test.ts` cover `getCurrentOrNextForFamilyHybrid`; worth noting given the 80 % coverage threshold
- no windows filesystem or token safety surface touched by this change

<h3>Confidence Score: 5/5</h3>

- safe to merge — the deletion is surgical, the tests correctly verify the new contract, and all remaining findings are style/coverage suggestions
- all findings are P2: one redundant test assertion, one missing concurrency vitest case, and the unchecked full-suite run. no logic bugs or data-integrity risks introduced by the change itself.
- test/accounts.test.ts — concurrency coverage gap for the hybrid selection path

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | removes the early-return fast path in getCurrentOrNextForFamilyHybrid so hybrid scoring always decides the next account; remaining state writes (currentAccountIndexByFamily, cursorByFamily, lastUsed) are unchanged and correct |
| test/accounts.test.ts | test descriptions and assertions correctly inverted to match new non-sticky behaviour; minor redundant assertion on line 2087; no concurrency coverage for the hybrid selection path |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant AccountManager
    participant selectHybridAccount
    participant HealthTracker
    participant TokenTracker

    Note over AccountManager: fast-path (current account sticky) REMOVED

    Caller->>AccountManager: getCurrentOrNextForFamilyHybrid(family)
    AccountManager->>AccountManager: build accountsWithMetrics[]<br/>(clearExpiredRateLimits, isAvailable)
    AccountManager->>HealthTracker: getHealthTracker()
    AccountManager->>TokenTracker: getTokenTracker()
    AccountManager->>selectHybridAccount: score all candidates
    selectHybridAccount-->>AccountManager: best scored account
    AccountManager->>AccountManager: update currentAccountIndexByFamily<br/>cursorByFamily, lastUsed
    AccountManager-->>Caller: ManagedAccount
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Faccounts.test.ts%3A2087%0A**Redundant%20assertion**%0A%0A%60toBe%281%29%60%20on%20the%20previous%20line%20already%20pins%20the%20exact%20value%2C%20so%20%60not.toBe%28selected%3F.index%29%60%20only%20adds%20signal%20when%20%60selected%3F.index%20!%3D%3D%201%60%20%E2%80%94%20which%20the%20setup%20guarantees%20%28account2%20is%20selected%20first%29%2C%20but%20the%20assertion%20itself%20carries%20no%20independent%20verification%20power.%20consider%20dropping%20it%20or%20replacing%20it%20with%20an%20explicit%20check%20on%20the%20first%20result%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20expect%28selected%3F.index%29.toBe%282%29%3B%0A%20%20%20%20%20%20expect%28secondCall%3F.index%29.toBe%281%29%3B%0A%60%60%60%0Athis%20makes%20the%20full%20sequence%20explicit%20%E2%80%94%20first%20call%20picks%20account2%20%28stalest%29%2C%20second%20call%20picks%20account1%20%28now%20stalest%20after%20account2.lastUsed%20is%20updated%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Faccounts.test.ts%3A2064-2088%0A**missing%20concurrency%20coverage%20for%20hybrid%20path**%0A%0A%60getCurrentOrNextForFamilyHybrid%60%20writes%20shared%20mutable%20state%20%E2%80%94%20%60this.currentAccountIndexByFamily%5Bfamily%5D%60%2C%20%60this.cursorByFamily%5Bfamily%5D%60%2C%20and%20%60account.lastUsed%60%20%E2%80%94%20after%20calling%20%60selectHybridAccount%60%20which%20reads%20%60getHealthTracker%28%29%60%20and%20%60getTokenTracker%28%29%60%20singletons.%20there%20is%20no%20test%20exercising%20two%20concurrent%20calls%20hitting%20this%20path%20simultaneously%20%28e.g.%20via%20%60Promise.all%60%29.%20a%20race%20between%20the%20read-score%20phase%20and%20the%20write-lastUsed%20phase%20could%20produce%20double-selection%20of%20the%20same%20account%20under%20load.%20suggest%20adding%20a%20vitest%20case%20that%20issues%20two%20concurrent%20hybrid%20calls%20and%20asserts%20distinct%20accounts%20are%20returned%20%28or%20that%20%60lastUsed%60%20is%20updated%20correctly%20for%20both%29.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/accounts.test.ts
Line: 2087

Comment:
**Redundant assertion**

`toBe(1)` on the previous line already pins the exact value, so `not.toBe(selected?.index)` only adds signal when `selected?.index !== 1` — which the setup guarantees (account2 is selected first), but the assertion itself carries no independent verification power. consider dropping it or replacing it with an explicit check on the first result:

```suggestion
      expect(selected?.index).toBe(2);
      expect(secondCall?.index).toBe(1);
```
this makes the full sequence explicit — first call picks account2 (stalest), second call picks account1 (now stalest after account2.lastUsed is updated).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/accounts.test.ts
Line: 2064-2088

Comment:
**missing concurrency coverage for hybrid path**

`getCurrentOrNextForFamilyHybrid` writes shared mutable state — `this.currentAccountIndexByFamily[family]`, `this.cursorByFamily[family]`, and `account.lastUsed` — after calling `selectHybridAccount` which reads `getHealthTracker()` and `getTokenTracker()` singletons. there is no test exercising two concurrent calls hitting this path simultaneously (e.g. via `Promise.all`). a race between the read-score phase and the write-lastUsed phase could produce double-selection of the same account under load. suggest adding a vitest case that issues two concurrent hybrid calls and asserts distinct accounts are returned (or that `lastUsed` is updated correctly for both).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix hybrid selection sticky current acco..."](https://github.com/ndycode/codex-multi-auth/commit/72e1c9ef0b3e42c9a20d40b376db776aa010fb9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26973555)</sub>

<!-- /greptile_comment -->