### PR TITLE
fix refresh guardian pool health scoring

### DIFF
--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -133,9 +133,11 @@ export class RefreshGuardian {
 						if (result.tokenResult?.type === "success") {
 							applyRefreshResult(account, result.tokenResult);
 							manager.clearAuthFailures(account);
+							manager.recordSuccess(account, "codex");
 							this.stats.refreshed += 1;
 						} else {
 							manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+							manager.recordFailure(account, "codex");
 							this.stats.failed += 1;
 							this.stats.networkFailed += 1;
 						}
@@ -143,6 +145,11 @@ export class RefreshGuardian {
 					case "failed": {
 						const cooldownReason = this.classifyFailureReason(result.tokenResult);
 						manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
+						if (cooldownReason === "rate-limit") {
+							manager.recordRateLimit(account, "codex");
+						} else {
+							manager.recordFailure(account, "codex");
+						}
 						this.stats.failed += 1;
 						if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
 						else if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
@@ -154,6 +161,7 @@ export class RefreshGuardian {
 						break;
 					case "no_refresh_token":
 						manager.markAccountCoolingDown(account, this.bufferMs, "auth-failure");
+						manager.recordFailure(account, "codex");
 						manager.setAccountEnabled(account.index, false);
 						this.stats.noRefreshToken += 1;
 						this.stats.failed += 1;

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,10 +1,12 @@
 import { createLogger } from "./logger.js";
 import { applyRefreshResult, refreshExpiringAccounts } from "./proactive-refresh.js";
 import type { AccountManager } from "./accounts.js";
+import type { ModelFamily } from "./prompts/codex.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
 
 const log = createLogger("refresh-guardian");
+const REFRESH_HEALTH_FAMILY: ModelFamily = "codex";
 
 export interface RefreshGuardianOptions {
 	intervalMs?: number;
@@ -133,11 +135,11 @@ export class RefreshGuardian {
 						if (result.tokenResult?.type === "success") {
 							applyRefreshResult(account, result.tokenResult);
 							manager.clearAuthFailures(account);
-							manager.recordSuccess(account, "codex");
+							manager.recordSuccess(account, REFRESH_HEALTH_FAMILY);
 							this.stats.refreshed += 1;
 						} else {
 							manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
-							manager.recordFailure(account, "codex");
+							manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 							this.stats.failed += 1;
 							this.stats.networkFailed += 1;
 						}
@@ -146,9 +148,9 @@ export class RefreshGuardian {
 						const cooldownReason = this.classifyFailureReason(result.tokenResult);
 						manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
 						if (cooldownReason === "rate-limit") {
-							manager.recordRateLimit(account, "codex");
+							manager.recordRateLimit(account, REFRESH_HEALTH_FAMILY);
 						} else {
-							manager.recordFailure(account, "codex");
+							manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 						}
 						this.stats.failed += 1;
 						if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
@@ -161,7 +163,7 @@ export class RefreshGuardian {
 						break;
 					case "no_refresh_token":
 						manager.markAccountCoolingDown(account, this.bufferMs, "auth-failure");
-						manager.recordFailure(account, "codex");
+						manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 						manager.setAccountEnabled(account.index, false);
 						this.stats.noRefreshToken += 1;
 						this.stats.failed += 1;

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -242,6 +242,9 @@ describe("refresh-guardian", () => {
           [liveB, liveA].find((account) => account.index === index) ?? null,
       ),
       clearAuthFailures: vi.fn(),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordRateLimit: vi.fn(),
       markAccountCoolingDown: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -279,6 +282,9 @@ describe("refresh-guardian", () => {
     expect(
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(liveB);
+    expect(
+      manager.recordSuccess as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveB, "codex");
   });
 
   it("classifies failure reasons and handles no-op branches", async () => {

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -20,7 +20,10 @@ function createManagedAccount(index: number): ManagedAccount {
   };
 }
 
-function createManagerMock(accounts: ManagedAccount[]): AccountManager {
+function createManagerMock(
+  accounts: ManagedAccount[],
+  overrides: Partial<AccountManager> = {},
+): AccountManager {
   return {
     getAccountsSnapshot: vi.fn(() => accounts),
     getAccountByIndex: vi.fn(
@@ -34,6 +37,7 @@ function createManagerMock(accounts: ManagedAccount[]): AccountManager {
     markAccountCoolingDown: vi.fn(),
     setAccountEnabled: vi.fn(),
     saveToDiskDebounced: vi.fn(),
+    ...overrides,
   } as unknown as AccountManager;
 }
 
@@ -233,7 +237,7 @@ describe("refresh-guardian", () => {
       [liveB, liveA],
     ];
     let readCount = 0;
-    const manager = {
+    const manager = createManagerMock([liveB, liveA], {
       getAccountsSnapshot: vi.fn(
         () => snapshots[Math.min(readCount++, snapshots.length - 1)],
       ),
@@ -241,13 +245,7 @@ describe("refresh-guardian", () => {
         (index: number) =>
           [liveB, liveA].find((account) => account.index === index) ?? null,
       ),
-      clearAuthFailures: vi.fn(),
-      recordSuccess: vi.fn(),
-      recordFailure: vi.fn(),
-      recordRateLimit: vi.fn(),
-      markAccountCoolingDown: vi.fn(),
-      saveToDiskDebounced: vi.fn(),
-    } as unknown as AccountManager;
+    });
     const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
     const guardian = new RefreshGuardian(() => manager, {
       bufferMs: 60_000,
@@ -410,7 +408,7 @@ describe("refresh-guardian", () => {
     const liveSnapshot = [accountA, accountB, accountC, accountD, accountE];
     let snapshotReads = 0;
 
-    const manager = {
+    const manager = createManagerMock(liveSnapshot, {
       getAccountsSnapshot: vi.fn(() => {
         if (snapshotReads === 0) {
           snapshotReads += 1;
@@ -422,14 +420,7 @@ describe("refresh-guardian", () => {
         (index: number) =>
           liveSnapshot.find((account) => account.index === index) ?? null,
       ),
-      clearAuthFailures: vi.fn(),
-      recordSuccess: vi.fn(),
-      recordFailure: vi.fn(),
-      recordRateLimit: vi.fn(),
-      markAccountCoolingDown: vi.fn(),
-      setAccountEnabled: vi.fn(),
-      saveToDiskDebounced: vi.fn(),
-    } as unknown as AccountManager;
+    });
     const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
     const guardian = new RefreshGuardian(() => manager, {
       bufferMs: 60_000,
@@ -596,7 +587,7 @@ describe("refresh-guardian", () => {
     const liveAfterRemoval = [{ ...originalB }];
     let snapshotReads = 0;
 
-    const manager = {
+    const manager = createManagerMock(liveAfterRemoval, {
       getAccountsSnapshot: vi.fn(() => {
         snapshotReads += 1;
         if (snapshotReads === 1) return [originalA, originalB];
@@ -605,14 +596,7 @@ describe("refresh-guardian", () => {
       getAccountByIndex: vi.fn(
         (index: number) => liveAfterRemoval[index] ?? null,
       ),
-      clearAuthFailures: vi.fn(),
-      recordSuccess: vi.fn(),
-      recordFailure: vi.fn(),
-      recordRateLimit: vi.fn(),
-      markAccountCoolingDown: vi.fn(),
-      setAccountEnabled: vi.fn(),
-      saveToDiskDebounced: vi.fn(),
-    } as unknown as AccountManager;
+    });
 
     const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
     const guardian = new RefreshGuardian(() => manager, {

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -28,6 +28,9 @@ function createManagerMock(accounts: ManagedAccount[]): AccountManager {
         accounts.find((account) => account.index === index) ?? null,
     ),
     clearAuthFailures: vi.fn(),
+    recordSuccess: vi.fn(),
+    recordFailure: vi.fn(),
+    recordRateLimit: vi.fn(),
     markAccountCoolingDown: vi.fn(),
     setAccountEnabled: vi.fn(),
     saveToDiskDebounced: vi.fn(),
@@ -160,8 +163,14 @@ describe("refresh-guardian", () => {
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountA);
     expect(
+      manager.recordSuccess as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountA, "codex");
+    expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountB, 60_000, "auth-failure");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountB, "codex");
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
@@ -353,6 +362,18 @@ describe("refresh-guardian", () => {
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
     ).toHaveBeenNthCalledWith(4, accountE, 60_000, "auth-failure");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountB, "codex");
+    expect(
+      manager.recordRateLimit as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountC, "codex");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountD, "codex");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountE, "codex");
 
     const stats = guardian.getStats();
     expect(stats.runs).toBe(1);
@@ -396,6 +417,9 @@ describe("refresh-guardian", () => {
           liveSnapshot.find((account) => account.index === index) ?? null,
       ),
       clearAuthFailures: vi.fn(),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordRateLimit: vi.fn(),
       markAccountCoolingDown: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
@@ -513,6 +537,21 @@ describe("refresh-guardian", () => {
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
     ).toHaveBeenNthCalledWith(5, accountE, 60_000, "network-error");
     expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA, "codex");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB, "codex");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(3, accountC, "codex");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(4, accountD, "codex");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(5, accountE, "codex");
+    expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
 
@@ -561,6 +600,9 @@ describe("refresh-guardian", () => {
         (index: number) => liveAfterRemoval[index] ?? null,
       ),
       clearAuthFailures: vi.fn(),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordRateLimit: vi.fn(),
       markAccountCoolingDown: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
@@ -614,6 +656,12 @@ describe("refresh-guardian", () => {
       expect.objectContaining({ refreshToken: originalB.refreshToken }),
       60_000,
       "rate-limit",
+    );
+    expect(
+      manager.recordRateLimit as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: originalB.refreshToken }),
+      "codex",
     );
   });
 });


### PR DESCRIPTION
## Summary

- make refresh-guardian outcomes update the pool health trackers instead of only mutating cooldown/auth state

## What Changed

- recorded guardian refresh successes through `manager.recordSuccess(account, "codex")`
- recorded guardian refresh failures through `manager.recordFailure(...)`, and routed rate-limited refresh failures through `manager.recordRateLimit(...)`
- extended guardian tests to assert those health-scoring calls alongside the existing cooldown and auth-failure behavior

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low
- Rollback plan: revert `802ebc3` and `000481f`

## Additional Notes

- Targeted regression run: `npm test -- test/refresh-guardian.test.ts test/documentation.test.ts`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR wires `recordSuccess`, `recordFailure`, and `recordRateLimit` into every result branch of `RefreshGuardian.tick()` so that background token refresh outcomes now propagate into the pool health tracker alongside the existing cooldown/auth-failure mutations. the change is minimal, targeted, and logically consistent with how `AccountManager` implements those three methods.

- `case \"success\"` (valid token): calls `recordSuccess` → health tracker picks up the positive signal
- `case \"success\"` (degenerate, non-success token result): calls `recordFailure` → consistent with the network-error cooldown already applied
- `case \"failed\"` with status 429: routes through `recordRateLimit` (also drains the token bucket via `getTokenTracker().drain`)
- `case \"failed\"` other reasons: routes through `recordFailure`
- `case \"no_refresh_token\"`: calls `recordFailure` before disabling the account
- `case \"not_needed\"`: correctly emits no health event (no network op occurred)
- test suite extended — `createManagerMock` now includes the three new mocks, all four result paths gain assertions, and three existing inline manager objects are refactored to use `createManagerMock`

one point to be aware of: `REFRESH_HEALTH_FAMILY` is hardcoded to `\"codex\"`, so health signals from refresh outcomes only update that one family's bucket. the other four model families won't see the penalty or recovery in the hybrid scorer. the cooldown mechanism already covers cross-family exclusion, so this is not a correctness regression — but the hybrid health ranking for non-`\"codex\"` families will have a blind spot for refresh-cycle quality. also, `npm test` (full suite) is unchecked in the validation checklist — the targeted regression run covers the affected file, but a full run should be confirmed before merge.

<h3>Confidence Score: 5/5</h3>

safe to merge — no correctness regressions; all new branches are tested; the only finding is a P2 architectural note about single-family health coverage

all three new manager calls are correctly placed, ordered, and independently tested. the cooldown mechanism already handles cross-family account exclusion, so the hardcoded "codex" health family is a gap but not a defect. tests cover every new code path.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/refresh-guardian.ts | adds recordSuccess/recordFailure/recordRateLimit calls in all result branches; logic is correct and consistent with how AccountManager implements each method |
| test/refresh-guardian.test.ts | extends createManagerMock with the three new methods and adds assertions covering success, rate-limit, failure, and no_refresh_token paths; all new branches hit |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tick - account result] --> B{result.reason}
    B -->|success| C{tokenResult.type == success?}
    C -->|yes| D[applyRefreshResult\nclearAuthFailures\nrecordSuccess codex]
    C -->|no| E[markAccountCoolingDown network-error\nrecordFailure codex]
    B -->|failed| F[classifyFailureReason]
    F --> G{cooldownReason}
    G -->|rate-limit| H[markAccountCoolingDown\nrecordRateLimit codex]
    G -->|other| I[markAccountCoolingDown\nrecordFailure codex]
    B -->|not_needed| J[stats.notNeeded++\nno health call]
    B -->|no_refresh_token| K[markAccountCoolingDown auth-failure\nrecordFailure codex\nsetAccountEnabled false]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Frefresh-guardian.ts%3A9%0A**health%20signals%20only%20reach%20the%20%60%22codex%22%60%20family%20bucket**%0A%0A%60REFRESH_HEALTH_FAMILY%60%20is%20hardcoded%20to%20%60%22codex%22%60%2C%20so%20%60recordSuccess%60%20%2F%20%60recordFailure%60%20%2F%20%60recordRateLimit%60%20only%20update%20the%20health%20tracker%20for%20%60quotaKey%20%3D%20%22codex%22%60.%20the%20other%20four%20model%20families%20%28%60%22gpt-5-codex%22%60%2C%20%60%22codex-max%22%60%2C%20%60%22gpt-5.2%22%60%2C%20%60%22gpt-5.1%22%60%29%20never%20receive%20a%20refresh-outcome%20signal.%0A%0Ain%20practice%20this%20is%20mostly%20fine%20because%20%60markAccountCoolingDown%60%20already%20gates%20all%20families%20out%20during%20the%20cooldown%20window.%20the%20gap%20shows%20up%20in%20%60getCurrentOrNextForFamilyHybrid%60%20%E2%80%94%20the%20hybrid%20scorer%20for%20non-%60%22codex%22%60%20families%20won't%20see%20the%20refresh%20penalty%20or%20recovery%2C%20so%20it%20can%20mis-rank%20an%20account%20that%20was%20recently%20failing%20refresh%20cycles%20for%20another%20family.%0A%0Aif%20coverage%20across%20all%20families%20is%20desirable%2C%20the%20simplest%20fix%20is%20to%20loop%3A%0A%0A%60%60%60typescript%0Afor%20%28const%20family%20of%20MODEL_FAMILIES%29%20%7B%0A%20%20%20%20manager.recordSuccess%28account%2C%20family%29%3B%0A%7D%0A%60%60%60%0A%0Aor%20accept%20a%20%60family%5B%5D%60%20param%20and%20record%20once%20per%20family.%20if%20the%20single-family%20design%20is%20intentional%20%28e.g.%2C%20refresh%20health%20is%20only%20relevant%20to%20the%20%60%22codex%22%60%20rotation%20path%29%2C%20a%20short%20comment%20here%20would%20help%20future%20readers.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/refresh-guardian.ts
Line: 9

Comment:
**health signals only reach the `"codex"` family bucket**

`REFRESH_HEALTH_FAMILY` is hardcoded to `"codex"`, so `recordSuccess` / `recordFailure` / `recordRateLimit` only update the health tracker for `quotaKey = "codex"`. the other four model families (`"gpt-5-codex"`, `"codex-max"`, `"gpt-5.2"`, `"gpt-5.1"`) never receive a refresh-outcome signal.

in practice this is mostly fine because `markAccountCoolingDown` already gates all families out during the cooldown window. the gap shows up in `getCurrentOrNextForFamilyHybrid` — the hybrid scorer for non-`"codex"` families won't see the refresh penalty or recovery, so it can mis-rank an account that was recently failing refresh cycles for another family.

if coverage across all families is desirable, the simplest fix is to loop:

```typescript
for (const family of MODEL_FAMILIES) {
    manager.recordSuccess(account, family);
}
```

or accept a `family[]` param and record once per family. if the single-family design is intentional (e.g., refresh health is only relevant to the `"codex"` rotation path), a short comment here would help future readers.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["\\ fix refresh guardian review cleanup\\"](https://github.com/ndycode/codex-multi-auth/commit/66150d2749ff1806031466fbd51bb1d39478c9ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26973810)</sub>

<!-- /greptile_comment -->