### PR TITLE
fix: unblock dev storage export and docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,9 +291,9 @@ codex auth doctor --json
 
 ## Release Notes
 
-- Current stable: [docs/releases/v1.2.0.md](docs/releases/v1.2.0.md)
-- Previous stable: [docs/releases/v1.1.10.md](docs/releases/v1.1.10.md)
-- Earlier stable: [docs/releases/v0.1.9.md](docs/releases/v0.1.9.md)
+- Current stable: [docs/releases/v1.1.10.md](docs/releases/v1.1.10.md)
+- Previous stable: [docs/releases/v0.1.9.md](docs/releases/v0.1.9.md)
+- Earlier stable: [docs/releases/v0.1.8.md](docs/releases/v0.1.8.md)
 - Archived prerelease: [docs/releases/v0.1.0-beta.0.md](docs/releases/v0.1.0-beta.0.md)
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,9 +26,9 @@ Public documentation for `codex-multi-auth`.
 | [troubleshooting.md](troubleshooting.md) | Recovery playbooks for install, login, switching, and stale state |
 | [privacy.md](privacy.md) | Data handling and local storage behavior |
 | [upgrade.md](upgrade.md) | Migration from legacy package and path history |
-| [releases/v1.2.0.md](releases/v1.2.0.md) | Stable release notes |
-| [releases/v1.1.10.md](releases/v1.1.10.md) | Previous stable release notes |
-| [releases/v0.1.9.md](releases/v0.1.9.md) | Earlier stable release notes |
+| [releases/v1.1.10.md](releases/v1.1.10.md) | Stable release notes |
+| [releases/v0.1.9.md](releases/v0.1.9.md) | Previous stable release notes |
+| [releases/v0.1.8.md](releases/v0.1.8.md) | Earlier stable release notes |
 | [releases/v0.1.7.md](releases/v0.1.7.md) | Archived stable release notes |
 | [releases/v0.1.6.md](releases/v0.1.6.md) | Archived stable release notes |
 | [releases/v0.1.5.md](releases/v0.1.5.md) | Archived stable release notes |
@@ -45,7 +45,7 @@ Public documentation for `codex-multi-auth`.
 | [reference/storage-paths.md](reference/storage-paths.md) | Canonical and compatibility storage paths |
 | [reference/public-api.md](reference/public-api.md) | Public API stability and semver contract |
 | [reference/error-contracts.md](reference/error-contracts.md) | CLI, JSON, and helper error semantics |
-| [releases/v1.2.0.md](releases/v1.2.0.md) | Current stable release notes |
+| [releases/v1.1.10.md](releases/v1.1.10.md) | Current stable release notes |
 | [releases/v0.1.0-beta.0.md](releases/v0.1.0-beta.0.md) | Archived prerelease reference |
 | [User Guides release notes](#user-guides) | Stable, previous, and archived release notes |
 | [releases/legacy-pre-0.1-history.md](releases/legacy-pre-0.1-history.md) | Archived pre-0.1 changelog history |

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Public documentation for `codex-multi-auth`.
 | [troubleshooting.md](troubleshooting.md) | Recovery playbooks for install, login, switching, and stale state |
 | [privacy.md](privacy.md) | Data handling and local storage behavior |
 | [upgrade.md](upgrade.md) | Migration from legacy package and path history |
-| [releases/v1.1.10.md](releases/v1.1.10.md) | Stable release notes |
+| [releases/v1.1.10.md](releases/v1.1.10.md) | Current stable release notes |
 | [releases/v0.1.9.md](releases/v0.1.9.md) | Previous stable release notes |
 | [releases/v0.1.8.md](releases/v0.1.8.md) | Earlier stable release notes |
 | [releases/v0.1.7.md](releases/v0.1.7.md) | Archived stable release notes |

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1937,6 +1937,13 @@ async function loadAccountsForExport(): Promise<AccountStorageV3 | null> {
 		return createEmptyStorageWithMetadata(false, "intentional-reset");
 	}
 	if (!existsSync(path)) {
+		if (migratedLegacyStorage) {
+			return migratedLegacyStorage;
+		}
+		const recoveredFromWal = await loadAccountsFromJournal(path);
+		if (recoveredFromWal) {
+			return recoveredFromWal;
+		}
 		return createEmptyStorageWithMetadata(true, "missing-storage");
 	}
 
@@ -1969,6 +1976,10 @@ async function loadAccountsForExport(): Promise<AccountStorageV3 | null> {
 		const code = (error as NodeJS.ErrnoException).code;
 		if (existsSync(resetMarkerPath)) {
 			return createEmptyStorageWithMetadata(false, "intentional-reset");
+		}
+		const recoveredFromWal = await loadAccountsFromJournal(path);
+		if (recoveredFromWal) {
+			return recoveredFromWal;
 		}
 		if (code === "ENOENT") {
 			return migratedLegacyStorage;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1926,6 +1926,54 @@ async function loadAccountsInternal(
 	}
 }
 
+async function loadAccountsForExport(): Promise<AccountStorageV3 | null> {
+	const path = getStoragePath();
+	const resetMarkerPath = getIntentionalResetMarkerPath(path);
+	await cleanupStaleRotatingBackupArtifacts(path);
+	const migratedLegacyStorage =
+		await migrateLegacyProjectStorageIfNeeded(saveAccountsUnlocked);
+
+	if (existsSync(resetMarkerPath)) {
+		return createEmptyStorageWithMetadata(false, "intentional-reset");
+	}
+
+	try {
+		const { normalized, storedVersion, schemaErrors } =
+			await loadAccountsFromPath(path);
+		if (schemaErrors.length > 0) {
+			log.warn("Account storage schema validation warnings", {
+				errors: schemaErrors.slice(0, 5),
+			});
+		}
+		if (normalized && storedVersion !== normalized.version) {
+			log.info("Migrating account storage to v3", {
+				from: storedVersion,
+				to: normalized.version,
+			});
+			try {
+				await saveAccountsUnlocked(normalized);
+			} catch (saveError) {
+				log.warn("Failed to persist migrated storage", {
+					error: String(saveError),
+				});
+			}
+		}
+		if (existsSync(resetMarkerPath)) {
+			return createEmptyStorageWithMetadata(false, "intentional-reset");
+		}
+		return normalized;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (existsSync(resetMarkerPath)) {
+			return createEmptyStorageWithMetadata(false, "intentional-reset");
+		}
+		if (code === "ENOENT") {
+			return migratedLegacyStorage;
+		}
+		throw error;
+	}
+}
+
 async function saveAccountsUnlocked(storage: AccountStorageV3): Promise<void> {
 	const path = getStoragePath();
 	const resetMarkerPath = getIntentionalResetMarkerPath(path);
@@ -2489,10 +2537,8 @@ export async function exportAccounts(
 		transactionState.storagePath === currentStoragePath
 			? transactionState.snapshot
 			: transactionState?.active
-				? await loadAccountsInternal(saveAccountsUnlocked)
-				: await withAccountStorageTransaction((current) =>
-						Promise.resolve(current),
-					);
+				? await loadAccountsForExport()
+				: await withStorageLock(loadAccountsForExport);
 	if (!storage || storage.accounts.length === 0) {
 		throw new Error("No accounts to export");
 	}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1936,6 +1936,9 @@ async function loadAccountsForExport(): Promise<AccountStorageV3 | null> {
 	if (existsSync(resetMarkerPath)) {
 		return createEmptyStorageWithMetadata(false, "intentional-reset");
 	}
+	if (!existsSync(path)) {
+		return createEmptyStorageWithMetadata(true, "missing-storage");
+	}
 
 	try {
 		const { normalized, storedVersion, schemaErrors } =

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -956,6 +956,33 @@ describe("storage", () => {
 			);
 		});
 
+		it("should fail export when only backup storage exists", async () => {
+			const { exportAccounts } = await import("../lib/storage.js");
+			const backupPath = `${testStoragePath}.bak`;
+			await fs.writeFile(
+				backupPath,
+				JSON.stringify({
+					version: 3,
+					activeIndex: 0,
+					accounts: [
+						{
+							accountId: "backup-only",
+							refreshToken: "backup-refresh",
+							addedAt: 1,
+							lastUsed: 1,
+						},
+					],
+				}),
+				"utf-8",
+			);
+
+			setStoragePathDirect(testStoragePath);
+			await expect(exportAccounts(exportPath)).rejects.toThrow(
+				/No accounts to export/,
+			);
+			expect(existsSync(exportPath)).toBe(false);
+		});
+
 		it("should fail import when file does not exist", async () => {
 			const { importAccounts } = await import("../lib/storage.js");
 			const nonexistentPath = join(testWorkDir, "nonexistent-file.json");

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -949,7 +950,6 @@ describe("storage", () => {
 		});
 
 		it("should fail export when no accounts exist", async () => {
-			const { exportAccounts } = await import("../lib/storage.js");
 			setStoragePathDirect(testStoragePath);
 			await expect(exportAccounts(exportPath)).rejects.toThrow(
 				/No accounts to export/,
@@ -957,7 +957,6 @@ describe("storage", () => {
 		});
 
 		it("should fail export when only backup storage exists", async () => {
-			const { exportAccounts } = await import("../lib/storage.js");
 			const backupPath = `${testStoragePath}.bak`;
 			await fs.writeFile(
 				backupPath,
@@ -980,6 +979,140 @@ describe("storage", () => {
 			await expect(exportAccounts(exportPath)).rejects.toThrow(
 				/No accounts to export/,
 			);
+			expect(existsSync(exportPath)).toBe(false);
+		});
+
+		it("should export from WAL recovery when primary storage is missing", async () => {
+			const walPath = `${testStoragePath}.wal`;
+			const storage = {
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "wal-only",
+						refreshToken: "wal-refresh",
+						addedAt: 1,
+						lastUsed: 1,
+					},
+				],
+			};
+			const content = JSON.stringify(storage, null, 2);
+			const checksum = createHash("sha256").update(content).digest("hex");
+			await fs.writeFile(
+				walPath,
+				JSON.stringify({
+					version: 1,
+					createdAt: 1,
+					path: testStoragePath,
+					checksum,
+					content,
+				}),
+				"utf-8",
+			);
+
+			await exportAccounts(exportPath);
+
+			const exported = JSON.parse(await fs.readFile(exportPath, "utf-8")) as {
+				accounts: Array<{ accountId: string; refreshToken: string }>;
+			};
+			expect(exported.accounts).toEqual([
+				expect.objectContaining({
+					accountId: "wal-only",
+					refreshToken: "wal-refresh",
+				}),
+			]);
+		});
+
+		it("should export from migrated legacy project storage when primary storage is missing", async () => {
+			const fakeHome = join(testWorkDir, "legacy-home");
+			const projectDir = join(testWorkDir, "legacy-project");
+			const legacyProjectConfigDir = join(projectDir, ".codex");
+			const legacyStoragePath = join(
+				legacyProjectConfigDir,
+				"openai-codex-accounts.json",
+			);
+			const originalHome = process.env.HOME;
+			const originalUserProfile = process.env.USERPROFILE;
+			try {
+				await fs.mkdir(fakeHome, { recursive: true });
+				await fs.mkdir(join(projectDir, ".git"), { recursive: true });
+				await fs.mkdir(legacyProjectConfigDir, { recursive: true });
+				process.env.HOME = fakeHome;
+				process.env.USERPROFILE = fakeHome;
+				setStoragePath(projectDir);
+				await fs.writeFile(
+					legacyStoragePath,
+					JSON.stringify({
+						version: 3,
+						activeIndex: 0,
+						accounts: [
+							{
+								accountId: "legacy-only",
+								refreshToken: "legacy-refresh",
+								addedAt: 1,
+								lastUsed: 1,
+							},
+						],
+					}),
+					"utf-8",
+				);
+
+				await exportAccounts(exportPath);
+
+				const exported = JSON.parse(await fs.readFile(exportPath, "utf-8")) as {
+					accounts: Array<{ accountId: string; refreshToken: string }>;
+				};
+				expect(exported.accounts).toEqual([
+					expect.objectContaining({
+						accountId: "legacy-only",
+						refreshToken: "legacy-refresh",
+					}),
+				]);
+				expect(existsSync(legacyStoragePath)).toBe(false);
+				expect(existsSync(getStoragePath())).toBe(true);
+			} finally {
+				if (originalHome === undefined) delete process.env.HOME;
+				else process.env.HOME = originalHome;
+				if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+				else process.env.USERPROFILE = originalUserProfile;
+				setStoragePathDirect(testStoragePath);
+			}
+		});
+
+		it("should fail export from backup-only storage on a different path during an active transaction", async () => {
+			const alternateStoragePath = join(
+				testWorkDir,
+				`accounts-alt-${Math.random().toString(36).slice(2)}.json`,
+			);
+			const alternateBackupPath = `${alternateStoragePath}.bak`;
+			await fs.writeFile(
+				alternateBackupPath,
+				JSON.stringify({
+					version: 3,
+					activeIndex: 0,
+					accounts: [
+						{
+							accountId: "backup-only",
+							refreshToken: "backup-refresh",
+							addedAt: 1,
+							lastUsed: 1,
+						},
+					],
+				}),
+				"utf-8",
+			);
+
+			await withAccountStorageTransaction(async () => {
+				setStoragePathDirect(alternateStoragePath);
+				try {
+					await expect(exportAccounts(exportPath)).rejects.toThrow(
+						/No accounts to export/,
+					);
+				} finally {
+					setStoragePathDirect(testStoragePath);
+				}
+			});
+
 			expect(existsSync(exportPath)).toBe(false);
 		});
 


### PR DESCRIPTION
## Summary
- fix export so an empty current pool rejects instead of exporting from stale restored state
- point README and docs release-note links at release files that actually exist on dev

## Validation
- npm exec vitest run test/documentation.test.ts test/storage.test.ts
- integrated dev stack (PR #206 + PR #212 + this fix): npm run lint, npm run typecheck, npm run build, npm test

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

two focused fixes: `exportAccounts` now loads via `loadAccountsForExport` — a new private function that intentionally skips backup recovery — so a missing primary storage file correctly rejects instead of silently exporting stale backup data. docs and readme release-note links are updated to point at files that actually exist on the dev branch (`v1.1.10`, `v0.1.9`, `v0.1.8`).

- **`lib/storage.ts`**: `loadAccountsForExport` mirrors `loadAccountsInternal` except it returns empty storage (not backup recovery) when the primary path is absent; `saveAccountsUnlocked` is lock-safe when called from inside `withStorageLock`; no reentrancy or deadlock risk
- **`test/storage.test.ts`**: regression test for backup-only rejection on the no-transaction path; cleanup falls under the existing `afterEach fs.rm`; the `transactionState.active && different-path` branch has no corresponding coverage (P2 note)
- **`README.md` / `docs/README.md`**: broken `v1.2.0.md` links removed; all three replacement files confirmed present in `docs/releases/`

<h3>Confidence Score: 5/5</h3>

safe to merge — fix is correct, no regressions, all changed doc links verified present on dev

the logic change is well-scoped: backup recovery is intentionally removed from the export path, saveAccountsUnlocked is lock-safe inside withStorageLock, and the regression test covers the primary failure mode. the only remaining finding is a P2 coverage gap for the active-transaction-different-path branch, which does not affect merge safety.

test/storage.test.ts — active-transaction-different-path branch has no backup-rejection test

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage.ts | adds loadAccountsForExport (no backup recovery) and wires it into exportAccounts; correctly rejects on backup-only or missing primary storage; saveAccountsUnlocked does not re-acquire the lock so no deadlock risk inside withStorageLock |
| test/storage.test.ts | adds regression test for backup-only rejection; cleanup is handled by the existing afterEach fs.rm; active-transaction-different-path branch has no backup-rejection coverage |
| README.md | points release-note links at files that actually exist on dev (v1.1.10, v0.1.9, v0.1.8 all verified present) |
| docs/README.md | same link fix as README.md — removes broken v1.2.0 references in both user-guides and reference tables |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[exportAccounts called] --> B{transactionState.active\nAND same storagePath?}
    B -- yes --> C[use transaction snapshot]
    B -- no --> D{transactionState.active\nAND different storagePath?}
    D -- yes --> E[loadAccountsForExport\nno lock]
    D -- no --> F[withStorageLock\nloadAccountsForExport]
    E --> G[loadAccountsForExport]
    F --> G
    G --> H{reset marker exists?}
    H -- yes --> I[return empty storage]
    H -- no --> J{primary path exists?}
    J -- no --> K[return empty storage\nmissing-storage]
    J -- yes --> L[loadAccountsFromPath]
    L --> M{parse error?}
    M -- ENOENT --> N[return migratedLegacyStorage]
    M -- other error --> O[throw]
    M -- success --> P[maybe save migration\nreturn normalized]
    C --> Q{accounts.length == 0?}
    I --> Q
    K --> Q
    N --> Q
    P --> Q
    Q -- yes --> R[throw: No accounts to export]
    Q -- no --> S[write export file]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fstorage.test.ts%3A959-984%0A**missing%20coverage%3A%20active-transaction-different-path%20branch**%0A%0Athe%20new%20test%20exercises%20the%20no-transaction%20path%20%28%60withStorageLock%28loadAccountsForExport%29%60%29.%20the%20other%20branch%20%E2%80%94%20%60transactionState%3F.active%20%26%26%20storagePath%20!%3D%3D%20currentStoragePath%60%20%E2%80%94%20calls%20%60loadAccountsForExport%28%29%60%20**without**%20a%20lock%20and%20is%20not%20tested.%20a%20concurrent%20write%20to%20the%20storage%20file%20during%20that%20window%20could%20yield%20stale%20or%20partial%20data%2C%20and%20there&#39;s%20no%20regression%20guard%20for%20it.%20worth%20adding%20a%20test%20that%20wraps%20%60exportAccounts%60%20inside%20a%20%60withAccountStorageTransaction%60%20on%20a%20*different*%20storage%20path%20and%20asserts%20the%20same%20backup-only%20rejection%20behaviour.%0A%0A&amp;repo=ndycode%2Fcodex-multi-auth" rel="nofollow noreferrer noopener" target="_blank"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

Prompt To Fix All With AI

`````markdown
This is a comment left during a code review.
Path: test/storage.test.ts
Line: 959-984

Comment:
**missing coverage: active-transaction-different-path branch**

the new test exercises the no-transaction path (`withStorageLock(loadAccountsForExport)`). the other branch — `transactionState?.active && storagePath !== currentStoragePath` — calls `loadAccountsForExport()` **without** a lock and is not tested. a concurrent write to the storage file during that window could yield stale or partial data, and there&#39;s no regression guard for it. worth adding a test that wraps `exportAccounts` inside a `withAccountStorageTransaction` on a *different* storage path and asserts the same backup-only rejection behaviour.

How can I resolve this? If you propose a fix, please make it concise.
`````

<sub>Reviews (2): Last reviewed commit: ["fix-export-primary-storage-only"](https://github.com/ndycode/codex-multi-auth/commit/e92d1f84c0f8a6529a4424087b2fd47c83213804) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26999085)</sub>

@coderabbitai ignore

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

two focused fixes: `exportAccounts` now loads via `loadAccountsForExport`, which intentionally skips backup recovery so a missing primary storage file correctly rejects instead of silently exporting stale backup data. doc and readme release-note links are updated to point at files that actually exist on dev (`v1.1.10`, `v0.1.9`, `v0.1.8`).

- **`lib/storage.ts`**: `loadAccountsForExport` mirrors `loadAccountsInternal` but removes the backup-candidate recovery loop — backup-only state now correctly yields 0 accounts and throws on export. WAL recovery and legacy migration are preserved intentionally.
- **`lib/storage.ts` (P2)**: `migrateLegacyProjectStorageIfNeeded(saveAccountsUnlocked)` fires at the top of `loadAccountsForExport` before path checks — on the no-lock branch (active transaction + different path), `saveAccountsUnlocked` can write to the alternate path without `storageMutex`. narrow edge case (only when a legacy migration is pending on the alternate path) but relevant on windows.
- **`test/storage.test.ts`**: four new regression tests — backup-only rejection, WAL recovery, legacy migration export, and the previously-uncovered active-transaction-different-path branch — all verified correct.
- **`README.md` / `docs/README.md`**: broken `v1.2.0.md` links removed; replacement files confirmed present in `docs/releases/`.

<h3>Confidence Score: 5/5</h3>

safe to merge — fix is correct, all three export branches now covered by regression tests, doc links verified present

only remaining finding is a P2 edge case: saveAccountsUnlocked can fire without the mutex on the no-lock branch if a legacy migration is triggered on an alternate path. the scenario requires an active transaction on a different path AND a pending legacy migration simultaneously — too narrow to block merge. all P0/P1 paths are clean.

lib/storage.ts line 1933-1934 — saveAccountsUnlocked without lock on no-lock export branch

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage.ts | adds `loadAccountsForExport` that mirrors `loadAccountsInternal` but omits backup recovery so a backup-only state correctly rejects; wires it into `exportAccounts` replacing the old paths; `saveAccountsUnlocked` is lock-safe inside `withStorageLock` but can fire without the mutex on the active-transaction-different-path branch if a legacy migration is triggered (P2 edge case) |
| test/storage.test.ts | adds four new export regression tests: backup-only rejection (no-transaction), WAL recovery, legacy migration, and active-transaction-different-path backup-only rejection; covers all three branches of the new exportAccounts logic |
| README.md | replaces broken v1.2.0 release-note links with v1.1.10, v0.1.9, v0.1.8 — all three files confirmed present in docs/releases/ |
| docs/README.md | removes two broken v1.2.0 references in user-guides and reference tables; replaces with v1.1.10 which exists on disk |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant caller
    participant exportAccounts
    participant loadAccountsForExport
    participant withStorageLock

    caller->>exportAccounts: exportAccounts(filePath)
    exportAccounts->>exportAccounts: read transactionSnapshotContext

    alt same-path active transaction
        exportAccounts->>exportAccounts: use transactionState.snapshot
    else different-path active transaction (no lock)
        exportAccounts->>loadAccountsForExport: loadAccountsForExport()
        loadAccountsForExport->>loadAccountsForExport: migrate legacy (saveAccountsUnlocked, no mutex)
        loadAccountsForExport->>loadAccountsForExport: check reset marker / primary path / WAL
        loadAccountsForExport-->>exportAccounts: storage | null
    else no active transaction
        exportAccounts->>withStorageLock: withStorageLock(loadAccountsForExport)
        withStorageLock->>loadAccountsForExport: loadAccountsForExport()
        loadAccountsForExport->>loadAccountsForExport: migrate legacy (saveAccountsUnlocked, inside lock)
        loadAccountsForExport->>loadAccountsForExport: check reset marker / primary path / WAL
        loadAccountsForExport-->>withStorageLock: storage | null
        withStorageLock-->>exportAccounts: storage | null
    end

    exportAccounts->>exportAccounts: accounts.length == 0? → throw "No accounts to export"
    exportAccounts->>exportAccounts: write export file (mode 0o600)
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fstorage.ts%3A1933-1934%0A**%60saveAccountsUnlocked%60%20called%20without%20lock%20on%20the%20no-lock%20branch**%0A%0A%60migrateLegacyProjectStorageIfNeeded%28saveAccountsUnlocked%29%60%20runs%20at%20the%20top%20of%20%60loadAccountsForExport%60%20regardless%20of%20which%20branch%20reaches%20it.%20on%20the%20active-transaction-different-path%20branch%20%28%60transactionState%3F.active%20%26%26%20storagePath%20!%3D%3D%20currentStoragePath%60%29%2C%20%60loadAccountsForExport%28%29%60%20is%20called%20**without**%20holding%20%60storageMutex%60.%20if%20a%20legacy%20migration%20is%20found%20and%20triggers%20%60saveAccountsUnlocked%60%2C%20that%20write%20to%20the%20alternate%20path%20has%20no%20mutex%20protection%20%E2%80%94%20on%20windows%20this%20can%20race%20with%20any%20concurrent%20i%2Fo%20on%20that%20file%20%28antivirus%20scans%2C%20other%20processes%29.%0A%0Athe%20scenario%20is%20narrow%20%28active%20transaction%20on%20path%20A%20%2B%20export%20of%20path%20B%20that%20has%20a%20pending%20legacy%20migration%29%2C%20but%20the%20project's%20%60AGENTS.md%60%20calls%20out%20windows%20filesystem%20races%20as%20a%20first-class%20concern.%20consider%20either%3A%20%28a%29%20skipping%20the%20migration%20persist%20during%20export-only%20reads%20%28pass%20%60undefined%60%20or%20a%20no-op%20as%20the%20persist%20callback%29%2C%20or%20%28b%29%20noting%20the%20assumption%20that%20the%20caller%20serialises%20access%20to%20%60alternateStoragePath%60%20externally.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/storage.ts
Line: 1933-1934

Comment:
**`saveAccountsUnlocked` called without lock on the no-lock branch**

`migrateLegacyProjectStorageIfNeeded(saveAccountsUnlocked)` runs at the top of `loadAccountsForExport` regardless of which branch reaches it. on the active-transaction-different-path branch (`transactionState?.active && storagePath !== currentStoragePath`), `loadAccountsForExport()` is called **without** holding `storageMutex`. if a legacy migration is found and triggers `saveAccountsUnlocked`, that write to the alternate path has no mutex protection — on windows this can race with any concurrent i/o on that file (antivirus scans, other processes).

the scenario is narrow (active transaction on path A + export of path B that has a pending legacy migration), but the project's `AGENTS.md` calls out windows filesystem races as a first-class concern. consider either: (a) skipping the migration persist during export-only reads (pass `undefined` or a no-op as the persist callback), or (b) noting the assumption that the caller serialises access to `alternateStoragePath` externally.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: restore export recovery paths"](https://github.com/ndycode/codex-multi-auth/commit/f096ed7300520c6591ed94739c6c32bdc1d8f393) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26999085)</sub>

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->