### PR TITLE
fix circuit breaker account pool integration

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -739,26 +739,31 @@ export class AccountManager {
 		const modelKey = model ? getQuotaKey(family, model) : null;
 
 		for (const account of enabledAccounts) {
+			const perAccountWaitTimes: number[] = [];
 			const baseResetAt = account.rateLimitResetTimes[baseKey];
 			if (typeof baseResetAt === "number") {
-				waitTimes.push(Math.max(0, baseResetAt - now));
+				perAccountWaitTimes.push(Math.max(0, baseResetAt - now));
 			}
 
 			if (modelKey) {
 				const modelResetAt = account.rateLimitResetTimes[modelKey];
 				if (typeof modelResetAt === "number") {
-					waitTimes.push(Math.max(0, modelResetAt - now));
+					perAccountWaitTimes.push(Math.max(0, modelResetAt - now));
 				}
 			}
 
 			if (typeof account.coolingDownUntil === "number") {
-				waitTimes.push(Math.max(0, account.coolingDownUntil - now));
+				perAccountWaitTimes.push(Math.max(0, account.coolingDownUntil - now));
 			}
 
 			const breaker = getCircuitBreaker(getAccountCircuitKey(account));
 			const breakerWait = breaker.getTimeUntilReset();
 			if (breakerWait > 0) {
-				waitTimes.push(breakerWait);
+				perAccountWaitTimes.push(breakerWait);
+			}
+
+			if (perAccountWaitTimes.length > 0) {
+				waitTimes.push(Math.max(...perAccountWaitTimes));
 			}
 		}
 

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -757,7 +757,7 @@ export class AccountManager {
 			}
 
 			const breaker = getCircuitBreaker(getAccountCircuitKey(account));
-			const breakerWait = breaker.getTimeUntilReset();
+			const breakerWait = breaker.getTimeUntilAvailable();
 			if (breakerWait > 0) {
 				perAccountWaitTimes.push(breakerWait);
 			}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -76,9 +76,14 @@ import {
 } from "./accounts/rate-limits.js";
 
 const log = createLogger("accounts");
+let nextRuntimeCircuitKeyId = 0;
 
 function getAccountCircuitKey(account: ManagedAccount): string {
-	return getAccountIdentityKey(account) ?? `index:${account.index}`;
+	if (!account.circuitKeyId) {
+		account.circuitKeyId =
+			getAccountIdentityKey(account) ?? `circuit:${nextRuntimeCircuitKeyId++}`;
+	}
+	return account.circuitKeyId;
 }
 
 function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
@@ -97,6 +102,7 @@ export interface Workspace {
 
 export interface ManagedAccount {
 	index: number;
+	circuitKeyId?: string;
 	accountId?: string;
 	accountIdSource?: AccountIdSource;
 	accountLabel?: string;

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -24,6 +24,8 @@ import {
 } from "./codex-cli/state.js";
 import { syncAccountStorageFromCodexCli } from "./codex-cli/sync.js";
 import { setCodexCliActiveSelection } from "./codex-cli/writer.js";
+import { getAccountIdentityKey } from "./storage/identity.js";
+import { getCircuitBreaker } from "./circuit-breaker.js";
 
 export {
 	extractAccountId,
@@ -74,6 +76,10 @@ import {
 } from "./accounts/rate-limits.js";
 
 const log = createLogger("accounts");
+
+function getAccountCircuitKey(account: ManagedAccount): string {
+	return getAccountIdentityKey(account) ?? `index:${account.index}`;
+}
 
 function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
 	return Object.fromEntries(
@@ -386,7 +392,11 @@ export class AccountManager {
 		if (!account) return false;
 		if (account.enabled === false) return false;
 		clearExpiredRateLimits(account);
-		return !isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
+		return (
+			!isRateLimitedForFamily(account, family, model) &&
+			!this.isAccountCoolingDown(account) &&
+			this.isCircuitAvailable(account)
+		);
 	}
 
 	setActiveIndex(index: number): ManagedAccount | null {
@@ -454,7 +464,11 @@ export class AccountManager {
 			if (account.enabled === false) continue;
 			
 			clearExpiredRateLimits(account);
-			if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
+			if (
+				isRateLimitedForFamily(account, family, model) ||
+				this.isAccountCoolingDown(account) ||
+				!this.isCircuitAvailable(account)
+			) {
 				continue;
 			}
 			
@@ -480,7 +494,11 @@ export class AccountManager {
 			if (account.enabled === false) continue;
 			
 			clearExpiredRateLimits(account);
-			if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
+			if (
+				isRateLimitedForFamily(account, family, model) ||
+				this.isAccountCoolingDown(account) ||
+				!this.isCircuitAvailable(account)
+			) {
 				continue;
 			}
 			
@@ -506,7 +524,8 @@ export class AccountManager {
 				clearExpiredRateLimits(currentAccount);
 				if (
 					!isRateLimitedForFamily(currentAccount, family, model) &&
-					!this.isAccountCoolingDown(currentAccount)
+					!this.isAccountCoolingDown(currentAccount) &&
+					this.isCircuitAvailable(currentAccount)
 				) {
 					currentAccount.lastUsed = nowMs();
 					return currentAccount;
@@ -525,7 +544,9 @@ export class AccountManager {
 				if (account.enabled === false) return null;
 				clearExpiredRateLimits(account);
 				const isAvailable =
-					!isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
+					!isRateLimitedForFamily(account, family, model) &&
+					!this.isAccountCoolingDown(account) &&
+					this.isCircuitAvailable(account);
 				return {
 					index: account.index,
 					isAvailable,
@@ -550,6 +571,7 @@ export class AccountManager {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		healthTracker.recordSuccess(account.index, quotaKey);
+		getCircuitBreaker(getAccountCircuitKey(account)).recordSuccess();
 	}
 
 	recordRateLimit(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
@@ -564,12 +586,23 @@ export class AccountManager {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		healthTracker.recordFailure(account.index, quotaKey);
+		getCircuitBreaker(getAccountCircuitKey(account)).recordFailure();
 	}
 
 	consumeToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
-		return tokenTracker.tryConsume(account.index, quotaKey);
+		if (!tokenTracker.tryConsume(account.index, quotaKey)) {
+			return false;
+		}
+
+		try {
+			getCircuitBreaker(getAccountCircuitKey(account)).canExecute();
+			return true;
+		} catch {
+			tokenTracker.refundToken(account.index, quotaKey);
+			return false;
+		}
 	}
 
 	/**
@@ -633,6 +666,10 @@ export class AccountManager {
 		delete account.cooldownReason;
 	}
 
+	private isCircuitAvailable(account: ManagedAccount): boolean {
+		return getCircuitBreaker(getAccountCircuitKey(account)).isAvailable();
+	}
+
 	incrementAuthFailures(account: ManagedAccount): number {
 		account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
 		return account.consecutiveAuthFailures;
@@ -688,7 +725,11 @@ export class AccountManager {
 		const enabledAccounts = this.accounts.filter((account) => account.enabled !== false);
 		const available = enabledAccounts.filter((account) => {
 			clearExpiredRateLimits(account);
-			return !isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
+			return (
+				!isRateLimitedForFamily(account, family, model) &&
+				!this.isAccountCoolingDown(account) &&
+				this.isCircuitAvailable(account)
+			);
 		});
 		if (available.length > 0) return 0;
 		if (enabledAccounts.length === 0) return 0;
@@ -712,6 +753,12 @@ export class AccountManager {
 
 			if (typeof account.coolingDownUntil === "number") {
 				waitTimes.push(Math.max(0, account.coolingDownUntil - now));
+			}
+
+			const breaker = getCircuitBreaker(getAccountCircuitKey(account));
+			const breakerWait = breaker.getTimeUntilReset();
+			if (breakerWait > 0) {
+				waitTimes.push(breakerWait);
 			}
 		}
 

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -54,6 +54,18 @@ export class CircuitBreaker {
 		return true;
 	}
 
+	isAvailable(now = Date.now()): boolean {
+		if (this.state === "open") {
+			return now - this.lastStateChange >= this.config.resetTimeoutMs;
+		}
+
+		if (this.state === "half-open") {
+			return this.halfOpenAttempts < this.config.halfOpenMaxAttempts;
+		}
+
+		return true;
+	}
+
 	recordSuccess(): void {
 		const now = Date.now();
 		if (this.state === "half-open") {

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -121,9 +121,8 @@ export class CircuitBreaker {
 			this.state === "half-open" &&
 			this.halfOpenAttempts >= this.config.halfOpenMaxAttempts
 		) {
-			// The probe slot is already in use, so return a conservative delay instead
-			// of reporting the circuit as immediately available.
-			return this.config.resetTimeoutMs;
+			const elapsed = Date.now() - this.lastStateChange;
+			return Math.max(0, this.config.resetTimeoutMs - elapsed);
 		}
 
 		return 0;

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -45,7 +45,11 @@ export class CircuitBreaker {
 
 		if (this.state === "half-open") {
 			if (this.halfOpenAttempts >= this.config.halfOpenMaxAttempts) {
-				throw new CircuitOpenError("Circuit is half-open");
+				if (this.hasHalfOpenProbeWaitElapsed(now)) {
+					this.resetHalfOpenProbeWindow(now);
+				} else {
+					throw new CircuitOpenError("Circuit is half-open");
+				}
 			}
 			this.halfOpenAttempts += 1;
 			return true;
@@ -60,7 +64,10 @@ export class CircuitBreaker {
 		}
 
 		if (this.state === "half-open") {
-			return this.halfOpenAttempts < this.config.halfOpenMaxAttempts;
+			return (
+				this.halfOpenAttempts < this.config.halfOpenMaxAttempts ||
+				this.hasHalfOpenProbeWaitElapsed(now)
+			);
 		}
 
 		return true;
@@ -141,6 +148,15 @@ export class CircuitBreaker {
 
 	private transitionToHalfOpen(now: number): void {
 		this.state = "half-open";
+		this.lastStateChange = now;
+		this.halfOpenAttempts = 0;
+	}
+
+	private hasHalfOpenProbeWaitElapsed(now: number): boolean {
+		return now - this.lastStateChange >= this.config.resetTimeoutMs;
+	}
+
+	private resetHalfOpenProbeWindow(now: number): void {
 		this.lastStateChange = now;
 		this.halfOpenAttempts = 0;
 	}

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -112,6 +112,23 @@ export class CircuitBreaker {
 		return Math.max(0, this.config.resetTimeoutMs - elapsed);
 	}
 
+	getTimeUntilAvailable(): number {
+		if (this.state === "open") {
+			return this.getTimeUntilReset();
+		}
+
+		if (
+			this.state === "half-open" &&
+			this.halfOpenAttempts >= this.config.halfOpenMaxAttempts
+		) {
+			// The probe slot is already in use, so return a conservative delay instead
+			// of reporting the circuit as immediately available.
+			return this.config.resetTimeoutMs;
+		}
+
+		return 0;
+	}
+
 	private pruneFailures(now: number): void {
 		const cutoff = now - this.config.failureWindowMs;
 		this.failures = this.failures.filter((timestamp) => timestamp >= cutoff);

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -54,7 +54,11 @@ export function getAccountHealth(
 	});
 
 	const healthyCount = accountHealths.filter(
-		(a) => !a.isRateLimited && !a.isCoolingDown && a.health >= 50,
+		(a) =>
+			!a.isRateLimited &&
+			!a.isCoolingDown &&
+			a.circuitState === "closed" &&
+			a.health >= 50,
 	).length;
 
 	const rateLimitedCount = accountHealths.filter((a) => a.isRateLimited).length;

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -28,6 +28,7 @@ export function getAccountHealth(
 		index: number;
 		email?: string;
 		accountId?: string;
+		refreshToken?: string;
 		health: number;
 		rateLimitedUntil?: number;
 		cooldownUntil?: number;

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -1,4 +1,5 @@
 import { getCircuitBreaker, type CircuitState } from "./circuit-breaker.js";
+import { getAccountIdentityKey } from "./storage/identity.js";
 
 export interface AccountHealth {
 	index: number;
@@ -36,7 +37,7 @@ export function getAccountHealth(
 	now = Date.now(),
 ): PluginHealth {
 	const accountHealths: AccountHealth[] = accounts.map((acc) => {
-		const circuitKey = `account:${acc.accountId ?? acc.index}`;
+		const circuitKey = getAccountIdentityKey(acc) ?? `index:${acc.index}`;
 		const circuit = getCircuitBreaker(circuitKey);
 
 		return {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -714,6 +714,35 @@ describe("AccountManager", () => {
       expect(manager.getAccountCount()).toBe(0);
       expect(manager.getCurrentAccount()).toBe(null);
     });
+
+    it("preserves circuit breaker state when an account shifts index after removal", () => {
+      clearCircuitBreakers();
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          { refreshToken: "token-1", addedAt: now, lastUsed: now },
+          { refreshToken: "token-2", addedAt: now, lastUsed: now },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const first = manager.getAccountByIndex(0)!;
+      const second = manager.getAccountByIndex(1)!;
+
+      manager.recordFailure(second, "codex");
+      manager.recordFailure(second, "codex");
+      manager.recordFailure(second, "codex");
+      expect(manager.consumeToken(second, "codex")).toBe(false);
+
+      expect(manager.removeAccount(first)).toBe(true);
+
+      const shifted = manager.getAccountByIndex(0)!;
+      expect(shifted.refreshToken).toBe("token-2");
+      expect(manager.consumeToken(shifted, "codex")).toBe(false);
+      clearCircuitBreakers();
+    });
   });
 
   describe("hasRefreshToken", () => {
@@ -884,12 +913,14 @@ describe("AccountManager", () => {
 
   describe("getMinWaitTimeForFamily", () => {
     beforeEach(() => {
+      resetTrackers();
       clearCircuitBreakers();
       vi.useFakeTimers();
       vi.setSystemTime(new Date(0));
     });
 
     afterEach(() => {
+      resetTrackers();
       clearCircuitBreakers();
       vi.useRealTimers();
     });
@@ -2039,34 +2070,37 @@ describe("AccountManager", () => {
     it("recordSuccess closes the circuit breaker after a half-open retry succeeds", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(0));
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "token-1",
-            email: "breaker@example.com",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
+      try {
+        const now = Date.now();
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            {
+              refreshToken: "token-1",
+              email: "breaker@example.com",
+              addedAt: now,
+              lastUsed: now,
+            },
+          ],
+        };
 
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getCurrentAccount()!;
+        const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
 
-      manager.recordFailure(account, "codex");
-      manager.recordFailure(account, "codex");
-      manager.recordFailure(account, "codex");
-      expect(breaker.getState()).toBe("open");
+        manager.recordFailure(account, "codex");
+        manager.recordFailure(account, "codex");
+        manager.recordFailure(account, "codex");
+        expect(breaker.getState()).toBe("open");
 
-      vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
-      expect(manager.consumeToken(account, "codex")).toBe(true);
-      manager.recordSuccess(account, "codex");
-      expect(breaker.getState()).toBe("closed");
-      vi.useRealTimers();
+        vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
+        expect(manager.consumeToken(account, "codex")).toBe(true);
+        manager.recordSuccess(account, "codex");
+        expect(breaker.getState()).toBe("closed");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("recordRateLimit updates health and drains token bucket", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -977,6 +977,33 @@ describe("AccountManager", () => {
         DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs,
       );
     });
+
+    it("uses the largest blocking delay for each account before taking the pool minimum", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "breaker@example.com",
+            addedAt: now,
+            lastUsed: now,
+            coolingDownUntil: now + 45_000,
+            rateLimitResetTimes: { codex: now + 60_000 },
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+
+      expect(manager.getMinWaitTimeForFamily("codex")).toBe(60_000);
+    });
   });
 
   describe("updateFromAuth", () => {
@@ -2153,6 +2180,44 @@ describe("AccountManager", () => {
 
       expect(manager.consumeToken(account, "codex")).toBe(false);
       expect(tokenTracker.getTokens(account.index, "codex")).toBe(initialTokens);
+    });
+
+    it("consumeToken returns false and refunds when the half-open slot is exhausted", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(0));
+
+      try {
+        const now = Date.now();
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            {
+              refreshToken: "token-1",
+              email: "breaker@example.com",
+              addedAt: now,
+              lastUsed: now,
+            },
+          ],
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getCurrentAccount()!;
+        const tokenTracker = getTokenTracker();
+        const initialTokens = tokenTracker.getTokens(account.index, "codex");
+
+        manager.recordFailure(account, "codex");
+        manager.recordFailure(account, "codex");
+        manager.recordFailure(account, "codex");
+
+        vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
+
+        expect(manager.consumeToken(account, "codex")).toBe(true);
+        expect(manager.consumeToken(account, "codex")).toBe(false);
+        expect(tokenTracker.getTokens(account.index, "codex")).toBe(initialTokens - 1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -11,6 +11,12 @@ import {
   getAccountIdCandidates,
 } from "../lib/accounts.js";
 import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
+import {
+  clearCircuitBreakers,
+  DEFAULT_CIRCUIT_BREAKER_CONFIG,
+  getCircuitBreaker,
+} from "../lib/circuit-breaker.js";
+import { getAccountIdentityKey } from "../lib/storage/identity.js";
 import type { OAuthAuthDetails } from "../lib/types.js";
 
 vi.mock("../lib/storage.js", async (importOriginal) => {
@@ -877,6 +883,17 @@ describe("AccountManager", () => {
   });
 
   describe("getMinWaitTimeForFamily", () => {
+    beforeEach(() => {
+      clearCircuitBreakers();
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(0));
+    });
+
+    afterEach(() => {
+      clearCircuitBreakers();
+      vi.useRealTimers();
+    });
+
     it("returns 0 when accounts are available", () => {
       const now = Date.now();
       const stored = {
@@ -937,6 +954,28 @@ describe("AccountManager", () => {
       const waitTime = manager.getMinWaitTimeForFamily("codex", "gpt-5.2");
       expect(waitTime).toBeGreaterThan(0);
       expect(waitTime).toBeLessThanOrEqual(45000);
+    });
+
+    it("considers circuit-breaker reset time when all accounts are open", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          { refreshToken: "token-1", addedAt: now, lastUsed: now },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+
+      expect(manager.getMinWaitTimeForFamily("codex")).toBe(
+        DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs,
+      );
     });
   });
 
@@ -1857,10 +1896,12 @@ describe("AccountManager", () => {
   describe("health and token tracking methods", () => {
     beforeEach(() => {
       resetTrackers();
+      clearCircuitBreakers();
     });
 
     afterEach(() => {
       resetTrackers();
+      clearCircuitBreakers();
     });
 
     it("recordSuccess updates health tracker with model-specific quotaKey", () => {
@@ -1881,6 +1922,7 @@ describe("AccountManager", () => {
       
       const score = healthTracker.getScore(account.index, "codex:gpt-5.1");
       expect(score).toBe(100);
+      expect(getCircuitBreaker(getAccountIdentityKey(account)!).getState()).toBe("closed");
     });
 
     it("recordSuccess updates health tracker with family-only quotaKey when model is null", () => {
@@ -1966,6 +2008,32 @@ describe("AccountManager", () => {
       expect(score).toBeLessThan(100);
     });
 
+    it("recordFailure opens the circuit breaker after repeated failures", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "breaker@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
+
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+
+      expect(breaker.getState()).toBe("open");
+    });
+
     it("recordFailure uses family-only quotaKey when model is null", () => {
       const now = Date.now();
       const stored = {
@@ -2025,15 +2093,45 @@ describe("AccountManager", () => {
 
       expect(result).toBe(true);
     });
+
+    it("consumeToken returns false and refunds the token when the circuit is open", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "breaker@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      const tokenTracker = getTokenTracker();
+      const initialTokens = tokenTracker.getTokens(account.index, "codex");
+
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+
+      expect(manager.consumeToken(account, "codex")).toBe(false);
+      expect(tokenTracker.getTokens(account.index, "codex")).toBe(initialTokens);
+    });
   });
 
   describe("hybrid selection fallback path", () => {
     beforeEach(() => {
       resetTrackers();
+      clearCircuitBreakers();
     });
 
     afterEach(() => {
       resetTrackers();
+      clearCircuitBreakers();
     });
 
     it("selects alternate account when current is rate-limited via selectHybridAccount", () => {
@@ -2104,6 +2202,41 @@ describe("AccountManager", () => {
       const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
       expect(selected).not.toBeNull();
       expect(selected?.index).toBe(0);
+    });
+
+    it("skips accounts whose circuit breaker is open", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        activeIndexByFamily: { codex: 0 },
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "first@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+          {
+            refreshToken: "token-2",
+            email: "second@example.com",
+            addedAt: now,
+            lastUsed: now - 10000,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored as never);
+      const blocked = manager.getAccountByIndex(0)!;
+
+      manager.recordFailure(blocked, "codex");
+      manager.recordFailure(blocked, "codex");
+      manager.recordFailure(blocked, "codex");
+
+      const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
+
+      expect(selected?.index).toBe(1);
+      expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
     });
   });
 });

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1945,6 +1945,34 @@ describe("AccountManager", () => {
       expect(score).toBe(100);
     });
 
+    it("recordSuccess closes the circuit breaker for the account", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "breaker@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
+
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      expect(breaker.getState()).toBe("open");
+
+      manager.recordSuccess(account, "codex");
+      expect(breaker.getState()).toBe("closed");
+    });
+
     it("recordRateLimit updates health and drains token bucket", () => {
       const now = Date.now();
       const stored = {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1945,7 +1945,9 @@ describe("AccountManager", () => {
       expect(score).toBe(100);
     });
 
-    it("recordSuccess closes the circuit breaker for the account", () => {
+    it("recordSuccess closes the circuit breaker after a half-open retry succeeds", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(0));
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -1969,8 +1971,11 @@ describe("AccountManager", () => {
       manager.recordFailure(account, "codex");
       expect(breaker.getState()).toBe("open");
 
+      vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
+      expect(manager.consumeToken(account, "codex")).toBe(true);
       manager.recordSuccess(account, "codex");
       expect(breaker.getState()).toBe("closed");
+      vi.useRealTimers();
     });
 
     it("recordRateLimit updates health and drains token bucket", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1004,6 +1004,70 @@ describe("AccountManager", () => {
 
       expect(manager.getMinWaitTimeForFamily("codex")).toBe(60_000);
     });
+
+    it("returns a conservative wait when the only account has an exhausted half-open probe slot", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "breaker@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+
+      vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
+
+      expect(manager.consumeToken(account, "codex")).toBe(true);
+      expect(manager.getMinWaitTimeForFamily("codex")).toBe(
+        DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs,
+      );
+    });
+
+    it("still prefers the soonest recovering account when another breaker is half-open and exhausted", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "breaker@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+          {
+            refreshToken: "token-2",
+            addedAt: now,
+            lastUsed: now,
+            rateLimitResetTimes: { codex: now + 40_000 },
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const breakerAccount = manager.getAccountByIndex(0)!;
+
+      manager.recordFailure(breakerAccount, "codex");
+      manager.recordFailure(breakerAccount, "codex");
+      manager.recordFailure(breakerAccount, "codex");
+
+      vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
+
+      expect(manager.consumeToken(breakerAccount, "codex")).toBe(true);
+      expect(manager.getMinWaitTimeForFamily("codex")).toBe(9_999);
+    });
   });
 
   describe("updateFromAuth", () => {

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -287,4 +287,20 @@ describe("Circuit breaker", () => {
     breaker.canExecute();
     expect(breaker.isAvailable()).toBe(false);
   });
+
+  it("allows a new half-open probe after the exhausted wait window elapses", () => {
+    const breaker = new CircuitBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.canExecute()).toBe(true);
+
+    vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs);
+
+    expect(breaker.isAvailable()).toBe(true);
+    expect(breaker.getTimeUntilAvailable()).toBe(0);
+    expect(breaker.canExecute()).toBe(true);
+  });
 });

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -234,6 +234,32 @@ describe("Circuit breaker", () => {
     expect(breaker.getTimeUntilReset()).toBe(0);
   });
 
+  it("getTimeUntilAvailable returns reset timeout while a half-open probe slot is exhausted", () => {
+    const breaker = new CircuitBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.canExecute()).toBe(true);
+
+    expect(breaker.getState()).toBe("half-open");
+    expect(breaker.getTimeUntilAvailable()).toBe(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs);
+  });
+
+  it("getTimeUntilAvailable stays at 0 when half-open still has probe capacity", () => {
+    const breaker = new CircuitBreaker({ halfOpenMaxAttempts: 2 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.canExecute()).toBe(true);
+
+    expect(breaker.getState()).toBe("half-open");
+    expect(breaker.getTimeUntilAvailable()).toBe(0);
+  });
+
   it("isAvailable is false while open and true after reset timeout", () => {
     const breaker = new CircuitBreaker();
     breaker.recordFailure();

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -234,7 +234,7 @@ describe("Circuit breaker", () => {
     expect(breaker.getTimeUntilReset()).toBe(0);
   });
 
-  it("getTimeUntilAvailable returns reset timeout while a half-open probe slot is exhausted", () => {
+  it("getTimeUntilAvailable returns remaining wait while a half-open probe slot is exhausted", () => {
     const breaker = new CircuitBreaker();
     breaker.recordFailure();
     breaker.recordFailure();
@@ -242,9 +242,14 @@ describe("Circuit breaker", () => {
 
     vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
     expect(breaker.canExecute()).toBe(true);
+    vi.setSystemTime(
+      new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1001),
+    );
 
     expect(breaker.getState()).toBe("half-open");
-    expect(breaker.getTimeUntilAvailable()).toBe(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs);
+    expect(breaker.getTimeUntilAvailable()).toBe(
+      DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs - 1000,
+    );
   });
 
   it("getTimeUntilAvailable stays at 0 when half-open still has probe capacity", () => {

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -233,4 +233,27 @@ describe("Circuit breaker", () => {
     vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1000));
     expect(breaker.getTimeUntilReset()).toBe(0);
   });
+
+  it("isAvailable is false while open and true after reset timeout", () => {
+    const breaker = new CircuitBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    expect(breaker.isAvailable()).toBe(false);
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.isAvailable()).toBe(true);
+  });
+
+  it("isAvailable becomes false when half-open attempts are exhausted", () => {
+    const breaker = new CircuitBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.isAvailable()).toBe(true);
+    breaker.canExecute();
+    expect(breaker.isAvailable()).toBe(false);
+  });
 });

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { getAccountHealth, formatHealthReport } from "../lib/health.js";
 import { clearCircuitBreakers, getCircuitBreaker } from "../lib/circuit-breaker.js";
+import { getAccountIdentityKey } from "../lib/storage/identity.js";
 
 describe("Health check", () => {
 	beforeEach(() => {
@@ -68,7 +69,7 @@ describe("Health check", () => {
 		const accounts = [
 			{ index: 0, email: "a@test.com", accountId: "acc1", health: 100 },
 		];
-		const circuit = getCircuitBreaker("account:acc1");
+		const circuit = getCircuitBreaker(getAccountIdentityKey(accounts[0]!)!);
 		circuit.recordFailure();
 		circuit.recordFailure();
 		circuit.recordFailure();
@@ -109,7 +110,7 @@ describe("Health check", () => {
 		const accounts = [
 			{ index: 0, email: "a@test.com", accountId: "acc1", health: 100 },
 		];
-		const circuit = getCircuitBreaker("account:acc1");
+		const circuit = getCircuitBreaker(getAccountIdentityKey(accounts[0]!)!);
 		circuit.recordFailure();
 		circuit.recordFailure();
 		circuit.recordFailure();

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -78,6 +78,21 @@ describe("Health check", () => {
 		expect(health.accounts[0].circuitState).toBe("open");
 	});
 
+	it("does not count circuit-open accounts as healthy", () => {
+		const accounts = [
+			{ index: 0, email: "a@test.com", accountId: "acc1", health: 100 },
+			{ index: 1, email: "b@test.com", accountId: "acc2", health: 100 },
+		];
+		const circuit = getCircuitBreaker(getAccountIdentityKey(accounts[0]!)!);
+		circuit.recordFailure();
+		circuit.recordFailure();
+		circuit.recordFailure();
+
+		const health = getAccountHealth(accounts);
+		expect(health.status).toBe("degraded");
+		expect(health.healthyAccountCount).toBe(1);
+	});
+
 	it("formats health report correctly", () => {
 		const now = Date.now();
 		const accounts = [


### PR DESCRIPTION
## Summary

- make circuit-breaker state participate in real account selection, request flow, and health reporting instead of only surfacing in reporting

## What Changed

- wired `AccountManager.recordSuccess` and `recordFailure` into stable per-account circuit-breaker instances keyed by account identity
- taught account availability, rotation, hybrid selection, and min-wait calculations to respect open breakers
- aligned health reporting with those same stable identity keys so breaker state and health snapshots stay attached to the right pooled account after index churn
- added a non-mutating `CircuitBreaker.isAvailable()` helper plus regressions covering breaker-open selection skips, refunded token consumption when a breaker is open, breaker-aware wait times, stable-key health reporting, and success-driven breaker recovery

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/accounts.test.ts test/health.test.ts test/circuit-breaker.test.ts test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low
- Rollback plan: revert `d5233e0`, `399d32d`, and `778d9df`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this PR properly integrates the circuit breaker into the live request path — availability checks, rotation, hybrid selection, wait-time calculations, and `consumeToken` all now consult the breaker. the `isAvailable()` helper is a clean non-mutating gate, and the per-account `Math.max` wait-time fix in `getMinWaitTimeForFamily` is a correctness improvement over the previous code. test coverage is thorough.

two issues need attention before merge:

- **`consumeToken` half-open slot not refundable** (`lib/accounts.ts`): `canExecute()` is a mutating call — it increments `halfOpenAttempts`. if a caller does `consumeToken` → network error → `refundToken` *without* a matching `recordFailure`, the probe slot is consumed with no circuit feedback. the circuit stays exhausted half-open for a full `resetTimeoutMs`.

- **fallback key format mismatch** (`lib/health.ts` vs `lib/accounts.ts`): when `getAccountIdentityKey` returns `undefined`, health uses `index:N` and the accounts manager uses `circuit:M` (auto-incremented). these produce different `CircuitBreaker` instances, so health can report `"closed"` while selection has the circuit `"open"`.

<h3>Confidence Score: 4/5</h3>

safe to merge after resolving the health fallback key mismatch and confirming refundToken call sites always pair with recordFailure

two P1 issues: (1) half-open probe slot orphaned if refundToken is called without recordFailure — real if any call site does this, silent otherwise; (2) fallback circuit key format differs between health.ts and accounts.ts — observable as stale health state for refreshToken-only accounts. core circuit breaker changes and test coverage are solid. scoring 4 until both are confirmed resolved.

lib/health.ts (fallback key mismatch), lib/accounts.ts (consumeToken refund coupling)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/accounts.ts | wires circuit breaker into availability checks, selection, wait time, and consumeToken; introduces half-open probe-slot orphan risk and a module-level counter not reset by clearCircuitBreakers |
| lib/circuit-breaker.ts | adds non-mutating isAvailable(), getTimeUntilAvailable(), probe-window reset helpers, and half-open re-probe logic; clean and well-tested |
| lib/health.ts | aligns health circuit key with getAccountIdentityKey but uses a different fallback format than accounts.ts, creating a key mismatch for refreshToken-only accounts when refreshToken is not passed |
| test/accounts.test.ts | solid regression coverage for breaker-open selection skips, token refund, stable-key identity after removal, and wait-time calculations; uses fake timers correctly |
| test/circuit-breaker.test.ts | new tests cover isAvailable, getTimeUntilAvailable exhausted/available, and re-probe after window reset; good coverage |
| test/health.test.ts | updates circuit key lookups to use getAccountIdentityKey and adds a degraded-when-circuit-open test; doesn't exercise the fallback key path for refreshToken-only accounts |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant AccountManager
    participant CircuitBreaker
    participant TokenTracker

    Caller->>AccountManager: isAccountAvailableForFamily(idx, family)
    AccountManager->>CircuitBreaker: isAvailable() [non-mutating]
    CircuitBreaker-->>AccountManager: true/false
    AccountManager-->>Caller: true/false

    Caller->>AccountManager: consumeToken(account, family)
    AccountManager->>TokenTracker: tryConsume(idx, quotaKey)
    TokenTracker-->>AccountManager: true (token available)
    AccountManager->>CircuitBreaker: canExecute() [increments halfOpenAttempts if half-open]
    alt circuit open / half-open exhausted
        CircuitBreaker-->>AccountManager: throws CircuitOpenError
        AccountManager->>TokenTracker: refundToken(idx, quotaKey)
        AccountManager-->>Caller: false
    else circuit closed / half-open with slot
        CircuitBreaker-->>AccountManager: true
        AccountManager-->>Caller: true
    end

    Caller->>AccountManager: recordSuccess(account, family)
    AccountManager->>CircuitBreaker: recordSuccess() [closes if half-open]

    Caller->>AccountManager: recordFailure(account, family)
    AccountManager->>CircuitBreaker: recordFailure() [opens if threshold exceeded]

    Note over Caller,TokenTracker: refundToken without recordFailure leaves half-open slot consumed
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (7)</h3></summary>

1. `lib/accounts.ts`, line 737-765 ([link](https://github.com/ndycode/codex-multi-auth/blob/778d9df58a7dee0c7f006764a897a2c962f8ff39/lib/accounts.ts#L737-L765)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`Math.min` across multi-constraint accounts returns an under-estimate**

   the loop pushes cooldown, rate-limit, and circuit wait times all into the same flat `waitTimes` array and then takes the global `Math.min`. for a single account that is both cooling-down (45 s) AND circuit-open (30 s), the function returns 30 s — but that account won't actually be available for 45 s. the correct per-account contribution is `Math.max(cooldownWait, rateLimitWait, circuitWait)`, with `Math.min` taken across accounts.

   this pattern was pre-existing for cooldown + rate-limit, but the circuit breaker push is written the same way and worsens it. callers will wake up 30 s early, find no available account, and spin. low probability of materialising in production (requires simultaneous cooldown + open circuit on every account), but worth fixing before it causes noisy false-negatives in high-churn pools.

   ```typescript
   // per-account max, then global min
   for (const account of enabledAccounts) {
       const perAccountTimes: number[] = [];

       const baseResetAt = account.rateLimitResetTimes[baseKey];
       if (typeof baseResetAt === "number") perAccountTimes.push(Math.max(0, baseResetAt - now));

       if (modelKey) {
           const modelResetAt = account.rateLimitResetTimes[modelKey];
           if (typeof modelResetAt === "number") perAccountTimes.push(Math.max(0, modelResetAt - now));
       }

       if (typeof account.coolingDownUntil === "number")
           perAccountTimes.push(Math.max(0, account.coolingDownUntil - now));

       const breakerWait = getCircuitBreaker(getAccountCircuitKey(account)).getTimeUntilReset();
       if (breakerWait > 0) perAccountTimes.push(breakerWait);

       if (perAccountTimes.length > 0) waitTimes.push(Math.max(...perAccountTimes));
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/accounts.ts
   Line: 737-765

   Comment:
   **`Math.min` across multi-constraint accounts returns an under-estimate**

   the loop pushes cooldown, rate-limit, and circuit wait times all into the same flat `waitTimes` array and then takes the global `Math.min`. for a single account that is both cooling-down (45 s) AND circuit-open (30 s), the function returns 30 s — but that account won't actually be available for 45 s. the correct per-account contribution is `Math.max(cooldownWait, rateLimitWait, circuitWait)`, with `Math.min` taken across accounts.

   this pattern was pre-existing for cooldown + rate-limit, but the circuit breaker push is written the same way and worsens it. callers will wake up 30 s early, find no available account, and spin. low probability of materialising in production (requires simultaneous cooldown + open circuit on every account), but worth fixing before it causes noisy false-negatives in high-churn pools.

   ```typescript
   // per-account max, then global min
   for (const account of enabledAccounts) {
       const perAccountTimes: number[] = [];

       const baseResetAt = account.rateLimitResetTimes[baseKey];
       if (typeof baseResetAt === "number") perAccountTimes.push(Math.max(0, baseResetAt - now));

       if (modelKey) {
           const modelResetAt = account.rateLimitResetTimes[modelKey];
           if (typeof modelResetAt === "number") perAccountTimes.push(Math.max(0, modelResetAt - now));
       }

       if (typeof account.coolingDownUntil === "number")
           perAccountTimes.push(Math.max(0, account.coolingDownUntil - now));

       const breakerWait = getCircuitBreaker(getAccountCircuitKey(account)).getTimeUntilReset();
       if (breakerWait > 0) perAccountTimes.push(breakerWait);

       if (perAccountTimes.length > 0) waitTimes.push(Math.max(...perAccountTimes));
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Faccounts.ts%0ALine%3A%20737-765%0A%0AComment%3A%0A**%60Math.min%60%20across%20multi-constraint%20accounts%20returns%20an%20under-estimate**%0A%0Athe%20loop%20pushes%20cooldown%2C%20rate-limit%2C%20and%20circuit%20wait%20times%20all%20into%20the%20same%20flat%20%60waitTimes%60%20array%20and%20then%20takes%20the%20global%20%60Math.min%60.%20for%20a%20single%20account%20that%20is%20both%20cooling-down%20%2845%20s%29%20AND%20circuit-open%20%2830%20s%29%2C%20the%20function%20returns%2030%20s%20%E2%80%94%20but%20that%20account%20won't%20actually%20be%20available%20for%2045%20s.%20the%20correct%20per-account%20contribution%20is%20%60Math.max%28cooldownWait%2C%20rateLimitWait%2C%20circuitWait%29%60%2C%20with%20%60Math.min%60%20taken%20across%20accounts.%0A%0Athis%20pattern%20was%20pre-existing%20for%20cooldown%20%2B%20rate-limit%2C%20but%20the%20circuit%20breaker%20push%20is%20written%20the%20same%20way%20and%20worsens%20it.%20callers%20will%20wake%20up%2030%20s%20early%2C%20find%20no%20available%20account%2C%20and%20spin.%20low%20probability%20of%20materialising%20in%20production%20%28requires%20simultaneous%20cooldown%20%2B%20open%20circuit%20on%20every%20account%29%2C%20but%20worth%20fixing%20before%20it%20causes%20noisy%20false-negatives%20in%20high-churn%20pools.%0A%0A%60%60%60typescript%0A%2F%2F%20per-account%20max%2C%20then%20global%20min%0Afor%20%28const%20account%20of%20enabledAccounts%29%20%7B%0A%20%20%20%20const%20perAccountTimes%3A%20number%5B%5D%20%3D%20%5B%5D%3B%0A%0A%20%20%20%20const%20baseResetAt%20%3D%20account.rateLimitResetTimes%5BbaseKey%5D%3B%0A%20%20%20%20if%20%28typeof%20baseResetAt%20%3D%3D%3D%20%22number%22%29%20perAccountTimes.push%28Math.max%280%2C%20baseResetAt%20-%20now%29%29%3B%0A%0A%20%20%20%20if%20%28modelKey%29%20%7B%0A%20%20%20%20%20%20%20%20const%20modelResetAt%20%3D%20account.rateLimitResetTimes%5BmodelKey%5D%3B%0A%20%20%20%20%20%20%20%20if%20%28typeof%20modelResetAt%20%3D%3D%3D%20%22number%22%29%20perAccountTimes.push%28Math.max%280%2C%20modelResetAt%20-%20now%29%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20%28typeof%20account.coolingDownUntil%20%3D%3D%3D%20%22number%22%29%0A%20%20%20%20%20%20%20%20perAccountTimes.push%28Math.max%280%2C%20account.coolingDownUntil%20-%20now%29%29%3B%0A%0A%20%20%20%20const%20breakerWait%20%3D%20getCircuitBreaker%28getAccountCircuitKey%28account%29%29.getTimeUntilReset%28%29%3B%0A%20%20%20%20if%20%28breakerWait%20%3E%200%29%20perAccountTimes.push%28breakerWait%29%3B%0A%0A%20%20%20%20if%20%28perAccountTimes.length%20%3E%200%29%20waitTimes.push%28Math.max%28...perAccountTimes%29%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

2. `lib/health.ts`, line 56-58 ([link](https://github.com/ndycode/codex-multi-auth/blob/778d9df58a7dee0c7f006764a897a2c962f8ff39/lib/health.ts#L56-L58)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **circuit-open accounts counted as healthy**

   `healthyCount` only checks `isRateLimited`, `isCoolingDown`, and `health >= 50`. an account whose circuit is open is still counted as healthy and contributes to the `healthy` / `degraded` / `unhealthy` status, even though the selection logic now skips it entirely. this is a pre-existing gap that this PR could close since it already aligns the circuit key.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/health.ts
   Line: 56-58

   Comment:
   **circuit-open accounts counted as healthy**

   `healthyCount` only checks `isRateLimited`, `isCoolingDown`, and `health >= 50`. an account whose circuit is open is still counted as healthy and contributes to the `healthy` / `degraded` / `unhealthy` status, even though the selection logic now skips it entirely. this is a pre-existing gap that this PR could close since it already aligns the circuit key.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fhealth.ts%0ALine%3A%2056-58%0A%0AComment%3A%0A**circuit-open%20accounts%20counted%20as%20healthy**%0A%0A%60healthyCount%60%20only%20checks%20%60isRateLimited%60%2C%20%60isCoolingDown%60%2C%20and%20%60health%20%3E%3D%2050%60.%20an%20account%20whose%20circuit%20is%20open%20is%20still%20counted%20as%20healthy%20and%20contributes%20to%20the%20%60healthy%60%20%2F%20%60degraded%60%20%2F%20%60unhealthy%60%20status%2C%20even%20though%20the%20selection%20logic%20now%20skips%20it%20entirely.%20this%20is%20a%20pre-existing%20gap%20that%20this%20PR%20could%20close%20since%20it%20already%20aligns%20the%20circuit%20key.%0A%0A%60%60%60suggestion%0A%09const%20healthyCount%20%3D%20accountHealths.filter%28%0A%09%09%28a%29%20%3D%3E%20!a.isRateLimited%20%26%26%20!a.isCoolingDown%20%26%26%20a.circuitState%20%3D%3D%3D%20%22closed%22%20%26%26%20a.health%20%3E%3D%2050%2C%0A%09%29.length%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

3. `lib/accounts.ts`, line 759-766 ([link](https://github.com/ndycode/codex-multi-auth/blob/5b471182ba70d4aeb696e7d64cab016e3b61429f/lib/accounts.ts#L759-L766)) 

   **`getMinWaitTimeForFamily` returns 0 when all accounts are half-open-exhausted**

   `getTimeUntilReset()` returns `0` for any state other than `"open"`. when a circuit has transitioned to `"half-open"` and its single allowed attempt has already been claimed by `consumeToken` (incrementing `halfOpenAttempts` to `halfOpenMaxAttempts`), `isAvailable()` returns `false` — so the account is correctly excluded from `available` — but `breakerWait` is `0`, nothing is pushed to `perAccountWaitTimes`, and the function returns `0`.

   callers that use this to schedule a retry will immediately re-enter the selection loop, find all accounts unavailable, get `0` again, and spin until the in-flight half-open probe resolves via `recordSuccess` / `recordFailure`. if the probe is never resolved (lost request, uncaught throw between `consumeToken` and the record calls), the pool is stuck returning `0` indefinitely.

   consider returning a small positive sentinel (or the remaining full reset timeout) when all accounts are blocked with a half-open exhausted circuit:

   ```typescript
   const breaker = getCircuitBreaker(getAccountCircuitKey(account));
   const breakerWait = breaker.getTimeUntilReset();
   const isHalfOpenExhausted =
       breaker.getState() === "half-open" && !breaker.isAvailable();
   if (breakerWait > 0 || isHalfOpenExhausted) {
       perAccountWaitTimes.push(breakerWait || DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs);
   }
   ```

4. `lib/health.ts`, line 27-40 ([link](https://github.com/ndycode/codex-multi-auth/blob/256d8b7e168c21e27e53db6147431c4eb8e57b81/lib/health.ts#L27-L40)) 

   **`refreshToken` absent from parameter type causes circuit-key mismatch**

   `getAccountHealth`'s `accounts` parameter type omits `refreshToken`. when `getAccountIdentityKey(acc)` is called, `acc.refreshToken` is `undefined` from TypeScript's view, so for any account that has only a refresh token (no `email`, no `accountId`) the function gets `undefined` back and falls back to `` `index:${acc.index}` ``.

   `accounts.ts` `getAccountCircuitKey` receives a full `ManagedAccount` (where `refreshToken: string` is required) and would resolve to `refresh:${hash}` for the same account. they look up different `CircuitBreaker` instances, so the health snapshot shows the wrong circuit state — `"closed"` on a tripped breaker, for example.

   at runtime when real `ManagedAccount` objects are passed, the extra runtime property IS present and everything works. but callers who construct a plain object matching the declared type (as every test does) will silently get the wrong key. adding `refreshToken?: string` to the parameter type makes this explicit and prevents future callers from hitting the mismatch.

5. `lib/circuit-breaker.ts`, line 115-129 ([link](https://github.com/ndycode/codex-multi-auth/blob/256d8b7e168c21e27e53db6147431c4eb8e57b81/lib/circuit-breaker.ts#L115-L129)) 

   **`getTimeUntilAvailable` returns 0 while `isAvailable` stays false — can cause a wait-spin**

   for a half-open circuit with exhausted probe slots, `getTimeUntilAvailable` measures `resetTimeoutMs - elapsed` where `elapsed = Date.now() - lastStateChange` (the moment the circuit entered half-open). once more than `resetTimeoutMs` has passed, `Math.max(0, ...)` clamps to 0.

   but `isAvailable()` checks `halfOpenAttempts < halfOpenMaxAttempts` which stays false — nothing resets the counter automatically. so after the half-open timeout window, the circuit is simultaneously:
   - `getTimeUntilAvailable() === 0` — no wait advertised
   - `isAvailable() === false` — account still blocked

   `getMinWaitTimeForFamily` skips adding the breaker delay (`if (breakerWait > 0)`) and can return 0 while the pool has no selectable account. a caller that uses the returned wait time to schedule a retry would immediately loop back, find the account still blocked, and spin.

   the stuck-circuit itself is a pre-existing edge case (only reachable if a probe token is consumed but neither `recordSuccess` nor `recordFailure` is ever called), but `getTimeUntilAvailable` now surfaces it to callers that previously never saw this path.

   a minimal fix: return `this.config.resetTimeoutMs` as a floor once the window has expired but the slot is still consumed:

6. `lib/accounts.ts`, line 598-612 ([link](https://github.com/ndycode/codex-multi-auth/blob/32e22d50659766a61e7ea703dca1413d332734e4/lib/accounts.ts#L598-L612)) 

   **half-open probe slot orphaned on token refund without `recordFailure`**

   `canExecute()` increments `halfOpenAttempts` as a side-effect when the circuit is half-open. if `consumeToken` succeeds and the caller subsequently calls `refundToken` (network/transport error) *without* also calling `recordFailure`, the probe slot is permanently consumed for the current window. `isCircuitAvailable` immediately returns `false`, and `getTimeUntilAvailable` returns the full `resetTimeoutMs` (~30 s), blocking selection on that account until the probe window resets.

   the codebase AGENTS note says network errors also trigger a health penalty (i.e. `recordFailure`), which would reopen the circuit correctly. but there's no enforced pairing — if any call site does `refundToken` without `recordFailure`, the circuit drifts into a silent half-open stall. worth verifying all `refundToken` callers always co-call `recordFailure`.


7. `lib/health.ts`, line 41 ([link](https://github.com/ndycode/codex-multi-auth/blob/32e22d50659766a61e7ea703dca1413d332734e4/lib/health.ts#L41)) 

   **fallback key mismatch causes health to read the wrong circuit breaker**

   when `getAccountIdentityKey(acc)` returns `undefined`, health falls back to `` `index:${acc.index}` ``. `getAccountCircuitKey` in `accounts.ts` falls back to `` `circuit:${nextRuntimeCircuitKeyId++}` ``. these two formats produce different map keys, so `getCircuitBreaker(circuitKey)` in health returns a freshly-created breaker — not the one actually gating selection.

   for accounts identified only by `refreshToken`, this mismatch fires any time `getAccountHealth` is called without passing `refreshToken` (it is `?` optional in the new signature). a circuit that is `"open"` in selection would report as `"closed"` in health. since `refreshToken` was just added to the signature in this PR, existing callers may not yet supply it.

   aligning the fallback to use a stable, consistent pattern across both sites would fix this.

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Faccounts.ts%3A598-612%0A**half-open%20probe%20slot%20orphaned%20on%20token%20refund%20without%20%60recordFailure%60**%0A%0A%60canExecute%28%29%60%20increments%20%60halfOpenAttempts%60%20as%20a%20side-effect%20when%20the%20circuit%20is%20half-open.%20if%20%60consumeToken%60%20succeeds%20and%20the%20caller%20subsequently%20calls%20%60refundToken%60%20%28network%2Ftransport%20error%29%20*without*%20also%20calling%20%60recordFailure%60%2C%20the%20probe%20slot%20is%20permanently%20consumed%20for%20the%20current%20window.%20%60isCircuitAvailable%60%20immediately%20returns%20%60false%60%2C%20and%20%60getTimeUntilAvailable%60%20returns%20the%20full%20%60resetTimeoutMs%60%20%28~30%20s%29%2C%20blocking%20selection%20on%20that%20account%20until%20the%20probe%20window%20resets.%0A%0Athe%20codebase%20AGENTS%20note%20says%20network%20errors%20also%20trigger%20a%20health%20penalty%20%28i.e.%20%60recordFailure%60%29%2C%20which%20would%20reopen%20the%20circuit%20correctly.%20but%20there's%20no%20enforced%20pairing%20%E2%80%94%20if%20any%20call%20site%20does%20%60refundToken%60%20without%20%60recordFailure%60%2C%20the%20circuit%20drifts%20into%20a%20silent%20half-open%20stall.%20worth%20verifying%20all%20%60refundToken%60%20callers%20always%20co-call%20%60recordFailure%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fhealth.ts%3A41%0A**fallback%20key%20mismatch%20causes%20health%20to%20read%20the%20wrong%20circuit%20breaker**%0A%0Awhen%20%60getAccountIdentityKey%28acc%29%60%20returns%20%60undefined%60%2C%20health%20falls%20back%20to%20%60%60%20%60index%3A%24%7Bacc.index%7D%60%20%60%60.%20%60getAccountCircuitKey%60%20in%20%60accounts.ts%60%20falls%20back%20to%20%60%60%20%60circuit%3A%24%7BnextRuntimeCircuitKeyId%2B%2B%7D%60%20%60%60.%20these%20two%20formats%20produce%20different%20map%20keys%2C%20so%20%60getCircuitBreaker%28circuitKey%29%60%20in%20health%20returns%20a%20freshly-created%20breaker%20%E2%80%94%20not%20the%20one%20actually%20gating%20selection.%0A%0Afor%20accounts%20identified%20only%20by%20%60refreshToken%60%2C%20this%20mismatch%20fires%20any%20time%20%60getAccountHealth%60%20is%20called%20without%20passing%20%60refreshToken%60%20%28it%20is%20%60%3F%60%20optional%20in%20the%20new%20signature%29.%20a%20circuit%20that%20is%20%60%22open%22%60%20in%20selection%20would%20report%20as%20%60%22closed%22%60%20in%20health.%20since%20%60refreshToken%60%20was%20just%20added%20to%20the%20signature%20in%20this%20PR%2C%20existing%20callers%20may%20not%20yet%20supply%20it.%0A%0Aaligning%20the%20fallback%20to%20use%20a%20stable%2C%20consistent%20pattern%20across%20both%20sites%20would%20fix%20this.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Faccounts.ts%3A79-87%0A**%60nextRuntimeCircuitKeyId%60%20not%20reset%20by%20%60clearCircuitBreakers%28%29%60**%0A%0A%60clearCircuitBreakers%28%29%60%20empties%20the%20map%20but%20the%20module-level%20counter%20keeps%20incrementing.%20if%20an%20account%20has%20no%20identity%20fields%20at%20all%2C%20two%20successive%20%60clearCircuitBreakers%60%20%2B%20account-create%20cycles%20would%20get%20%60circuit%3A0%60%20vs%20%60circuit%3A1%60%20%E2%80%94%20different%20breakers%2C%20stale%20state%20between%20runs.%0A%0Ain%20practice%20every%20%60ManagedAccount%60%20has%20a%20%60refreshToken%60%20so%20%60getAccountIdentityKey%60%20never%20returns%20%60undefined%60%20for%20real%20accounts%2C%20making%20this%20a%20low-risk%20defensive%20gap.%20but%20if%20%60clearCircuitBreakers%60%20is%20expected%20to%20fully%20reset%20circuit%20state%20it%20should%20also%20reset%20the%20counter.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/accounts.ts
Line: 598-612

Comment:
**half-open probe slot orphaned on token refund without `recordFailure`**

`canExecute()` increments `halfOpenAttempts` as a side-effect when the circuit is half-open. if `consumeToken` succeeds and the caller subsequently calls `refundToken` (network/transport error) *without* also calling `recordFailure`, the probe slot is permanently consumed for the current window. `isCircuitAvailable` immediately returns `false`, and `getTimeUntilAvailable` returns the full `resetTimeoutMs` (~30 s), blocking selection on that account until the probe window resets.

the codebase AGENTS note says network errors also trigger a health penalty (i.e. `recordFailure`), which would reopen the circuit correctly. but there's no enforced pairing — if any call site does `refundToken` without `recordFailure`, the circuit drifts into a silent half-open stall. worth verifying all `refundToken` callers always co-call `recordFailure`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/health.ts
Line: 41

Comment:
**fallback key mismatch causes health to read the wrong circuit breaker**

when `getAccountIdentityKey(acc)` returns `undefined`, health falls back to `` `index:${acc.index}` ``. `getAccountCircuitKey` in `accounts.ts` falls back to `` `circuit:${nextRuntimeCircuitKeyId++}` ``. these two formats produce different map keys, so `getCircuitBreaker(circuitKey)` in health returns a freshly-created breaker — not the one actually gating selection.

for accounts identified only by `refreshToken`, this mismatch fires any time `getAccountHealth` is called without passing `refreshToken` (it is `?` optional in the new signature). a circuit that is `"open"` in selection would report as `"closed"` in health. since `refreshToken` was just added to the signature in this PR, existing callers may not yet supply it.

aligning the fallback to use a stable, consistent pattern across both sites would fix this.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts.ts
Line: 79-87

Comment:
**`nextRuntimeCircuitKeyId` not reset by `clearCircuitBreakers()`**

`clearCircuitBreakers()` empties the map but the module-level counter keeps incrementing. if an account has no identity fields at all, two successive `clearCircuitBreakers` + account-create cycles would get `circuit:0` vs `circuit:1` — different breakers, stale state between runs.

in practice every `ManagedAccount` has a `refreshToken` so `getAccountIdentityKey` never returns `undefined` for real accounts, making this a low-risk defensive gap. but if `clearCircuitBreakers` is expected to fully reset circuit state it should also reset the counter.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix-half-open-breaker-recovery-window"](https://github.com/ndycode/codex-multi-auth/commit/32e22d50659766a61e7ea703dca1413d332734e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26974045)</sub>

<!-- /greptile_comment -->