### PR TITLE
release: align main with published 1.2.2

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -177,6 +177,7 @@ import {
 import { applyFastSessionDefaults } from "./lib/request/request-transformer.js";
 import { applyResponseCompaction } from "./lib/request/response-compaction.js";
 import { isEmptyResponse } from "./lib/request/response-handler.js";
+import { CodexAuthError } from "./lib/errors.js";
 import {
 	parseRetryAfterHintMs,
 	sanitizeResponseHeadersForLog,
@@ -997,9 +998,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 													accountAuth,
 													client,
 												)) as OAuthAuthDetails;
-												accountManager.updateFromAuth(account, accountAuth);
-												accountManager.clearAuthFailures(account);
-												accountManager.saveToDiskDebounced();
+												await accountManager.commitRefreshedAuth(
+													account,
+													accountAuth,
+												);
 											}
 										} catch (err) {
 											logDebug(
@@ -1010,18 +1012,48 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 											runtimeMetrics.accountRotations++;
 											runtimeMetrics.lastError =
 												(err as Error)?.message ?? String(err);
-											const failures =
-												accountManager.incrementAuthFailures(account);
+											const isRetryableRefreshError =
+												err instanceof CodexAuthError && err.retryable;
 											const accountLabel = formatAccountLabel(
 												account,
 												account.index,
 											);
 
+											sessionAffinityStore?.forgetSession(sessionAffinityKey);
+
+											if (isRetryableRefreshError) {
+												runtimeMetrics.networkErrors++;
+												const retryableRefreshPolicy = evaluateFailurePolicy(
+													{ kind: "network", failoverMode },
+													{ networkCooldownMs: networkErrorCooldownMs },
+												);
+												if (retryableRefreshPolicy.recordFailure) {
+													accountManager.recordFailure(
+														account,
+														modelFamily,
+														model,
+													);
+												}
+												if (
+													typeof retryableRefreshPolicy.cooldownMs === "number" &&
+													retryableRefreshPolicy.cooldownReason
+												) {
+													accountManager.markAccountCoolingDown(
+														account,
+														retryableRefreshPolicy.cooldownMs,
+														retryableRefreshPolicy.cooldownReason,
+													);
+													accountManager.saveToDiskDebounced();
+												}
+												continue;
+											}
+
+											const failures =
+												accountManager.incrementAuthFailures(account);
 											const authFailurePolicy = evaluateFailurePolicy({
 												kind: "auth-refresh",
 												consecutiveAuthFailures: failures,
 											});
-											sessionAffinityStore?.forgetSession(sessionAffinityKey);
 
 											if (authFailurePolicy.removeAccount) {
 												const removedIndex = account.index;
@@ -1945,14 +1977,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 																		fallbackAuth,
 																		client,
 																	)) as OAuthAuthDetails;
-																	accountManager.updateFromAuth(
+																	await accountManager.commitRefreshedAuth(
 																		fallbackAccount,
 																		fallbackAuth,
 																	);
-																	accountManager.clearAuthFailures(
-																		fallbackAccount,
-																	);
-																	accountManager.saveToDiskDebounced();
 																}
 															} catch (refreshError) {
 																logWarn(

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -19,6 +19,8 @@ import {
 	type HybridSelectionOptions,
 } from "./rotation.js";
 import { nowMs } from "./utils.js";
+import { ERROR_MESSAGES } from "./constants.js";
+import { CodexAuthError } from "./errors.js";
 import {
 	loadCodexCliState,
 	type CodexCliTokenCacheEntry,
@@ -801,66 +803,70 @@ export class AccountManager {
 	): Promise<ManagedAccount | null> {
 		const nextAccountId = extractAccountId(auth.access)?.trim() || undefined;
 		const nextEmail = sanitizeEmail(extractAccountEmail(auth.access));
+		try {
+			return await withAccountStorageTransaction(async (current, persist) => {
+				const nextStorage = structuredClone(
+					current ?? this.buildStorageSnapshot(),
+				) as AccountStorageV3;
+				const storageIndex = findAccountIndexByIdentity(
+					nextStorage.accounts,
+					source,
+					auth,
+				);
+				if (storageIndex === undefined) {
+					log.warn("Unable to resolve refreshed account for persistence", {
+						sourceIndex: source.index,
+					});
+					return null;
+				}
 
-		await withAccountStorageTransaction(async (current, persist) => {
-			const nextStorage = structuredClone(
-				current ?? this.buildStorageSnapshot(),
-			) as AccountStorageV3;
-			const storageIndex = findAccountIndexByIdentity(
-				nextStorage.accounts,
-				source,
-				auth,
-			);
-			if (storageIndex === undefined) {
-				log.warn("Unable to resolve refreshed account for persistence", {
-					sourceIndex: source.index,
-					email: source.email,
-				});
-				return;
-			}
+				const storedAccount = nextStorage.accounts[storageIndex];
+				if (!storedAccount) {
+					return null;
+				}
 
-			const storedAccount = nextStorage.accounts[storageIndex];
-			if (!storedAccount) {
-				return;
-			}
+				storedAccount.refreshToken = auth.refresh;
+				storedAccount.accessToken = auth.access;
+				storedAccount.expiresAt = auth.expires;
+				if (
+					nextAccountId &&
+					shouldUpdateAccountIdFromToken(
+						storedAccount.accountIdSource,
+						storedAccount.accountId,
+					)
+				) {
+					storedAccount.accountId = nextAccountId;
+					storedAccount.accountIdSource = "token";
+				}
+				if (nextEmail) {
+					storedAccount.email = nextEmail;
+				}
+				storedAccount.enabled = undefined;
+				delete storedAccount.coolingDownUntil;
+				delete storedAccount.cooldownReason;
 
-			storedAccount.refreshToken = auth.refresh;
-			storedAccount.accessToken = auth.access;
-			storedAccount.expiresAt = auth.expires;
-			if (
-				nextAccountId &&
-				shouldUpdateAccountIdFromToken(
-					storedAccount.accountIdSource,
-					storedAccount.accountId,
-				)
-			) {
-				storedAccount.accountId = nextAccountId;
-				storedAccount.accountIdSource = "token";
-			}
-			if (nextEmail) {
-				storedAccount.email = nextEmail;
-			}
-			storedAccount.enabled = undefined;
-			delete storedAccount.coolingDownUntil;
-			delete storedAccount.cooldownReason;
+				await persist(nextStorage);
 
-			await persist(nextStorage);
-		});
+				const liveAccount = this.getAccountByIdentity(source, auth);
+				if (!liveAccount) {
+					log.warn("Unable to resolve refreshed live account after persistence", {
+						sourceIndex: source.index,
+					});
+					return null;
+				}
 
-		const liveAccount = this.getAccountByIdentity(source, auth);
-		if (!liveAccount) {
-			log.warn("Unable to resolve refreshed live account after persistence", {
-				sourceIndex: source.index,
-				email: source.email,
+				this.updateFromAuth(liveAccount, auth);
+				liveAccount.enabled = true;
+				this.clearAccountCooldown(liveAccount);
+				this.clearAuthFailures(liveAccount);
+				return liveAccount;
 			});
-			return null;
+		} catch (error) {
+			throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+				retryable: true,
+				cause: error,
+			});
 		}
-
-		this.updateFromAuth(liveAccount, auth);
-		liveAccount.enabled = true;
-		this.clearAccountCooldown(liveAccount);
-		this.clearAuthFailures(liveAccount);
-		return liveAccount;
 	}
 
 	toAuthDetails(account: ManagedAccount): Auth {
@@ -973,7 +979,9 @@ export class AccountManager {
 	}
 
 	async saveToDisk(): Promise<void> {
-		await saveAccounts(this.buildStorageSnapshot());
+		await withAccountStorageTransaction(async (_current, persist) => {
+			await persist(this.buildStorageSnapshot());
+		});
 	}
 
 	saveToDiskDebounced(delayMs = 500): void {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -19,7 +19,7 @@ import {
 	type HybridSelectionOptions,
 } from "./rotation.js";
 import { nowMs } from "./utils.js";
-import { ERROR_MESSAGES } from "./constants.js";
+import { ERROR_MESSAGES, HTTP_STATUS } from "./constants.js";
 import { CodexAuthError } from "./errors.js";
 import {
 	loadCodexCliState,
@@ -157,6 +157,37 @@ function findAccountIndexByIdentity<
 		}
 	}
 	return undefined;
+}
+
+const RETRYABLE_AUTH_PERSISTENCE_CODES = new Set(["EAGAIN", "EBUSY", "EPERM"]);
+
+function isRetryableAuthPersistenceError(error: unknown): boolean {
+	if (!error || typeof error !== "object") {
+		return false;
+	}
+
+	const candidate = error as {
+		code?: unknown;
+		status?: unknown;
+		cause?: unknown;
+	};
+	const code =
+		typeof candidate.code === "string"
+			? candidate.code.toUpperCase()
+			: undefined;
+	if (code && RETRYABLE_AUTH_PERSISTENCE_CODES.has(code)) {
+		return true;
+	}
+
+	if (candidate.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
+		return true;
+	}
+
+	if (candidate.cause && candidate.cause !== error) {
+		return isRetryableAuthPersistenceError(candidate.cause);
+	}
+
+	return false;
 }
 
 export interface Workspace {
@@ -845,25 +876,68 @@ export class AccountManager {
 				delete storedAccount.coolingDownUntil;
 				delete storedAccount.cooldownReason;
 
-				await persist(nextStorage);
-
 				const liveAccount = this.getAccountByIdentity(source, auth);
-				if (!liveAccount) {
-					log.warn("Unable to resolve refreshed live account after persistence", {
-						sourceIndex: source.index,
-					});
-					return null;
+				if (liveAccount) {
+					const previousLiveAccountState = {
+						access: liveAccount.access,
+						refreshToken: liveAccount.refreshToken,
+						expires: liveAccount.expires,
+						accountId: liveAccount.accountId,
+						accountIdSource: liveAccount.accountIdSource,
+						email: liveAccount.email,
+						enabled: liveAccount.enabled,
+						coolingDownUntil: liveAccount.coolingDownUntil,
+						cooldownReason: liveAccount.cooldownReason,
+						consecutiveAuthFailures: liveAccount.consecutiveAuthFailures,
+					};
+
+					this.updateFromAuth(liveAccount, auth);
+					liveAccount.enabled = true;
+					this.clearAccountCooldown(liveAccount);
+					this.clearAuthFailures(liveAccount);
+
+					try {
+						await persist(nextStorage);
+					} catch (error) {
+						liveAccount.access = previousLiveAccountState.access;
+						liveAccount.refreshToken = previousLiveAccountState.refreshToken;
+						liveAccount.expires = previousLiveAccountState.expires;
+						liveAccount.accountId = previousLiveAccountState.accountId;
+						liveAccount.accountIdSource =
+							previousLiveAccountState.accountIdSource;
+						liveAccount.email = previousLiveAccountState.email;
+						liveAccount.enabled = previousLiveAccountState.enabled;
+						liveAccount.consecutiveAuthFailures =
+							previousLiveAccountState.consecutiveAuthFailures;
+						if (
+							previousLiveAccountState.coolingDownUntil === undefined
+						) {
+							delete liveAccount.coolingDownUntil;
+						} else {
+							liveAccount.coolingDownUntil =
+								previousLiveAccountState.coolingDownUntil;
+						}
+						if (previousLiveAccountState.cooldownReason === undefined) {
+							delete liveAccount.cooldownReason;
+						} else {
+							liveAccount.cooldownReason =
+								previousLiveAccountState.cooldownReason;
+						}
+						throw error;
+					}
+
+					return liveAccount;
 				}
 
-				this.updateFromAuth(liveAccount, auth);
-				liveAccount.enabled = true;
-				this.clearAccountCooldown(liveAccount);
-				this.clearAuthFailures(liveAccount);
-				return liveAccount;
+				await persist(nextStorage);
+				log.warn("Unable to resolve refreshed live account after persistence", {
+					sourceIndex: source.index,
+				});
+				return null;
 			});
 		} catch (error) {
 			throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-				retryable: true,
+				retryable: isRetryableAuthPersistenceError(error),
 				cause: error,
 			});
 		}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -804,9 +804,9 @@ export class AccountManager {
 		const nextAccountId = extractAccountId(auth.access)?.trim() || undefined;
 		const nextEmail = sanitizeEmail(extractAccountEmail(auth.access));
 		try {
-			return await withAccountStorageTransaction(async (current, persist) => {
+			return await withAccountStorageTransaction(async (_current, persist) => {
 				const nextStorage = structuredClone(
-					current ?? this.buildStorageSnapshot(),
+					this.buildStorageSnapshot(),
 				) as AccountStorageV3;
 				const storageIndex = findAccountIndexByIdentity(
 					nextStorage.accounts,

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -188,7 +188,11 @@ export class AccountManager {
 				changed = true;
 			}
 
-			if (cached.refreshToken && cached.refreshToken !== account.refreshToken) {
+			if (
+				cachedAccessUsable &&
+				cached.refreshToken &&
+				cached.refreshToken !== account.refreshToken
+			) {
 				account.refreshToken = cached.refreshToken;
 				changed = true;
 			}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -74,6 +74,7 @@ import {
 } from "./accounts/rate-limits.js";
 
 const log = createLogger("accounts");
+const ACCOUNT_SELECTION_FRESH_WINDOW_MS = 5 * 60_000;
 
 function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
 	return Object.fromEntries(
@@ -381,12 +382,45 @@ export class AccountManager {
 		return account ?? null;
 	}
 
+	private hasFreshAccessToken(account: ManagedAccount): boolean {
+		if (!account.access) return false;
+		if (typeof account.expires !== "number" || !Number.isFinite(account.expires)) {
+			return false;
+		}
+		return account.expires > nowMs() + ACCOUNT_SELECTION_FRESH_WINDOW_MS;
+	}
+
+	private isAccountSelectableForFamily(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+		requireFresh = false,
+	): boolean {
+		if (account.enabled === false) return false;
+		clearExpiredRateLimits(account);
+		if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
+			return false;
+		}
+		return !requireFresh || this.hasFreshAccessToken(account);
+	}
+
+	private hasFreshAvailableAccountForFamily(
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		return this.accounts.some(
+			(account) =>
+				Boolean(account) &&
+				this.isAccountSelectableForFamily(account, family, model) &&
+				this.hasFreshAccessToken(account),
+		);
+	}
+
 	isAccountAvailableForFamily(index: number, family: ModelFamily, model?: string | null): boolean {
 		const account = this.getAccountByIndex(index);
 		if (!account) return false;
-		if (account.enabled === false) return false;
-		clearExpiredRateLimits(account);
-		return !isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
+		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
+		return this.isAccountSelectableForFamily(account, family, model, requireFresh);
 	}
 
 	setActiveIndex(index: number): ManagedAccount | null {
@@ -446,15 +480,13 @@ export class AccountManager {
 		if (count === 0) return null;
 
 		const cursor = this.cursorByFamily[family];
+		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
 		
 		for (let i = 0; i < count; i++) {
 			const idx = (cursor + i) % count;
 			const account = this.accounts[idx];
 			if (!account) continue;
-			if (account.enabled === false) continue;
-			
-			clearExpiredRateLimits(account);
-			if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
+			if (!this.isAccountSelectableForFamily(account, family, model, requireFresh)) {
 				continue;
 			}
 			
@@ -472,15 +504,13 @@ export class AccountManager {
 		if (count === 0) return null;
 
 		const cursor = this.cursorByFamily[family];
+		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
 		
 		for (let i = 0; i < count; i++) {
 			const idx = (cursor + i) % count;
 			const account = this.accounts[idx];
 			if (!account) continue;
-			if (account.enabled === false) continue;
-			
-			clearExpiredRateLimits(account);
-			if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
+			if (!this.isAccountSelectableForFamily(account, family, model, requireFresh)) {
 				continue;
 			}
 			
@@ -495,6 +525,7 @@ export class AccountManager {
 	getCurrentOrNextForFamilyHybrid(family: ModelFamily, model?: string | null, options?: HybridSelectionOptions): ManagedAccount | null {
 		const count = this.accounts.length;
 		if (count === 0) return null;
+		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
 
 		const currentIndex = this.currentAccountIndexByFamily[family];
 		if (currentIndex >= 0 && currentIndex < count) {
@@ -503,10 +534,13 @@ export class AccountManager {
 				if (currentAccount.enabled === false) {
 					// Fall through to hybrid selection.
 				} else {
-				clearExpiredRateLimits(currentAccount);
 				if (
-					!isRateLimitedForFamily(currentAccount, family, model) &&
-					!this.isAccountCoolingDown(currentAccount)
+					this.isAccountSelectableForFamily(
+						currentAccount,
+						family,
+						model,
+						requireFresh,
+					)
 				) {
 					currentAccount.lastUsed = nowMs();
 					return currentAccount;
@@ -522,13 +556,14 @@ export class AccountManager {
 		const accountsWithMetrics: AccountWithMetrics[] = this.accounts
 			.map((account): AccountWithMetrics | null => {
 				if (!account) return null;
-				if (account.enabled === false) return null;
-				clearExpiredRateLimits(account);
-				const isAvailable =
-					!isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
 				return {
 					index: account.index,
-					isAvailable,
+					isAvailable: this.isAccountSelectableForFamily(
+						account,
+						family,
+						model,
+						requireFresh,
+					),
 					lastUsed: account.lastUsed,
 				};
 			})

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -188,11 +188,7 @@ export class AccountManager {
 				changed = true;
 			}
 
-			if (
-				cachedAccessUsable &&
-				cached.refreshToken &&
-				!account.refreshToken
-			) {
+			if (cached.refreshToken && !account.refreshToken) {
 				account.refreshToken = cached.refreshToken;
 				changed = true;
 			}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -550,6 +550,24 @@ export class AccountManager {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		healthTracker.recordSuccess(account.index, quotaKey);
+		const hadCooldownMetadata =
+			account.coolingDownUntil !== undefined || account.cooldownReason !== undefined;
+		const hadAuthFailures = (account.consecutiveAuthFailures ?? 0) > 0;
+		const isCoolingDown = this.isAccountCoolingDown(account);
+		let healed = false;
+
+		if (!isCoolingDown && hadCooldownMetadata) {
+			healed = true;
+		}
+
+		if (!isCoolingDown && hadAuthFailures) {
+			this.clearAuthFailures(account);
+			healed = true;
+		}
+
+		if (healed) {
+			this.saveToDiskDebounced();
+		}
 	}
 
 	recordRateLimit(account: ManagedAccount, family: ModelFamily, model?: string | null): void {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -7,6 +7,7 @@ import {
 	type CooldownReason,
 	type RateLimitStateV3,
 	findMatchingAccountIndex,
+	withAccountStorageTransaction,
 } from "./storage.js";
 import type { AccountIdSource, OAuthAuthDetails } from "./types.js";
 import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
@@ -79,6 +80,81 @@ function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
 	return Object.fromEntries(
 		MODEL_FAMILIES.map((family) => [family, defaultValue]),
 	) as Record<ModelFamily, number>;
+}
+
+type AccountIdentityCandidate = Pick<
+	ManagedAccount,
+	"accountId" | "email" | "refreshToken"
+> & {
+	index?: number;
+};
+
+function getAuthIdentityCandidate(
+	auth: OAuthAuthDetails | undefined,
+): AccountIdentityCandidate {
+	const accountId = extractAccountId(auth?.access)?.trim() || undefined;
+	const email = sanitizeEmail(extractAccountEmail(auth?.access));
+	return {
+		accountId,
+		email,
+		refreshToken: auth?.refresh,
+	};
+}
+
+function buildAccountIdentityCandidates(
+	source: AccountIdentityCandidate,
+	auth?: OAuthAuthDetails,
+): AccountIdentityCandidate[] {
+	const derived = getAuthIdentityCandidate(auth);
+	const candidates: AccountIdentityCandidate[] = [];
+	const seen = new Set<string>();
+
+	const pushCandidate = (candidate: AccountIdentityCandidate): void => {
+		const key = `${candidate.accountId ?? ""}|${candidate.email ?? ""}|${candidate.refreshToken ?? ""}`;
+		if (seen.has(key)) return;
+		seen.add(key);
+		candidates.push(candidate);
+	};
+
+	pushCandidate(source);
+	pushCandidate({
+		accountId: source.accountId ?? derived.accountId,
+		email: source.email ?? derived.email,
+		refreshToken: source.refreshToken,
+		index: source.index,
+	});
+	pushCandidate({
+		accountId: derived.accountId ?? source.accountId,
+		email: derived.email ?? source.email,
+		refreshToken: source.refreshToken,
+		index: source.index,
+	});
+	pushCandidate({
+		accountId: derived.accountId ?? source.accountId,
+		email: derived.email ?? source.email,
+		refreshToken: derived.refreshToken ?? source.refreshToken,
+		index: source.index,
+	});
+
+	return candidates;
+}
+
+function findAccountIndexByIdentity<
+	T extends Pick<AccountIdentityCandidate, "accountId" | "email" | "refreshToken">,
+>(
+	accounts: readonly T[],
+	source: AccountIdentityCandidate,
+	auth?: OAuthAuthDetails,
+): number | undefined {
+	for (const candidate of buildAccountIdentityCandidates(source, auth)) {
+		const matchIndex = findMatchingAccountIndex(accounts, candidate, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		});
+		if (matchIndex !== undefined) {
+			return matchIndex;
+		}
+	}
+	return undefined;
 }
 
 export interface Workspace {
@@ -642,6 +718,17 @@ export class AccountManager {
 		account.consecutiveAuthFailures = 0;
 	}
 
+	getAccountByIdentity(
+		candidate: AccountIdentityCandidate,
+		auth?: OAuthAuthDetails,
+	): ManagedAccount | null {
+		const index = findAccountIndexByIdentity(this.accounts, candidate, auth);
+		if (index === undefined) {
+			return null;
+		}
+		return this.accounts[index] ?? null;
+	}
+
 	shouldShowAccountToast(accountIndex: number, debounceMs = 30000): boolean {
 		const now = nowMs();
 		if (accountIndex === this.lastToastAccountIndex && now - this.lastToastTime < debounceMs) {
@@ -668,6 +755,112 @@ export class AccountManager {
 			account.accountIdSource = "token";
 		}
 		account.email = sanitizeEmail(extractAccountEmail(auth.access)) ?? account.email;
+	}
+
+	private buildStorageSnapshot(): AccountStorageV3 {
+		const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
+		for (const family of MODEL_FAMILIES) {
+			const raw = this.currentAccountIndexByFamily[family];
+			activeIndexByFamily[family] = clampNonNegativeInt(raw, 0);
+		}
+
+		const activeIndex = clampNonNegativeInt(activeIndexByFamily.codex, 0);
+
+		return {
+			version: 3,
+			accounts: this.accounts.map((account) => ({
+				accountId: account.accountId,
+				accountIdSource: account.accountIdSource,
+				accountLabel: account.accountLabel,
+				email: account.email,
+				refreshToken: account.refreshToken,
+				accessToken: account.access,
+				expiresAt: account.expires,
+				enabled: account.enabled === false ? false : undefined,
+				addedAt: account.addedAt,
+				lastUsed: account.lastUsed,
+				lastSwitchReason: account.lastSwitchReason,
+				rateLimitResetTimes:
+					Object.keys(account.rateLimitResetTimes).length > 0 ? account.rateLimitResetTimes : undefined,
+				coolingDownUntil: account.coolingDownUntil,
+				cooldownReason: account.cooldownReason,
+				workspaces: account.workspaces,
+				currentWorkspaceIndex: account.currentWorkspaceIndex,
+			})),
+			activeIndex,
+			activeIndexByFamily,
+		};
+	}
+
+	async commitRefreshedAuth(
+		source: Pick<
+			ManagedAccount,
+			"index" | "accountId" | "email" | "refreshToken"
+		>,
+		auth: OAuthAuthDetails,
+	): Promise<ManagedAccount | null> {
+		const nextAccountId = extractAccountId(auth.access)?.trim() || undefined;
+		const nextEmail = sanitizeEmail(extractAccountEmail(auth.access));
+
+		await withAccountStorageTransaction(async (current, persist) => {
+			const nextStorage = structuredClone(
+				current ?? this.buildStorageSnapshot(),
+			) as AccountStorageV3;
+			const storageIndex = findAccountIndexByIdentity(
+				nextStorage.accounts,
+				source,
+				auth,
+			);
+			if (storageIndex === undefined) {
+				log.warn("Unable to resolve refreshed account for persistence", {
+					sourceIndex: source.index,
+					email: source.email,
+				});
+				return;
+			}
+
+			const storedAccount = nextStorage.accounts[storageIndex];
+			if (!storedAccount) {
+				return;
+			}
+
+			storedAccount.refreshToken = auth.refresh;
+			storedAccount.accessToken = auth.access;
+			storedAccount.expiresAt = auth.expires;
+			if (
+				nextAccountId &&
+				shouldUpdateAccountIdFromToken(
+					storedAccount.accountIdSource,
+					storedAccount.accountId,
+				)
+			) {
+				storedAccount.accountId = nextAccountId;
+				storedAccount.accountIdSource = "token";
+			}
+			if (nextEmail) {
+				storedAccount.email = nextEmail;
+			}
+			storedAccount.enabled = undefined;
+			delete storedAccount.coolingDownUntil;
+			delete storedAccount.cooldownReason;
+
+			await persist(nextStorage);
+		});
+
+		const liveAccount = this.getAccountByIdentity(source, auth);
+		if (!liveAccount) {
+			log.warn("Unable to resolve refreshed live account after persistence", {
+				sourceIndex: source.index,
+				email: source.email,
+			});
+			return null;
+		}
+
+		this.updateFromAuth(liveAccount, auth);
+		liveAccount.enabled = true;
+		this.clearAccountCooldown(liveAccount);
+		this.clearAuthFailures(liveAccount);
+		return liveAccount;
 	}
 
 	toAuthDetails(account: ManagedAccount): Auth {
@@ -780,40 +973,7 @@ export class AccountManager {
 	}
 
 	async saveToDisk(): Promise<void> {
-		const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
-		for (const family of MODEL_FAMILIES) {
-			const raw = this.currentAccountIndexByFamily[family];
-			activeIndexByFamily[family] = clampNonNegativeInt(raw, 0);
-		}
-
-		const activeIndex = clampNonNegativeInt(activeIndexByFamily.codex, 0);
-
-		const storage: AccountStorageV3 = {
-			version: 3,
-			accounts: this.accounts.map((account) => ({
-				accountId: account.accountId,
-				accountIdSource: account.accountIdSource,
-				accountLabel: account.accountLabel,
-				email: account.email,
-				refreshToken: account.refreshToken,
-				accessToken: account.access,
-				expiresAt: account.expires,
-				enabled: account.enabled === false ? false : undefined,
-				addedAt: account.addedAt,
-				lastUsed: account.lastUsed,
-				lastSwitchReason: account.lastSwitchReason,
-				rateLimitResetTimes:
-					Object.keys(account.rateLimitResetTimes).length > 0 ? account.rateLimitResetTimes : undefined,
-				coolingDownUntil: account.coolingDownUntil,
-				cooldownReason: account.cooldownReason,
-				workspaces: account.workspaces,
-				currentWorkspaceIndex: account.currentWorkspaceIndex,
-			})),
-			activeIndex,
-			activeIndexByFamily,
-		};
-
-		await saveAccounts(storage);
+		await saveAccounts(this.buildStorageSnapshot());
 	}
 
 	saveToDiskDebounced(delayMs = 500): void {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -557,6 +557,7 @@ export class AccountManager {
 		let healed = false;
 
 		if (!isCoolingDown && hadCooldownMetadata) {
+			this.clearAccountCooldown(account);
 			healed = true;
 		}
 

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -779,7 +779,7 @@ export class AccountManager {
 		account.refreshToken = auth.refresh;
 		account.access = auth.access;
 		account.expires = auth.expires;
-		const tokenAccountId = extractAccountId(auth.access);
+		const tokenAccountId = extractAccountId(auth.access)?.trim() || undefined;
 		if (
 			tokenAccountId &&
 			(shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId))
@@ -836,6 +836,8 @@ export class AccountManager {
 		const nextEmail = sanitizeEmail(extractAccountEmail(auth.access));
 		try {
 			return await withAccountStorageTransaction(async (_current, persist) => {
+				// Snapshot the live in-memory pool under the storage lock so refresh
+				// persistence merges against the latest account state.
 				const nextStorage = structuredClone(
 					this.buildStorageSnapshot(),
 				) as AccountStorageV3;

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -191,7 +191,7 @@ export class AccountManager {
 			if (
 				cachedAccessUsable &&
 				cached.refreshToken &&
-				cached.refreshToken !== account.refreshToken
+				!account.refreshToken
 			) {
 				account.refreshToken = cached.refreshToken;
 				changed = true;

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -175,17 +175,21 @@ export class AccountManager {
 			const cached = cache.get(email);
 			if (!cached) continue;
 
-			if (typeof cached.expiresAt === "number" && cached.expiresAt <= now) {
-				continue;
-			}
+			const cachedAccessUsable =
+				typeof cached.expiresAt !== "number" || cached.expiresAt > now;
 
 			const missingOrExpired =
 				!account.access || account.expires === undefined || account.expires <= now;
-			if (missingOrExpired) {
+			if (missingOrExpired && cachedAccessUsable) {
 				account.access = cached.accessToken;
 				if (typeof cached.expiresAt === "number") {
 					account.expires = cached.expiresAt;
 				}
+				changed = true;
+			}
+
+			if (cached.refreshToken && cached.refreshToken !== account.refreshToken) {
+				account.refreshToken = cached.refreshToken;
 				changed = true;
 			}
 

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -27,6 +27,11 @@ import {
 } from "./codex-cli/state.js";
 import { syncAccountStorageFromCodexCli } from "./codex-cli/sync.js";
 import { setCodexCliActiveSelection } from "./codex-cli/writer.js";
+import {
+	getAccountIdentityKey,
+	getRuntimeAccountIdentityKey,
+} from "./storage/identity.js";
+import { getCircuitBreaker } from "./circuit-breaker.js";
 
 export {
 	extractAccountId,
@@ -77,7 +82,27 @@ import {
 } from "./accounts/rate-limits.js";
 
 const log = createLogger("accounts");
-const ACCOUNT_SELECTION_FRESH_WINDOW_MS = 5 * 60_000;
+let nextRuntimeCircuitKeyId = 0;
+
+function getAccountCircuitKey(account: ManagedAccount): string {
+	if (!account.circuitKeyId) {
+		account.circuitKeyId =
+			getAccountIdentityKey(account) ?? `circuit:${nextRuntimeCircuitKeyId++}`;
+	}
+	return account.circuitKeyId;
+}
+
+export function getRuntimeTrackerKey(
+	account: ManagedAccount,
+): string | number {
+	if (account._runtimeTrackerKey !== undefined) {
+		return account._runtimeTrackerKey;
+	}
+
+	const trackerKey = getRuntimeAccountIdentityKey(account) ?? account.index;
+	account._runtimeTrackerKey = trackerKey;
+	return trackerKey;
+}
 
 function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
 	return Object.fromEntries(
@@ -201,6 +226,8 @@ export interface Workspace {
 
 export interface ManagedAccount {
 	index: number;
+	_runtimeTrackerKey?: string | number;
+	circuitKeyId?: string;
 	accountId?: string;
 	accountIdSource?: AccountIdSource;
 	accountLabel?: string;
@@ -285,21 +312,17 @@ export class AccountManager {
 			const cached = cache.get(email);
 			if (!cached) continue;
 
-			const cachedAccessUsable =
-				typeof cached.expiresAt !== "number" || cached.expiresAt > now;
+			if (typeof cached.expiresAt === "number" && cached.expiresAt <= now) {
+				continue;
+			}
 
 			const missingOrExpired =
 				!account.access || account.expires === undefined || account.expires <= now;
-			if (missingOrExpired && cachedAccessUsable) {
+			if (missingOrExpired) {
 				account.access = cached.accessToken;
 				if (typeof cached.expiresAt === "number") {
 					account.expires = cached.expiresAt;
 				}
-				changed = true;
-			}
-
-			if (cached.refreshToken && !account.refreshToken) {
-				account.refreshToken = cached.refreshToken;
 				changed = true;
 			}
 
@@ -482,10 +505,16 @@ export class AccountManager {
 	}
 
 	getAccountsSnapshot(): ManagedAccount[] {
-		return this.accounts.map((account) => ({
-			...account,
-			rateLimitResetTimes: { ...account.rateLimitResetTimes },
-		}));
+		return this.accounts.map((account) => {
+			const trackerKey = getRuntimeTrackerKey(account);
+			const circuitKeyId = getAccountCircuitKey(account);
+			return {
+				...account,
+				_runtimeTrackerKey: trackerKey,
+				circuitKeyId,
+				rateLimitResetTimes: { ...account.rateLimitResetTimes },
+			};
+		});
 	}
 
 	getAccountByIndex(index: number): ManagedAccount | null {
@@ -495,45 +524,16 @@ export class AccountManager {
 		return account ?? null;
 	}
 
-	private hasFreshAccessToken(account: ManagedAccount): boolean {
-		if (!account.access) return false;
-		if (typeof account.expires !== "number" || !Number.isFinite(account.expires)) {
-			return false;
-		}
-		return account.expires > nowMs() + ACCOUNT_SELECTION_FRESH_WINDOW_MS;
-	}
-
-	private isAccountSelectableForFamily(
-		account: ManagedAccount,
-		family: ModelFamily,
-		model?: string | null,
-		requireFresh = false,
-	): boolean {
-		if (account.enabled === false) return false;
-		clearExpiredRateLimits(account);
-		if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
-			return false;
-		}
-		return !requireFresh || this.hasFreshAccessToken(account);
-	}
-
-	private hasFreshAvailableAccountForFamily(
-		family: ModelFamily,
-		model?: string | null,
-	): boolean {
-		return this.accounts.some(
-			(account) =>
-				Boolean(account) &&
-				this.isAccountSelectableForFamily(account, family, model) &&
-				this.hasFreshAccessToken(account),
-		);
-	}
-
 	isAccountAvailableForFamily(index: number, family: ModelFamily, model?: string | null): boolean {
 		const account = this.getAccountByIndex(index);
 		if (!account) return false;
-		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
-		return this.isAccountSelectableForFamily(account, family, model, requireFresh);
+		if (account.enabled === false) return false;
+		clearExpiredRateLimits(account);
+		return (
+			!isRateLimitedForFamily(account, family, model) &&
+			!this.isAccountCoolingDown(account) &&
+			this.isCircuitAvailable(account)
+		);
 	}
 
 	setActiveIndex(index: number): ManagedAccount | null {
@@ -593,13 +593,19 @@ export class AccountManager {
 		if (count === 0) return null;
 
 		const cursor = this.cursorByFamily[family];
-		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
 		
 		for (let i = 0; i < count; i++) {
 			const idx = (cursor + i) % count;
 			const account = this.accounts[idx];
 			if (!account) continue;
-			if (!this.isAccountSelectableForFamily(account, family, model, requireFresh)) {
+			if (account.enabled === false) continue;
+
+			clearExpiredRateLimits(account);
+			if (
+				isRateLimitedForFamily(account, family, model) ||
+				this.isAccountCoolingDown(account) ||
+				!this.isCircuitAvailable(account)
+			) {
 				continue;
 			}
 			
@@ -617,13 +623,19 @@ export class AccountManager {
 		if (count === 0) return null;
 
 		const cursor = this.cursorByFamily[family];
-		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
 		
 		for (let i = 0; i < count; i++) {
 			const idx = (cursor + i) % count;
 			const account = this.accounts[idx];
 			if (!account) continue;
-			if (!this.isAccountSelectableForFamily(account, family, model, requireFresh)) {
+			if (account.enabled === false) continue;
+
+			clearExpiredRateLimits(account);
+			if (
+				isRateLimitedForFamily(account, family, model) ||
+				this.isAccountCoolingDown(account) ||
+				!this.isCircuitAvailable(account)
+			) {
 				continue;
 			}
 			
@@ -638,29 +650,6 @@ export class AccountManager {
 	getCurrentOrNextForFamilyHybrid(family: ModelFamily, model?: string | null, options?: HybridSelectionOptions): ManagedAccount | null {
 		const count = this.accounts.length;
 		if (count === 0) return null;
-		const requireFresh = this.hasFreshAvailableAccountForFamily(family, model);
-
-		const currentIndex = this.currentAccountIndexByFamily[family];
-		if (currentIndex >= 0 && currentIndex < count) {
-			const currentAccount = this.accounts[currentIndex];
-			if (currentAccount) {
-				if (currentAccount.enabled === false) {
-					// Fall through to hybrid selection.
-				} else {
-				if (
-					this.isAccountSelectableForFamily(
-						currentAccount,
-						family,
-						model,
-						requireFresh,
-					)
-				) {
-					currentAccount.lastUsed = nowMs();
-					return currentAccount;
-				}
-				}
-			}
-		}
 
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
@@ -669,14 +658,16 @@ export class AccountManager {
 		const accountsWithMetrics: AccountWithMetrics[] = this.accounts
 			.map((account): AccountWithMetrics | null => {
 				if (!account) return null;
+				if (account.enabled === false) return null;
+				clearExpiredRateLimits(account);
+				const isAvailable =
+					!isRateLimitedForFamily(account, family, model) &&
+					!this.isAccountCoolingDown(account) &&
+					this.isCircuitAvailable(account);
 				return {
 					index: account.index,
-					isAvailable: this.isAccountSelectableForFamily(
-						account,
-						family,
-						model,
-						requireFresh,
-					),
+					trackerKey: getRuntimeTrackerKey(account),
+					isAvailable,
 					lastUsed: account.lastUsed,
 				};
 			})
@@ -697,7 +688,7 @@ export class AccountManager {
 	recordSuccess(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
-		healthTracker.recordSuccess(account.index, quotaKey);
+		healthTracker.recordSuccess(getRuntimeTrackerKey(account), quotaKey);
 		const hadCooldownMetadata =
 			account.coolingDownUntil !== undefined || account.cooldownReason !== undefined;
 		const hadAuthFailures = (account.consecutiveAuthFailures ?? 0) > 0;
@@ -717,26 +708,40 @@ export class AccountManager {
 		if (healed) {
 			this.saveToDiskDebounced();
 		}
+		getCircuitBreaker(getAccountCircuitKey(account)).recordSuccess();
 	}
 
 	recordRateLimit(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		const tokenTracker = getTokenTracker();
-		healthTracker.recordRateLimit(account.index, quotaKey);
-		tokenTracker.drain(account.index, quotaKey);
+		const trackerKey = getRuntimeTrackerKey(account);
+		healthTracker.recordRateLimit(trackerKey, quotaKey);
+		tokenTracker.drain(trackerKey, quotaKey);
 	}
 
 	recordFailure(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
-		healthTracker.recordFailure(account.index, quotaKey);
+		healthTracker.recordFailure(getRuntimeTrackerKey(account), quotaKey);
+		getCircuitBreaker(getAccountCircuitKey(account)).recordFailure();
 	}
 
 	consumeToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
-		return tokenTracker.tryConsume(account.index, quotaKey);
+		const trackerKey = getRuntimeTrackerKey(account);
+		if (!tokenTracker.tryConsume(trackerKey, quotaKey)) {
+			return false;
+		}
+
+		try {
+			getCircuitBreaker(getAccountCircuitKey(account)).canExecute();
+			return true;
+		} catch {
+			tokenTracker.refundToken(trackerKey, quotaKey);
+			return false;
+		}
 	}
 
 	/**
@@ -747,7 +752,7 @@ export class AccountManager {
 	refundToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
-		return tokenTracker.refundToken(account.index, quotaKey);
+		return tokenTracker.refundToken(getRuntimeTrackerKey(account), quotaKey);
 	}
 
 	markSwitched(account: ManagedAccount, reason: "rate-limit" | "initial" | "rotation", family: ModelFamily): void {
@@ -770,9 +775,14 @@ export class AccountManager {
 		const resetAt = nowMs() + retryMs;
 
 		const baseKey = getQuotaKey(family);
-		account.rateLimitResetTimes[baseKey] = resetAt;
+		if (!model || reason === "quota" || reason === "unknown") {
+			account.rateLimitResetTimes[baseKey] = resetAt;
+		}
 
-		if (model) {
+		if (
+			model &&
+			(reason === "tokens" || reason === "concurrent" || reason === "unknown")
+		) {
 			const modelKey = getQuotaKey(family, model);
 			account.rateLimitResetTimes[modelKey] = resetAt;
 		}
@@ -798,6 +808,10 @@ export class AccountManager {
 	clearAccountCooldown(account: ManagedAccount): void {
 		delete account.coolingDownUntil;
 		delete account.cooldownReason;
+	}
+
+	private isCircuitAvailable(account: ManagedAccount): boolean {
+		return getCircuitBreaker(getAccountCircuitKey(account)).isAvailable();
 	}
 
 	incrementAuthFailures(account: ManagedAccount): number {
@@ -1021,7 +1035,11 @@ export class AccountManager {
 		const enabledAccounts = this.accounts.filter((account) => account.enabled !== false);
 		const available = enabledAccounts.filter((account) => {
 			clearExpiredRateLimits(account);
-			return !isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
+			return (
+				!isRateLimitedForFamily(account, family, model) &&
+				!this.isAccountCoolingDown(account) &&
+				this.isCircuitAvailable(account)
+			);
 		});
 		if (available.length > 0) return 0;
 		if (enabledAccounts.length === 0) return 0;
@@ -1031,20 +1049,32 @@ export class AccountManager {
 		const modelKey = model ? getQuotaKey(family, model) : null;
 
 		for (const account of enabledAccounts) {
+			const perAccountWaitTimes: number[] = [];
 			const baseResetAt = account.rateLimitResetTimes[baseKey];
 			if (typeof baseResetAt === "number") {
-				waitTimes.push(Math.max(0, baseResetAt - now));
+				perAccountWaitTimes.push(Math.max(0, baseResetAt - now));
 			}
 
 			if (modelKey) {
 				const modelResetAt = account.rateLimitResetTimes[modelKey];
 				if (typeof modelResetAt === "number") {
-					waitTimes.push(Math.max(0, modelResetAt - now));
+					perAccountWaitTimes.push(Math.max(0, modelResetAt - now));
 				}
 			}
 
 			if (typeof account.coolingDownUntil === "number") {
-				waitTimes.push(Math.max(0, account.coolingDownUntil - now));
+				perAccountWaitTimes.push(Math.max(0, account.coolingDownUntil - now));
+			}
+
+			const breakerWait = getCircuitBreaker(
+				getAccountCircuitKey(account),
+			).getTimeUntilAvailable();
+			if (breakerWait > 0) {
+				perAccountWaitTimes.push(breakerWait);
+			}
+
+			if (perAccountWaitTimes.length > 0) {
+				waitTimes.push(Math.max(...perAccountWaitTimes));
 			}
 		}
 

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -45,10 +45,29 @@ export class CircuitBreaker {
 
 		if (this.state === "half-open") {
 			if (this.halfOpenAttempts >= this.config.halfOpenMaxAttempts) {
-				throw new CircuitOpenError("Circuit is half-open");
+				if (this.hasHalfOpenProbeWaitElapsed(now)) {
+					this.resetHalfOpenProbeWindow(now);
+				} else {
+					throw new CircuitOpenError("Circuit is half-open");
+				}
 			}
 			this.halfOpenAttempts += 1;
 			return true;
+		}
+
+		return true;
+	}
+
+	isAvailable(now = Date.now()): boolean {
+		if (this.state === "open") {
+			return now - this.lastStateChange >= this.config.resetTimeoutMs;
+		}
+
+		if (this.state === "half-open") {
+			return (
+				this.halfOpenAttempts < this.config.halfOpenMaxAttempts ||
+				this.hasHalfOpenProbeWaitElapsed(now)
+			);
 		}
 
 		return true;
@@ -100,6 +119,21 @@ export class CircuitBreaker {
 		return Math.max(0, this.config.resetTimeoutMs - elapsed);
 	}
 
+	getTimeUntilAvailable(now = Date.now()): number {
+		if (this.state === "open") {
+			return Math.max(0, this.config.resetTimeoutMs - (now - this.lastStateChange));
+		}
+
+		if (
+			this.state === "half-open" &&
+			this.halfOpenAttempts >= this.config.halfOpenMaxAttempts
+		) {
+			return Math.max(0, this.config.resetTimeoutMs - (now - this.lastStateChange));
+		}
+
+		return 0;
+	}
+
 	private pruneFailures(now: number): void {
 		const cutoff = now - this.config.failureWindowMs;
 		this.failures = this.failures.filter((timestamp) => timestamp >= cutoff);
@@ -113,6 +147,15 @@ export class CircuitBreaker {
 
 	private transitionToHalfOpen(now: number): void {
 		this.state = "half-open";
+		this.lastStateChange = now;
+		this.halfOpenAttempts = 0;
+	}
+
+	private hasHalfOpenProbeWaitElapsed(now: number): boolean {
+		return now - this.lastStateChange >= this.config.resetTimeoutMs;
+	}
+
+	private resetHalfOpenProbeWindow(now: number): void {
 		this.lastStateChange = now;
 		this.halfOpenAttempts = 0;
 	}

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -2325,6 +2325,7 @@ async function runForecast(args: string[]): Promise<number> {
 	return runForecastCommand(args, {
 		setStoragePath,
 		loadAccounts,
+		saveAccounts,
 		loadDashboardDisplaySettings,
 		resolveActiveIndex,
 		loadQuotaCache,
@@ -3221,6 +3222,7 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 			setStoragePath,
 			getStoragePath,
 			loadAccounts,
+			saveAccounts,
 			resolveActiveIndex,
 			queuedRefresh,
 			fetchCodexQuotaSnapshot,

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -1,4 +1,5 @@
 import type { DashboardDisplaySettings } from "../../dashboard-settings.js";
+import { extractAccountEmail, sanitizeEmail } from "../../accounts.js";
 import {
 	buildForecastExplanation,
 	type ForecastAccountResult,
@@ -6,8 +7,13 @@ import {
 import type { QuotaCacheData } from "../../quota-cache.js";
 import type { CodexQuotaSnapshot } from "../../quota-probe.js";
 import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
-import type { AccountMetadataV3, AccountStorageV3 } from "../../storage.js";
+import {
+	findMatchingAccountIndex,
+	type AccountMetadataV3,
+	type AccountStorageV3,
+} from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
+import { sleep } from "../../utils.js";
 
 interface ForecastCliOptions {
 	live: boolean;
@@ -26,9 +32,12 @@ type QuotaEmailFallbackState = ReadonlyMap<
 	{ matchingCount: number; distinctAccountIds: Set<string> }
 >;
 
+const RETRYABLE_STORAGE_WRITE_CODES = new Set(["EBUSY", "EPERM"]);
+
 export interface ForecastCommandDeps {
 	setStoragePath: (path: string | null) => void;
 	loadAccounts: () => Promise<AccountStorageV3 | null>;
+	saveAccounts: (storage: AccountStorageV3) => Promise<void>;
 	loadDashboardDisplaySettings?: () => Promise<DashboardDisplaySettings>;
 	resolveActiveIndex: (storage: AccountStorageV3, family?: "codex") => number;
 	loadQuotaCache: () => Promise<QuotaCacheData | null>;
@@ -101,6 +110,82 @@ export interface ForecastCommandDeps {
 	logInfo?: (message: string) => void;
 	logError?: (message: string) => void;
 	getNow?: () => number;
+}
+
+function isRetryableStorageWriteError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_STORAGE_WRITE_CODES.has(code);
+}
+
+async function saveAccountsWithRetry(
+	storage: AccountStorageV3,
+	saveAccounts: ForecastCommandDeps["saveAccounts"],
+): Promise<void> {
+	for (let attempt = 0; ; attempt += 1) {
+		try {
+			await saveAccounts(storage);
+			return;
+		} catch (error) {
+			if (!isRetryableStorageWriteError(error) || attempt >= 3) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+}
+
+type AccountIdentityMatch = Pick<
+	AccountMetadataV3,
+	"accountId" | "email" | "refreshToken"
+>;
+type RefreshedAccountPatch = Pick<
+	AccountMetadataV3,
+	"refreshToken" | "accessToken" | "expiresAt"
+> & {
+	email?: AccountMetadataV3["email"];
+	accountId?: AccountMetadataV3["accountId"];
+	accountIdSource?: AccountMetadataV3["accountIdSource"];
+};
+
+function applyRefreshedAccountPatch(
+	account: AccountMetadataV3,
+	patch: RefreshedAccountPatch,
+): void {
+	account.refreshToken = patch.refreshToken;
+	account.accessToken = patch.accessToken;
+	account.expiresAt = patch.expiresAt;
+	if (patch.email) account.email = patch.email;
+	if (patch.accountId) {
+		account.accountId = patch.accountId;
+		account.accountIdSource = patch.accountIdSource;
+	}
+}
+
+async function persistRefreshedAccountPatch(
+	storage: AccountStorageV3,
+	accountMatch: AccountIdentityMatch,
+	patch: RefreshedAccountPatch,
+	loadAccounts: ForecastCommandDeps["loadAccounts"],
+	saveAccounts: ForecastCommandDeps["saveAccounts"],
+): Promise<void> {
+	const latestStorage = (await loadAccounts()) ?? storage;
+	const nextStorage = structuredClone(latestStorage);
+	const targetIndex =
+		findMatchingAccountIndex(nextStorage.accounts, accountMatch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		}) ??
+		findMatchingAccountIndex(nextStorage.accounts, patch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		});
+	if (targetIndex === undefined) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	const targetAccount = nextStorage.accounts[targetIndex];
+	if (!targetAccount) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	applyRefreshedAccountPatch(targetAccount, patch);
+	await saveAccountsWithRetry(nextStorage, saveAccounts);
 }
 
 function joinStyledSegments(
@@ -287,9 +372,59 @@ export async function runForecastCommand(
 				});
 				continue;
 			}
+			const refreshedEmail = sanitizeEmail(
+				extractAccountEmail(refreshResult.access, refreshResult.idToken),
+			);
+			const refreshedAccountId = deps.extractAccountId(refreshResult.access);
+			const previousRefreshToken = account.refreshToken;
+			const previousAccessToken = account.accessToken;
+			const previousExpiresAt = account.expiresAt;
+			const previousEmail = account.email;
+			const previousAccountId = account.accountId;
+			const refreshPatch: RefreshedAccountPatch = {
+				refreshToken: refreshResult.refresh,
+				accessToken: refreshResult.access,
+				expiresAt: refreshResult.expires,
+			};
+			if (refreshedEmail) {
+				refreshPatch.email = refreshedEmail;
+			}
+			if (refreshedAccountId) {
+				refreshPatch.accountId = refreshedAccountId;
+				refreshPatch.accountIdSource = "token";
+			}
+			const accountMatch: AccountIdentityMatch = {
+				refreshToken: previousRefreshToken,
+				email: previousEmail,
+				accountId: previousAccountId,
+			};
+			applyRefreshedAccountPatch(account, refreshPatch);
 			probeAccessToken = refreshResult.access;
-			probeAccountId =
-				account.accountId ?? deps.extractAccountId(refreshResult.access);
+			probeAccountId = account.accountId ?? refreshedAccountId;
+			if (
+				previousRefreshToken !== refreshPatch.refreshToken ||
+				previousAccessToken !== refreshPatch.accessToken ||
+				previousExpiresAt !== refreshPatch.expiresAt ||
+				previousEmail !== account.email ||
+				previousAccountId !== account.accountId
+			) {
+				try {
+					await persistRefreshedAccountPatch(
+						storage,
+						accountMatch,
+						refreshPatch,
+						deps.loadAccounts,
+						deps.saveAccounts,
+					);
+				} catch (error) {
+					const message = deps.normalizeFailureDetail(
+						error instanceof Error ? error.message : String(error),
+						undefined,
+					);
+					probeErrors.push(`${deps.formatAccountLabel(account, i)}: ${message}`);
+					continue;
+				}
+			}
 		}
 
 		if (!probeAccessToken || !probeAccountId) {

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -1,6 +1,11 @@
 import { promises as fs } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { extractAccountId, formatAccountLabel } from "../../accounts.js";
+import {
+	extractAccountEmail,
+	extractAccountId,
+	formatAccountLabel,
+	sanitizeEmail,
+} from "../../accounts.js";
 import {
 	evaluateForecastAccounts,
 	type ForecastAccountResult,
@@ -17,7 +22,11 @@ import {
 	getModelProfile,
 	resolveNormalizedModel,
 } from "../../request/helpers/model-map.js";
-import type { AccountStorageV3 } from "../../storage.js";
+import {
+	findMatchingAccountIndex,
+	type AccountMetadataV3,
+	type AccountStorageV3,
+} from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 import { sleep } from "../../utils.js";
 
@@ -47,6 +56,7 @@ export interface ReportCommandDeps {
 	setStoragePath: (path: string | null) => void;
 	getStoragePath: () => string;
 	loadAccounts: () => Promise<AccountStorageV3 | null>;
+	saveAccounts: (storage: AccountStorageV3) => Promise<void>;
 	resolveActiveIndex: (storage: AccountStorageV3, family?: "codex") => number;
 	queuedRefresh: (refreshToken: string) => Promise<TokenResult>;
 	fetchCodexQuotaSnapshot: (input: {
@@ -245,6 +255,77 @@ async function defaultWriteFile(path: string, contents: string): Promise<void> {
 	}
 }
 
+async function saveAccountsWithRetry(
+	storage: AccountStorageV3,
+	saveAccounts: ReportCommandDeps["saveAccounts"],
+): Promise<void> {
+	for (let attempt = 0; ; attempt += 1) {
+		try {
+			await saveAccounts(storage);
+			return;
+		} catch (error) {
+			if (!isRetryableWriteError(error) || attempt >= 3) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+}
+
+type AccountIdentityMatch = Pick<
+	AccountMetadataV3,
+	"accountId" | "email" | "refreshToken"
+>;
+type RefreshedAccountPatch = Pick<
+	AccountMetadataV3,
+	"refreshToken" | "accessToken" | "expiresAt"
+> & {
+	email?: AccountMetadataV3["email"];
+	accountId?: AccountMetadataV3["accountId"];
+	accountIdSource?: AccountMetadataV3["accountIdSource"];
+};
+
+function applyRefreshedAccountPatch(
+	account: AccountMetadataV3,
+	patch: RefreshedAccountPatch,
+): void {
+	account.refreshToken = patch.refreshToken;
+	account.accessToken = patch.accessToken;
+	account.expiresAt = patch.expiresAt;
+	if (patch.email) account.email = patch.email;
+	if (patch.accountId) {
+		account.accountId = patch.accountId;
+		account.accountIdSource = patch.accountIdSource;
+	}
+}
+
+async function persistRefreshedAccountPatch(
+	storage: AccountStorageV3,
+	accountMatch: AccountIdentityMatch,
+	patch: RefreshedAccountPatch,
+	loadAccounts: ReportCommandDeps["loadAccounts"],
+	saveAccounts: ReportCommandDeps["saveAccounts"],
+): Promise<void> {
+	const latestStorage = (await loadAccounts()) ?? storage;
+	const nextStorage = structuredClone(latestStorage);
+	const targetIndex =
+		findMatchingAccountIndex(nextStorage.accounts, accountMatch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		}) ??
+		findMatchingAccountIndex(nextStorage.accounts, patch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		});
+	if (targetIndex === undefined) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	const targetAccount = nextStorage.accounts[targetIndex];
+	if (!targetAccount) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	applyRefreshedAccountPatch(targetAccount, patch);
+	await saveAccountsWithRetry(nextStorage, saveAccounts);
+}
+
 export async function runReportCommand(
 	args: string[],
 	deps: ReportCommandDeps,
@@ -293,8 +374,60 @@ export async function runReportCommand(
 				continue;
 			}
 
-			const accountId =
-				account.accountId ?? extractAccountId(refreshResult.access);
+			const refreshedEmail = sanitizeEmail(
+				extractAccountEmail(refreshResult.access, refreshResult.idToken),
+			);
+			const tokenDerivedAccountId = extractAccountId(refreshResult.access);
+			const refreshedAccountId = account.accountId ?? tokenDerivedAccountId;
+			const previousRefreshToken = account.refreshToken;
+			const previousAccessToken = account.accessToken;
+			const previousExpiresAt = account.expiresAt;
+			const previousEmail = account.email;
+			const previousAccountId = account.accountId;
+			const refreshPatch: RefreshedAccountPatch = {
+				refreshToken: refreshResult.refresh,
+				accessToken: refreshResult.access,
+				expiresAt: refreshResult.expires,
+			};
+			if (refreshedEmail) {
+				refreshPatch.email = refreshedEmail;
+			}
+			if (tokenDerivedAccountId) {
+				refreshPatch.accountId = tokenDerivedAccountId;
+				refreshPatch.accountIdSource = "token";
+			}
+			const accountMatch: AccountIdentityMatch = {
+				refreshToken: previousRefreshToken,
+				email: previousEmail,
+				accountId: previousAccountId,
+			};
+			applyRefreshedAccountPatch(account, refreshPatch);
+			if (
+				previousRefreshToken !== refreshPatch.refreshToken ||
+				previousAccessToken !== refreshPatch.accessToken ||
+				previousExpiresAt !== refreshPatch.expiresAt ||
+				previousEmail !== account.email ||
+				previousAccountId !== account.accountId
+			) {
+				try {
+					await persistRefreshedAccountPatch(
+						storage,
+						accountMatch,
+						refreshPatch,
+						deps.loadAccounts,
+						deps.saveAccounts,
+					);
+				} catch (error) {
+					const message = deps.normalizeFailureDetail(
+						error instanceof Error ? error.message : String(error),
+						undefined,
+					);
+					probeErrors.push(`${formatAccountLabel(account, i)}: ${message}`);
+					continue;
+				}
+			}
+
+			const accountId = account.accountId ?? refreshedAccountId;
 			if (!accountId) {
 				probeErrors.push(
 					`${formatAccountLabel(account, i)}: missing accountId for live probe`,

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -1,4 +1,5 @@
 import { getCircuitBreaker, type CircuitState } from "./circuit-breaker.js";
+import { getAccountIdentityKey } from "./storage/identity.js";
 
 export interface AccountHealth {
 	index: number;
@@ -27,6 +28,7 @@ export function getAccountHealth(
 		index: number;
 		email?: string;
 		accountId?: string;
+		refreshToken?: string;
 		health: number;
 		rateLimitedUntil?: number;
 		cooldownUntil?: number;
@@ -36,7 +38,7 @@ export function getAccountHealth(
 	now = Date.now(),
 ): PluginHealth {
 	const accountHealths: AccountHealth[] = accounts.map((acc) => {
-		const circuitKey = `account:${acc.accountId ?? acc.index}`;
+		const circuitKey = getAccountIdentityKey(acc) ?? `account:${acc.index}`;
 		const circuit = getCircuitBreaker(circuitKey);
 
 		return {
@@ -53,7 +55,11 @@ export function getAccountHealth(
 	});
 
 	const healthyCount = accountHealths.filter(
-		(a) => !a.isRateLimited && !a.isCoolingDown && a.health >= 50,
+		(a) =>
+			!a.isRateLimited &&
+			!a.isCoolingDown &&
+			a.health >= 50 &&
+			a.circuitState === "closed",
 	).length;
 
 	const rateLimitedCount = accountHealths.filter((a) => a.isRateLimited).length;

--- a/lib/parallel-probe.ts
+++ b/lib/parallel-probe.ts
@@ -1,4 +1,8 @@
-import type { ManagedAccount, AccountManager } from "./accounts.js";
+import {
+	getRuntimeTrackerKey,
+	type ManagedAccount,
+	type AccountManager,
+} from "./accounts.js";
 import type { ModelFamily } from "./prompts/codex.js";
 import { createLogger } from "./logger.js";
 import {
@@ -108,6 +112,7 @@ export function getTopCandidates(
 
 		accountsWithMetrics.push({
 			index: account.index,
+			trackerKey: getRuntimeTrackerKey(account),
 			isAvailable,
 			lastUsed: account.lastUsed,
 			account,
@@ -119,8 +124,9 @@ export function getTopCandidates(
 
 	const now = Date.now();
 	const scored = available.map((a) => {
-		const health = healthTracker.getScore(a.index, quotaKey);
-		const tokens = tokenTracker.getTokens(a.index, quotaKey);
+		const trackerKey = a.trackerKey ?? a.index;
+		const health = healthTracker.getScore(trackerKey, quotaKey);
+		const tokens = tokenTracker.getTokens(trackerKey, quotaKey);
 		const hoursSinceUsed = (now - a.lastUsed) / (1000 * 60 * 60);
 		const score = health * 2 + tokens * 5 + hoursSinceUsed * 2.0;
 		return { ...a, score };

--- a/lib/proactive-refresh.ts
+++ b/lib/proactive-refresh.ts
@@ -14,6 +14,12 @@ import { queuedRefresh } from "./refresh-queue.js";
 import { createLogger } from "./logger.js";
 import type { ManagedAccount } from "./accounts.js";
 import type { TokenResult } from "./types.js";
+import {
+	extractAccountEmail,
+	extractAccountId,
+	sanitizeEmail,
+	shouldUpdateAccountIdFromToken,
+} from "./auth/token-utils.js";
 
 const log = createLogger("proactive-refresh");
 
@@ -43,14 +49,14 @@ export function shouldRefreshProactively(
 	account: ManagedAccount,
 	bufferMs: number = DEFAULT_PROACTIVE_BUFFER_MS,
 ): boolean {
-	// No expiry set - can't determine if refresh is needed
-	if (account.expires === undefined) {
-		return false;
-	}
-
 	// No access token - definitely needs refresh
 	if (!account.access) {
 		return true;
+	}
+
+	// No expiry set - can't determine if refresh is needed
+	if (account.expires === undefined) {
+		return false;
 	}
 
 	// Clamp buffer to minimum
@@ -135,6 +141,10 @@ export async function proactiveRefreshAccount(
 export async function refreshExpiringAccounts(
 	accounts: ManagedAccount[],
 	bufferMs: number = DEFAULT_PROACTIVE_BUFFER_MS,
+	onResult?: (
+		account: ManagedAccount,
+		result: ProactiveRefreshResult,
+	) => Promise<void> | void,
 ): Promise<Map<number, ProactiveRefreshResult>> {
 	const results = new Map<number, ProactiveRefreshResult>();
 	const accountsToRefresh = accounts.filter((a) =>
@@ -151,6 +161,7 @@ export async function refreshExpiringAccounts(
 	// Refresh in parallel for efficiency
 	const refreshPromises = accountsToRefresh.map(async (account) => {
 		const result = await proactiveRefreshAccount(account, bufferMs);
+		await onResult?.(account, result);
 		return { index: account.index, result };
 	});
 
@@ -194,4 +205,13 @@ export function applyRefreshResult(
 	if (result.refresh !== account.refreshToken) {
 		account.refreshToken = result.refresh;
 	}
+	const tokenAccountId = extractAccountId(result.access)?.trim() || undefined;
+	if (
+		tokenAccountId &&
+		shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId)
+	) {
+		account.accountId = tokenAccountId;
+		account.accountIdSource = "token";
+	}
+	account.email = sanitizeEmail(extractAccountEmail(result.access)) ?? account.email;
 }

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -95,6 +95,70 @@ export class RefreshGuardian {
 		return "network-error";
 	}
 
+	private async applyRefreshOutcome(
+		manager: AccountManager,
+		sourceAccount: ReturnType<AccountManager["getAccountsSnapshot"]>[number],
+		result: Awaited<ReturnType<typeof refreshExpiringAccounts>> extends Map<
+			number,
+			infer TValue
+		>
+			? TValue
+			: never,
+	): Promise<boolean> {
+		switch (result.reason) {
+			case "success": {
+				if (result.tokenResult?.type !== "success") {
+					const account = manager.getAccountByIdentity(sourceAccount);
+					if (!account) return false;
+					manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+					this.stats.failed += 1;
+					this.stats.networkFailed += 1;
+					return true;
+				}
+
+				const refreshedAuth = {
+					type: "oauth" as const,
+					access: result.tokenResult.access,
+					refresh: result.tokenResult.refresh,
+					expires: result.tokenResult.expires,
+					multiAccount: true,
+				};
+				const account = manager.getAccountByIdentity(sourceAccount, refreshedAuth);
+				if (account) {
+					applyRefreshResult(account, result.tokenResult);
+					manager.clearAuthFailures(account);
+				}
+				await manager.commitRefreshedAuth(sourceAccount, refreshedAuth);
+				this.stats.refreshed += 1;
+				return false;
+			}
+			case "failed": {
+				const account = manager.getAccountByIdentity(sourceAccount);
+				if (!account) return false;
+				const cooldownReason = this.classifyFailureReason(result.tokenResult);
+				manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
+				this.stats.failed += 1;
+				if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
+				else if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
+				else this.stats.networkFailed += 1;
+				return true;
+			}
+			case "not_needed":
+				this.stats.notNeeded += 1;
+				return false;
+			case "no_refresh_token": {
+				const account = manager.getAccountByIdentity(sourceAccount);
+				if (!account) return false;
+				manager.markAccountCoolingDown(account, this.bufferMs, "auth-failure");
+				manager.setAccountEnabled(account.index, false);
+				this.stats.noRefreshToken += 1;
+				this.stats.failed += 1;
+				this.stats.authFailed += 1;
+				return true;
+			}
+		}
+	}
+
 	async tick(): Promise<void> {
 		if (this.running) return;
 		const manager = this.getAccountManager();
@@ -106,7 +170,30 @@ export class RefreshGuardian {
 				return;
 			}
 
-			const refreshResults = await refreshExpiringAccounts(snapshot, this.bufferMs);
+			const eligibleSnapshot = snapshot.filter((account) => !manager.isAccountCoolingDown(account));
+			if (eligibleSnapshot.length === 0) {
+				this.stats.runs += 1;
+				this.stats.lastRunAt = Date.now();
+				return;
+			}
+
+			let requiresSave = false;
+			const processed = new Set<number>();
+			const refreshResults = await refreshExpiringAccounts(
+				eligibleSnapshot,
+				this.bufferMs,
+				async (sourceAccount, result) => {
+					const saveNeeded = await this.applyRefreshOutcome(
+						manager,
+						sourceAccount,
+						result,
+					);
+					if (saveNeeded) {
+						requiresSave = true;
+					}
+					processed.add(sourceAccount.index);
+				},
+			);
 			if (refreshResults.size === 0) {
 				this.stats.runs += 1;
 				this.stats.lastRunAt = Date.now();
@@ -114,55 +201,29 @@ export class RefreshGuardian {
 			}
 
 			const snapshotByIndex = new Map<number, (typeof snapshot)[number]>();
-			for (const candidate of snapshot) {
+			for (const candidate of eligibleSnapshot) {
 				snapshotByIndex.set(candidate.index, candidate);
 			}
 
 			for (const [accountIndex, result] of refreshResults.entries()) {
+				if (processed.has(accountIndex)) {
+					continue;
+				}
 				const sourceAccount = snapshotByIndex.get(accountIndex);
 				if (!sourceAccount) continue;
-				const liveAccounts = manager.getAccountsSnapshot();
-				const resolvedIndex = liveAccounts.findIndex(
-					(candidate) => candidate.refreshToken === sourceAccount.refreshToken,
+				const saveNeeded = await this.applyRefreshOutcome(
+					manager,
+					sourceAccount,
+					result,
 				);
-				const account = resolvedIndex >= 0 ? manager.getAccountByIndex(resolvedIndex) : null;
-				if (!account) continue;
-
-				switch (result.reason) {
-					case "success":
-						if (result.tokenResult?.type === "success") {
-							applyRefreshResult(account, result.tokenResult);
-							manager.clearAuthFailures(account);
-							this.stats.refreshed += 1;
-						} else {
-							manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
-							this.stats.failed += 1;
-							this.stats.networkFailed += 1;
-						}
-						break;
-					case "failed": {
-						const cooldownReason = this.classifyFailureReason(result.tokenResult);
-						manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
-						this.stats.failed += 1;
-						if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
-						else if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
-						else this.stats.networkFailed += 1;
-						break;
-					}
-					case "not_needed":
-						this.stats.notNeeded += 1;
-						break;
-					case "no_refresh_token":
-						manager.markAccountCoolingDown(account, this.bufferMs, "auth-failure");
-						manager.setAccountEnabled(account.index, false);
-						this.stats.noRefreshToken += 1;
-						this.stats.failed += 1;
-						this.stats.authFailed += 1;
-						break;
+				if (saveNeeded) {
+					requiresSave = true;
 				}
 			}
 
-			manager.saveToDiskDebounced();
+			if (requiresSave) {
+				manager.saveToDiskDebounced();
+			}
 			this.stats.runs += 1;
 			this.stats.lastRunAt = Date.now();
 		} catch (error) {

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -124,7 +124,25 @@ export class RefreshGuardian {
 					multiAccount: true,
 				};
 				try {
-					await manager.commitRefreshedAuth(sourceAccount, refreshedAuth);
+					const committedAccount = await manager.commitRefreshedAuth(
+						sourceAccount,
+						refreshedAuth,
+					);
+					if (!committedAccount) {
+						const account =
+							manager.getAccountByIdentity(sourceAccount, refreshedAuth) ??
+							manager.getAccountByIdentity(sourceAccount);
+						if (account) {
+							manager.markAccountCoolingDown(
+								account,
+								this.bufferMs,
+								"network-error",
+							);
+						}
+						this.stats.failed += 1;
+						this.stats.networkFailed += 1;
+						return !!account;
+					}
 				} catch (error) {
 					log.warn("Refresh guardian commit failed", {
 						sourceIndex: sourceAccount.index,

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "./logger.js";
 import { applyRefreshResult, refreshExpiringAccounts } from "./proactive-refresh.js";
 import type { AccountManager } from "./accounts.js";
+import { ACCOUNT_LIMITS } from "./constants.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
 
@@ -24,6 +25,7 @@ export interface RefreshGuardianStats {
 }
 
 const DEFAULT_INTERVAL_MS = 60_000;
+const NETWORK_FAILURE_COOLDOWN_MS = 6_000;
 
 export class RefreshGuardian {
 	private readonly getAccountManager: () => AccountManager | null;
@@ -95,6 +97,15 @@ export class RefreshGuardian {
 		return "network-error";
 	}
 
+	private getNetworkFailureCooldownMs(): number {
+		return Math.min(this.bufferMs, NETWORK_FAILURE_COOLDOWN_MS);
+	}
+
+	private getAuthFailureCooldownMs(failureCount: number): number {
+		const streak = Math.max(1, Math.floor(failureCount));
+		return Math.min(this.bufferMs, ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS * streak);
+	}
+
 	async tick(): Promise<void> {
 		if (this.running) return;
 		const manager = this.getAccountManager();
@@ -135,14 +146,33 @@ export class RefreshGuardian {
 							manager.clearAuthFailures(account);
 							this.stats.refreshed += 1;
 						} else {
-							manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+							manager.markAccountCoolingDown(
+								account,
+								this.getNetworkFailureCooldownMs(),
+								"network-error",
+							);
 							this.stats.failed += 1;
 							this.stats.networkFailed += 1;
 						}
 						break;
 					case "failed": {
 						const cooldownReason = this.classifyFailureReason(result.tokenResult);
-						manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
+						if (cooldownReason === "rate-limit") {
+							manager.markRateLimited(account, this.bufferMs, "codex");
+						} else if (cooldownReason === "auth-failure") {
+							const failureCount = manager.incrementAuthFailures(account);
+							manager.markAccountCoolingDown(
+								account,
+								this.getAuthFailureCooldownMs(failureCount),
+								cooldownReason,
+							);
+						} else {
+							manager.markAccountCoolingDown(
+								account,
+								this.getNetworkFailureCooldownMs(),
+								cooldownReason,
+							);
+						}
 						this.stats.failed += 1;
 						if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
 						else if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
@@ -153,7 +183,11 @@ export class RefreshGuardian {
 						this.stats.notNeeded += 1;
 						break;
 					case "no_refresh_token":
-						manager.markAccountCoolingDown(account, this.bufferMs, "auth-failure");
+						manager.markAccountCoolingDown(
+							account,
+							ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS,
+							"auth-failure",
+						);
 						manager.setAccountEnabled(account.index, false);
 						this.stats.noRefreshToken += 1;
 						this.stats.failed += 1;

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -146,6 +146,7 @@ export class RefreshGuardian {
 							manager.clearAuthFailures(account);
 							this.stats.refreshed += 1;
 						} else {
+							manager.clearAuthFailures(account);
 							manager.markAccountCoolingDown(
 								account,
 								this.getNetworkFailureCooldownMs(),
@@ -158,6 +159,7 @@ export class RefreshGuardian {
 					case "failed": {
 						const cooldownReason = this.classifyFailureReason(result.tokenResult);
 						if (cooldownReason === "rate-limit") {
+							manager.clearAuthFailures(account);
 							manager.markRateLimited(account, this.bufferMs, "codex");
 						} else if (cooldownReason === "auth-failure") {
 							const failureCount = manager.incrementAuthFailures(account);
@@ -167,6 +169,7 @@ export class RefreshGuardian {
 								cooldownReason,
 							);
 						} else {
+							manager.clearAuthFailures(account);
 							manager.markAccountCoolingDown(
 								account,
 								this.getNetworkFailureCooldownMs(),

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "./logger.js";
-import { applyRefreshResult, refreshExpiringAccounts } from "./proactive-refresh.js";
+import { refreshExpiringAccounts } from "./proactive-refresh.js";
 import type { AccountManager } from "./accounts.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
@@ -123,12 +123,21 @@ export class RefreshGuardian {
 					expires: result.tokenResult.expires,
 					multiAccount: true,
 				};
-				const account = manager.getAccountByIdentity(sourceAccount, refreshedAuth);
-				if (account) {
-					applyRefreshResult(account, result.tokenResult);
-					manager.clearAuthFailures(account);
+				try {
+					await manager.commitRefreshedAuth(sourceAccount, refreshedAuth);
+				} catch (error) {
+					log.warn("Refresh guardian commit failed", {
+						sourceIndex: sourceAccount.index,
+						error: error instanceof Error ? error.message : String(error),
+					});
+					const account = manager.getAccountByIdentity(sourceAccount, refreshedAuth);
+					if (account) {
+						manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+					}
+					this.stats.failed += 1;
+					this.stats.networkFailed += 1;
+					return !!account;
 				}
-				await manager.commitRefreshedAuth(sourceAccount, refreshedAuth);
 				this.stats.refreshed += 1;
 				return false;
 			}

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -25,28 +25,78 @@ export interface RefreshGuardianStats {
 
 const DEFAULT_INTERVAL_MS = 60_000;
 
+function findMatchingLiveAccountIndexes(
+	liveAccounts: ManagedAccount[],
+	predicate: (candidate: ManagedAccount) => boolean,
+): number[] {
+	const matches: number[] = [];
+	for (const [index, candidate] of liveAccounts.entries()) {
+		if (predicate(candidate)) {
+			matches.push(index);
+		}
+	}
+	return matches;
+}
+
 function resolveLiveAccountIndex(
 	liveAccounts: ManagedAccount[],
 	sourceAccount: ManagedAccount,
 ): number {
 	if (sourceAccount.accountId) {
-		const byAccountId = liveAccounts.findIndex(
+		const accountIdMatches = findMatchingLiveAccountIndexes(
+			liveAccounts,
 			(candidate) => candidate.accountId === sourceAccount.accountId,
 		);
-		if (byAccountId >= 0) return byAccountId;
+		const resolvedIndex = accountIdMatches[0];
+		if (resolvedIndex !== undefined) {
+			log.debug("Resolved refreshed account by accountId", {
+				sourceIndex: sourceAccount.index,
+				resolvedIndex,
+				matchCount: accountIdMatches.length,
+			});
+			if (accountIdMatches.length > 1) {
+				log.warn("Duplicate live accountId matches during refresh reconciliation", {
+					sourceIndex: sourceAccount.index,
+					resolvedIndex,
+					matchCount: accountIdMatches.length,
+				});
+			}
+			return resolvedIndex;
+		}
 	}
 
 	const sourceEmail = sanitizeEmail(sourceAccount.email);
 	if (sourceEmail) {
-		const byEmail = liveAccounts.findIndex(
+		const emailMatches = findMatchingLiveAccountIndexes(
+			liveAccounts,
 			(candidate) => sanitizeEmail(candidate.email) === sourceEmail,
 		);
-		if (byEmail >= 0) return byEmail;
+		const resolvedIndex = emailMatches[0];
+		if (resolvedIndex !== undefined) {
+			log.debug("Resolved refreshed account by email", {
+				sourceIndex: sourceAccount.index,
+				resolvedIndex,
+				matchCount: emailMatches.length,
+			});
+			if (emailMatches.length > 1) {
+				log.warn("Duplicate live email matches during refresh reconciliation", {
+					sourceIndex: sourceAccount.index,
+					resolvedIndex,
+					matchCount: emailMatches.length,
+				});
+			}
+			return resolvedIndex;
+		}
 	}
 
-	return liveAccounts.findIndex(
+	const byToken = liveAccounts.findIndex(
 		(candidate) => candidate.refreshToken === sourceAccount.refreshToken,
 	);
+	log.debug("Resolved refreshed account by refresh token fallback", {
+		sourceIndex: sourceAccount.index,
+		resolvedIndex: byToken,
+	});
+	return byToken;
 }
 
 export class RefreshGuardian {
@@ -141,11 +191,11 @@ export class RefreshGuardian {
 			for (const candidate of snapshot) {
 				snapshotByIndex.set(candidate.index, candidate);
 			}
+			const liveAccounts = manager.getAccountsSnapshot();
 
 			for (const [accountIndex, result] of refreshResults.entries()) {
 				const sourceAccount = snapshotByIndex.get(accountIndex);
 				if (!sourceAccount) continue;
-				const liveAccounts = manager.getAccountsSnapshot();
 				const resolvedIndex = resolveLiveAccountIndex(liveAccounts, sourceAccount);
 				const account = resolvedIndex >= 0 ? manager.getAccountByIndex(resolvedIndex) : null;
 				if (!account) continue;

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -205,7 +205,6 @@ export class RefreshGuardian {
 			}
 
 			let requiresSave = false;
-			const processed = new Set<number>();
 			const refreshResults = await refreshExpiringAccounts(
 				eligibleSnapshot,
 				this.bufferMs,
@@ -218,34 +217,12 @@ export class RefreshGuardian {
 					if (saveNeeded) {
 						requiresSave = true;
 					}
-					processed.add(sourceAccount.index);
 				},
 			);
 			if (refreshResults.size === 0) {
 				this.stats.runs += 1;
 				this.stats.lastRunAt = Date.now();
 				return;
-			}
-
-			const snapshotByIndex = new Map<number, (typeof snapshot)[number]>();
-			for (const candidate of eligibleSnapshot) {
-				snapshotByIndex.set(candidate.index, candidate);
-			}
-
-			for (const [accountIndex, result] of refreshResults.entries()) {
-				if (processed.has(accountIndex)) {
-					continue;
-				}
-				const sourceAccount = snapshotByIndex.get(accountIndex);
-				if (!sourceAccount) continue;
-				const saveNeeded = await this.applyRefreshOutcome(
-					manager,
-					sourceAccount,
-					result,
-				);
-				if (saveNeeded) {
-					requiresSave = true;
-				}
 			}
 
 			if (requiresSave) {

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "./logger.js";
 import { applyRefreshResult, refreshExpiringAccounts } from "./proactive-refresh.js";
-import type { AccountManager } from "./accounts.js";
+import { sanitizeEmail, type AccountManager, type ManagedAccount } from "./accounts.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
 
@@ -24,6 +24,30 @@ export interface RefreshGuardianStats {
 }
 
 const DEFAULT_INTERVAL_MS = 60_000;
+
+function resolveLiveAccountIndex(
+	liveAccounts: ManagedAccount[],
+	sourceAccount: ManagedAccount,
+): number {
+	if (sourceAccount.accountId) {
+		const byAccountId = liveAccounts.findIndex(
+			(candidate) => candidate.accountId === sourceAccount.accountId,
+		);
+		if (byAccountId >= 0) return byAccountId;
+	}
+
+	const sourceEmail = sanitizeEmail(sourceAccount.email);
+	if (sourceEmail) {
+		const byEmail = liveAccounts.findIndex(
+			(candidate) => sanitizeEmail(candidate.email) === sourceEmail,
+		);
+		if (byEmail >= 0) return byEmail;
+	}
+
+	return liveAccounts.findIndex(
+		(candidate) => candidate.refreshToken === sourceAccount.refreshToken,
+	);
+}
 
 export class RefreshGuardian {
 	private readonly getAccountManager: () => AccountManager | null;
@@ -122,9 +146,7 @@ export class RefreshGuardian {
 				const sourceAccount = snapshotByIndex.get(accountIndex);
 				if (!sourceAccount) continue;
 				const liveAccounts = manager.getAccountsSnapshot();
-				const resolvedIndex = liveAccounts.findIndex(
-					(candidate) => candidate.refreshToken === sourceAccount.refreshToken,
-				);
+				const resolvedIndex = resolveLiveAccountIndex(liveAccounts, sourceAccount);
 				const account = resolvedIndex >= 0 ? manager.getAccountByIndex(resolvedIndex) : null;
 				if (!account) continue;
 

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "./logger.js";
 import { refreshExpiringAccounts } from "./proactive-refresh.js";
 import type { AccountManager } from "./accounts.js";
+import { CodexAuthError } from "./errors.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
 
@@ -148,12 +149,19 @@ export class RefreshGuardian {
 						sourceIndex: sourceAccount.index,
 						error: error instanceof Error ? error.message : String(error),
 					});
-					const account = manager.getAccountByIdentity(sourceAccount, refreshedAuth);
+					const account =
+						manager.getAccountByIdentity(sourceAccount, refreshedAuth) ??
+						manager.getAccountByIdentity(sourceAccount);
+					const cooldownReason: CooldownReason =
+						error instanceof CodexAuthError && !error.retryable
+							? "auth-failure"
+							: "network-error";
 					if (account) {
-						manager.markAccountCoolingDown(account, this.bufferMs, "network-error");
+						manager.markAccountCoolingDown(account, this.bufferMs, cooldownReason);
 					}
 					this.stats.failed += 1;
-					this.stats.networkFailed += 1;
+					if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
+					else this.stats.networkFailed += 1;
 					return !!account;
 				}
 				this.stats.refreshed += 1;

--- a/lib/refresh-guardian.ts
+++ b/lib/refresh-guardian.ts
@@ -3,10 +3,12 @@ import { refreshExpiringAccounts } from "./proactive-refresh.js";
 import type { AccountManager } from "./accounts.js";
 import { ACCOUNT_LIMITS } from "./constants.js";
 import { CodexAuthError } from "./errors.js";
+import type { ModelFamily } from "./prompts/codex.js";
 import type { CooldownReason } from "./storage.js";
 import type { TokenResult } from "./types.js";
 
 const log = createLogger("refresh-guardian");
+const REFRESH_HEALTH_FAMILY: ModelFamily = "codex";
 
 export interface RefreshGuardianOptions {
 	intervalMs?: number;
@@ -128,6 +130,7 @@ export class RefreshGuardian {
 						this.getNetworkFailureCooldownMs(),
 						"network-error",
 					);
+					manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 					this.stats.failed += 1;
 					this.stats.networkFailed += 1;
 					return true;
@@ -156,11 +159,13 @@ export class RefreshGuardian {
 								this.getNetworkFailureCooldownMs(),
 								"network-error",
 							);
+							manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 						}
 						this.stats.failed += 1;
 						this.stats.networkFailed += 1;
 						return !!account;
 					}
+					manager.recordSuccess(committedAccount, REFRESH_HEALTH_FAMILY);
 				} catch (error) {
 					log.warn("Refresh guardian commit failed", {
 						sourceIndex: sourceAccount.index,
@@ -189,6 +194,7 @@ export class RefreshGuardian {
 								cooldownReason,
 							);
 						}
+						manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 					}
 					this.stats.failed += 1;
 					if (cooldownReason === "auth-failure") this.stats.authFailed += 1;
@@ -205,6 +211,7 @@ export class RefreshGuardian {
 				if (cooldownReason === "rate-limit") {
 					manager.clearAuthFailures(account);
 					manager.markRateLimited(account, this.bufferMs, "codex");
+					manager.recordRateLimit(account, REFRESH_HEALTH_FAMILY);
 				} else if (cooldownReason === "auth-failure") {
 					const failureCount = manager.incrementAuthFailures(account);
 					manager.markAccountCoolingDown(
@@ -212,6 +219,7 @@ export class RefreshGuardian {
 						this.getAuthFailureCooldownMs(failureCount),
 						cooldownReason,
 					);
+					manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 				} else {
 					manager.clearAuthFailures(account);
 					manager.markAccountCoolingDown(
@@ -219,6 +227,7 @@ export class RefreshGuardian {
 						this.getNetworkFailureCooldownMs(),
 						cooldownReason,
 					);
+					manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 				}
 				this.stats.failed += 1;
 				if (cooldownReason === "rate-limit") this.stats.rateLimited += 1;
@@ -238,6 +247,7 @@ export class RefreshGuardian {
 					this.getAuthFailureCooldownMs(failureCount),
 					"auth-failure",
 				);
+				manager.recordFailure(account, REFRESH_HEALTH_FAMILY);
 				manager.setAccountEnabled(account.index, false);
 				this.stats.noRefreshToken += 1;
 				this.stats.failed += 1;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -19,7 +19,7 @@ import {
 	convertSseToJson,
 	ensureContentType,
 } from "./response-handler.js";
-import type { UserConfig, RequestBody } from "../types.js";
+import type { UserConfig, RequestBody, TokenResult } from "../types.js";
 import { registerCleanup } from "../shutdown.js";
 import { CodexAuthError } from "../errors.js";
 import { isRecord } from "../utils.js";
@@ -428,6 +428,26 @@ export function shouldRefreshToken(auth: Auth, skewMs = 0): boolean {
 	return auth.expires <= Date.now() + safeSkewMs;
 }
 
+function isRetryableRefreshFailure(
+	result: Extract<TokenResult, { type: "failed" }>,
+): boolean {
+	switch (result.reason) {
+		case "network_error":
+		case "unknown":
+		case "invalid_response":
+		case "missing_refresh":
+			return true;
+		case "http_error":
+			return !(
+				result.statusCode === HTTP_STATUS.BAD_REQUEST ||
+				result.statusCode === HTTP_STATUS.UNAUTHORIZED ||
+				result.statusCode === HTTP_STATUS.FORBIDDEN
+			);
+		default:
+			return false;
+	}
+}
+
 /**
  * Refreshes the OAuth token and updates stored credentials
  * @param currentAuth - Current auth state
@@ -440,26 +460,39 @@ export async function refreshAndUpdateToken(
 ): Promise<Auth> {
 	const authSetter = (client as Partial<CodexAuthSetter>).auth;
 	if (!authSetter || typeof authSetter.set !== "function") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, { retryable: false });
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, { retryable: true });
 	}
 
 	const refreshToken = currentAuth.type === "oauth" ? currentAuth.refresh : "";
 	const refreshResult = await queuedRefresh(refreshToken);
 
 	if (refreshResult.type === "failed") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, { retryable: false });
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: isRetryableRefreshFailure(refreshResult),
+			context: {
+				refreshFailureReason: refreshResult.reason,
+				statusCode: refreshResult.statusCode,
+			},
+		});
 	}
 
-	await authSetter.set({
-		path: { id: "openai" },
-		body: {
-			type: "oauth",
-			access: refreshResult.access,
-			refresh: refreshResult.refresh,
-			expires: refreshResult.expires,
-			multiAccount: true,
-		},
-	});
+	try {
+		await authSetter.set({
+			path: { id: "openai" },
+			body: {
+				type: "oauth",
+				access: refreshResult.access,
+				refresh: refreshResult.refresh,
+				expires: refreshResult.expires,
+				multiAccount: true,
+			},
+		});
+	} catch (error) {
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: true,
+			cause: error,
+		});
+	}
 
 	// Update current auth reference if it's OAuth type
 	if (currentAuth.type === "oauth") {

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -435,8 +435,9 @@ function isRetryableRefreshFailure(
 		case "network_error":
 		case "unknown":
 		case "invalid_response":
-		case "missing_refresh":
 			return true;
+		case "missing_refresh":
+			return false;
 		case "http_error":
 			return !(
 				result.statusCode === HTTP_STATUS.BAD_REQUEST ||

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -461,7 +461,9 @@ export async function refreshAndUpdateToken(
 ): Promise<Auth> {
 	const authSetter = (client as Partial<CodexAuthSetter>).auth;
 	if (!authSetter || typeof authSetter.set !== "function") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, { retryable: true });
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: false,
+		});
 	}
 
 	const refreshToken = currentAuth.type === "oauth" ? currentAuth.refresh : "";

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -449,6 +449,35 @@ function isRetryableRefreshFailure(
 	}
 }
 
+function isRetryableAuthSetterError(error: unknown): boolean {
+	if (!error || typeof error !== "object") {
+		return false;
+	}
+
+	const candidate = error as {
+		code?: unknown;
+		status?: unknown;
+		cause?: unknown;
+	};
+	const code =
+		typeof candidate.code === "string"
+			? candidate.code.toUpperCase()
+			: undefined;
+	if (code === "EAGAIN" || code === "EBUSY" || code === "EPERM") {
+		return true;
+	}
+
+	if (candidate.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
+		return true;
+	}
+
+	if (candidate.cause && candidate.cause !== error) {
+		return isRetryableAuthSetterError(candidate.cause);
+	}
+
+	return false;
+}
+
 /**
  * Refreshes the OAuth token and updates stored credentials
  * @param currentAuth - Current auth state
@@ -492,7 +521,7 @@ export async function refreshAndUpdateToken(
 		});
 	} catch (error) {
 		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-			retryable: true,
+			retryable: isRetryableAuthSetterError(error),
 			cause: error,
 		});
 	}

--- a/lib/rotation.ts
+++ b/lib/rotation.ts
@@ -44,6 +44,14 @@ interface HealthEntry {
   consecutiveFailures: number;
 }
 
+type TrackerKey = number | string;
+
+function normalizeTrackerKey(accountKey: TrackerKey, quotaKey?: string): string {
+	const normalizedKey =
+		typeof accountKey === "number" ? `${accountKey}` : accountKey;
+	return JSON.stringify([normalizedKey, quotaKey ?? null]);
+}
+
 /**
  * Tracks health scores for accounts to prioritize healthy accounts.
  * Accounts with higher health scores are preferred for selection.
@@ -56,8 +64,8 @@ export class HealthScoreTracker {
     this.config = { ...DEFAULT_HEALTH_SCORE_CONFIG, ...config };
   }
 
-  private getKey(accountIndex: number, quotaKey?: string): string {
-    return quotaKey ? `${accountIndex}:${quotaKey}` : `${accountIndex}`;
+  private getKey(accountKey: TrackerKey, quotaKey?: string): string {
+    return normalizeTrackerKey(accountKey, quotaKey);
   }
 
   private applyPassiveRecovery(entry: HealthEntry): number {
@@ -67,21 +75,21 @@ export class HealthScoreTracker {
     return Math.min(entry.score + recovery, this.config.maxScore);
   }
 
-  getScore(accountIndex: number, quotaKey?: string): number {
-    const key = this.getKey(accountIndex, quotaKey);
+  getScore(accountKey: TrackerKey, quotaKey?: string): number {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     if (!entry) return this.config.maxScore;
     return this.applyPassiveRecovery(entry);
   }
 
-  getConsecutiveFailures(accountIndex: number, quotaKey?: string): number {
-    const key = this.getKey(accountIndex, quotaKey);
+  getConsecutiveFailures(accountKey: TrackerKey, quotaKey?: string): number {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     return entry?.consecutiveFailures ?? 0;
   }
 
-  recordSuccess(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  recordSuccess(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
     const newScore = Math.min(baseScore + this.config.successDelta, this.config.maxScore);
@@ -92,8 +100,8 @@ export class HealthScoreTracker {
     });
   }
 
-  recordRateLimit(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  recordRateLimit(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
     const newScore = Math.max(baseScore + this.config.rateLimitDelta, this.config.minScore);
@@ -104,8 +112,8 @@ export class HealthScoreTracker {
     });
   }
 
-  recordFailure(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  recordFailure(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.entries.get(key);
     const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
     const newScore = Math.max(baseScore + this.config.failureDelta, this.config.minScore);
@@ -116,8 +124,8 @@ export class HealthScoreTracker {
     });
   }
 
-  reset(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  reset(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     this.entries.delete(key);
   }
 
@@ -162,8 +170,8 @@ export class TokenBucketTracker {
     this.config = { ...DEFAULT_TOKEN_BUCKET_CONFIG, ...config };
   }
 
-  private getKey(accountIndex: number, quotaKey?: string): string {
-    return quotaKey ? `${accountIndex}:${quotaKey}` : `${accountIndex}`;
+  private getKey(accountKey: TrackerKey, quotaKey?: string): string {
+    return normalizeTrackerKey(accountKey, quotaKey);
   }
 
   private refillTokens(entry: TokenBucketEntry): number {
@@ -173,8 +181,8 @@ export class TokenBucketTracker {
     return Math.min(entry.tokens + tokensToAdd, this.config.maxTokens);
   }
 
-  getTokens(accountIndex: number, quotaKey?: string): number {
-    const key = this.getKey(accountIndex, quotaKey);
+  getTokens(accountKey: TrackerKey, quotaKey?: string): number {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.buckets.get(key);
     if (!entry) return this.config.maxTokens;
     return this.refillTokens(entry);
@@ -183,8 +191,8 @@ export class TokenBucketTracker {
   /**
    * Attempt to consume a token. Returns true if successful, false if bucket is empty.
    */
-  tryConsume(accountIndex: number, quotaKey?: string): boolean {
-    const key = this.getKey(accountIndex, quotaKey);
+  tryConsume(accountKey: TrackerKey, quotaKey?: string): boolean {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.buckets.get(key);
     const currentTokens = entry ? this.refillTokens(entry) : this.config.maxTokens;
 
@@ -212,8 +220,8 @@ export class TokenBucketTracker {
    * Use this when a request fails due to network errors (not rate limits).
    * @returns true if refund was successful, false if no valid consumption found
    */
-  refundToken(accountIndex: number, quotaKey?: string): boolean {
-    const key = this.getKey(accountIndex, quotaKey);
+  refundToken(accountKey: TrackerKey, quotaKey?: string): boolean {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.buckets.get(key);
     if (!entry || entry.consumptions.length === 0) return false;
 
@@ -239,8 +247,8 @@ export class TokenBucketTracker {
   /**
    * Drain tokens on rate limit to prevent immediate retries.
    */
-  drain(accountIndex: number, quotaKey?: string, drainAmount: number = 10): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  drain(accountKey: TrackerKey, quotaKey?: string, drainAmount: number = 10): void {
+    const key = this.getKey(accountKey, quotaKey);
     const entry = this.buckets.get(key);
     const currentTokens = entry ? this.refillTokens(entry) : this.config.maxTokens;
     this.buckets.set(key, {
@@ -250,8 +258,8 @@ export class TokenBucketTracker {
     });
   }
 
-  reset(accountIndex: number, quotaKey?: string): void {
-    const key = this.getKey(accountIndex, quotaKey);
+  reset(accountKey: TrackerKey, quotaKey?: string): void {
+    const key = this.getKey(accountKey, quotaKey);
     this.buckets.delete(key);
   }
 
@@ -266,6 +274,7 @@ export class TokenBucketTracker {
 
 export interface AccountWithMetrics {
   index: number;
+  trackerKey?: TrackerKey;
   isAvailable: boolean;
   lastUsed: number;
 }
@@ -393,8 +402,9 @@ export function selectHybridAccount(
   const pidBonus = resolvedOptions.pidOffsetEnabled ? (process.pid % 100) * 0.01 : 0;
 
   for (const account of available) {
-    const health = resolvedHealthTracker.getScore(account.index, resolvedQuotaKey);
-    const tokens = resolvedTokenTracker.getTokens(account.index, resolvedQuotaKey);
+    const trackerKey = account.trackerKey ?? account.index;
+    const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
+    const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
     const hoursSinceUsed = (now - account.lastUsed) / (1000 * 60 * 60);
 
     const capabilityBoost =
@@ -421,8 +431,9 @@ export function selectHybridAccount(
   }
 
   if (bestAccount && available.length > 1) {
-    const health = resolvedHealthTracker.getScore(bestAccount.index, resolvedQuotaKey);
-    const tokens = resolvedTokenTracker.getTokens(bestAccount.index, resolvedQuotaKey);
+    const trackerKey = bestAccount.trackerKey ?? bestAccount.index;
+    const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
+    const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
     log.debug("Selected account", {
       index: bestAccount.index,
       health: Math.round(health),

--- a/lib/storage/identity.ts
+++ b/lib/storage/identity.ts
@@ -6,6 +6,12 @@ type AccountLike = {
 	refreshToken?: string;
 };
 
+type RuntimeAccountLike = {
+	accountId?: string;
+	email?: string;
+	index?: number;
+};
+
 export type AccountIdentityRef = {
 	accountId?: string;
 	emailKey?: string;
@@ -52,19 +58,39 @@ export function toAccountIdentityRef(
 	};
 }
 
-export function getAccountIdentityKey(
-	account: Pick<AccountLike, "accountId" | "email" | "refreshToken">,
+function getIdentityKeyFromRef(
+	ref: AccountIdentityRef,
+	options: { allowRefreshFallback: boolean },
 ): string | undefined {
-	const ref = toAccountIdentityRef(account);
 	if (ref.accountId && ref.emailKey) {
 		return `account:${ref.accountId}::email:${ref.emailKey}`;
 	}
 	if (ref.accountId) return `account:${ref.accountId}`;
 	if (ref.emailKey) return `email:${ref.emailKey}`;
-	if (ref.refreshToken) {
+	if (options.allowRefreshFallback && ref.refreshToken) {
 		// Legacy refresh-only identity keys embedded raw tokens. Hashing preserves
 		// deterministic fallback matching without exposing token material in logs.
 		return `refresh:${hashRefreshTokenKey(ref.refreshToken)}`;
 	}
 	return undefined;
+}
+
+export function getAccountIdentityKey(
+	account: Pick<AccountLike, "accountId" | "email" | "refreshToken">,
+): string | undefined {
+	const ref = toAccountIdentityRef(account);
+	return getIdentityKeyFromRef(ref, { allowRefreshFallback: true });
+}
+
+export function getRuntimeAccountIdentityKey(
+	account: Pick<RuntimeAccountLike, "accountId" | "email" | "index">,
+): string | number | undefined {
+	const ref = toAccountIdentityRef({
+		accountId: account.accountId,
+		email: account.email,
+	});
+	return (
+		getIdentityKeyFromRef(ref, { allowRefreshFallback: false }) ??
+		(typeof account.index === "number" ? account.index : undefined)
+	);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-multi-auth",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-multi-auth",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "bundleDependencies": [
         "@codex-ai/plugin"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "Multi-account OAuth manager and codex auth wrapper for the official @openai/codex CLI, with switching, health checks, and recovery tools",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -3,6 +3,7 @@ import type { OAuthAuthDetails } from "../lib/types.js";
 
 const mockLoadAccounts = vi.fn();
 const mockSaveAccounts = vi.fn();
+const mockWithAccountStorageTransaction = vi.fn();
 const mockLoadCodexCliState = vi.fn();
 const mockSyncAccountStorageFromCodexCli = vi.fn();
 const mockSetCodexCliActiveSelection = vi.fn();
@@ -14,6 +15,7 @@ vi.mock("../lib/storage.js", async (importOriginal) => {
     ...actual,
     loadAccounts: mockLoadAccounts,
     saveAccounts: mockSaveAccounts,
+    withAccountStorageTransaction: mockWithAccountStorageTransaction,
   };
 });
 
@@ -81,6 +83,11 @@ describe("accounts edge branches", () => {
     vi.clearAllMocks();
     mockLoadAccounts.mockResolvedValue(null);
     mockSaveAccounts.mockResolvedValue(undefined);
+    mockWithAccountStorageTransaction.mockImplementation(async (handler) =>
+      handler(null, async (storage) => {
+        await mockSaveAccounts(storage);
+      }),
+    );
     mockLoadCodexCliState.mockResolvedValue(null);
     mockSyncAccountStorageFromCodexCli.mockImplementation(async (storage) => ({
       storage,

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -188,7 +188,7 @@ describe("accounts edge branches", () => {
 
     const expired = snapshot[1];
     expect(expired?.access).toBe("existing-access");
-    expect(expired?.refreshToken).toBe("expired-refresh-updated");
+    expect(expired?.refreshToken).toBe("refresh-2");
     expect(expired?.accountId).toBe("expired-id");
     expect(expired?.accountIdSource).toBe("token");
   });

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -231,6 +231,47 @@ describe("accounts edge branches", () => {
     expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
+  it("hydrates a missing local refresh token from an expired CLI cache entry", async () => {
+    const now = Date.now();
+    const stored = buildStored([
+      buildStoredAccount({
+        refreshToken: "local-refresh-placeholder",
+        email: "expired@example.com",
+        accessToken: "local-access",
+        expiresAt: now + 120_000,
+      }),
+    ]);
+
+    const { AccountManager } = await importAccountsModule();
+    const manager = new AccountManager(undefined, stored as never);
+    const account = manager.getAccountByIndex(0)!;
+    account.refreshToken = "";
+
+    mockLoadCodexCliState.mockResolvedValue({
+      sourceUpdatedAtMs: now - 60_000,
+      accounts: [
+        {
+          email: "expired@example.com",
+          accessToken: "cached-access-old",
+          expiresAt: now - 1,
+          refreshToken: "cached-refresh-restored",
+          accountId: "expired-account-id",
+        },
+      ],
+    });
+
+    const hydrate = getPrivate<() => Promise<void>>(
+      manager as object,
+      "hydrateFromCodexCli",
+    );
+    await hydrate.call(manager);
+
+    const snapshot = manager.getAccountsSnapshot();
+    expect(snapshot[0]?.refreshToken).toBe("cached-refresh-restored");
+    expect(snapshot[0]?.access).toBe("local-access");
+    expect(snapshot[0]?.accountId).toBe("expired-account-id");
+  });
+
   it("returns early when Codex CLI state has no usable cache entries", async () => {
     const stored = buildStored([
       buildStoredAccount({

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -182,7 +182,7 @@ describe("accounts edge branches", () => {
     const snapshot = manager.getAccountsSnapshot();
     const updated = snapshot[0];
     expect(updated?.access).toBe("refreshed-access");
-    expect(updated?.refreshToken).toBe("refreshed-refresh");
+    expect(updated?.refreshToken).toBe("refresh-1");
     expect(updated?.accountId).toBe("account-from-cache");
     expect(updated?.accountIdSource).toBe("token");
 
@@ -191,6 +191,44 @@ describe("accounts edge branches", () => {
     expect(expired?.refreshToken).toBe("refresh-2");
     expect(expired?.accountId).toBe("expired-id");
     expect(expired?.accountIdSource).toBe("token");
+  });
+
+  it("does not overwrite a local refresh token with a stale usable CLI cache token", async () => {
+    const now = Date.now();
+    const stored = buildStored([
+      buildStoredAccount({
+        refreshToken: "local-refresh-new",
+        email: "match@example.com",
+        accessToken: "local-access",
+        expiresAt: now + 120_000,
+      }),
+    ]);
+
+    const { AccountManager } = await importAccountsModule();
+    const manager = new AccountManager(undefined, stored as never);
+
+    mockLoadCodexCliState.mockResolvedValue({
+      sourceUpdatedAtMs: now - 60_000,
+      accounts: [
+        {
+          email: "match@example.com",
+          accessToken: "cached-access-old",
+          expiresAt: now + 300_000,
+          refreshToken: "cached-refresh-old",
+        },
+      ],
+    });
+
+    const hydrate = getPrivate<() => Promise<void>>(
+      manager as object,
+      "hydrateFromCodexCli",
+    );
+    await hydrate.call(manager);
+
+    const snapshot = manager.getAccountsSnapshot();
+    expect(snapshot[0]?.refreshToken).toBe("local-refresh-new");
+    expect(snapshot[0]?.access).toBe("local-access");
+    expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
   it("returns early when Codex CLI state has no usable cache entries", async () => {

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -196,8 +196,8 @@ describe("accounts edge branches", () => {
     const expired = snapshot[1];
     expect(expired?.access).toBe("existing-access");
     expect(expired?.refreshToken).toBe("refresh-2");
-    expect(expired?.accountId).toBe("expired-id");
-    expect(expired?.accountIdSource).toBe("token");
+    expect(expired?.accountId).toBeUndefined();
+    expect(expired?.accountIdSource).toBeUndefined();
   });
 
   it("does not overwrite a local refresh token with a stale usable CLI cache token", async () => {
@@ -238,7 +238,7 @@ describe("accounts edge branches", () => {
     expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
-  it("hydrates a missing local refresh token from an expired CLI cache entry", async () => {
+  it("does not hydrate from an expired CLI cache entry", async () => {
     const now = Date.now();
     const stored = buildStored([
       buildStoredAccount({
@@ -274,9 +274,10 @@ describe("accounts edge branches", () => {
     await hydrate.call(manager);
 
     const snapshot = manager.getAccountsSnapshot();
-    expect(snapshot[0]?.refreshToken).toBe("cached-refresh-restored");
+    expect(snapshot[0]?.refreshToken).toBe("");
     expect(snapshot[0]?.access).toBe("local-access");
-    expect(snapshot[0]?.accountId).toBe("expired-account-id");
+    expect(snapshot[0]?.accountId).toBeUndefined();
+    expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
   it("returns early when Codex CLI state has no usable cache entries", async () => {

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -154,12 +154,14 @@ describe("accounts edge branches", () => {
           email: "match@example.com",
           accessToken: "refreshed-access",
           expiresAt: now + 300_000,
+          refreshToken: "refreshed-refresh",
           accountId: "account-from-cache",
         },
         {
           email: "expired@example.com",
           accessToken: "expired-access",
           expiresAt: now - 1,
+          refreshToken: "expired-refresh-updated",
           accountId: "expired-id",
         },
         {
@@ -180,12 +182,15 @@ describe("accounts edge branches", () => {
     const snapshot = manager.getAccountsSnapshot();
     const updated = snapshot[0];
     expect(updated?.access).toBe("refreshed-access");
+    expect(updated?.refreshToken).toBe("refreshed-refresh");
     expect(updated?.accountId).toBe("account-from-cache");
     expect(updated?.accountIdSource).toBe("token");
 
     const expired = snapshot[1];
     expect(expired?.access).toBe("existing-access");
-    expect(expired?.accountId).toBeUndefined();
+    expect(expired?.refreshToken).toBe("expired-refresh-updated");
+    expect(expired?.accountId).toBe("expired-id");
+    expect(expired?.accountIdSource).toBe("token");
   });
 
   it("returns early when Codex CLI state has no usable cache entries", async () => {

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -1,12 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AccountManager } from "../lib/accounts.js";
 
+const {
+  mockLoadAccounts,
+  mockSaveAccounts,
+  mockWithAccountStorageTransaction,
+} = vi.hoisted(() => ({
+  mockLoadAccounts: vi.fn(),
+  mockSaveAccounts: vi.fn(),
+  mockWithAccountStorageTransaction: vi.fn(),
+}));
+
 vi.mock("../lib/storage.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/storage.js")>();
   return {
     ...actual,
-    loadAccounts: vi.fn(),
-    saveAccounts: vi.fn().mockResolvedValue(undefined),
+    loadAccounts: mockLoadAccounts,
+    saveAccounts: mockSaveAccounts,
+    withAccountStorageTransaction: mockWithAccountStorageTransaction,
   };
 });
 
@@ -22,7 +33,6 @@ vi.mock("../lib/codex-cli/writer.js", () => ({
   setCodexCliActiveSelection: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { loadAccounts, saveAccounts } from "../lib/storage.js";
 import { syncAccountStorageFromCodexCli } from "../lib/codex-cli/sync.js";
 import { loadCodexCliState } from "../lib/codex-cli/state.js";
 import { setCodexCliActiveSelection } from "../lib/codex-cli/writer.js";
@@ -30,8 +40,13 @@ import { setCodexCliActiveSelection } from "../lib/codex-cli/writer.js";
 describe("AccountManager loadFromDisk", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(loadAccounts).mockResolvedValue(null);
-    vi.mocked(saveAccounts).mockResolvedValue(undefined);
+    mockLoadAccounts.mockResolvedValue(null);
+    mockSaveAccounts.mockResolvedValue(undefined);
+    mockWithAccountStorageTransaction.mockImplementation(async (handler) =>
+      handler(null, async (storage) => {
+        await mockSaveAccounts(storage);
+      }),
+    );
     vi.mocked(syncAccountStorageFromCodexCli).mockResolvedValue({
       changed: false,
       storage: null,
@@ -56,7 +71,7 @@ describe("AccountManager loadFromDisk", () => {
       ],
     };
 
-    vi.mocked(loadAccounts).mockResolvedValue(stored);
+    mockLoadAccounts.mockResolvedValue(stored);
     vi.mocked(syncAccountStorageFromCodexCli).mockResolvedValue({
       changed: true,
       storage: synced,
@@ -64,7 +79,7 @@ describe("AccountManager loadFromDisk", () => {
 
     const manager = await AccountManager.loadFromDisk();
 
-    expect(saveAccounts).toHaveBeenCalledWith(synced);
+    expect(mockSaveAccounts).toHaveBeenCalledWith(synced);
     expect(manager.getAccountCount()).toBe(2);
     expect(manager.getCurrentAccount()?.refreshToken).toBe("stored-refresh");
   });
@@ -81,7 +96,7 @@ describe("AccountManager loadFromDisk", () => {
       changed: true,
       storage: synced,
     });
-    vi.mocked(saveAccounts).mockRejectedValueOnce(new Error("forced persist failure"));
+    mockSaveAccounts.mockRejectedValueOnce(new Error("forced persist failure"));
 
     const manager = await AccountManager.loadFromDisk();
 
@@ -91,7 +106,7 @@ describe("AccountManager loadFromDisk", () => {
 
   it("hydrates missing access/accountId fields from Codex CLI token cache", async () => {
     const now = Date.now();
-    vi.mocked(loadAccounts).mockResolvedValue({
+    mockLoadAccounts.mockResolvedValue({
       version: 3 as const,
       activeIndex: 0,
       accounts: [
@@ -122,12 +137,12 @@ describe("AccountManager loadFromDisk", () => {
     expect(account?.expires).toBe(now + 120_000);
     expect(account?.accountId).toBe("acct-123");
     expect(account?.accountIdSource).toBe("token");
-    expect(saveAccounts).toHaveBeenCalledTimes(1);
+    expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
   });
 
   it("skips expired Codex CLI cache entries and does not persist", async () => {
     const now = Date.now();
-    vi.mocked(loadAccounts).mockResolvedValue({
+    mockLoadAccounts.mockResolvedValue({
       version: 3 as const,
       activeIndex: 0,
       accounts: [
@@ -156,7 +171,7 @@ describe("AccountManager loadFromDisk", () => {
 
     expect(account?.access).toBeUndefined();
     expect(account?.accountId).toBeUndefined();
-    expect(saveAccounts).not.toHaveBeenCalled();
+    expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
   it("syncCodexCliActiveSelectionForIndex ignores invalid indices and syncs a valid one", async () => {

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -125,7 +125,7 @@ describe("AccountManager loadFromDisk", () => {
     expect(saveAccounts).toHaveBeenCalledTimes(1);
   });
 
-  it("skips expired Codex CLI cache entries and does not persist", async () => {
+  it("skips expired access hydration but backfills missing account identity", async () => {
     const now = Date.now();
     vi.mocked(loadAccounts).mockResolvedValue({
       version: 3 as const,
@@ -155,8 +155,9 @@ describe("AccountManager loadFromDisk", () => {
     const account = manager.getCurrentAccount();
 
     expect(account?.access).toBeUndefined();
-    expect(account?.accountId).toBeUndefined();
-    expect(saveAccounts).not.toHaveBeenCalled();
+    expect(account?.accountId).toBe("acct-expired");
+    expect(account?.accountIdSource).toBe("token");
+    expect(saveAccounts).toHaveBeenCalledTimes(1);
   });
 
   it("syncCodexCliActiveSelectionForIndex ignores invalid indices and syncs a valid one", async () => {

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -253,4 +253,31 @@ describe("AccountManager loadFromDisk", () => {
 
     expect(manager.getNextForFamily("codex")).toBeNull();
   });
+
+  it("getNextForFamily falls back to stale accounts when no fresh option exists", () => {
+    const now = Date.now();
+    const manager = new AccountManager(undefined, {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        {
+          refreshToken: "stale-1",
+          accessToken: "access-1",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "stale-2",
+          accessToken: "access-2",
+          expiresAt: now + 120_000,
+          addedAt: now,
+          lastUsed: now - 5_000,
+        },
+      ],
+    } as never);
+
+    const selected = manager.getNextForFamily("codex");
+    expect(selected?.refreshToken).toBe("stale-1");
+  });
 });

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -140,7 +140,7 @@ describe("AccountManager loadFromDisk", () => {
     expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
   });
 
-  it("skips expired access hydration but backfills missing account identity", async () => {
+  it("ignores expired Codex CLI cache entries entirely", async () => {
     const now = Date.now();
     mockLoadAccounts.mockResolvedValue({
       version: 3 as const,
@@ -170,9 +170,9 @@ describe("AccountManager loadFromDisk", () => {
     const account = manager.getCurrentAccount();
 
     expect(account?.access).toBeUndefined();
-    expect(account?.accountId).toBe("acct-expired");
-    expect(account?.accountIdSource).toBe("token");
-    expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+    expect(account?.accountId).toBeUndefined();
+    expect(account?.accountIdSource).toBeUndefined();
+    expect(mockSaveAccounts).not.toHaveBeenCalled();
   });
 
   it("syncCodexCliActiveSelectionForIndex ignores invalid indices and syncs a valid one", async () => {
@@ -297,7 +297,7 @@ describe("AccountManager loadFromDisk", () => {
     expect(selected?.refreshToken).toBe("stale-1");
   });
 
-  it("getNextForFamily prefers a fresh account when one is available", () => {
+  it("getNextForFamily follows cursor order instead of access-token freshness", () => {
     const now = Date.now();
     const manager = new AccountManager(undefined, {
       version: 3 as const,
@@ -322,6 +322,6 @@ describe("AccountManager loadFromDisk", () => {
     } as never);
 
     const selected = manager.getNextForFamily("codex");
-    expect(selected?.refreshToken).toBe("token-fresh");
+    expect(selected?.refreshToken).toBe("stale-1");
   });
 });

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -280,4 +280,32 @@ describe("AccountManager loadFromDisk", () => {
     const selected = manager.getNextForFamily("codex");
     expect(selected?.refreshToken).toBe("stale-1");
   });
+
+  it("getNextForFamily prefers a fresh account when one is available", () => {
+    const now = Date.now();
+    const manager = new AccountManager(undefined, {
+      version: 3 as const,
+      activeIndex: 0,
+      activeIndexByFamily: { codex: 0 },
+      accounts: [
+        {
+          refreshToken: "stale-1",
+          accessToken: "access-1",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "token-fresh",
+          accessToken: "access-fresh",
+          expiresAt: now + 10 * 60_000,
+          addedAt: now,
+          lastUsed: now - 5_000,
+        },
+      ],
+    } as never);
+
+    const selected = manager.getNextForFamily("codex");
+    expect(selected?.refreshToken).toBe("token-fresh");
+  });
 });

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -406,6 +406,62 @@ describe("AccountManager", () => {
     expect(account?.rateLimitResetTimes?.codex).toBeUndefined();
   });
 
+  it("prefers accounts with fresh access tokens in availability checks", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        {
+          refreshToken: "token-stale",
+          accessToken: "access-stale",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "token-fresh",
+          accessToken: "access-fresh",
+          expiresAt: now + 10 * 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+      ],
+    };
+    const manager = new AccountManager(undefined, stored);
+
+    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
+    expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
+  });
+
+  it("keeps stale accounts available when the whole pool is stale", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        {
+          refreshToken: "token-stale-1",
+          accessToken: "access-stale-1",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "token-stale-2",
+          accessToken: "access-stale-2",
+          expiresAt: now + 120_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+      ],
+    };
+    const manager = new AccountManager(undefined, stored);
+
+    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
+    expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
+  });
+
   it("rotates when the active account is rate-limited", () => {
     const now = Date.now();
     const stored = {
@@ -612,6 +668,36 @@ describe("AccountManager", () => {
     expect(gpt51First?.refreshToken).toBe("token-1");
     expect(codexSecond?.refreshToken).toBe("token-2");
     expect(gpt51Second?.refreshToken).toBe("token-2");
+  });
+
+  it("skips a stale active account when a fresher account is available", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      activeIndexByFamily: { codex: 0 },
+      accounts: [
+        {
+          refreshToken: "token-stale",
+          accessToken: "access-stale",
+          expiresAt: now + 60_000,
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "token-fresh",
+          accessToken: "access-fresh",
+          expiresAt: now + 10 * 60_000,
+          addedAt: now,
+          lastUsed: now - 5_000,
+        },
+      ],
+    };
+
+    const manager = new AccountManager(undefined, stored as never);
+    const selected = manager.getCurrentOrNextForFamily("codex");
+
+    expect(selected?.refreshToken).toBe("token-fresh");
   });
 
   it("hybrid selection prefers active index when available", () => {
@@ -2083,6 +2169,37 @@ describe("AccountManager", () => {
       
       const secondCall = manager.getCurrentOrNextForFamilyHybrid("codex");
       expect(secondCall?.index).toBe(selected?.index);
+    });
+
+    it("prefers a fresh alternate account over a stale current account", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        activeIndexByFamily: { codex: 0 },
+        accounts: [
+          {
+            refreshToken: "token-stale",
+            accessToken: "access-stale",
+            expiresAt: now + 60_000,
+            addedAt: now,
+            lastUsed: now,
+          },
+          {
+            refreshToken: "token-fresh",
+            accessToken: "access-fresh",
+            expiresAt: now + 10 * 60_000,
+            addedAt: now,
+            lastUsed: now - 5_000,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored as never);
+      const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
+
+      expect(selected?.refreshToken).toBe("token-fresh");
+      expect(selected?.index).toBe(1);
     });
 
     it("falls back to least-recently-used when all accounts are rate-limited", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1903,7 +1903,11 @@ describe("AccountManager", () => {
       expect(score).toBe(100);
     });
 
-    it("recordSuccess clears stale auth failure state and persists the healed account", () => {
+    it("recordSuccess clears stale auth failure state and persists the healed account", async () => {
+      const { saveAccounts } = await import("../lib/storage.js");
+      const mockSaveAccounts = vi.mocked(saveAccounts);
+      mockSaveAccounts.mockClear();
+
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -1923,19 +1927,58 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       account.consecutiveAuthFailures = 2;
-      const saveSpy = vi
-        .spyOn(manager, "saveToDiskDebounced")
-        .mockImplementation(() => {});
 
       manager.recordSuccess(account, "codex", "gpt-5.1");
+      await manager.flushPendingSave();
 
       expect(account.consecutiveAuthFailures).toBe(0);
       expect(account.coolingDownUntil).toBeUndefined();
       expect(account.cooldownReason).toBeUndefined();
-      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+      const persisted = mockSaveAccounts.mock.calls[0]?.[0];
+      expect(persisted?.accounts[0]?.consecutiveAuthFailures ?? 0).toBe(0);
+      expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
+      expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
     });
 
-    it("recordSuccess does not clear an active cooldown from a newer concurrent failure", () => {
+    it("recordSuccess clears stale cooldown metadata when only the reason remains", async () => {
+      const { saveAccounts } = await import("../lib/storage.js");
+      const mockSaveAccounts = vi.mocked(saveAccounts);
+      mockSaveAccounts.mockClear();
+
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            addedAt: now,
+            lastUsed: now,
+            cooldownReason: "network-error" as const,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+
+      manager.recordSuccess(account, "codex", "gpt-5.1");
+      await manager.flushPendingSave();
+
+      expect(account.coolingDownUntil).toBeUndefined();
+      expect(account.cooldownReason).toBeUndefined();
+      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+      const persisted = mockSaveAccounts.mock.calls[0]?.[0];
+      expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
+      expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
+    });
+
+    it("recordSuccess does not clear an active cooldown from a newer concurrent failure", async () => {
+      const { saveAccounts } = await import("../lib/storage.js");
+      const mockSaveAccounts = vi.mocked(saveAccounts);
+      mockSaveAccounts.mockClear();
+
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -1955,16 +1998,14 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       account.consecutiveAuthFailures = 2;
-      const saveSpy = vi
-        .spyOn(manager, "saveToDiskDebounced")
-        .mockImplementation(() => {});
 
       manager.recordSuccess(account, "codex", "gpt-5.1");
+      await manager.flushPendingSave();
 
       expect(account.consecutiveAuthFailures).toBe(2);
       expect(account.coolingDownUntil).toBe(now + 60_000);
       expect(account.cooldownReason).toBe("auth-failure");
-      expect(saveSpy).not.toHaveBeenCalled();
+      expect(mockSaveAccounts).not.toHaveBeenCalled();
     });
 
     it("recordRateLimit updates health and drains token bucket", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -18,6 +18,7 @@ vi.mock("../lib/storage.js", async (importOriginal) => {
   return {
     ...actual,
     saveAccounts: vi.fn().mockResolvedValue(undefined),
+    withAccountStorageTransaction: vi.fn(),
   };
 });
 
@@ -1046,6 +1047,92 @@ describe("AccountManager", () => {
       
       expect(account.accountId).toBe("org-selected-id");
       expect(account.accountIdSource).toBe("org");
+    });
+  });
+
+  describe("commitRefreshedAuth", () => {
+    it("persists refreshed auth transactionally and updates the live account", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "old-refresh",
+            accessToken: "old-access",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+            email: "old@example.com",
+            accountId: "old-account-id",
+            accountIdSource: "token" as const,
+            enabled: false,
+            coolingDownUntil: now + 30_000,
+            cooldownReason: "auth-failure" as const,
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const account = manager.getAccountByIndex(0)!;
+      account.enabled = false;
+      manager.markAccountCoolingDown(account, 30_000, "auth-failure");
+      manager.incrementAuthFailures(account);
+
+      const payload = Buffer.from(
+        JSON.stringify({
+          email: "new@example.com",
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "new-account-id",
+          },
+        }),
+      ).toString("base64url");
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: `header.${payload}.signature`,
+        refresh: "new-refresh",
+        expires: now + 3_600_000,
+      };
+
+      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
+        const persist = vi.fn().mockResolvedValue(undefined);
+        const result = await handler(stored as any, persist);
+
+        expect(persist).toHaveBeenCalledTimes(1);
+        const persistedStorage = persist.mock.calls[0]?.[0];
+        expect(persistedStorage?.accounts[0]?.refreshToken).toBe("new-refresh");
+        expect(persistedStorage?.accounts[0]?.accessToken).toBe(
+          refreshedAuth.access,
+        );
+        expect(persistedStorage?.accounts[0]?.expiresAt).toBe(
+          refreshedAuth.expires,
+        );
+        expect(persistedStorage?.accounts[0]?.accountId).toBe("new-account-id");
+        expect(persistedStorage?.accounts[0]?.accountIdSource).toBe("token");
+        expect(persistedStorage?.accounts[0]?.email).toBe("new@example.com");
+        expect(persistedStorage?.accounts[0]?.enabled).toBeUndefined();
+        expect(persistedStorage?.accounts[0]?.coolingDownUntil).toBeUndefined();
+        expect(persistedStorage?.accounts[0]?.cooldownReason).toBeUndefined();
+
+        return result;
+      });
+
+      const updated = await manager.commitRefreshedAuth(account, refreshedAuth);
+
+      expect(updated).toBe(account);
+      expect(account.refreshToken).toBe("new-refresh");
+      expect(account.access).toBe(refreshedAuth.access);
+      expect(account.expires).toBe(refreshedAuth.expires);
+      expect(account.accountId).toBe("new-account-id");
+      expect(account.accountIdSource).toBe("token");
+      expect(account.email).toBe("new@example.com");
+      expect(account.enabled).toBe(true);
+      expect(account.coolingDownUntil).toBeUndefined();
+      expect(account.cooldownReason).toBeUndefined();
+      expect(account.consecutiveAuthFailures).toBe(0);
     });
   });
 

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1159,6 +1159,76 @@ describe("AccountManager", () => {
       expect(account.consecutiveAuthFailures).toBe(0);
     });
 
+    it("preserves unsaved live pool state when persisting refreshed auth", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        activeIndexByFamily: {
+          codex: 0,
+        },
+        accounts: [
+          {
+            refreshToken: "old-refresh-a",
+            accessToken: "old-access-a",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+            email: "a@example.com",
+          },
+          {
+            refreshToken: "old-refresh-b",
+            accessToken: "old-access-b",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+            email: "b@example.com",
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const accountA = manager.getAccountByIndex(0)!;
+      const accountB = manager.getAccountByIndex(1)!;
+      manager.markSwitched(accountB, "rotation", "codex");
+      manager.markRateLimited(accountB, 45_000, "codex");
+      manager.markAccountCoolingDown(accountB, 30_000, "network-error");
+
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: "header.payload.signature",
+        refresh: "new-refresh-a",
+        expires: now + 3_600_000,
+      };
+
+      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
+        const persist = vi.fn().mockResolvedValue(undefined);
+        const result = await handler(stored as any, persist);
+
+        expect(persist).toHaveBeenCalledTimes(1);
+        const persistedStorage = persist.mock.calls[0]?.[0];
+        expect(persistedStorage?.activeIndex).toBe(1);
+        expect(persistedStorage?.activeIndexByFamily?.codex).toBe(1);
+        expect(persistedStorage?.accounts[0]?.refreshToken).toBe("new-refresh-a");
+        expect(persistedStorage?.accounts[1]?.rateLimitResetTimes?.codex).toBeGreaterThan(
+          now,
+        );
+        expect(persistedStorage?.accounts[1]?.cooldownReason).toBe(
+          "network-error",
+        );
+        expect(persistedStorage?.accounts[1]?.coolingDownUntil).toBeGreaterThan(
+          now,
+        );
+
+        return result;
+      });
+
+      await manager.commitRefreshedAuth(accountA, refreshedAuth);
+    });
+
     it("propagates storage write failure as retryable CodexAuthError", async () => {
       const { withAccountStorageTransaction } = await import("../lib/storage.js");
       const mockWithAccountStorageTransaction = vi.mocked(

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -11,6 +11,7 @@ import {
   getAccountIdCandidates,
 } from "../lib/accounts.js";
 import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
+import { CodexAuthError } from "../lib/errors.js";
 import type { OAuthAuthDetails } from "../lib/types.js";
 
 vi.mock("../lib/storage.js", async (importOriginal) => {
@@ -20,6 +21,29 @@ vi.mock("../lib/storage.js", async (importOriginal) => {
     saveAccounts: vi.fn().mockResolvedValue(undefined),
     withAccountStorageTransaction: vi.fn(),
   };
+});
+
+beforeEach(async () => {
+  resetTrackers();
+  const { saveAccounts, withAccountStorageTransaction } = await import(
+    "../lib/storage.js"
+  );
+  const mockSaveAccounts = vi.mocked(saveAccounts);
+  const mockWithAccountStorageTransaction = vi.mocked(
+    withAccountStorageTransaction,
+  );
+
+  mockSaveAccounts.mockReset();
+  mockSaveAccounts.mockResolvedValue(undefined);
+  mockWithAccountStorageTransaction.mockReset();
+  mockWithAccountStorageTransaction.mockImplementation(async (handler) => {
+    let current = null;
+    const persist = async (storage: Parameters<typeof saveAccounts>[0]) => {
+      current = structuredClone(storage);
+      await mockSaveAccounts(storage);
+    };
+    return handler(current as never, persist);
+  });
 });
 
 describe("parseRateLimitReason", () => {
@@ -1133,6 +1157,144 @@ describe("AccountManager", () => {
       expect(account.coolingDownUntil).toBeUndefined();
       expect(account.cooldownReason).toBeUndefined();
       expect(account.consecutiveAuthFailures).toBe(0);
+    });
+
+    it("propagates storage write failure as retryable CodexAuthError", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      mockWithAccountStorageTransaction.mockRejectedValueOnce(
+        Object.assign(new Error("EBUSY"), { code: "EBUSY" }),
+      );
+
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "old-refresh",
+            accessToken: "old-access",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const account = manager.getAccountByIndex(0)!;
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: "header.payload.signature",
+        refresh: "new-refresh",
+        expires: now + 3_600_000,
+      };
+
+      const error = await manager.commitRefreshedAuth(account, refreshedAuth).catch(
+        (err) => err as CodexAuthError,
+      );
+
+      expect(error).toBeInstanceOf(CodexAuthError);
+      expect(error.retryable).toBe(true);
+      expect(account.refreshToken).toBe("old-refresh");
+    });
+
+    it("prevents debounced saves from writing stale auth during refresh persistence", async () => {
+      vi.useFakeTimers();
+      try {
+        const { saveAccounts, withAccountStorageTransaction } = await import(
+          "../lib/storage.js"
+        );
+        const mockSaveAccounts = vi.mocked(saveAccounts);
+        const mockWithAccountStorageTransaction = vi.mocked(
+          withAccountStorageTransaction,
+        );
+
+        const now = Date.now();
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            {
+              refreshToken: "old-refresh",
+              accessToken: "old-access",
+              expiresAt: now,
+              addedAt: now,
+              lastUsed: now,
+            },
+          ],
+        };
+        const manager = new AccountManager(undefined, stored as any);
+        const account = manager.getAccountByIndex(0)!;
+        const refreshedAuth: OAuthAuthDetails = {
+          type: "oauth",
+          access: "new-access",
+          refresh: "new-refresh",
+          expires: now + 3_600_000,
+        };
+
+        let storageState = structuredClone(stored) as typeof stored;
+        let lock = Promise.resolve();
+        let releasePersist!: () => void;
+        const persistBlocked = new Promise<void>((resolve) => {
+          releasePersist = resolve;
+        });
+        let notifyPersistStarted!: () => void;
+        const persistStarted = new Promise<void>((resolve) => {
+          notifyPersistStarted = resolve;
+        });
+
+        mockWithAccountStorageTransaction.mockImplementation((handler) => {
+          const run = async () => {
+            const current = structuredClone(storageState) as typeof storageState;
+            const persist = async (
+              nextStorage: Parameters<typeof saveAccounts>[0],
+            ) => {
+              if (
+                nextStorage.accounts[0]?.refreshToken === "new-refresh" &&
+                nextStorage.accounts[0]?.accessToken === "new-access"
+              ) {
+                notifyPersistStarted();
+                await persistBlocked;
+              }
+              storageState = structuredClone(nextStorage) as typeof storageState;
+              await mockSaveAccounts(nextStorage);
+            };
+            return handler(current as never, persist);
+          };
+
+          const result = lock.then(run, run);
+          lock = result.then(
+            () => undefined,
+            () => undefined,
+          );
+          return result;
+        });
+
+        const commitPromise = manager.commitRefreshedAuth(account, refreshedAuth);
+        await persistStarted;
+
+        manager.saveToDiskDebounced(0);
+        await vi.advanceTimersByTimeAsync(0);
+
+        releasePersist();
+        await commitPromise;
+        await manager.flushPendingSave();
+
+        expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
+        expect(mockSaveAccounts.mock.calls[0]?.[0]?.accounts[0]?.refreshToken).toBe(
+          "new-refresh",
+        );
+        expect(mockSaveAccounts.mock.calls[1]?.[0]?.accounts[0]?.refreshToken).toBe(
+          "new-refresh",
+        );
+        expect(mockSaveAccounts.mock.calls[1]?.[0]?.accounts[0]?.accessToken).toBe(
+          "new-access",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1270,6 +1270,47 @@ describe("AccountManager", () => {
       expect(account.refreshToken).toBe("old-refresh");
     });
 
+    it("propagates non-transient storage write failure as terminal CodexAuthError", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      mockWithAccountStorageTransaction.mockRejectedValueOnce(
+        Object.assign(new Error("EACCES"), { code: "EACCES" }),
+      );
+
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "old-refresh",
+            accessToken: "old-access",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const account = manager.getAccountByIndex(0)!;
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: "header.payload.signature",
+        refresh: "new-refresh",
+        expires: now + 3_600_000,
+      };
+
+      const error = await manager.commitRefreshedAuth(account, refreshedAuth).catch(
+        (err) => err as CodexAuthError,
+      );
+
+      expect(error).toBeInstanceOf(CodexAuthError);
+      expect(error.retryable).toBe(false);
+      expect(account.refreshToken).toBe("old-refresh");
+    });
+
     it("prevents debounced saves from writing stale auth during refresh persistence", async () => {
       vi.useFakeTimers();
       try {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1903,6 +1903,70 @@ describe("AccountManager", () => {
       expect(score).toBe(100);
     });
 
+    it("recordSuccess clears stale auth failure state and persists the healed account", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            addedAt: now,
+            lastUsed: now,
+            consecutiveAuthFailures: 2,
+            coolingDownUntil: now - 1000,
+            cooldownReason: "network-error" as const,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      account.consecutiveAuthFailures = 2;
+      const saveSpy = vi
+        .spyOn(manager, "saveToDiskDebounced")
+        .mockImplementation(() => {});
+
+      manager.recordSuccess(account, "codex", "gpt-5.1");
+
+      expect(account.consecutiveAuthFailures).toBe(0);
+      expect(account.coolingDownUntil).toBeUndefined();
+      expect(account.cooldownReason).toBeUndefined();
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("recordSuccess does not clear an active cooldown from a newer concurrent failure", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            addedAt: now,
+            lastUsed: now,
+            consecutiveAuthFailures: 2,
+            coolingDownUntil: now + 60_000,
+            cooldownReason: "auth-failure" as const,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      account.consecutiveAuthFailures = 2;
+      const saveSpy = vi
+        .spyOn(manager, "saveToDiskDebounced")
+        .mockImplementation(() => {});
+
+      manager.recordSuccess(account, "codex", "gpt-5.1");
+
+      expect(account.consecutiveAuthFailures).toBe(2);
+      expect(account.coolingDownUntil).toBe(now + 60_000);
+      expect(account.cooldownReason).toBe("auth-failure");
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
     it("recordRateLimit updates health and drains token bucket", () => {
       const now = Date.now();
       const stored = {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -9,9 +9,19 @@ import {
   formatCooldown,
   shouldUpdateAccountIdFromToken,
   getAccountIdCandidates,
+  getRuntimeTrackerKey,
 } from "../lib/accounts.js";
 import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
 import { CodexAuthError } from "../lib/errors.js";
+import {
+  clearCircuitBreakers,
+  DEFAULT_CIRCUIT_BREAKER_CONFIG,
+  getCircuitBreaker,
+} from "../lib/circuit-breaker.js";
+import {
+  getAccountIdentityKey,
+  getRuntimeAccountIdentityKey,
+} from "../lib/storage/identity.js";
 import type { OAuthAuthDetails } from "../lib/types.js";
 
 vi.mock("../lib/storage.js", async (importOriginal) => {
@@ -431,7 +441,7 @@ describe("AccountManager", () => {
     expect(account?.rateLimitResetTimes?.codex).toBeUndefined();
   });
 
-  it("prefers accounts with fresh access tokens in availability checks", () => {
+  it("does not block available accounts just because another token expires later", () => {
     const now = Date.now();
     const stored = {
       version: 3 as const,
@@ -455,7 +465,7 @@ describe("AccountManager", () => {
     };
     const manager = new AccountManager(undefined, stored);
 
-    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
+    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
     expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
   });
 
@@ -695,7 +705,7 @@ describe("AccountManager", () => {
     expect(gpt51Second?.refreshToken).toBe("token-2");
   });
 
-  it("skips a stale active account when a fresher account is available", () => {
+  it("keeps cursor ordering even when another access token lives longer", () => {
     const now = Date.now();
     const stored = {
       version: 3 as const,
@@ -722,10 +732,10 @@ describe("AccountManager", () => {
     const manager = new AccountManager(undefined, stored as never);
     const selected = manager.getCurrentOrNextForFamily("codex");
 
-    expect(selected?.refreshToken).toBe("token-fresh");
+    expect(selected?.refreshToken).toBe("token-stale");
   });
 
-  it("hybrid selection prefers active index when available", () => {
+  it("hybrid selection prefers the healthier candidate over the active index", () => {
     const now = Date.now();
     const stored = {
       version: 3 as const,
@@ -739,10 +749,9 @@ describe("AccountManager", () => {
 
     const manager = new AccountManager(undefined, stored as any);
     
-    // Even though token-1 has better freshness score, token-2 is active and available
     const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
-    expect(selected?.refreshToken).toBe("token-2");
-    expect(selected?.index).toBe(1);
+    expect(selected?.refreshToken).toBe("token-1");
+    expect(selected?.index).toBe(0);
   });
 
   describe("removeAccount", () => {
@@ -873,7 +882,7 @@ describe("AccountManager", () => {
       expect(account.rateLimitResetTimes["codex"]).toBeDefined();
     });
 
-    it("marks both base and model-specific keys", () => {
+    it("scopes token rate limits to the model-specific key", () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -887,7 +896,7 @@ describe("AccountManager", () => {
       const account = manager.getCurrentAccount()!;
       manager.markRateLimitedWithReason(account, 60000, "codex", "tokens", "gpt-5.2");
       
-      expect(account.rateLimitResetTimes["codex"]).toBeDefined();
+      expect(account.rateLimitResetTimes["codex"]).toBeUndefined();
       expect(account.rateLimitResetTimes["codex:gpt-5.2"]).toBeDefined();
     });
   });
@@ -2356,10 +2365,12 @@ describe("AccountManager", () => {
   describe("health and token tracking methods", () => {
     beforeEach(() => {
       resetTrackers();
+      clearCircuitBreakers();
     });
 
     afterEach(() => {
       resetTrackers();
+      clearCircuitBreakers();
     });
 
     it("recordSuccess updates health tracker with model-specific quotaKey", () => {
@@ -2375,10 +2386,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordSuccess(account, "codex", "gpt-5.1");
       
-      const score = healthTracker.getScore(account.index, "codex:gpt-5.1");
+      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
       expect(score).toBe(100);
     });
 
@@ -2395,11 +2407,49 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordSuccess(account, "codex", null);
       
-      const score = healthTracker.getScore(account.index, "codex");
+      const score = healthTracker.getScore(trackerKey, "codex");
       expect(score).toBe(100);
+    });
+
+    it("recordSuccess closes the circuit breaker after a half-open retry succeeds", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(0));
+
+      try {
+        const now = Date.now();
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            {
+              refreshToken: "token-1",
+              email: "breaker@example.com",
+              addedAt: now,
+              lastUsed: now,
+            },
+          ],
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getCurrentAccount()!;
+        const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
+
+        manager.recordFailure(account, "codex");
+        manager.recordFailure(account, "codex");
+        manager.recordFailure(account, "codex");
+        expect(breaker.getState()).toBe("open");
+
+        vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
+        expect(manager.consumeToken(account, "codex")).toBe(true);
+        manager.recordSuccess(account, "codex");
+        expect(breaker.getState()).toBe("closed");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("recordSuccess clears stale auth failure state and persists the healed account", async () => {
@@ -2521,11 +2571,12 @@ describe("AccountManager", () => {
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
       const tokenTracker = getTokenTracker();
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordRateLimit(account, "codex", "gpt-5.1");
       
-      const score = healthTracker.getScore(account.index, "codex:gpt-5.1");
-      const tokens = tokenTracker.getTokens(account.index, "codex:gpt-5.1");
+      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+      const tokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
       expect(score).toBeLessThan(100);
       expect(tokens).toBeLessThan(50);
     });
@@ -2543,11 +2594,58 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordRateLimit(account, "gpt-5.2");
       
-      const score = healthTracker.getScore(account.index, "gpt-5.2");
+      const score = healthTracker.getScore(trackerKey, "gpt-5.2");
       expect(score).toBeLessThan(100);
+    });
+
+    it("scopes quota rate limits to the family bucket only", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+
+      manager.markRateLimitedWithReason(
+        account,
+        60_000,
+        "codex",
+        "quota",
+        "gpt-5.1",
+      );
+
+      expect(account.rateLimitResetTimes.codex).toBeTypeOf("number");
+      expect(account.rateLimitResetTimes["codex:gpt-5.1"]).toBeUndefined();
+    });
+
+    it("scopes token rate limits to the model bucket", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+
+      manager.markRateLimitedWithReason(
+        account,
+        60_000,
+        "codex",
+        "tokens",
+        "gpt-5.1",
+      );
+
+      expect(account.rateLimitResetTimes.codex).toBeUndefined();
+      expect(account.rateLimitResetTimes["codex:gpt-5.1"]).toBeTypeOf("number");
     });
 
     it("recordFailure updates health tracker", () => {
@@ -2563,11 +2661,38 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordFailure(account, "codex", "gpt-5.2");
       
-      const score = healthTracker.getScore(account.index, "codex:gpt-5.2");
+      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.2");
       expect(score).toBeLessThan(100);
+    });
+
+    it("recordFailure opens the circuit breaker after repeated failures", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "breaker@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
+
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+
+      expect(breaker.getState()).toBe("open");
     });
 
     it("recordFailure uses family-only quotaKey when model is null", () => {
@@ -2583,10 +2708,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const healthTracker = getHealthTracker();
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
       manager.recordFailure(account, "gpt-5.1", null);
       
-      const score = healthTracker.getScore(account.index, "gpt-5.1");
+      const score = healthTracker.getScore(trackerKey, "gpt-5.1");
       expect(score).toBeLessThan(100);
     });
 
@@ -2603,10 +2729,11 @@ describe("AccountManager", () => {
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
       const tokenTracker = getTokenTracker();
+      const trackerKey = getRuntimeAccountIdentityKey(account)!;
 
-      const initialTokens = tokenTracker.getTokens(account.index, "codex:gpt-5.1");
+      const initialTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
       const result = manager.consumeToken(account, "codex", "gpt-5.1");
-      const afterTokens = tokenTracker.getTokens(account.index, "codex:gpt-5.1");
+      const afterTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
 
       expect(result).toBe(true);
       expect(afterTokens).toBeLessThan(initialTokens);
@@ -2629,15 +2756,208 @@ describe("AccountManager", () => {
 
       expect(result).toBe(true);
     });
+
+    it("consumeToken returns false and refunds the token when the circuit is open", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "breaker@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      const tokenTracker = getTokenTracker();
+      const trackerKey = getRuntimeTrackerKey(account);
+      const initialTokens = tokenTracker.getTokens(trackerKey, "codex");
+
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+      manager.recordFailure(account, "codex");
+
+      expect(manager.consumeToken(account, "codex")).toBe(false);
+      expect(tokenTracker.getTokens(trackerKey, "codex")).toBe(initialTokens);
+    });
+
+    it("consumeToken returns false and refunds when the half-open slot is exhausted", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(0));
+
+      try {
+        const now = Date.now();
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            {
+              refreshToken: "token-1",
+              email: "breaker@example.com",
+              addedAt: now,
+              lastUsed: now,
+            },
+          ],
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getCurrentAccount()!;
+        const tokenTracker = getTokenTracker();
+        const trackerKey = getRuntimeTrackerKey(account);
+        const initialTokens = tokenTracker.getTokens(trackerKey, "codex");
+
+        manager.recordFailure(account, "codex");
+        manager.recordFailure(account, "codex");
+        manager.recordFailure(account, "codex");
+
+        vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
+
+        expect(manager.consumeToken(account, "codex")).toBe(true);
+        expect(manager.consumeToken(account, "codex")).toBe(false);
+        expect(tokenTracker.getTokens(trackerKey, "codex")).toBe(initialTokens - 1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("keeps refresh-only tracker state stable when the refresh token rotates", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          { refreshToken: "token-1", addedAt: now, lastUsed: now },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getCurrentAccount()!;
+      const healthTracker = getHealthTracker();
+      const tokenTracker = getTokenTracker();
+      const trackerKey = getRuntimeTrackerKey(account);
+
+      manager.recordFailure(account, "codex", "gpt-5.1");
+      const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+      expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
+
+      account.refreshToken = "token-1-rotated";
+
+      const rotatedAccount = manager.getCurrentAccount()!;
+      expect(getRuntimeTrackerKey(rotatedAccount)).toBe(trackerKey);
+      expect(getRuntimeAccountIdentityKey(rotatedAccount)).toBe(trackerKey);
+      expect(getAccountIdentityKey(rotatedAccount)).not.toBe(`${trackerKey}`);
+      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBe(degradedScore);
+      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
+    });
+
+    it("keeps pinned runtime tracker state stable after updateFromAuth enriches identity", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          { refreshToken: "token-1", addedAt: now, lastUsed: now },
+          {
+            refreshToken: "token-2",
+            email: "healthy@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const account = manager.getAccountByIndex(0)!;
+      const healthTracker = getHealthTracker();
+      const tokenTracker = getTokenTracker();
+      const trackerKey = getRuntimeTrackerKey(account);
+
+      manager.recordFailure(account, "codex", "gpt-5.1");
+      const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+      expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
+
+      const payload = Buffer.from(JSON.stringify({
+        email: "enriched@example.com",
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "account-enriched",
+        },
+        exp: Math.floor((now + 3600000) / 1000),
+      })).toString("base64url");
+      const accessToken = `header.${payload}.signature`;
+
+      manager.updateFromAuth(account, {
+        type: "oauth",
+        access: accessToken,
+        refresh: "token-1-rotated",
+        expires: now + 3600000,
+      });
+
+      expect(account.accountId).toBe("account-enriched");
+      expect(account.email).toBe("enriched@example.com");
+      expect(getRuntimeAccountIdentityKey(account)).toBe(
+        "account:account-enriched::email:enriched@example.com",
+      );
+      expect(getRuntimeTrackerKey(account)).toBe(trackerKey);
+      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBe(degradedScore);
+      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
+    });
+
+    it("preserves tracker state when account indexes shift", () => {
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 1,
+        activeIndexByFamily: { codex: 1 },
+        accounts: [
+          {
+            refreshToken: "token-1",
+            email: "first@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+          {
+            refreshToken: "token-2",
+            email: "second@example.com",
+            addedAt: now,
+            lastUsed: now,
+          },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored as never);
+      const trackedAccount = manager.getAccountByIndex(1)!;
+      const trackerKey = getAccountIdentityKey(trackedAccount)!;
+      const healthTracker = getHealthTracker();
+      const tokenTracker = getTokenTracker();
+
+      manager.recordFailure(trackedAccount, "codex", "gpt-5.1");
+      expect(manager.consumeToken(trackedAccount, "codex", "gpt-5.1")).toBe(true);
+
+      expect(manager.removeAccountByIndex(0)).toBe(true);
+
+      const remainingAccount = manager.getAccountByIndex(0)!;
+      expect(remainingAccount.email).toBe("second@example.com");
+      expect(remainingAccount.index).toBe(0);
+      expect(getAccountIdentityKey(remainingAccount)).toBe(trackerKey);
+      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeLessThan(100);
+      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
+    });
   });
 
   describe("hybrid selection fallback path", () => {
     beforeEach(() => {
       resetTrackers();
+      clearCircuitBreakers();
     });
 
     afterEach(() => {
       resetTrackers();
+      clearCircuitBreakers();
     });
 
     it("selects alternate account when current is rate-limited via selectHybridAccount", () => {
@@ -2664,7 +2984,7 @@ describe("AccountManager", () => {
       expect(selected?.index).toBe(1);
     });
 
-    it("updates cursor and family index after hybrid selection", () => {
+    it("re-scores on the next call instead of sticking to the prior hybrid winner", () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -2686,10 +3006,11 @@ describe("AccountManager", () => {
       expect(selected).not.toBeNull();
       
       const secondCall = manager.getCurrentOrNextForFamilyHybrid("codex");
-      expect(secondCall?.index).toBe(selected?.index);
+      expect(secondCall?.index).toBe(1);
+      expect(secondCall?.index).not.toBe(selected?.index);
     });
 
-    it("prefers a fresh alternate account over a stale current account", () => {
+    it("skips accounts whose circuit breaker is open", () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -2697,27 +3018,32 @@ describe("AccountManager", () => {
         activeIndexByFamily: { codex: 0 },
         accounts: [
           {
-            refreshToken: "token-stale",
-            accessToken: "access-stale",
-            expiresAt: now + 60_000,
+            refreshToken: "token-1",
+            email: "first@example.com",
             addedAt: now,
             lastUsed: now,
           },
           {
-            refreshToken: "token-fresh",
-            accessToken: "access-fresh",
-            expiresAt: now + 10 * 60_000,
+            refreshToken: "token-2",
+            email: "second@example.com",
             addedAt: now,
-            lastUsed: now - 5_000,
+            lastUsed: now - 10_000,
           },
         ],
       };
 
       const manager = new AccountManager(undefined, stored as never);
+      const blocked = manager.getAccountByIndex(0)!;
+
+      manager.recordFailure(blocked, "codex");
+      manager.recordFailure(blocked, "codex");
+      manager.recordFailure(blocked, "codex");
+
       const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
 
-      expect(selected?.refreshToken).toBe("token-fresh");
+      expect(selected?.refreshToken).toBe("token-2");
       expect(selected?.index).toBe(1);
+      expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
     });
 
     it("falls back to least-recently-used when all accounts are rate-limited", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1229,6 +1229,59 @@ describe("AccountManager", () => {
       await manager.commitRefreshedAuth(accountA, refreshedAuth);
     });
 
+    it("keeps trimmed token accountId identical in memory and persisted storage", async () => {
+      const { withAccountStorageTransaction } = await import("../lib/storage.js");
+      const mockWithAccountStorageTransaction = vi.mocked(
+        withAccountStorageTransaction,
+      );
+      const now = Date.now();
+      const payload = Buffer.from(
+        JSON.stringify({
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "  matching-account-id  ",
+          },
+        }),
+      ).toString("base64url");
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "old-refresh",
+            accessToken: "old-access",
+            expiresAt: now,
+            addedAt: now,
+            lastUsed: now,
+            accountId: "matching-account-id",
+            accountIdSource: "token" as const,
+          },
+        ],
+      };
+      const manager = new AccountManager(undefined, stored as any);
+      const account = manager.getAccountByIndex(0)!;
+      const refreshedAuth: OAuthAuthDetails = {
+        type: "oauth",
+        access: `header.${payload}.signature`,
+        refresh: "new-refresh",
+        expires: now + 3_600_000,
+      };
+
+      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
+        const persist = vi.fn().mockResolvedValue(undefined);
+        const result = await handler(stored as any, persist);
+
+        expect(persist).toHaveBeenCalledTimes(1);
+        const persistedStorage = persist.mock.calls[0]?.[0];
+        expect(persistedStorage?.accounts[0]?.accountId).toBe("matching-account-id");
+
+        return result;
+      });
+
+      await manager.commitRefreshedAuth(account, refreshedAuth);
+
+      expect(account.accountId).toBe("matching-account-id");
+    });
+
     it("propagates storage write failure as retryable CodexAuthError", async () => {
       const { withAccountStorageTransaction } = await import("../lib/storage.js");
       const mockWithAccountStorageTransaction = vi.mocked(

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -233,4 +233,74 @@ describe("Circuit breaker", () => {
     vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1000));
     expect(breaker.getTimeUntilReset()).toBe(0);
   });
+
+  it("getTimeUntilAvailable returns remaining wait while a half-open probe slot is exhausted", () => {
+    const breaker = new CircuitBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.canExecute()).toBe(true);
+    vi.setSystemTime(
+      new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1001),
+    );
+
+    expect(breaker.getState()).toBe("half-open");
+    expect(breaker.getTimeUntilAvailable()).toBe(
+      DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs - 1000,
+    );
+  });
+
+  it("getTimeUntilAvailable stays at 0 when half-open still has probe capacity", () => {
+    const breaker = new CircuitBreaker({ halfOpenMaxAttempts: 2 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.canExecute()).toBe(true);
+
+    expect(breaker.getState()).toBe("half-open");
+    expect(breaker.getTimeUntilAvailable()).toBe(0);
+  });
+
+  it("isAvailable is false while open and true after reset timeout", () => {
+    const breaker = new CircuitBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    expect(breaker.isAvailable()).toBe(false);
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.isAvailable()).toBe(true);
+  });
+
+  it("isAvailable becomes false when half-open attempts are exhausted", () => {
+    const breaker = new CircuitBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.isAvailable()).toBe(true);
+    breaker.canExecute();
+    expect(breaker.isAvailable()).toBe(false);
+  });
+
+  it("allows a new half-open probe after the exhausted wait window elapses", () => {
+    const breaker = new CircuitBreaker();
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordFailure();
+
+    vi.setSystemTime(new Date(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1));
+    expect(breaker.canExecute()).toBe(true);
+
+    vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs);
+
+    expect(breaker.isAvailable()).toBe(true);
+    expect(breaker.getTimeUntilAvailable()).toBe(0);
+    expect(breaker.canExecute()).toBe(true);
+  });
 });

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -36,6 +36,7 @@ function createDeps(
 	return {
 		setStoragePath: vi.fn(),
 		loadAccounts: vi.fn(async () => createStorage()),
+		saveAccounts: vi.fn(async () => undefined),
 		resolveActiveIndex: vi.fn(() => 0),
 		loadQuotaCache: vi.fn(async () => ({ byAccountId: {}, byEmail: {} })),
 		saveQuotaCache: vi.fn(async () => undefined),
@@ -137,6 +138,92 @@ describe("runForecastCommand", () => {
 		expect(result).toBe(0);
 		expect(deps.logInfo).toHaveBeenCalledWith(
 			expect.stringContaining('"command": "forecast"'),
+		);
+	});
+
+	it("persists refreshed probe tokens before forecasting live quota", async () => {
+		const storage = createStorage();
+		const concurrentStorage = createStorage();
+		concurrentStorage.accounts[0] = {
+			...concurrentStorage.accounts[0],
+			currentWorkspaceIndex: 7,
+		};
+		const callLog: string[] = [];
+		let persistedStorage: AccountStorageV3 | null = null;
+		let loadCount = 0;
+		const deps = createDeps({
+			loadAccounts: vi.fn(async () => {
+				loadCount += 1;
+				return loadCount === 1
+					? storage
+					: structuredClone(concurrentStorage);
+			}),
+			saveAccounts: vi.fn(async (nextStorage) => {
+				callLog.push(
+					`save-${callLog.filter((entry) => entry.startsWith("save-")).length + 1}`,
+				);
+				if (callLog.length === 1) {
+					throw Object.assign(new Error("EBUSY write in progress"), {
+						code: "EBUSY",
+					});
+				}
+				persistedStorage = structuredClone(nextStorage);
+			}),
+			hasUsableAccessToken: vi.fn(() => false),
+			queuedRefresh: vi.fn(async () => ({
+				type: "success",
+				access: "access-forecast-updated",
+				refresh: "refresh-forecast-updated",
+				expires: 999_999,
+				idToken: "id-token-forecast-updated",
+			})),
+			extractAccountId: vi.fn(() => "account-id-updated"),
+			fetchCodexQuotaSnapshot: vi.fn(async (input) => {
+				callLog.push("fetch");
+				expect(persistedStorage?.accounts[0]?.refreshToken).toBe(
+					"refresh-forecast-updated",
+				);
+				expect(persistedStorage?.accounts[0]?.accessToken).toBe(
+					"access-forecast-updated",
+				);
+				expect(persistedStorage?.accounts[0]?.currentWorkspaceIndex).toBe(7);
+				expect(input.accessToken).toBe(
+					persistedStorage?.accounts[0]?.accessToken,
+				);
+				return {
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {},
+					secondary: {},
+				};
+			}),
+		});
+
+		const result = await runForecastCommand(["--json", "--live"], deps);
+
+		expect(result).toBe(0);
+		expect(callLog).toEqual(["save-1", "save-2", "fetch"]);
+		expect(deps.loadAccounts).toHaveBeenCalledTimes(2);
+		expect(deps.saveAccounts).toHaveBeenCalledTimes(2);
+		expect(deps.saveAccounts).toHaveBeenCalledWith(
+			expect.objectContaining({
+				accounts: [
+					expect.objectContaining({
+						refreshToken: "refresh-forecast-updated",
+						accessToken: "access-forecast-updated",
+						expiresAt: 999_999,
+						accountId: "account-id-updated",
+						accountIdSource: "token",
+						currentWorkspaceIndex: 7,
+					}),
+				],
+			}),
+		);
+		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				accountId: "account-id-updated",
+				accessToken: "access-forecast-updated",
+			}),
 		);
 	});
 

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -33,6 +33,7 @@ function createDeps(
 		setStoragePath: vi.fn(),
 		getStoragePath: vi.fn(() => "/mock/openai-codex-accounts.json"),
 		loadAccounts: vi.fn(async () => createStorage()),
+		saveAccounts: vi.fn(async () => undefined),
 		resolveActiveIndex: vi.fn(() => 0),
 		queuedRefresh: vi.fn(async () => ({
 			type: "success",
@@ -189,6 +190,109 @@ describe("runReportCommand", () => {
 			"token expired",
 		);
 		expect(jsonOutput.forecast.accounts[3]?.liveQuota?.planType).toBe("pro");
+	});
+
+	it("persists refreshed probe tokens before report live probes", async () => {
+		const storage = createStorage([
+			{
+				email: "one@example.com",
+				accountId: "acct-report",
+				accountIdSource: "org",
+				refreshToken: "refresh-token-1",
+				accessToken: "access-token-1",
+				expiresAt: 10,
+				addedAt: 1,
+				lastUsed: 1,
+				enabled: true,
+			},
+		]);
+		const concurrentStorage = createStorage([
+			{
+				email: "one@example.com",
+				accountId: "acct-report",
+				accountIdSource: "org",
+				refreshToken: "refresh-token-1",
+				accessToken: "access-token-1",
+				expiresAt: 10,
+				currentWorkspaceIndex: 5,
+				addedAt: 1,
+				lastUsed: 1,
+				enabled: true,
+			},
+		]);
+		const callLog: string[] = [];
+		let persistedStorage: AccountStorageV3 | null = null;
+		let loadCount = 0;
+		const deps = createDeps({
+			loadAccounts: vi.fn(async () => {
+				loadCount += 1;
+				return loadCount === 1 ? storage : structuredClone(concurrentStorage);
+			}),
+			saveAccounts: vi.fn(async (nextStorage) => {
+				callLog.push(
+					`save-${callLog.filter((entry) => entry.startsWith("save-")).length + 1}`,
+				);
+				if (callLog.length === 1) {
+					throw Object.assign(new Error("EPERM write blocked"), {
+						code: "EPERM",
+					});
+				}
+				persistedStorage = structuredClone(nextStorage);
+			}),
+			queuedRefresh: vi.fn(async () => ({
+				type: "success",
+				access: "access-token-updated",
+				refresh: "refresh-token-updated",
+				expires: 500,
+				idToken: "id-token-updated",
+			})),
+			fetchCodexQuotaSnapshot: vi.fn(async (input) => {
+				callLog.push("fetch");
+				expect(persistedStorage?.accounts[0]?.refreshToken).toBe(
+					"refresh-token-updated",
+				);
+				expect(persistedStorage?.accounts[0]?.accessToken).toBe(
+					"access-token-updated",
+				);
+				expect(persistedStorage?.accounts[0]?.currentWorkspaceIndex).toBe(5);
+				expect(input.accessToken).toBe(
+					persistedStorage?.accounts[0]?.accessToken,
+				);
+				return {
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {},
+					secondary: {},
+				};
+			}),
+		});
+
+		const result = await runReportCommand(["--live", "--json"], deps);
+
+		expect(result).toBe(0);
+		expect(callLog).toEqual(["save-1", "save-2", "fetch"]);
+		expect(deps.loadAccounts).toHaveBeenCalledTimes(2);
+		expect(deps.saveAccounts).toHaveBeenCalledTimes(2);
+		expect(deps.saveAccounts).toHaveBeenCalledWith(
+			expect.objectContaining({
+				accounts: [
+					expect.objectContaining({
+						refreshToken: "refresh-token-updated",
+						accessToken: "access-token-updated",
+						expiresAt: 500,
+						accountId: "acct-report",
+						accountIdSource: "org",
+						currentWorkspaceIndex: 5,
+					}),
+				],
+			}),
+		);
+		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				accountId: "acct-report",
+				accessToken: "access-token-updated",
+			}),
+		);
 	});
 
 	it("prints a human-readable report and announces the output path", async () => {

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -183,7 +183,9 @@ describe('Fetch Helpers Module', () => {
 			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'oldr', expires: 0 };
 			const client = {
 				auth: {
-					set: vi.fn().mockRejectedValue(new Error('persist failed')),
+					set: vi.fn().mockRejectedValue(
+						Object.assign(new Error('persist failed'), { code: 'EBUSY' }),
+					),
 				},
 			} as any;
 			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
@@ -198,6 +200,29 @@ describe('Fetch Helpers Module', () => {
 			);
 			expect(error).toBeInstanceOf(CodexAuthError);
 			expect(error.retryable).toBe(true);
+		});
+
+		it('throws terminal auth errors when auth persistence fails permanently', async () => {
+			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'oldr', expires: 0 };
+			const client = {
+				auth: {
+					set: vi.fn().mockRejectedValue(
+						Object.assign(new Error('persist failed'), { code: 'EACCES' }),
+					),
+				},
+			} as any;
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'success',
+				access: 'new',
+				refresh: 'newr',
+				expires: 123,
+			} as any);
+
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(false);
 		});
 	});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -86,7 +86,7 @@ describe('Fetch Helpers Module', () => {
 				(err) => err as CodexAuthError,
 			);
 			expect(error).toBeInstanceOf(CodexAuthError);
-			expect(error.retryable).toBe(true);
+			expect(error.retryable).toBe(false);
 			expect(refreshSpy).not.toHaveBeenCalled();
 		});
 
@@ -99,7 +99,7 @@ describe('Fetch Helpers Module', () => {
 				(err) => err as CodexAuthError,
 			);
 			expect(error).toBeInstanceOf(CodexAuthError);
-			expect(error.retryable).toBe(true);
+			expect(error.retryable).toBe(false);
 			expect(refreshSpy).not.toHaveBeenCalled();
 		});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -23,6 +23,7 @@ import * as loggerModule from '../lib/logger.js';
 import type { Auth } from '../lib/types.js';
 import type { CreateCodexHeadersParams } from '../lib/request/fetch-helpers.js';
 import { URL_PATHS, OPENAI_HEADERS, OPENAI_HEADER_VALUES, CODEX_BASE_URL } from '../lib/constants.js';
+import { CodexAuthError } from '../lib/errors.js';
 
 describe('Fetch Helpers Module', () => {
         afterEach(async () => {
@@ -81,7 +82,11 @@ describe('Fetch Helpers Module', () => {
 			const client = {} as any;
 			const refreshSpy = vi.spyOn(refreshQueueModule, 'queuedRefresh');
 
-			await expect(refreshAndUpdateToken(auth, client)).rejects.toThrow();
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
 			expect(refreshSpy).not.toHaveBeenCalled();
 		});
 
@@ -90,16 +95,45 @@ describe('Fetch Helpers Module', () => {
 			const client = { auth: { set: 'bad' } } as any;
 			const refreshSpy = vi.spyOn(refreshQueueModule, 'queuedRefresh');
 
-			await expect(refreshAndUpdateToken(auth, client)).rejects.toThrow();
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
 			expect(refreshSpy).not.toHaveBeenCalled();
 		});
 
-		it('throws when refresh fails', async () => {
+		it('throws retryable auth errors for transient refresh failures', async () => {
 			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'bad', expires: 0 };
 			const client = { auth: { set: vi.fn() } } as any;
-			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({ type: 'failed' } as any);
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'failed',
+				reason: 'network_error',
+				message: 'temporary network issue',
+			} as any);
 
-			await expect(refreshAndUpdateToken(auth, client)).rejects.toThrow();
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
+		});
+
+		it('throws terminal auth errors for explicit invalid-refresh responses', async () => {
+			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'bad', expires: 0 };
+			const client = { auth: { set: vi.fn() } } as any;
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'failed',
+				reason: 'http_error',
+				statusCode: 401,
+				message: 'refresh token rejected',
+			} as any);
+
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(false);
 		});
 
 		it('updates stored auth on success', async () => {
@@ -127,6 +161,27 @@ describe('Fetch Helpers Module', () => {
 			expect(updated.access).toBe('new');
 			expect(updated.refresh).toBe('newr');
 			expect(updated.expires).toBe(123);
+		});
+
+		it('throws retryable auth errors when auth persistence fails', async () => {
+			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'oldr', expires: 0 };
+			const client = {
+				auth: {
+					set: vi.fn().mockRejectedValue(new Error('persist failed')),
+				},
+			} as any;
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'success',
+				access: 'new',
+				refresh: 'newr',
+				expires: 123,
+			} as any);
+
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
 		});
 	});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -136,6 +136,22 @@ describe('Fetch Helpers Module', () => {
 			expect(error.retryable).toBe(false);
 		});
 
+		it('treats missing refresh tokens as terminal auth errors', async () => {
+			const auth: Auth = { type: 'oauth', access: 'old', refresh: '', expires: 0 };
+			const client = { auth: { set: vi.fn() } } as any;
+			vi.spyOn(refreshQueueModule, 'queuedRefresh').mockResolvedValue({
+				type: 'failed',
+				reason: 'missing_refresh',
+				message: 'missing refresh token',
+			} as any);
+
+			const error = await refreshAndUpdateToken(auth, client).catch(
+				(err) => err as CodexAuthError,
+			);
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(false);
+		});
+
 		it('updates stored auth on success', async () => {
 			const auth: Auth = { type: 'oauth', access: 'old', refresh: 'oldr', expires: 0 };
 			const client = { auth: { set: vi.fn() } } as any;

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { getAccountHealth, formatHealthReport } from "../lib/health.js";
 import { clearCircuitBreakers, getCircuitBreaker } from "../lib/circuit-breaker.js";
+import { getAccountIdentityKey } from "../lib/storage/identity.js";
 
 describe("Health check", () => {
 	beforeEach(() => {
@@ -68,13 +69,28 @@ describe("Health check", () => {
 		const accounts = [
 			{ index: 0, email: "a@test.com", accountId: "acc1", health: 100 },
 		];
-		const circuit = getCircuitBreaker("account:acc1");
+		const circuit = getCircuitBreaker(getAccountIdentityKey(accounts[0]!)!);
 		circuit.recordFailure();
 		circuit.recordFailure();
 		circuit.recordFailure();
 
 		const health = getAccountHealth(accounts);
 		expect(health.accounts[0].circuitState).toBe("open");
+	});
+
+	it("does not count circuit-open accounts as healthy", () => {
+		const accounts = [
+			{ index: 0, email: "a@test.com", accountId: "acc1", health: 100 },
+			{ index: 1, email: "b@test.com", accountId: "acc2", health: 100 },
+		];
+		const circuit = getCircuitBreaker(getAccountIdentityKey(accounts[0]!)!);
+		circuit.recordFailure();
+		circuit.recordFailure();
+		circuit.recordFailure();
+
+		const health = getAccountHealth(accounts);
+		expect(health.status).toBe("degraded");
+		expect(health.healthyAccountCount).toBe(1);
 	});
 
 	it("formats health report correctly", () => {
@@ -109,7 +125,7 @@ describe("Health check", () => {
 		const accounts = [
 			{ index: 0, email: "a@test.com", accountId: "acc1", health: 100 },
 		];
-		const circuit = getCircuitBreaker("account:acc1");
+		const circuit = getCircuitBreaker(getAccountIdentityKey(accounts[0]!)!);
 		circuit.recordFailure();
 		circuit.recordFailure();
 		circuit.recordFailure();

--- a/test/parallel-probe.test.ts
+++ b/test/parallel-probe.test.ts
@@ -1,11 +1,17 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	probeAccountsInParallel,
 	createProbeCandidates,
 	getTopCandidates,
 	type ProbeCandidate,
 } from "../lib/parallel-probe.js";
-import type { ManagedAccount } from "../lib/accounts.js";
+import {
+	AccountManager,
+	getRuntimeTrackerKey,
+	type ManagedAccount,
+} from "../lib/accounts.js";
+import { getHealthTracker, resetTrackers } from "../lib/rotation.js";
+import { getRuntimeAccountIdentityKey } from "../lib/storage/identity.js";
 
 function createMockAccount(index: number, overrides: Partial<ManagedAccount> = {}): ManagedAccount {
 	return {
@@ -19,6 +25,14 @@ function createMockAccount(index: number, overrides: Partial<ManagedAccount> = {
 }
 
 describe("parallel-probe", () => {
+	beforeEach(() => {
+		resetTrackers();
+	});
+
+	afterEach(() => {
+		resetTrackers();
+	});
+
 	describe("createProbeCandidates", () => {
 		it("creates candidates with abort controllers", () => {
 			const accounts = [createMockAccount(0), createMockAccount(1)];
@@ -259,6 +273,122 @@ describe("parallel-probe", () => {
 
 			expect(candidates).toHaveLength(2);
 			expect(candidates[0].index).toBe(1);
+		});
+
+		it("uses runtime tracker keys when ranking candidates", () => {
+			const now = Date.now();
+			const penalizedAccount = createMockAccount(0, {
+				email: "first@example.com",
+				lastUsed: now,
+			});
+			const healthyAccount = createMockAccount(1, {
+				email: "second@example.com",
+				lastUsed: now,
+			});
+			const trackerKey = getRuntimeAccountIdentityKey(penalizedAccount)!;
+			getHealthTracker().recordFailure(trackerKey, "codex");
+
+			const mockManager = {
+				getAccountsSnapshot: vi
+					.fn()
+					.mockReturnValue([penalizedAccount, healthyAccount]),
+			};
+
+			const candidates = getTopCandidates(
+				mockManager as unknown as Parameters<typeof getTopCandidates>[0],
+				"codex",
+				null,
+				2,
+			);
+
+			expect(candidates).toHaveLength(2);
+			expect(candidates[0]?.email).toBe("second@example.com");
+			expect(candidates[1]?.email).toBe("first@example.com");
+		});
+
+		it("reuses pinned tracker keys after accounts gain identity fields", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{
+						refreshToken: "token-2",
+						email: "healthy@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getAccountByIndex(0)!;
+			const pinnedTrackerKey = getRuntimeTrackerKey(account);
+			getHealthTracker().recordFailure(pinnedTrackerKey, "codex");
+
+			const payload = Buffer.from(JSON.stringify({
+				email: "enriched@example.com",
+				"https://api.openai.com/auth": {
+					chatgpt_account_id: "account-enriched",
+				},
+				exp: Math.floor((now + 3600000) / 1000),
+			})).toString("base64url");
+			const accessToken = `header.${payload}.signature`;
+
+			manager.updateFromAuth(account, {
+				type: "oauth",
+				access: accessToken,
+				refresh: "token-1-rotated",
+				expires: now + 3600000,
+			});
+
+			const candidates = getTopCandidates(manager, "codex", null, 2);
+			const enrichedCandidate = candidates.find(
+				(candidate) => candidate.refreshToken === "token-1-rotated",
+			);
+
+			expect(candidates).toHaveLength(2);
+			expect(candidates[0]?.email).toBe("healthy@example.com");
+			expect(enrichedCandidate?._runtimeTrackerKey).toBe(pinnedTrackerKey);
+		});
+
+		it("does not alias tracker state when tracker and quota keys contain delimiters", () => {
+			const now = Date.now();
+			const collidingWriter = createMockAccount(0, {
+				accountId: "one",
+				lastUsed: now,
+			});
+			const shouldStayHealthy = createMockAccount(1, {
+				accountId: "one:codex",
+				lastUsed: now,
+			});
+			const healthyPeer = createMockAccount(2, {
+				accountId: "peer",
+				lastUsed: now,
+			});
+
+			getHealthTracker().recordFailure(
+				getRuntimeTrackerKey(collidingWriter),
+				"codex:gpt-5.1:three",
+			);
+
+			const mockManager = {
+				getAccountsSnapshot: vi
+					.fn()
+					.mockReturnValue([shouldStayHealthy, healthyPeer]),
+			};
+
+			const candidates = getTopCandidates(
+				mockManager as unknown as Parameters<typeof getTopCandidates>[0],
+				"gpt-5.1",
+				"three",
+				2,
+			);
+
+			expect(candidates).toHaveLength(2);
+			expect(candidates[0]?.accountId).toBe("one:codex");
+			expect(candidates[1]?.accountId).toBe("peer");
 		});
 
 		it("supports named-parameter options form", () => {

--- a/test/proactive-refresh.test.ts
+++ b/test/proactive-refresh.test.ts
@@ -39,7 +39,10 @@ describe("proactive-refresh", () => {
 
 	describe("shouldRefreshProactively", () => {
 		it("returns false when no expiry is set", () => {
-			const account = createMockAccount({ expires: undefined });
+			const account = createMockAccount({
+				access: "test-access",
+				expires: undefined,
+			});
 			expect(shouldRefreshProactively(account)).toBe(false);
 		});
 
@@ -47,6 +50,14 @@ describe("proactive-refresh", () => {
 			const account = createMockAccount({
 				access: undefined,
 				expires: Date.now() + 600000,
+			});
+			expect(shouldRefreshProactively(account)).toBe(true);
+		});
+
+		it("returns true when access token is missing even if expiry is undefined", () => {
+			const account = createMockAccount({
+				access: undefined,
+				expires: undefined,
 			});
 			expect(shouldRefreshProactively(account)).toBe(true);
 		});
@@ -360,6 +371,47 @@ describe("proactive-refresh", () => {
 			expect(results.get(0)?.reason).toBe("success");
 			expect(results.get(1)?.reason).toBe("failed");
 		});
+
+		it("invokes onResult for each refreshed account", async () => {
+			const accounts = [
+				createMockAccount({
+					index: 0,
+					access: "access-0",
+					expires: Date.now() + 60_000,
+					refreshToken: "refresh-0",
+				}),
+				createMockAccount({
+					index: 1,
+					access: "access-1",
+					expires: Date.now() + 10 * 60 * 1000,
+					refreshToken: "refresh-1",
+				}),
+			];
+			const onResult = vi.fn();
+
+			vi.mocked(refreshQueue.queuedRefresh).mockResolvedValue({
+				type: "success" as const,
+				access: "new-access",
+				refresh: "new-refresh",
+				expires: Date.now() + 3_600_000,
+			});
+
+			const results = await refreshExpiringAccounts(
+				accounts,
+				DEFAULT_PROACTIVE_BUFFER_MS,
+				onResult,
+			);
+
+			expect(results.size).toBe(1);
+			expect(onResult).toHaveBeenCalledTimes(1);
+			expect(onResult).toHaveBeenCalledWith(
+				accounts[0],
+				expect.objectContaining({
+					refreshed: true,
+					reason: "success",
+				}),
+			);
+		});
 	});
 
 	describe("applyRefreshResult", () => {
@@ -398,6 +450,36 @@ describe("proactive-refresh", () => {
 			});
 
 			expect(account.refreshToken).toBe("same-refresh");
+		});
+
+		it("updates account identity fields from refreshed access tokens", () => {
+			const account = createMockAccount({
+				access: "old-access",
+				expires: Date.now(),
+				refreshToken: "old-refresh",
+				accountId: "old-account-id",
+				accountIdSource: "token",
+				email: "old@example.com",
+			});
+			const payload = Buffer.from(
+				JSON.stringify({
+					email: "new@example.com",
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "new-account-id",
+					},
+				}),
+			).toString("base64url");
+
+			applyRefreshResult(account, {
+				type: "success",
+				access: `header.${payload}.signature`,
+				refresh: "new-refresh",
+				expires: Date.now() + 3_600_000,
+			});
+
+			expect(account.accountId).toBe("new-account-id");
+			expect(account.accountIdSource).toBe("token");
+			expect(account.email).toBe("new@example.com");
 		});
 	});
 

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import type { AccountManager, ManagedAccount } from "../lib/accounts.js";
+import type { AccountManager, ManagedAccount, OAuthAuthDetails } from "../lib/accounts.js";
 
 const refreshExpiringAccountsMock = vi.fn();
 const applyRefreshResultMock = vi.fn();
@@ -218,14 +218,10 @@ describe("refresh-guardian", () => {
     await guardian.tick();
 
     expect(refreshExpiringAccountsMock).toHaveBeenCalledTimes(1);
-    expect(applyRefreshResultMock).toHaveBeenCalledTimes(1);
-    expect(applyRefreshResultMock).toHaveBeenCalledWith(
-      accountA,
-      expect.objectContaining({ type: "success" }),
-    );
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
     expect(
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(accountA);
+    ).not.toHaveBeenCalled();
     expect(
       manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(
@@ -346,14 +342,17 @@ describe("refresh-guardian", () => {
 
     await guardian.tick();
 
-    expect(applyRefreshResultMock).toHaveBeenCalledTimes(1);
-    expect(applyRefreshResultMock).toHaveBeenCalledWith(
-      liveB,
-      expect.objectContaining({ type: "success" }),
-    );
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
     expect(
-      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(liveB);
+      manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      originalB,
+      expect.objectContaining({
+        type: "oauth",
+        access: "access-shifted",
+        refresh: "refresh-shifted",
+      }),
+    );
   });
 
   it("classifies failure reasons and handles no-op branches", async () => {
@@ -702,10 +701,7 @@ describe("refresh-guardian", () => {
     );
 
     await expect(guardian.tick()).resolves.toBeUndefined();
-    expect(applyRefreshResultMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ refreshToken: originalA.refreshToken }),
-      expect.anything(),
-    );
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(
@@ -713,5 +709,79 @@ describe("refresh-guardian", () => {
       60_000,
       "rate-limit",
     );
+  });
+
+  it("treats commit failures as retryable network cooldowns and continues the batch", async () => {
+    const accountA = createManagedAccount(0);
+    const accountB = createManagedAccount(1);
+    const manager = createManagerMock([accountA, accountB]);
+    const commitRefreshedAuthMock = manager
+      .commitRefreshedAuth as ReturnType<typeof vi.fn>;
+    commitRefreshedAuthMock.mockImplementation(
+      async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) => {
+        if (candidate.refreshToken === accountA.refreshToken) {
+          throw Object.assign(new Error("EBUSY"), { code: "EBUSY" });
+        }
+        return manager.getAccountByIdentity(candidate, auth);
+      },
+    );
+
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-0",
+              refresh: "refresh-0-new",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+        [
+          1,
+          {
+            refreshed: true,
+            reason: "failed",
+            tokenResult: {
+              type: "failed",
+              reason: "http_error",
+              statusCode: 429,
+              message: "rate limited",
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
+    expect(commitRefreshedAuthMock).toHaveBeenCalledTimes(1);
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA, 60_000, "network-error");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB, 60_000, "rate-limit");
+    expect(
+      manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledTimes(1);
+
+    const stats = guardian.getStats();
+    expect(stats.runs).toBe(1);
+    expect(stats.refreshed).toBe(0);
+    expect(stats.failed).toBe(2);
+    expect(stats.networkFailed).toBe(1);
+    expect(stats.rateLimited).toBe(1);
   });
 });

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -20,12 +20,52 @@ function createManagedAccount(index: number): ManagedAccount {
   };
 }
 
+function findAccountByIdentity(
+  accounts: ManagedAccount[],
+  candidate: Partial<ManagedAccount>,
+): ManagedAccount | null {
+  return (
+    accounts.find((account) => {
+      if (
+        typeof candidate.index === "number" &&
+        account.index === candidate.index
+      ) {
+        return true;
+      }
+      if (
+        candidate.refreshToken &&
+        account.refreshToken === candidate.refreshToken
+      ) {
+        return true;
+      }
+      if (candidate.accountId && account.accountId === candidate.accountId) {
+        return true;
+      }
+      if (candidate.email && account.email === candidate.email) {
+        return true;
+      }
+      return false;
+    }) ?? null
+  );
+}
+
 function createManagerMock(accounts: ManagedAccount[]): AccountManager {
   return {
     getAccountsSnapshot: vi.fn(() => accounts),
     getAccountByIndex: vi.fn(
       (index: number) =>
         accounts.find((account) => account.index === index) ?? null,
+    ),
+    isAccountCoolingDown: vi.fn(
+      (account: ManagedAccount) =>
+        typeof account.coolingDownUntil === "number" &&
+        account.coolingDownUntil > Date.now(),
+    ),
+    getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
+      findAccountByIdentity(accounts, candidate),
+    ),
+    commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
+      findAccountByIdentity(accounts, candidate),
     ),
     clearAuthFailures: vi.fn(),
     markAccountCoolingDown: vi.fn(),
@@ -108,6 +148,33 @@ describe("refresh-guardian", () => {
     expect(stats.lastRunAt).not.toBeNull();
   });
 
+  it("skips accounts that are already cooling down", async () => {
+    const coolingAccount = {
+      ...createManagedAccount(0),
+      coolingDownUntil: Date.now() + 60_000,
+      cooldownReason: "auth-failure" as const,
+    };
+    const readyAccount = createManagedAccount(1);
+    const manager = createManagerMock([coolingAccount, readyAccount]);
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      intervalMs: 5_000,
+      bufferMs: 60_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(new Map());
+
+    await guardian.tick();
+
+    expect(refreshExpiringAccountsMock).toHaveBeenCalledWith(
+      [readyAccount],
+      60_000,
+      expect.any(Function),
+    );
+    expect(manager.markAccountCoolingDown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(guardian.getStats().runs).toBe(1);
+  });
+
   it("applies refresh outcomes and updates stats", async () => {
     const accountA = createManagedAccount(0);
     const accountB = createManagedAccount(1);
@@ -159,6 +226,16 @@ describe("refresh-guardian", () => {
     expect(
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountA);
+    expect(
+      manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      accountA,
+      expect.objectContaining({
+        type: "oauth",
+        access: "access-0",
+        refresh: "refresh-0-new",
+      }),
+    );
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountB, 60_000, "auth-failure");
@@ -231,6 +308,13 @@ describe("refresh-guardian", () => {
       getAccountByIndex: vi.fn(
         (index: number) =>
           [liveB, liveA].find((account) => account.index === index) ?? null,
+      ),
+      isAccountCoolingDown: vi.fn(() => false),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity([liveB, liveA], candidate),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity([liveB, liveA], candidate),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
@@ -394,6 +478,13 @@ describe("refresh-guardian", () => {
       getAccountByIndex: vi.fn(
         (index: number) =>
           liveSnapshot.find((account) => account.index === index) ?? null,
+      ),
+      isAccountCoolingDown: vi.fn(() => false),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity(liveSnapshot, candidate),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity(liveSnapshot, candidate),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
@@ -559,6 +650,13 @@ describe("refresh-guardian", () => {
       }),
       getAccountByIndex: vi.fn(
         (index: number) => liveAfterRemoval[index] ?? null,
+      ),
+      isAccountCoolingDown: vi.fn(() => false),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity(liveAfterRemoval, candidate),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
+        findAccountByIdentity(liveAfterRemoval, candidate),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -216,7 +216,7 @@ describe("refresh-guardian", () => {
     expect(tickSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves refreshed account using stable refresh token when indices shift", async () => {
+  it("resolves refreshed account by accountId when indices shift", async () => {
     const originalA = createManagedAccount(0);
     const originalB = createManagedAccount(1);
     const liveB = { ...originalB, index: 0 };
@@ -336,8 +336,73 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledWith(liveA);
   });
 
-  it("falls back to normalized email when accountId is unavailable", async () => {
-    const originalA = { ...createManagedAccount(0), accountId: undefined, email: " User0@Example.com " };
+  it("falls back to refreshToken when accountId is unavailable and email is invalid", async () => {
+    const originalA = {
+      ...createManagedAccount(0),
+      accountId: undefined,
+      email: "invalid-no-at",
+    };
+    const originalB = createManagedAccount(1);
+    const liveA = {
+      ...originalA,
+      index: 1,
+    };
+    const liveB = { ...originalB, index: 0 };
+    const snapshots = [
+      [originalA, originalB],
+      [liveB, liveA],
+    ];
+    let readCount = 0;
+    const manager = {
+      getAccountsSnapshot: vi.fn(
+        () => snapshots[Math.min(readCount++, snapshots.length - 1)],
+      ),
+      getAccountByIndex: vi.fn(
+        (index: number) =>
+          [liveB, liveA].find((account) => account.index === index) ?? null,
+      ),
+      clearAuthFailures: vi.fn(),
+      markAccountCoolingDown: vi.fn(),
+      setAccountEnabled: vi.fn(),
+      saveToDiskDebounced: vi.fn(),
+    } as unknown as AccountManager;
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-token",
+              refresh: "refresh-token",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).toHaveBeenCalledWith(
+      liveA,
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA);
+  });
+
+  it("treats empty string accountId the same as undefined by using normalized email", async () => {
+    const originalA = { ...createManagedAccount(0), accountId: "", email: " User0@Example.com " };
     const originalB = createManagedAccount(1);
     const liveA = {
       ...originalA,
@@ -642,6 +707,9 @@ describe("refresh-guardian", () => {
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
+    expect(
+      manager.getAccountsSnapshot as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledTimes(2);
 
     const stats = guardian.getStats();
     expect(stats.runs).toBe(1);

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -638,6 +638,149 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledTimes(2);
   });
 
+  it("resets auth failure streaks after network and rate-limit outcomes", async () => {
+    const accountA = createManagedAccount(0);
+    const accountB = createManagedAccount(1);
+    const manager = createManagerMock([accountA, accountB]);
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock
+      .mockResolvedValueOnce(
+        new Map([
+          [
+            0,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 401,
+                message: "expired-a",
+              },
+            },
+          ],
+          [
+            1,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 401,
+                message: "expired-b",
+              },
+            },
+          ],
+        ]),
+      )
+      .mockResolvedValueOnce(
+        new Map([
+          [
+            0,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "network_error",
+                message: "timeout-a",
+              },
+            },
+          ],
+          [
+            1,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 429,
+                message: "rate-limit-b",
+              },
+            },
+          ],
+        ]),
+      )
+      .mockResolvedValueOnce(
+        new Map([
+          [
+            0,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 401,
+                message: "expired-a-again",
+              },
+            },
+          ],
+          [
+            1,
+            {
+              refreshed: true,
+              reason: "failed",
+              tokenResult: {
+                type: "failed",
+                reason: "http_error",
+                statusCode: 401,
+                message: "expired-b-again",
+              },
+            },
+          ],
+        ]),
+      );
+
+    await guardian.tick();
+    await guardian.tick();
+    await guardian.tick();
+
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA);
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(3, accountA);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(4, accountB);
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountA, 30_000, "auth-failure");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountB, 30_000, "auth-failure");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(3, accountA, 6_000, "network-error");
+    expect(
+      manager.markRateLimited as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountB, 60_000, "codex");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(4, accountA, 30_000, "auth-failure");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(5, accountB, 30_000, "auth-failure");
+  });
+
   it("handles account removal during tick without throwing", async () => {
     const originalA = createManagedAccount(0);
     const originalB = createManagedAccount(1);

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -27,9 +27,34 @@ function createManagerMock(accounts: ManagedAccount[]): AccountManager {
       (index: number) =>
         accounts.find((account) => account.index === index) ?? null,
     ),
-    clearAuthFailures: vi.fn(),
-    markAccountCoolingDown: vi.fn(),
-    setAccountEnabled: vi.fn(),
+    clearAuthFailures: vi.fn((account: ManagedAccount) => {
+      account.consecutiveAuthFailures = 0;
+    }),
+    incrementAuthFailures: vi.fn((account: ManagedAccount) => {
+      account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+      return account.consecutiveAuthFailures;
+    }),
+    markAccountCoolingDown: vi.fn(
+      (
+        account: ManagedAccount,
+        cooldownMs: number,
+        reason: "auth-failure" | "network-error" | "rate-limit",
+      ) => {
+        account.coolingDownUntil = Date.now() + cooldownMs;
+        account.cooldownReason = reason;
+      },
+    ),
+    markRateLimited: vi.fn(
+      (account: ManagedAccount, retryAfterMs: number) => {
+        account.rateLimitResetTimes.codex = Date.now() + retryAfterMs;
+      },
+    ),
+    setAccountEnabled: vi.fn((index: number, enabled: boolean) => {
+      const account = accounts.find((candidate) => candidate.index === index);
+      if (account) {
+        account.enabled = enabled;
+      }
+    }),
     saveToDiskDebounced: vi.fn(),
   } as unknown as AccountManager;
 }
@@ -160,8 +185,11 @@ describe("refresh-guardian", () => {
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountA);
     expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountB);
+    expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(accountB, 60_000, "auth-failure");
+    ).toHaveBeenCalledWith(accountB, 30_000, "auth-failure");
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
@@ -232,8 +260,15 @@ describe("refresh-guardian", () => {
         (index: number) =>
           [liveB, liveA].find((account) => account.index === index) ?? null,
       ),
-      clearAuthFailures: vi.fn(),
+      clearAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = 0;
+      }),
+      incrementAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+        return account.consecutiveAuthFailures;
+      }),
       markAccountCoolingDown: vi.fn(),
+      markRateLimited: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
     const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
@@ -343,16 +378,19 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledWith(1, false);
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(1, accountB, 60_000, "auth-failure");
+    ).toHaveBeenNthCalledWith(1, accountB, 30_000, "auth-failure");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(2, accountC, 60_000, "rate-limit");
+    ).toHaveBeenNthCalledWith(2, accountD, 6_000, "network-error");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(3, accountD, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(3, accountE, 30_000, "auth-failure");
     expect(
-      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(4, accountE, 60_000, "auth-failure");
+      manager.markRateLimited as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountC, 60_000, "codex");
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountE);
 
     const stats = guardian.getStats();
     expect(stats.runs).toBe(1);
@@ -395,8 +433,15 @@ describe("refresh-guardian", () => {
         (index: number) =>
           liveSnapshot.find((account) => account.index === index) ?? null,
       ),
-      clearAuthFailures: vi.fn(),
+      clearAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = 0;
+      }),
+      incrementAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+        return account.consecutiveAuthFailures;
+      }),
       markAccountCoolingDown: vi.fn(),
+      markRateLimited: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -499,19 +544,25 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledTimes(5);
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(1, accountA, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(1, accountA, 6_000, "network-error");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(2, accountB, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(2, accountB, 6_000, "network-error");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(3, accountC, 60_000, "auth-failure");
+    ).toHaveBeenNthCalledWith(3, accountC, 30_000, "auth-failure");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(4, accountD, 60_000, "auth-failure");
+    ).toHaveBeenNthCalledWith(4, accountD, 30_000, "auth-failure");
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(5, accountE, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(5, accountE, 6_000, "network-error");
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, accountC);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountD);
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
@@ -545,6 +596,48 @@ describe("refresh-guardian", () => {
     expect(Reflect.get(guardian, "running")).toBe(false);
   });
 
+  it("escalates auth cooldowns across repeated guardian failures", async () => {
+    const account = createManagedAccount(0);
+    const manager = createManagerMock([account]);
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 120_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "failed",
+            tokenResult: {
+              type: "failed",
+              reason: "http_error",
+              statusCode: 401,
+              message: "expired",
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+    await vi.advanceTimersByTimeAsync(30_001);
+    await guardian.tick();
+
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(1, account, 30_000, "auth-failure");
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, account, 60_000, "auth-failure");
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledTimes(2);
+  });
+
   it("handles account removal during tick without throwing", async () => {
     const originalA = createManagedAccount(0);
     const originalB = createManagedAccount(1);
@@ -560,8 +653,15 @@ describe("refresh-guardian", () => {
       getAccountByIndex: vi.fn(
         (index: number) => liveAfterRemoval[index] ?? null,
       ),
-      clearAuthFailures: vi.fn(),
+      clearAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = 0;
+      }),
+      incrementAuthFailures: vi.fn((account: ManagedAccount) => {
+        account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+        return account.consecutiveAuthFailures;
+      }),
       markAccountCoolingDown: vi.fn(),
+      markRateLimited: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -609,11 +709,11 @@ describe("refresh-guardian", () => {
       expect.anything(),
     );
     expect(
-      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+      manager.markRateLimited as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(
       expect.objectContaining({ refreshToken: originalB.refreshToken }),
       60_000,
-      "rate-limit",
+      "codex",
     );
   });
 });

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import type { AccountManager, ManagedAccount, OAuthAuthDetails } from "../lib/accounts.js";
+import {
+  extractAccountEmail,
+  extractAccountId,
+  sanitizeEmail,
+} from "../lib/auth/token-utils.js";
+import { findMatchingAccountIndex } from "../lib/storage.js";
 
 const refreshExpiringAccountsMock = vi.fn();
 const applyRefreshResultMock = vi.fn();
 
 vi.mock("../lib/proactive-refresh.js", () => ({
-  refreshExpiringAccounts: refreshExpiringAccountsMock,
+  refreshExpiringAccounts: vi.fn(async (accounts, bufferMs, onResult) => {
+    const results = await refreshExpiringAccountsMock(accounts, bufferMs, onResult);
+    if (results instanceof Map && typeof onResult === "function") {
+      for (const [accountIndex, result] of results.entries()) {
+        const sourceAccount = accounts.find(
+          (account) => account.index === accountIndex,
+        );
+        if (!sourceAccount) {
+          continue;
+        }
+        await onResult(sourceAccount, result);
+      }
+    }
+    return results;
+  }),
   applyRefreshResult: applyRefreshResultMock,
 }));
 
@@ -23,30 +43,52 @@ function createManagedAccount(index: number): ManagedAccount {
 function findAccountByIdentity(
   accounts: ManagedAccount[],
   candidate: Partial<ManagedAccount>,
+  auth?: OAuthAuthDetails,
 ): ManagedAccount | null {
-  return (
-    accounts.find((account) => {
-      if (
-        typeof candidate.index === "number" &&
-        account.index === candidate.index
-      ) {
-        return true;
-      }
-      if (
-        candidate.refreshToken &&
-        account.refreshToken === candidate.refreshToken
-      ) {
-        return true;
-      }
-      if (candidate.accountId && account.accountId === candidate.accountId) {
-        return true;
-      }
-      if (candidate.email && account.email === candidate.email) {
-        return true;
-      }
-      return false;
-    }) ?? null
-  );
+  const derived = {
+    accountId: extractAccountId(auth?.access)?.trim() || undefined,
+    email: sanitizeEmail(extractAccountEmail(auth?.access)),
+    refreshToken: auth?.refresh,
+  };
+  const lookupCandidates = [
+    candidate,
+    {
+      accountId: candidate.accountId ?? derived.accountId,
+      email: candidate.email ?? derived.email,
+      refreshToken: candidate.refreshToken,
+    },
+    {
+      accountId: derived.accountId ?? candidate.accountId,
+      email: derived.email ?? candidate.email,
+      refreshToken: candidate.refreshToken,
+    },
+    {
+      accountId: derived.accountId ?? candidate.accountId,
+      email: derived.email ?? candidate.email,
+      refreshToken: derived.refreshToken ?? candidate.refreshToken,
+    },
+  ];
+
+  const seen = new Set<string>();
+  for (const lookupCandidate of lookupCandidates) {
+    const key = `${lookupCandidate.accountId ?? ""}|${lookupCandidate.email ?? ""}|${lookupCandidate.refreshToken ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    const matchIndex = findMatchingAccountIndex(accounts, {
+      accountId: lookupCandidate.accountId,
+      email: lookupCandidate.email,
+      refreshToken: lookupCandidate.refreshToken,
+    }, {
+      allowUniqueAccountIdFallbackWithoutEmail: true,
+    });
+    if (matchIndex !== undefined) {
+      return accounts[matchIndex] ?? null;
+    }
+  }
+
+  return null;
 }
 
 function createManagerMock(accounts: ManagedAccount[]): AccountManager {
@@ -61,11 +103,11 @@ function createManagerMock(accounts: ManagedAccount[]): AccountManager {
         typeof account.coolingDownUntil === "number" &&
         account.coolingDownUntil > Date.now(),
     ),
-    getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
-      findAccountByIdentity(accounts, candidate),
+    getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+      findAccountByIdentity(accounts, candidate, auth),
     ),
-    commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
-      findAccountByIdentity(accounts, candidate),
+    commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+      findAccountByIdentity(accounts, candidate, auth),
     ),
     clearAuthFailures: vi.fn(),
     markAccountCoolingDown: vi.fn(),
@@ -306,11 +348,11 @@ describe("refresh-guardian", () => {
           [liveB, liveA].find((account) => account.index === index) ?? null,
       ),
       isAccountCoolingDown: vi.fn(() => false),
-      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity([liveB, liveA], candidate),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity([liveB, liveA], candidate, auth),
       ),
-      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity([liveB, liveA], candidate),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity([liveB, liveA], candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
@@ -479,11 +521,11 @@ describe("refresh-guardian", () => {
           liveSnapshot.find((account) => account.index === index) ?? null,
       ),
       isAccountCoolingDown: vi.fn(() => false),
-      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity(liveSnapshot, candidate),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveSnapshot, candidate, auth),
       ),
-      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity(liveSnapshot, candidate),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveSnapshot, candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
@@ -651,11 +693,11 @@ describe("refresh-guardian", () => {
         (index: number) => liveAfterRemoval[index] ?? null,
       ),
       isAccountCoolingDown: vi.fn(() => false),
-      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity(liveAfterRemoval, candidate),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAfterRemoval, candidate, auth),
       ),
-      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>) =>
-        findAccountByIdentity(liveAfterRemoval, candidate),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAfterRemoval, candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -711,6 +711,52 @@ describe("refresh-guardian", () => {
     );
   });
 
+  it("treats null commit results as retryable network cooldowns", async () => {
+    const accountA = createManagedAccount(0);
+    const manager = createManagerMock([accountA]);
+    const commitRefreshedAuthMock = manager
+      .commitRefreshedAuth as ReturnType<typeof vi.fn>;
+    commitRefreshedAuthMock.mockResolvedValueOnce(null);
+
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-0",
+              refresh: "refresh-0-new",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).not.toHaveBeenCalled();
+    expect(commitRefreshedAuthMock).toHaveBeenCalledTimes(1);
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountA, 60_000, "network-error");
+
+    const stats = guardian.getStats();
+    expect(stats.runs).toBe(1);
+    expect(stats.refreshed).toBe(0);
+    expect(stats.failed).toBe(1);
+    expect(stats.networkFailed).toBe(1);
+  });
+
   it("treats commit failures as retryable network cooldowns and continues the batch", async () => {
     const accountA = createManagedAccount(0);
     const accountB = createManagedAccount(1);

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -12,6 +12,8 @@ vi.mock("../lib/proactive-refresh.js", () => ({
 function createManagedAccount(index: number): ManagedAccount {
   return {
     index,
+    accountId: `acct-${index}`,
+    email: `user${index}@example.com`,
     refreshToken: `refresh-${index}`,
     addedAt: Date.now() - 10_000,
     lastUsed: Date.now() - 5_000,
@@ -270,6 +272,131 @@ describe("refresh-guardian", () => {
     expect(
       manager.clearAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(liveB);
+  });
+
+  it("resolves refreshed account by accountId after refresh token rotation", async () => {
+    const originalA = createManagedAccount(0);
+    const originalB = createManagedAccount(1);
+    const liveA = {
+      ...originalA,
+      index: 1,
+      refreshToken: "refresh-0-rotated",
+    };
+    const liveB = { ...originalB, index: 0 };
+    const snapshots = [
+      [originalA, originalB],
+      [liveB, liveA],
+    ];
+    let readCount = 0;
+    const manager = {
+      getAccountsSnapshot: vi.fn(
+        () => snapshots[Math.min(readCount++, snapshots.length - 1)],
+      ),
+      getAccountByIndex: vi.fn(
+        (index: number) =>
+          [liveB, liveA].find((account) => account.index === index) ?? null,
+      ),
+      clearAuthFailures: vi.fn(),
+      markAccountCoolingDown: vi.fn(),
+      setAccountEnabled: vi.fn(),
+      saveToDiskDebounced: vi.fn(),
+    } as unknown as AccountManager;
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-account-id",
+              refresh: "refresh-account-id",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).toHaveBeenCalledWith(
+      liveA,
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA);
+  });
+
+  it("falls back to normalized email when accountId is unavailable", async () => {
+    const originalA = { ...createManagedAccount(0), accountId: undefined, email: " User0@Example.com " };
+    const originalB = createManagedAccount(1);
+    const liveA = {
+      ...originalA,
+      index: 1,
+      refreshToken: "refresh-0-rotated",
+      email: "user0@example.com",
+    };
+    const liveB = { ...originalB, index: 0 };
+    const snapshots = [
+      [originalA, originalB],
+      [liveB, liveA],
+    ];
+    let readCount = 0;
+    const manager = {
+      getAccountsSnapshot: vi.fn(
+        () => snapshots[Math.min(readCount++, snapshots.length - 1)],
+      ),
+      getAccountByIndex: vi.fn(
+        (index: number) =>
+          [liveB, liveA].find((account) => account.index === index) ?? null,
+      ),
+      clearAuthFailures: vi.fn(),
+      markAccountCoolingDown: vi.fn(),
+      setAccountEnabled: vi.fn(),
+      saveToDiskDebounced: vi.fn(),
+    } as unknown as AccountManager;
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-email",
+              refresh: "refresh-email",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(applyRefreshResultMock).toHaveBeenCalledWith(
+      liveA,
+      expect.objectContaining({ type: "success" }),
+    );
+    expect(
+      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA);
   });
 
   it("classifies failure reasons and handles no-op branches", async () => {

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import type { AccountManager, ManagedAccount, OAuthAuthDetails } from "../lib/accounts.js";
+import type { AccountManager, ManagedAccount } from "../lib/accounts.js";
 import {
   extractAccountEmail,
   extractAccountId,
   sanitizeEmail,
 } from "../lib/auth/token-utils.js";
+import { CodexAuthError } from "../lib/errors.js";
 import { findMatchingAccountIndex } from "../lib/storage.js";
+import type { OAuthAuthDetails } from "../lib/types.js";
 
 const refreshExpiringAccountsMock = vi.fn();
 const applyRefreshResultMock = vi.fn();
@@ -871,5 +873,49 @@ describe("refresh-guardian", () => {
     expect(stats.failed).toBe(2);
     expect(stats.networkFailed).toBe(1);
     expect(stats.rateLimited).toBe(1);
+  });
+
+  it("treats non-retryable commit failures as auth cooldowns", async () => {
+    const accountA = createManagedAccount(0);
+    const manager = createManagerMock([accountA]);
+    const commitRefreshedAuthMock = manager
+      .commitRefreshedAuth as ReturnType<typeof vi.fn>;
+    commitRefreshedAuthMock.mockRejectedValueOnce(
+      new CodexAuthError("refresh persistence failed", { retryable: false }),
+    );
+
+    const { RefreshGuardian } = await import("../lib/refresh-guardian.js");
+    const guardian = new RefreshGuardian(() => manager, {
+      bufferMs: 60_000,
+      intervalMs: 5_000,
+    });
+
+    refreshExpiringAccountsMock.mockResolvedValue(
+      new Map([
+        [
+          0,
+          {
+            refreshed: true,
+            reason: "success",
+            tokenResult: {
+              type: "success",
+              access: "access-0",
+              refresh: "refresh-0-new",
+              expires: Date.now() + 3_600_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    await guardian.tick();
+
+    expect(
+      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountA, 60_000, "auth-failure");
+    const stats = guardian.getStats();
+    expect(stats.failed).toBe(1);
+    expect(stats.authFailed).toBe(1);
+    expect(stats.networkFailed).toBe(0);
   });
 });

--- a/test/refresh-guardian.test.ts
+++ b/test/refresh-guardian.test.ts
@@ -135,6 +135,9 @@ function createManagerMock(accounts: ManagedAccount[]): AccountManager {
         account.rateLimitResetTimes.codex = Date.now() + retryAfterMs;
       },
     ),
+    recordSuccess: vi.fn(),
+    recordFailure: vi.fn(),
+    recordRateLimit: vi.fn(),
     setAccountEnabled: vi.fn((index: number, enabled: boolean) => {
       const account = accounts.find((candidate) => candidate.index === index);
       if (account) {
@@ -304,11 +307,17 @@ describe("refresh-guardian", () => {
       }),
     );
     expect(
+      manager.recordSuccess as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountA, "codex");
+    expect(
       manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountB);
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledWith(accountB, 30_000, "auth-failure");
+    expect(
+      manager.recordFailure as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountB, "codex");
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
@@ -445,21 +454,32 @@ describe("refresh-guardian", () => {
       refreshToken: "refresh-0-rotated",
     };
     const liveB = { ...originalB, index: 0 };
+    const liveAccounts = [liveB, liveA];
     const snapshots = [
       [originalA, originalB],
-      [liveB, liveA],
+      liveAccounts,
     ];
     let readCount = 0;
     const manager = {
       getAccountsSnapshot: vi.fn(
         () => snapshots[Math.min(readCount++, snapshots.length - 1)],
       ),
+      isAccountCoolingDown: vi.fn(() => false),
       getAccountByIndex: vi.fn(
         (index: number) =>
-          [liveB, liveA].find((account) => account.index === index) ?? null,
+          liveAccounts.find((account) => account.index === index) ?? null,
+      ),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAccounts, candidate, auth),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAccounts, candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordRateLimit: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -489,13 +509,18 @@ describe("refresh-guardian", () => {
 
     await guardian.tick();
 
-    expect(applyRefreshResultMock).toHaveBeenCalledWith(
-      liveA,
-      expect.objectContaining({ type: "success" }),
+    expect(
+      manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      originalA,
+      expect.objectContaining({
+        type: "oauth",
+        refresh: "refresh-account-id",
+      }),
     );
     expect(
-      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(liveA);
+      manager.recordSuccess as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA, "codex");
   });
 
   it("falls back to refreshToken when accountId is unavailable and email is invalid", async () => {
@@ -510,21 +535,32 @@ describe("refresh-guardian", () => {
       index: 1,
     };
     const liveB = { ...originalB, index: 0 };
+    const liveAccounts = [liveB, liveA];
     const snapshots = [
       [originalA, originalB],
-      [liveB, liveA],
+      liveAccounts,
     ];
     let readCount = 0;
     const manager = {
       getAccountsSnapshot: vi.fn(
         () => snapshots[Math.min(readCount++, snapshots.length - 1)],
       ),
+      isAccountCoolingDown: vi.fn(() => false),
       getAccountByIndex: vi.fn(
         (index: number) =>
-          [liveB, liveA].find((account) => account.index === index) ?? null,
+          liveAccounts.find((account) => account.index === index) ?? null,
+      ),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAccounts, candidate, auth),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAccounts, candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordRateLimit: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -554,13 +590,18 @@ describe("refresh-guardian", () => {
 
     await guardian.tick();
 
-    expect(applyRefreshResultMock).toHaveBeenCalledWith(
-      liveA,
-      expect.objectContaining({ type: "success" }),
+    expect(
+      manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      originalA,
+      expect.objectContaining({
+        type: "oauth",
+        refresh: "refresh-token",
+      }),
     );
     expect(
-      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(liveA);
+      manager.recordSuccess as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA, "codex");
   });
 
   it("treats empty string accountId the same as undefined by using normalized email", async () => {
@@ -573,21 +614,32 @@ describe("refresh-guardian", () => {
       email: "user0@example.com",
     };
     const liveB = { ...originalB, index: 0 };
+    const liveAccounts = [liveB, liveA];
     const snapshots = [
       [originalA, originalB],
-      [liveB, liveA],
+      liveAccounts,
     ];
     let readCount = 0;
     const manager = {
       getAccountsSnapshot: vi.fn(
         () => snapshots[Math.min(readCount++, snapshots.length - 1)],
       ),
+      isAccountCoolingDown: vi.fn(() => false),
       getAccountByIndex: vi.fn(
         (index: number) =>
-          [liveB, liveA].find((account) => account.index === index) ?? null,
+          liveAccounts.find((account) => account.index === index) ?? null,
+      ),
+      getAccountByIdentity: vi.fn((candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAccounts, candidate, auth),
+      ),
+      commitRefreshedAuth: vi.fn(async (candidate: Partial<ManagedAccount>, auth?: OAuthAuthDetails) =>
+        findAccountByIdentity(liveAccounts, candidate, auth),
       ),
       clearAuthFailures: vi.fn(),
       markAccountCoolingDown: vi.fn(),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordRateLimit: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -617,13 +669,18 @@ describe("refresh-guardian", () => {
 
     await guardian.tick();
 
-    expect(applyRefreshResultMock).toHaveBeenCalledWith(
-      liveA,
-      expect.objectContaining({ type: "success" }),
+    expect(
+      manager.commitRefreshedAuth as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      originalA,
+      expect.objectContaining({
+        type: "oauth",
+        refresh: "refresh-email",
+      }),
     );
     expect(
-      manager.clearAuthFailures as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(liveA);
+      manager.recordSuccess as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(liveA, "codex");
   });
 
   it("classifies failure reasons and handles no-op branches", async () => {
@@ -709,7 +766,10 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledWith(accountC, 60_000, "codex");
     expect(
       manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(1, accountE);
+    ).toHaveBeenNthCalledWith(1, accountB);
+    expect(
+      manager.incrementAuthFailures as ReturnType<typeof vi.fn>,
+    ).toHaveBeenNthCalledWith(2, accountE);
 
     const stats = guardian.getStats();
     expect(stats.runs).toBe(1);
@@ -768,6 +828,9 @@ describe("refresh-guardian", () => {
       }),
       markAccountCoolingDown: vi.fn(),
       markRateLimited: vi.fn(),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordRateLimit: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -894,7 +957,7 @@ describe("refresh-guardian", () => {
     ).toHaveBeenCalledTimes(1);
     expect(
       manager.getAccountsSnapshot as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledTimes(1);
 
     const stats = guardian.getStats();
     expect(stats.runs).toBe(1);
@@ -1069,7 +1132,9 @@ describe("refresh-guardian", () => {
       );
 
     await guardian.tick();
+    await vi.advanceTimersByTimeAsync(30_001);
     await guardian.tick();
+    await vi.advanceTimersByTimeAsync(60_001);
     await guardian.tick();
 
     expect(
@@ -1141,6 +1206,9 @@ describe("refresh-guardian", () => {
       }),
       markAccountCoolingDown: vi.fn(),
       markRateLimited: vi.fn(),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordRateLimit: vi.fn(),
       setAccountEnabled: vi.fn(),
       saveToDiskDebounced: vi.fn(),
     } as unknown as AccountManager;
@@ -1191,6 +1259,12 @@ describe("refresh-guardian", () => {
       60_000,
       "codex",
     );
+    expect(
+      manager.recordRateLimit as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: originalB.refreshToken }),
+      "codex",
+    );
   });
 
   it("treats null commit results as retryable network cooldowns", async () => {
@@ -1230,7 +1304,7 @@ describe("refresh-guardian", () => {
     expect(commitRefreshedAuthMock).toHaveBeenCalledTimes(1);
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(accountA, 60_000, "network-error");
+    ).toHaveBeenCalledWith(accountA, 6_000, "network-error");
 
     const stats = guardian.getStats();
     expect(stats.runs).toBe(1);
@@ -1297,10 +1371,10 @@ describe("refresh-guardian", () => {
     expect(commitRefreshedAuthMock).toHaveBeenCalledTimes(1);
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(1, accountA, 60_000, "network-error");
+    ).toHaveBeenNthCalledWith(1, accountA, 6_000, "network-error");
     expect(
-      manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenNthCalledWith(2, accountB, 60_000, "rate-limit");
+      manager.markRateLimited as ReturnType<typeof vi.fn>,
+    ).toHaveBeenCalledWith(accountB, 60_000, "codex");
     expect(
       manager.saveToDiskDebounced as ReturnType<typeof vi.fn>,
     ).toHaveBeenCalledTimes(1);
@@ -1350,7 +1424,7 @@ describe("refresh-guardian", () => {
 
     expect(
       manager.markAccountCoolingDown as ReturnType<typeof vi.fn>,
-    ).toHaveBeenCalledWith(accountA, 60_000, "auth-failure");
+    ).toHaveBeenCalledWith(accountA, 30_000, "auth-failure");
     const stats = guardian.getStats();
     expect(stats.failed).toBe(1);
     expect(stats.authFailed).toBe(1);

--- a/test/rotation.test.ts
+++ b/test/rotation.test.ts
@@ -376,6 +376,29 @@ describe("selectHybridAccount", () => {
 		expect(result?.index).toBe(1);
 	});
 
+	it("uses trackerKey when runtime state is keyed by stable identity", () => {
+		const now = Date.now();
+		const accounts: AccountWithMetrics[] = [
+			{
+				index: 0,
+				trackerKey: "email:first@example.com",
+				isAvailable: true,
+				lastUsed: now,
+			},
+			{
+				index: 1,
+				trackerKey: "email:second@example.com",
+				isAvailable: true,
+				lastUsed: now,
+			},
+		];
+
+		healthTracker.recordFailure("email:first@example.com");
+
+		const result = selectHybridAccount(accounts, healthTracker, tokenTracker);
+		expect(result?.index).toBe(1);
+	});
+
 	it("pidOffsetEnabled false does not change selection", () => {
 		const accounts: AccountWithMetrics[] = [
 			{ index: 0, isAvailable: true, lastUsed: Date.now() },

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getConfigDir, getProjectStorageKey } from "../lib/storage/paths.js";
 import { setStoragePathState } from "../lib/storage/path-state.js";
 import { getIntentionalResetMarkerPath } from "../lib/storage/backup-paths.js";
+import { getRuntimeAccountIdentityKey } from "../lib/storage/identity.js";
 import {
 	buildNamedBackupPath,
 	clearAccounts,
@@ -151,6 +152,16 @@ describe("storage", () => {
 
 			expect(identityKey).toBe(`refresh:${expectedHash}`);
 			expect(identityKey).not.toContain(refreshToken.trim());
+		});
+
+		it("uses numeric index as the runtime key for refresh-only accounts", () => {
+			expect(
+				getRuntimeAccountIdentityKey({
+					accountId: " ",
+					email: " ",
+					index: 7,
+				}),
+			).toBe(7);
 		});
 	});
 	describe("deduplication", () => {


### PR DESCRIPTION
## What Changed
- aligns `main` with the already-published `codex-multi-auth@1.2.2` release integration
- carries the validated account-pool health, refresh persistence, guardian, forecast/report, and runtime identity fixes from `release/integration-1.2.2`
- supersedes the individual main-target PR stack `#323`-`#334`

## Why
- `1.2.2` was published from the validated integration branch before the PR stack landed on `main`
- this catch-up PR makes `main` match the shipped npm package before tagging and GitHub release creation

## Validation
- `npm run clean:repo:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- --pool=threads --maxWorkers=1`
- `npm pack --dry-run`
- full suite passed: `221/221` files, `3221/3221` tests

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this catch-up pr aligns `main` with the already-published `codex-multi-auth@1.2.2` release by merging the validated `release/integration-1.2.2` branch. it carries a substantial set of correctness and reliability fixes across the account pool, token refresh path, and circuit-breaker integration.

key changes:
- **transactional refresh persistence** — `AccountManager.commitRefreshedAuth` replaces the previous fire-and-forget `updateFromAuth + clearAuthFailures + saveToDiskDebounced` triple with a single `withAccountStorageTransaction` call that rolls back live in-memory state if the disk write fails
- **circuit-breaker integration** — account selection, `consumeToken`, `recordSuccess`, and `recordFailure` all now route through the per-account circuit breaker; healthy-count requires `circuitState === "closed"`
- **runtime tracker keys** — `HealthScoreTracker` and `TokenBucketTracker` accept `string | number` tracker keys so accounts keep consistent health/token state across index reassignments
- **proactive-refresh ordering fix** — missing access token now triggers refresh before checking for a missing expiry
- **guardian hardening** — `RefreshGuardian.tick` filters cooling-down accounts, graduates auth-failure penalties by streak, delegates persistence to `commitRefreshedAuth`
- **retryable error classification** — refresh failures and auth-setter errors are classified as retryable vs non-retryable, driving different cooldown policies
- **rate-limit scoping fix** — token-level and concurrency-level failures no longer pollute the family-base quota key
- **windows filesystem safety** — `EAGAIN`/`EBUSY`/`EPERM` retries present in all new persistence paths

two p2 style notes: duplicate persistence helpers in `forecast.ts`/`report.ts`, and missing vitest coverage for the `consumeToken` open-circuit token-refund path.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are p2 style/coverage suggestions with no correctness impact

the core transactional refresh, circuit-breaker wiring, and guardian hardening all look correctly implemented; rollback on persist failure is properly scoped; the only open items are a duplicate-code extraction opportunity and one missing vitest case for the token-refund-on-open-circuit path, both p2

lib/codex-manager/commands/forecast.ts and lib/codex-manager/commands/report.ts — duplicate persistence helpers should be extracted before the two copies diverge

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.ts | replaces inline updateFromAuth+clearAuthFailures+saveToDiskDebounced triples with commitRefreshedAuth; adds retryable-refresh error branching with session-affinity forget and correct failure policy routing |
| lib/accounts.ts | large refactor: adds commitRefreshedAuth transactional write, circuit-breaker integration in consumeToken/recordSuccess/recordFailure, runtime tracker keys, and identity resolution helpers; rollback on persist failure is correctly implemented |
| lib/codex-manager/commands/forecast.ts | adds token-refresh persistence to the forecast loop with retry; helpers are functionally correct but duplicated verbatim from report.ts |
| lib/codex-manager/commands/report.ts | same refresh-persistence helpers as forecast.ts, copy-pasted; logic itself is correct |
| lib/circuit-breaker.ts | adds isAvailable(), getTimeUntilAvailable(), and half-open probe-window reset; logic looks correct and aligns with the new consumeToken usage |
| lib/refresh-guardian.ts | replaces inline applyRefreshResult with commitRefreshedAuth transaction, graduates auth-failure penalties correctly, adds eligibleSnapshot filtering to skip already-cooling accounts |
| lib/rotation.ts | generalises tracker keys from number to TrackerKey = number | string, using normalizeTrackerKey to keep map keys stable; no logic change |
| lib/request/fetch-helpers.ts | adds isRetryableRefreshFailure and isRetryableAuthSetterError to propagate retryable classification through CodexAuthError; isRetryableAuthSetterError duplicates the EAGAIN/EBUSY/EPERM logic already in accounts.ts |
| lib/health.ts | healthy-count now requires circuitState === closed, correctly excluding open/half-open accounts from the healthy pool |
| lib/storage/identity.ts | extracts getIdentityKeyFromRef to support a runtime variant (getRuntimeAccountIdentityKey) that omits the refresh-token hash fallback for in-memory tracking |
| lib/proactive-refresh.ts | fixes check ordering so a missing access token triggers refresh regardless of expiry state; adds onResult callback for guardian integration |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Plugin as index.ts
    participant AM as AccountManager
    participant ST as StorageTransaction
    participant CB as CircuitBreaker
    participant Disk as Storage

    Plugin->>AM: commitRefreshedAuth(source, auth)
    AM->>ST: acquire storage lock
    ST-->>AM: (current, persist)
    AM->>AM: buildStorageSnapshot()
    AM->>AM: findAccountIndexByIdentity()
    AM->>AM: patch storedAccount tokens and clear cooldown
    AM->>AM: getAccountByIdentity() to get liveAccount
    AM->>AM: snapshot previousLiveAccountState
    AM->>AM: updateFromAuth(liveAccount, auth)
    AM->>AM: enable liveAccount and clear auth failures
    AM->>ST: persist(nextStorage)
    ST->>Disk: writeFile accounts.json
    alt persist succeeds
        Disk-->>ST: ok
        ST-->>AM: committed
        AM->>CB: recordSuccess()
        AM-->>Plugin: liveAccount
    else persist fails
        Disk-->>ST: error
        ST-->>AM: throw
        AM->>AM: revert liveAccount to previousLiveAccountState
        AM-->>Plugin: throw CodexAuthError retryable flag set
    end
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fcodex-manager%2Fcommands%2Fforecast.ts%3A120-188%0A**duplicated%20persistence%20helpers%20across%20forecast%20and%20report**%0A%0A%60saveAccountsWithRetry%60%2C%20%60AccountIdentityMatch%60%2C%20%60RefreshedAccountPatch%60%2C%20%60applyRefreshedAccountPatch%60%2C%20and%20%60persistRefreshedAccountPatch%60%20are%20copy-pasted%20verbatim%20in%20%60lib%2Fcodex-manager%2Fcommands%2Freport.ts%60%20%28lines%20258%E2%80%93327%29.%20any%20bug%20fix%20or%20behaviour%20change%20to%20one%20must%20be%20manually%20mirrored%20in%20the%20other.%20worth%20extracting%20to%20a%20shared%20internal%20module%20%28e.g.%20%60lib%2Fcodex-manager%2Fcommands%2Frefresh-persistence.ts%60%29%20before%20these%20diverge.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Faccounts.ts%3A730-746%0A**%60consumeToken%60%20has%20no%20vitest%20coverage%20for%20the%20open-circuit%20refund%20path**%0A%0Athe%20new%20branch%20where%20a%20token%20is%20successfully%20consumed%20from%20the%20bucket%20and%20then%20refunded%20because%20%60canExecute%28%29%60%20throws%20%28%60CircuitOpenError%60%29%20is%20not%20exercised%20by%20any%20test%20in%20%60test%2Faccounts.test.ts%60%20or%20%60test%2Fcircuit-breaker.test.ts%60.%20a%20focused%20test%20%28open%20circuit%20%E2%86%92%20%60consumeToken%60%20%E2%86%92%20returns%20%60false%60%2C%20token%20bucket%20unchanged%29%20would%20lock%20down%20the%20invariant.%0A%0Aadditionally%3A%20%60canExecute%28%29%60%20increments%20%60halfOpenAttempts%60%20as%20a%20side-effect.%20calling%20%60consumeToken%60%20on%20a%20half-open%20account%20therefore%20uses%20a%20probe%20slot%20at%20token-consumption%20time%20rather%20than%20at%20request-execution%20time.%20with%20very%20low%20%60halfOpenMaxAttempts%60%20configs%20this%20could%20exhaust%20probe%20slots%20before%20any%20real%20request%20fires%20%E2%80%94%20worth%20a%20note%20in%20the%20method%20doc%20or%20a%20concurrency%20test.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager/commands/forecast.ts
Line: 120-188

Comment:
**duplicated persistence helpers across forecast and report**

`saveAccountsWithRetry`, `AccountIdentityMatch`, `RefreshedAccountPatch`, `applyRefreshedAccountPatch`, and `persistRefreshedAccountPatch` are copy-pasted verbatim in `lib/codex-manager/commands/report.ts` (lines 258–327). any bug fix or behaviour change to one must be manually mirrored in the other. worth extracting to a shared internal module (e.g. `lib/codex-manager/commands/refresh-persistence.ts`) before these diverge.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts.ts
Line: 730-746

Comment:
**`consumeToken` has no vitest coverage for the open-circuit refund path**

the new branch where a token is successfully consumed from the bucket and then refunded because `canExecute()` throws (`CircuitOpenError`) is not exercised by any test in `test/accounts.test.ts` or `test/circuit-breaker.test.ts`. a focused test (open circuit → `consumeToken` → returns `false`, token bucket unchanged) would lock down the invariant.

additionally: `canExecute()` increments `halfOpenAttempts` as a side-effect. calling `consumeToken` on a half-open account therefore uses a probe slot at token-consumption time rather than at request-execution time. with very low `halfOpenMaxAttempts` configs this could exhaust probe slots before any real request fires — worth a note in the method doc or a concurrency test.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: finalize 1.2.2 release integratio..."](https://github.com/ndycode/codex-multi-auth/commit/22db10b94e4912c9588d8c6784891708dad9205f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27032309)</sub>

<!-- /greptile_comment -->