### PR TITLE
fix config validation and flagged backup recovery

### DIFF
--- a/docs/reference/storage-paths.md
+++ b/docs/reference/storage-paths.md
@@ -21,6 +21,7 @@ Override root:
 | File | Default path |
 | --- | --- |
 | Unified settings | `~/.codex/multi-auth/settings.json` |
+| Unified settings backup | `~/.codex/multi-auth/settings.json.bak` |
 | Accounts | `~/.codex/multi-auth/openai-codex-accounts.json` |
 | Accounts backup | `~/.codex/multi-auth/openai-codex-accounts.json.bak` |
 | Accounts WAL | `~/.codex/multi-auth/openai-codex-accounts.json.wal` |
@@ -48,6 +49,8 @@ Compatibility note:
 Backup metadata:
 
 - `getBackupMetadata()` reports deterministic snapshot lists for the canonical account pool (primary, WAL, `.bak`, `.bak.1`, `.bak.2`, and discovered manual backups) and flagged-account state (primary, `.bak`, `.bak.1`, `.bak.2`, and discovered manual backups). Cache-like artifacts and `.reset-intent` markers are excluded from recovery candidates.
+- `settings.json.bak` stores the last valid unified settings snapshot before each write and is used as a recovery fallback when `settings.json` is unreadable.
+- Flagged-account backup recovery is suppressed whenever the flagged reset marker is still present, so partial clears cannot revive previously cleared flagged entries.
 
 ---
 

--- a/docs/reference/storage-paths.md
+++ b/docs/reference/storage-paths.md
@@ -52,6 +52,12 @@ Backup metadata:
 - `settings.json.bak` stores the last valid unified settings snapshot before each write and is used as a recovery fallback when `settings.json` is unreadable.
 - Flagged-account backup recovery is suppressed whenever the flagged reset marker is still present, so partial clears cannot revive previously cleared flagged entries.
 
+Upgrade note:
+
+- Restore workflows now distinguish between unreadable state and intentionally cleared state. `settings.json.bak` is only used when `settings.json` exists but cannot be read, while flagged-account backups stay suppressed whenever the reset marker survives a partial clear.
+- Operators validating a restore or clear flow should use `codex auth verify-flagged`, `codex auth fix --dry-run`, and `codex auth doctor --fix` to confirm what will be recovered, what stays cleared, and whether manual repair is still needed.
+- Maintainers validating the on-disk upgrade behavior can run `npm run build` plus `npm test -- --run test/unified-settings.test.ts test/storage-recovery-paths.test.ts test/storage-flagged.test.ts` before shipping backup or restore changes.
+
 ---
 
 ## Project-Scoped Account Paths

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -199,6 +199,11 @@ export const DEFAULT_PLUGIN_CONFIG: PluginConfig = {
 	preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
 };
 
+const PLUGIN_CONFIG_FIELD_SCHEMAS = PluginConfigSchema.shape;
+const PLUGIN_CONFIG_KEYS = Object.keys(DEFAULT_PLUGIN_CONFIG) as Array<
+	keyof PluginConfig
+>;
+
 /**
  * Return a shallow copy of the default plugin configuration.
  *
@@ -238,6 +243,10 @@ export function loadPluginConfig(): PluginConfig {
 			sourceKind = "file";
 		}
 
+		const normalizedUserConfig = sanitizePluginConfigRecord(userConfig, {
+			warnOnInvalid: true,
+		});
+
 		const hasFallbackEnvOverride =
 			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL !== undefined ||
 			process.env.CODEX_AUTH_FALLBACK_GPT53_TO_GPT52 !== undefined;
@@ -255,16 +264,9 @@ export function loadPluginConfig(): PluginConfig {
 			}
 		}
 
-		const schemaErrors = getValidationErrors(PluginConfigSchema, userConfig);
-		if (schemaErrors.length > 0) {
-			logConfigWarnOnce(
-				`Plugin config validation warnings: ${schemaErrors.slice(0, 3).join(", ")}`,
-			);
-		}
-
 		if (
 			sourceKind === "file" &&
-			isRecord(userConfig) &&
+			normalizedUserConfig !== null &&
 			(process.env.CODEX_MULTI_AUTH_CONFIG_PATH ?? "").trim().length === 0
 		) {
 			logConfigWarnOnce(
@@ -274,7 +276,7 @@ export function loadPluginConfig(): PluginConfig {
 
 		return {
 			...DEFAULT_PLUGIN_CONFIG,
-			...(userConfig as Partial<PluginConfig>),
+			...(normalizedUserConfig ?? {}),
 		};
 	} catch (error) {
 		const configPath = resolvePluginConfigPath() ?? CONFIG_PATH;
@@ -283,6 +285,62 @@ export function loadPluginConfig(): PluginConfig {
 		);
 		return { ...DEFAULT_PLUGIN_CONFIG };
 	}
+}
+
+function sanitizePluginConfigRecord(
+	data: unknown,
+	options?: { warnOnInvalid?: boolean },
+): Partial<PluginConfig> | null {
+	if (!isRecord(data)) {
+		return null;
+	}
+
+	if (options?.warnOnInvalid) {
+		const schemaErrors = getValidationErrors(PluginConfigSchema, data);
+		if (schemaErrors.length > 0) {
+			logConfigWarnOnce(
+				`Plugin config validation warnings: ${schemaErrors.slice(0, 3).join(", ")}`,
+			);
+		}
+	}
+
+	const sanitized: Record<string, unknown> = {};
+	for (const key of PLUGIN_CONFIG_KEYS) {
+		const value = data[key];
+		if (value === undefined) {
+			continue;
+		}
+		const schema = PLUGIN_CONFIG_FIELD_SCHEMAS[key];
+		const result = schema.safeParse(value);
+		if (result.success) {
+			sanitized[String(key)] = result.data;
+		}
+	}
+
+	return sanitized as Partial<PluginConfig>;
+}
+
+function sanitizeStoredPluginConfigRecord(
+	data: unknown,
+): Record<string, unknown> {
+	if (!isRecord(data)) {
+		return {};
+	}
+
+	const sanitized: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(data)) {
+		if (!PLUGIN_CONFIG_KEYS.includes(key as keyof PluginConfig)) {
+			sanitized[key] = value;
+			continue;
+		}
+		const schema = PLUGIN_CONFIG_FIELD_SCHEMAS[key as keyof PluginConfig];
+		const result = schema.safeParse(value);
+		if (result.success) {
+			sanitized[key] = result.data;
+		}
+	}
+
+	return sanitized;
 }
 
 /**
@@ -443,7 +501,8 @@ function resolveStoredPluginConfigRecord(): {
 function sanitizePluginConfigForSave(
 	config: Partial<PluginConfig>,
 ): Record<string, unknown> {
-	const entries = Object.entries(config as Record<string, unknown>);
+	const normalized = sanitizePluginConfigRecord(config as Record<string, unknown>);
+	const entries = Object.entries((normalized ?? {}) as Record<string, unknown>);
 	const sanitized: Record<string, unknown> = {};
 	for (const [key, value] of entries) {
 		if (value === undefined) continue;
@@ -478,8 +537,11 @@ export async function savePluginConfig(
 
 	if (envPath.length > 0) {
 		await withConfigSaveLock(envPath, async () => {
+			const existingConfig = sanitizeStoredPluginConfigRecord(
+				readConfigRecordFromPath(envPath),
+			);
 			const merged = {
-				...(readConfigRecordFromPath(envPath) ?? {}),
+				...(existingConfig ?? {}),
 				...sanitizedPatch,
 			};
 			await writeJsonFileAtomicWithRetry(envPath, merged);
@@ -489,11 +551,16 @@ export async function savePluginConfig(
 
 	const unifiedPath = getUnifiedSettingsPath();
 	await withConfigSaveLock(unifiedPath, async () => {
-		const unifiedConfig = loadUnifiedPluginConfigSync();
+		const unifiedConfig = sanitizeStoredPluginConfigRecord(
+			loadUnifiedPluginConfigSync(),
+		);
 		const legacyPath = unifiedConfig ? null : resolvePluginConfigPath();
+		const legacyConfig = legacyPath
+			? sanitizeStoredPluginConfigRecord(readConfigRecordFromPath(legacyPath))
+			: null;
 		const merged = {
 			...(unifiedConfig ??
-				(legacyPath ? readConfigRecordFromPath(legacyPath) : null) ??
+				legacyConfig ??
 				{}),
 			...sanitizedPatch,
 		};
@@ -510,12 +577,30 @@ export async function savePluginConfig(
  */
 function parseBooleanEnv(value: string | undefined): boolean | undefined {
 	if (value === undefined) return undefined;
-	return value === "1";
+	const normalized = value.trim().toLowerCase();
+	if (normalized.length === 0) return undefined;
+	if (
+		normalized === "1" ||
+		normalized === "true" ||
+		normalized === "yes"
+	) {
+		return true;
+	}
+	if (
+		normalized === "0" ||
+		normalized === "false" ||
+		normalized === "no"
+	) {
+		return false;
+	}
+	return undefined;
 }
 
 function parseNumberEnv(value: string | undefined): number | undefined {
 	if (value === undefined) return undefined;
-	const parsed = Number(value);
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return undefined;
+	const parsed = Number(trimmed);
 	if (!Number.isFinite(parsed)) return undefined;
 	return parsed;
 }
@@ -544,7 +629,13 @@ function resolveBooleanSetting(
 	configValue: boolean | undefined,
 	defaultValue: boolean,
 ): boolean {
-	const envValue = parseBooleanEnv(process.env[envName]);
+	const rawEnvValue = process.env[envName];
+	const envValue = parseBooleanEnv(rawEnvValue);
+	if (rawEnvValue !== undefined && envValue === undefined) {
+		logConfigWarnOnce(
+			`Ignoring invalid boolean env ${envName}=${JSON.stringify(rawEnvValue)}. Expected 0/1, true/false, or yes/no.`,
+		);
+	}
 	if (envValue !== undefined) return envValue;
 	return configValue ?? defaultValue;
 }
@@ -566,7 +657,13 @@ function resolveNumberSetting(
 	defaultValue: number,
 	options?: { min?: number; max?: number },
 ): number {
-	const envValue = parseNumberEnv(process.env[envName]);
+	const rawEnvValue = process.env[envName];
+	const envValue = parseNumberEnv(rawEnvValue);
+	if (rawEnvValue !== undefined && envValue === undefined) {
+		logConfigWarnOnce(
+			`Ignoring invalid numeric env ${envName}=${JSON.stringify(rawEnvValue)}. Expected a finite number.`,
+		);
+	}
 	const candidate = envValue ?? configValue ?? defaultValue;
 	const min = options?.min ?? Number.NEGATIVE_INFINITY;
 	const max = options?.max ?? Number.POSITIVE_INFINITY;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -320,11 +320,18 @@ function sanitizePluginConfigRecord(
 	return sanitized as Partial<PluginConfig>;
 }
 
+/**
+ * Sanitize a stored plugin-config record while preserving unknown keys.
+ *
+ * Known plugin-config keys are schema-validated before they are merged back
+ * into runtime state. Unknown keys are kept so legacy and forward-compatible
+ * settings survive env-path saves.
+ */
 function sanitizeStoredPluginConfigRecord(
 	data: unknown,
-): Record<string, unknown> {
+): Record<string, unknown> | null {
 	if (!isRecord(data)) {
-		return {};
+		return null;
 	}
 
 	const sanitized: Record<string, unknown> = {};
@@ -551,10 +558,11 @@ export async function savePluginConfig(
 
 	const unifiedPath = getUnifiedSettingsPath();
 	await withConfigSaveLock(unifiedPath, async () => {
+		const unifiedConfigRecord = loadUnifiedPluginConfigSync();
 		const unifiedConfig = sanitizeStoredPluginConfigRecord(
-			loadUnifiedPluginConfigSync(),
+			unifiedConfigRecord,
 		);
-		const legacyPath = unifiedConfig ? null : resolvePluginConfigPath();
+		const legacyPath = unifiedConfigRecord ? null : resolvePluginConfigPath();
 		const legacyConfig = legacyPath
 			? sanitizeStoredPluginConfigRecord(readConfigRecordFromPath(legacyPath))
 			: null;
@@ -631,7 +639,11 @@ function resolveBooleanSetting(
 ): boolean {
 	const rawEnvValue = process.env[envName];
 	const envValue = parseBooleanEnv(rawEnvValue);
-	if (rawEnvValue !== undefined && envValue === undefined) {
+	if (
+		rawEnvValue !== undefined &&
+		rawEnvValue.trim().length > 0 &&
+		envValue === undefined
+	) {
 		logConfigWarnOnce(
 			`Ignoring invalid boolean env ${envName}=${JSON.stringify(rawEnvValue)}. Expected 0/1, true/false, or yes/no.`,
 		);
@@ -659,7 +671,11 @@ function resolveNumberSetting(
 ): number {
 	const rawEnvValue = process.env[envName];
 	const envValue = parseNumberEnv(rawEnvValue);
-	if (rawEnvValue !== undefined && envValue === undefined) {
+	if (
+		rawEnvValue !== undefined &&
+		rawEnvValue.trim().length > 0 &&
+		envValue === undefined
+	) {
 		logConfigWarnOnce(
 			`Ignoring invalid numeric env ${envName}=${JSON.stringify(rawEnvValue)}. Expected a finite number.`,
 		);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -41,6 +41,13 @@ const UNSUPPORTED_CODEX_POLICIES = new Set(["strict", "fallback"]);
 const emittedConfigWarnings = new Set<string>();
 const configSaveQueues = new Map<string, Promise<void>>();
 const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+const RETRYABLE_CONFIG_READ_CODES = new Set(["EBUSY", "EPERM", "EAGAIN"]);
+
+type ConfigReadState =
+	| { status: "missing" }
+	| { status: "ok"; record: Record<string, unknown> }
+	| { status: "invalid"; errorMessage: string }
+	| { status: "unreadable"; errorMessage: string };
 
 export type UnsupportedCodexPolicy = "strict" | "fallback";
 
@@ -456,6 +463,53 @@ function readConfigRecordFromPath(
 	}
 }
 
+async function readConfigRecordForSave(
+	configPath: string,
+): Promise<ConfigReadState> {
+	if (!existsSync(configPath)) {
+		return { status: "missing" };
+	}
+
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			const fileContent = await fs.readFile(configPath, "utf-8");
+			const normalizedFileContent = stripUtf8Bom(fileContent);
+			const parsed = JSON.parse(normalizedFileContent) as unknown;
+			if (!isRecord(parsed)) {
+				const errorMessage = `Config at ${configPath} must contain a JSON object at the root.`;
+				logConfigWarnOnce(errorMessage);
+				return { status: "invalid", errorMessage };
+			}
+			return { status: "ok", record: parsed };
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException | undefined)?.code;
+			if (code === "ENOENT") {
+				return { status: "missing" };
+			}
+			if (
+				typeof code === "string" &&
+				RETRYABLE_CONFIG_READ_CODES.has(code) &&
+				attempt < 4
+			) {
+				await sleep(10 * 2 ** attempt);
+				continue;
+			}
+			const errorMessage = `Failed to read config from ${configPath}: ${
+				error instanceof Error ? error.message : String(error)
+			}`;
+			logConfigWarnOnce(errorMessage);
+			if (typeof code === "string" && RETRYABLE_CONFIG_READ_CODES.has(code)) {
+				return { status: "unreadable", errorMessage };
+			}
+			return { status: "invalid", errorMessage };
+		}
+	}
+
+	const errorMessage = `Failed to read config from ${configPath}.`;
+	logConfigWarnOnce(errorMessage);
+	return { status: "unreadable", errorMessage };
+}
+
 function resolveStoredPluginConfigRecord(): {
 	configPath: string | null;
 	storageKind: ConfigExplainStorageKind;
@@ -507,10 +561,17 @@ function resolveStoredPluginConfigRecord(): {
  */
 function sanitizePluginConfigForSave(
 	config: Partial<PluginConfig>,
-): Record<string, unknown> {
+	): { sanitized: Record<string, unknown>; droppedKeys: string[] } {
 	const normalized = sanitizePluginConfigRecord(config as Record<string, unknown>);
 	const entries = Object.entries((normalized ?? {}) as Record<string, unknown>);
 	const sanitized: Record<string, unknown> = {};
+	const inputRecord = isRecord(config) ? config : {};
+	const droppedKeys = PLUGIN_CONFIG_KEYS.filter((key) => {
+		if (!(key in inputRecord) || inputRecord[key] === undefined) {
+			return false;
+		}
+		return !(key in (normalized ?? {}));
+	});
 	for (const [key, value] of entries) {
 		if (value === undefined) continue;
 		if (typeof value === "number" && !Number.isFinite(value)) continue;
@@ -520,7 +581,7 @@ function sanitizePluginConfigForSave(
 		}
 		sanitized[key] = value;
 	}
-	return sanitized;
+	return { sanitized, droppedKeys };
 }
 
 /**
@@ -539,14 +600,27 @@ function sanitizePluginConfigForSave(
 export async function savePluginConfig(
 	configPatch: Partial<PluginConfig>,
 ): Promise<void> {
-	const sanitizedPatch = sanitizePluginConfigForSave(configPatch);
+	const { sanitized: sanitizedPatch, droppedKeys } =
+		sanitizePluginConfigForSave(configPatch);
+	if (droppedKeys.length > 0) {
+		logConfigWarnOnce(
+			`Ignoring invalid plugin config field(s): ${droppedKeys.join(", ")}.`,
+		);
+	}
 	const envPath = (process.env.CODEX_MULTI_AUTH_CONFIG_PATH ?? "").trim();
 
 	if (envPath.length > 0) {
 		await withConfigSaveLock(envPath, async () => {
-			const existingConfig = sanitizeStoredPluginConfigRecord(
-				readConfigRecordFromPath(envPath),
-			);
+			const envConfigState = await readConfigRecordForSave(envPath);
+			if (envConfigState.status === "unreadable") {
+				throw new Error(
+					`Aborting config save because ${envPath} is unreadable.`,
+				);
+			}
+			const existingConfig =
+				envConfigState.status === "ok"
+					? sanitizeStoredPluginConfigRecord(envConfigState.record)
+					: null;
 			const merged = {
 				...(existingConfig ?? {}),
 				...sanitizedPatch,
@@ -558,14 +632,34 @@ export async function savePluginConfig(
 
 	const unifiedPath = getUnifiedSettingsPath();
 	await withConfigSaveLock(unifiedPath, async () => {
-		const unifiedConfigRecord = loadUnifiedPluginConfigSync();
-		const unifiedConfig = sanitizeStoredPluginConfigRecord(
-			unifiedConfigRecord,
-		);
-		const legacyPath = unifiedConfigRecord ? null : resolvePluginConfigPath();
-		const legacyConfig = legacyPath
-			? sanitizeStoredPluginConfigRecord(readConfigRecordFromPath(legacyPath))
+		const unifiedConfigState = await readConfigRecordForSave(unifiedPath);
+		if (unifiedConfigState.status === "unreadable") {
+			throw new Error(
+				`Aborting config save because ${unifiedPath} is unreadable.`,
+			);
+		}
+		const unifiedConfigRecord =
+			unifiedConfigState.status === "ok"
+				? unifiedConfigState.record.pluginConfig
+				: loadUnifiedPluginConfigSync();
+		const unifiedConfig = sanitizeStoredPluginConfigRecord(unifiedConfigRecord);
+		const legacyPath =
+			unifiedConfigState.status === "missing" ||
+			(unifiedConfigState.status === "ok" && !unifiedConfig)
+				? resolvePluginConfigPath()
+				: null;
+		const legacyConfigState = legacyPath
+			? await readConfigRecordForSave(legacyPath)
 			: null;
+		if (legacyConfigState?.status === "unreadable") {
+			throw new Error(
+				`Aborting config save because ${legacyPath} is unreadable.`,
+			);
+		}
+		const legacyConfig =
+			legacyConfigState?.status === "ok"
+				? sanitizeStoredPluginConfigRecord(legacyConfigState.record)
+				: null;
 		const merged = {
 			...(unifiedConfig ??
 				legacyConfig ??

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -645,7 +645,7 @@ function resolveBooleanSetting(
 		envValue === undefined
 	) {
 		logConfigWarnOnce(
-			`Ignoring invalid boolean env ${envName}=${JSON.stringify(rawEnvValue)}. Expected 0/1, true/false, or yes/no.`,
+			`Ignoring invalid boolean env ${envName}. Expected 0/1, true/false, or yes/no.`,
 		);
 	}
 	if (envValue !== undefined) return envValue;
@@ -677,7 +677,7 @@ function resolveNumberSetting(
 		envValue === undefined
 	) {
 		logConfigWarnOnce(
-			`Ignoring invalid numeric env ${envName}=${JSON.stringify(rawEnvValue)}. Expected a finite number.`,
+			`Ignoring invalid numeric env ${envName}. Expected a finite number.`,
 		);
 	}
 	const candidate = envValue ?? configValue ?? defaultValue;

--- a/lib/storage/flagged-storage-io.ts
+++ b/lib/storage/flagged-storage-io.ts
@@ -2,11 +2,35 @@ import { existsSync, promises as fs } from "node:fs";
 import { dirname } from "node:path";
 import type { FlaggedAccountStorageV1 } from "../storage.js";
 
+const RETRYABLE_UNLINK_CODES = new Set(["EBUSY", "EAGAIN", "EPERM"]);
+
 /**
  * Return the ordered backup paths consulted for flagged-account recovery.
  */
 function getFlaggedBackupPaths(path: string): string[] {
 	return [`${path}.bak`, `${path}.bak.1`, `${path}.bak.2`];
+}
+
+async function unlinkWithRetry(candidatePath: string): Promise<void> {
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await fs.unlink(candidatePath);
+			return;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code === "ENOENT") {
+				return;
+			}
+			if (
+				!code ||
+				!RETRYABLE_UNLINK_CODES.has(code) ||
+				attempt >= 4
+			) {
+				throw error;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 10 * 2 ** attempt));
+		}
+	}
 }
 
 export async function loadFlaggedAccountsState(params: {
@@ -191,7 +215,7 @@ export async function clearFlaggedAccountsOnDisk(params: {
 		...params.backupPaths,
 	]) {
 		try {
-			await fs.unlink(candidate);
+			await unlinkWithRetry(candidate);
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code !== "ENOENT") {
@@ -208,7 +232,7 @@ export async function clearFlaggedAccountsOnDisk(params: {
 	}
 	if (!keepResetMarker) {
 		try {
-			await fs.unlink(params.markerPath);
+			await unlinkWithRetry(params.markerPath);
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
 			if (code !== "ENOENT") {

--- a/lib/storage/flagged-storage-io.ts
+++ b/lib/storage/flagged-storage-io.ts
@@ -2,6 +2,9 @@ import { existsSync, promises as fs } from "node:fs";
 import { dirname } from "node:path";
 import type { FlaggedAccountStorageV1 } from "../storage.js";
 
+/**
+ * Return the ordered backup paths consulted for flagged-account recovery.
+ */
 function getFlaggedBackupPaths(path: string): string[] {
 	return [`${path}.bak`, `${path}.bak.1`, `${path}.bak.2`];
 }
@@ -28,6 +31,9 @@ export async function loadFlaggedAccountsState(params: {
 				const backupContent = await fs.readFile(backupPath, "utf-8");
 				const backupData = JSON.parse(backupContent) as unknown;
 				const recovered = params.normalizeFlaggedStorage(backupData);
+				if (existsSync(params.resetMarkerPath)) {
+					return empty;
+				}
 				params.logInfo("Recovered flagged account storage from backup", {
 					from: backupPath,
 					to: params.path,

--- a/lib/storage/flagged-storage-io.ts
+++ b/lib/storage/flagged-storage-io.ts
@@ -2,6 +2,10 @@ import { existsSync, promises as fs } from "node:fs";
 import { dirname } from "node:path";
 import type { FlaggedAccountStorageV1 } from "../storage.js";
 
+function getFlaggedBackupPaths(path: string): string[] {
+	return [`${path}.bak`, `${path}.bak.1`, `${path}.bak.2`];
+}
+
 export async function loadFlaggedAccountsState(params: {
 	path: string;
 	legacyPath: string;
@@ -12,6 +16,34 @@ export async function loadFlaggedAccountsState(params: {
 	logInfo: (message: string, details: Record<string, unknown>) => void;
 }): Promise<FlaggedAccountStorageV1> {
 	const empty: FlaggedAccountStorageV1 = { version: 1, accounts: [] };
+	if (existsSync(params.resetMarkerPath)) {
+		return empty;
+	}
+	const loadFlaggedBackup = async (): Promise<FlaggedAccountStorageV1 | null> => {
+		for (const backupPath of getFlaggedBackupPaths(params.path)) {
+			if (!existsSync(backupPath)) {
+				continue;
+			}
+			try {
+				const backupContent = await fs.readFile(backupPath, "utf-8");
+				const backupData = JSON.parse(backupContent) as unknown;
+				const recovered = params.normalizeFlaggedStorage(backupData);
+				params.logInfo("Recovered flagged account storage from backup", {
+					from: backupPath,
+					to: params.path,
+					accounts: recovered.accounts.length,
+				});
+				return recovered;
+			} catch (backupError) {
+				params.logError("Failed to recover flagged account storage from backup", {
+					from: backupPath,
+					to: params.path,
+					error: String(backupError),
+				});
+			}
+		}
+		return null;
+	};
 
 	try {
 		const content = await fs.readFile(params.path, "utf-8");
@@ -28,8 +60,13 @@ export async function loadFlaggedAccountsState(params: {
 				path: params.path,
 				error: String(error),
 			});
-			return empty;
+			return (await loadFlaggedBackup()) ?? empty;
 		}
+	}
+
+	const recoveredBackup = await loadFlaggedBackup();
+	if (recoveredBackup) {
+		return recoveredBackup;
 	}
 
 	if (!existsSync(params.legacyPath)) {
@@ -129,6 +166,7 @@ export async function clearFlaggedAccountsOnDisk(params: {
 	backupPaths: string[];
 	logError: (message: string, details: Record<string, unknown>) => void;
 }): Promise<void> {
+	let keepResetMarker = false;
 	try {
 		await fs.writeFile(params.markerPath, "reset", {
 			encoding: "utf-8",
@@ -145,7 +183,6 @@ export async function clearFlaggedAccountsOnDisk(params: {
 	for (const candidate of [
 		params.path,
 		...params.backupPaths,
-		params.markerPath,
 	]) {
 		try {
 			await fs.unlink(candidate);
@@ -159,6 +196,21 @@ export async function clearFlaggedAccountsOnDisk(params: {
 				if (candidate === params.path) {
 					throw error;
 				}
+				keepResetMarker = true;
+			}
+		}
+	}
+	if (!keepResetMarker) {
+		try {
+			await fs.unlink(params.markerPath);
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code !== "ENOENT") {
+				params.logError("Failed to clear flagged account storage", {
+					path: params.markerPath,
+					error: String(error),
+				});
+				throw error;
 			}
 		}
 	}

--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -71,6 +71,22 @@ async function readSettingsRecordAsyncFromPath(
 	return parseSettingsRecord(await fs.readFile(filePath, "utf8"));
 }
 
+function readSettingsBackupSync(): JsonRecord | null {
+	try {
+		return readSettingsRecordSyncFromPath(UNIFIED_SETTINGS_BACKUP_PATH);
+	} catch {
+		return null;
+	}
+}
+
+async function readSettingsBackupAsync(): Promise<JsonRecord | null> {
+	try {
+		return await readSettingsRecordAsyncFromPath(UNIFIED_SETTINGS_BACKUP_PATH);
+	} catch {
+		return null;
+	}
+}
+
 function trySnapshotUnifiedSettingsBackupSync(): void {
 	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
 		return;
@@ -122,16 +138,14 @@ function readSettingsRecordSync(): JsonRecord | null {
 			return primaryRecord;
 		}
 	} catch (error) {
-		const backupRecord = readSettingsRecordSyncFromPath(
-			UNIFIED_SETTINGS_BACKUP_PATH,
-		);
+		const backupRecord = readSettingsBackupSync();
 		if (backupRecord) {
 			return backupRecord;
 		}
 		throw error;
 	}
 
-	return readSettingsRecordSyncFromPath(UNIFIED_SETTINGS_BACKUP_PATH);
+	return readSettingsBackupSync();
 }
 
 /**
@@ -150,16 +164,14 @@ async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
 			return primaryRecord;
 		}
 	} catch (error) {
-		const backupRecord = await readSettingsRecordAsyncFromPath(
-			UNIFIED_SETTINGS_BACKUP_PATH,
-		);
+		const backupRecord = await readSettingsBackupAsync();
 		if (backupRecord) {
 			return backupRecord;
 		}
 		throw error;
 	}
 
-	return readSettingsRecordAsyncFromPath(UNIFIED_SETTINGS_BACKUP_PATH);
+	return readSettingsBackupAsync();
 }
 
 /**

--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -21,7 +21,11 @@ const UNIFIED_SETTINGS_BACKUP_PATH = `${UNIFIED_SETTINGS_PATH}.bak`;
 const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
 const TRANSIENT_READ_FS_CODES = new Set(["EBUSY", "EAGAIN"]);
 let settingsWriteQueue: Promise<void> = Promise.resolve();
-let backupDerivedReadPending = false;
+
+type SettingsReadResult = {
+	record: JsonRecord | null;
+	usedBackup: boolean;
+};
 
 function isRetryableFsError(error: unknown): boolean {
 	const code = (error as NodeJS.ErrnoException | undefined)?.code;
@@ -137,8 +141,10 @@ function shouldFallbackToSettingsBackup(
  * When the current in-memory state was recovered from backup, snapshotting is
  * skipped so a corrupt primary cannot overwrite the only known-good backup.
  */
-function trySnapshotUnifiedSettingsBackupSync(): void {
-	if (backupDerivedReadPending) {
+function trySnapshotUnifiedSettingsBackupSync(options?: {
+	skipBecauseBackupRead?: boolean;
+}): void {
+	if (options?.skipBecauseBackupRead) {
 		return;
 	}
 	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
@@ -160,8 +166,10 @@ function trySnapshotUnifiedSettingsBackupSync(): void {
 /**
  * Async variant of `trySnapshotUnifiedSettingsBackupSync`.
  */
-async function trySnapshotUnifiedSettingsBackupAsync(): Promise<void> {
-	if (backupDerivedReadPending) {
+async function trySnapshotUnifiedSettingsBackupAsync(options?: {
+	skipBecauseBackupRead?: boolean;
+}): Promise<void> {
+	if (options?.skipBecauseBackupRead) {
 		return;
 	}
 	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
@@ -190,12 +198,12 @@ async function trySnapshotUnifiedSettingsBackupAsync(): Promise<void> {
  * - Windows: file locking on Windows may cause reads to fail; in those cases this function returns `null`.
  * - Sensitive data: this function performs no token or secret redaction; any sensitive values present in the file are returned as-is and callers are responsible for redaction before logging or external exposure.
  */
-function readSettingsRecordSync(): JsonRecord | null {
+function readSettingsRecordSyncInternal(): SettingsReadResult {
 	const primaryExists = existsSync(UNIFIED_SETTINGS_PATH);
 	try {
 		const primaryRecord = readSettingsRecordSyncFromPath(UNIFIED_SETTINGS_PATH);
 		if (primaryRecord) {
-			return primaryRecord;
+			return { record: primaryRecord, usedBackup: false };
 		}
 	} catch (error) {
 		if (!shouldFallbackToSettingsBackup(primaryExists, error)) {
@@ -203,13 +211,16 @@ function readSettingsRecordSync(): JsonRecord | null {
 		}
 		const backupRecord = readSettingsBackupSync();
 		if (backupRecord) {
-			backupDerivedReadPending = true;
-			return backupRecord;
+			return { record: backupRecord, usedBackup: true };
 		}
 		throw error;
 	}
 
-	return null;
+	return { record: null, usedBackup: false };
+}
+
+function readSettingsRecordSync(): JsonRecord | null {
+	return readSettingsRecordSyncInternal().record;
 }
 
 /**
@@ -219,14 +230,14 @@ function readSettingsRecordSync(): JsonRecord | null {
  *
  * @returns The parsed settings record as an object clone, or `null` if unavailable or invalid.
  */
-async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
+async function readSettingsRecordAsyncInternal(): Promise<SettingsReadResult> {
 	const primaryExists = existsSync(UNIFIED_SETTINGS_PATH);
 	try {
 		const primaryRecord = await readSettingsRecordAsyncFromPath(
 			UNIFIED_SETTINGS_PATH,
 		);
 		if (primaryRecord) {
-			return primaryRecord;
+			return { record: primaryRecord, usedBackup: false };
 		}
 	} catch (error) {
 		if (!shouldFallbackToSettingsBackup(primaryExists, error)) {
@@ -234,13 +245,16 @@ async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
 		}
 		const backupRecord = await readSettingsBackupAsync();
 		if (backupRecord) {
-			backupDerivedReadPending = true;
-			return backupRecord;
+			return { record: backupRecord, usedBackup: true };
 		}
 		throw error;
 	}
 
-	return null;
+	return { record: null, usedBackup: false };
+}
+
+async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
+	return (await readSettingsRecordAsyncInternal()).record;
 }
 
 /**
@@ -275,12 +289,17 @@ function normalizeForWrite(record: JsonRecord): JsonRecord {
  *
  * @param record - The settings object to persist; it will be normalized to include the unified settings version.
  */
-function writeSettingsRecordSync(record: JsonRecord): void {
+function writeSettingsRecordSync(
+	record: JsonRecord,
+	options?: { skipBackupSnapshot?: boolean },
+): void {
 	mkdirSync(getCodexMultiAuthDir(), { recursive: true });
 	const payload = normalizeForWrite(record);
 	const data = `${JSON.stringify(payload, null, 2)}\n`;
 	const tempPath = `${UNIFIED_SETTINGS_PATH}.${process.pid}.${Date.now()}.tmp`;
-	trySnapshotUnifiedSettingsBackupSync();
+	trySnapshotUnifiedSettingsBackupSync({
+		skipBecauseBackupRead: options?.skipBackupSnapshot,
+	});
 	writeFileSync(tempPath, data, "utf8");
 	let moved = false;
 	try {
@@ -288,7 +307,6 @@ function writeSettingsRecordSync(record: JsonRecord): void {
 			try {
 				renameSync(tempPath, UNIFIED_SETTINGS_PATH);
 				moved = true;
-				backupDerivedReadPending = false;
 				return;
 			} catch (error) {
 				if (!isRetryableFsError(error) || attempt >= 4) {
@@ -328,12 +346,17 @@ function writeSettingsRecordSync(record: JsonRecord): void {
  *
  * @param record - The settings object to persist; it will be normalized (version set)
  */
-async function writeSettingsRecordAsync(record: JsonRecord): Promise<void> {
+async function writeSettingsRecordAsync(
+	record: JsonRecord,
+	options?: { skipBackupSnapshot?: boolean },
+): Promise<void> {
 	await fs.mkdir(getCodexMultiAuthDir(), { recursive: true });
 	const payload = normalizeForWrite(record);
 	const data = `${JSON.stringify(payload, null, 2)}\n`;
 	const tempPath = `${UNIFIED_SETTINGS_PATH}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
-	await trySnapshotUnifiedSettingsBackupAsync();
+	await trySnapshotUnifiedSettingsBackupAsync({
+		skipBecauseBackupRead: options?.skipBackupSnapshot,
+	});
 	await fs.writeFile(tempPath, data, "utf8");
 	let moved = false;
 	try {
@@ -341,7 +364,6 @@ async function writeSettingsRecordAsync(record: JsonRecord): Promise<void> {
 			try {
 				await fs.rename(tempPath, UNIFIED_SETTINGS_PATH);
 				moved = true;
-				backupDerivedReadPending = false;
 				return;
 			} catch (error) {
 				if (!isRetryableFsError(error) || attempt >= 4) {
@@ -413,9 +435,12 @@ export function loadUnifiedPluginConfigSync(): JsonRecord | null {
  * @param pluginConfig - Key/value map representing plugin configuration to persist
  */
 export function saveUnifiedPluginConfigSync(pluginConfig: JsonRecord): void {
-	const record = readSettingsRecordSync() ?? {};
-	record.pluginConfig = { ...pluginConfig };
-	writeSettingsRecordSync(record);
+	const { record, usedBackup } = readSettingsRecordSyncInternal();
+	const nextRecord = record ?? {};
+	nextRecord.pluginConfig = { ...pluginConfig };
+	writeSettingsRecordSync(nextRecord, {
+		skipBackupSnapshot: usedBackup,
+	});
 }
 
 /**
@@ -430,9 +455,12 @@ export function saveUnifiedPluginConfigSync(pluginConfig: JsonRecord): void {
  */
 export async function saveUnifiedPluginConfig(pluginConfig: JsonRecord): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		const record = await readSettingsRecordAsync() ?? {};
-		record.pluginConfig = { ...pluginConfig };
-		await writeSettingsRecordAsync(record);
+		const { record, usedBackup } = await readSettingsRecordAsyncInternal();
+		const nextRecord = record ?? {};
+		nextRecord.pluginConfig = { ...pluginConfig };
+		await writeSettingsRecordAsync(nextRecord, {
+			skipBackupSnapshot: usedBackup,
+		});
 	});
 }
 
@@ -473,8 +501,11 @@ export async function saveUnifiedDashboardSettings(
 	dashboardDisplaySettings: JsonRecord,
 ): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		const record = await readSettingsRecordAsync() ?? {};
-		record.dashboardDisplaySettings = { ...dashboardDisplaySettings };
-		await writeSettingsRecordAsync(record);
+		const { record, usedBackup } = await readSettingsRecordAsyncInternal();
+		const nextRecord = record ?? {};
+		nextRecord.dashboardDisplaySettings = { ...dashboardDisplaySettings };
+		await writeSettingsRecordAsync(nextRecord, {
+			skipBackupSnapshot: usedBackup,
+		});
 	});
 }

--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -19,7 +19,9 @@ export const UNIFIED_SETTINGS_VERSION = 1 as const;
 const UNIFIED_SETTINGS_PATH = join(getCodexMultiAuthDir(), "settings.json");
 const UNIFIED_SETTINGS_BACKUP_PATH = `${UNIFIED_SETTINGS_PATH}.bak`;
 const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+const TRANSIENT_READ_FS_CODES = new Set(["EBUSY", "EAGAIN"]);
 let settingsWriteQueue: Promise<void> = Promise.resolve();
+let backupDerivedReadPending = false;
 
 function isRetryableFsError(error: unknown): boolean {
 	const code = (error as NodeJS.ErrnoException | undefined)?.code;
@@ -55,6 +57,12 @@ function parseSettingsRecord(content: string): JsonRecord {
 	return parsed;
 }
 
+/**
+ * Read a unified-settings record from a specific path.
+ *
+ * Returns `null` when the file is absent and throws when the file exists but
+ * cannot be parsed into the expected object shape.
+ */
 function readSettingsRecordSyncFromPath(filePath: string): JsonRecord | null {
 	if (!existsSync(filePath)) {
 		return null;
@@ -62,6 +70,9 @@ function readSettingsRecordSyncFromPath(filePath: string): JsonRecord | null {
 	return parseSettingsRecord(readFileSync(filePath, "utf8"));
 }
 
+/**
+ * Async variant of `readSettingsRecordSyncFromPath`.
+ */
 async function readSettingsRecordAsyncFromPath(
 	filePath: string,
 ): Promise<JsonRecord | null> {
@@ -71,6 +82,12 @@ async function readSettingsRecordAsyncFromPath(
 	return parseSettingsRecord(await fs.readFile(filePath, "utf8"));
 }
 
+/**
+ * Best-effort backup reader for sync callers.
+ *
+ * Backup corruption is treated as an unavailable backup so callers can keep
+ * their legacy null-on-unavailable behavior.
+ */
 function readSettingsBackupSync(): JsonRecord | null {
 	try {
 		return readSettingsRecordSyncFromPath(UNIFIED_SETTINGS_BACKUP_PATH);
@@ -79,6 +96,9 @@ function readSettingsBackupSync(): JsonRecord | null {
 	}
 }
 
+/**
+ * Best-effort backup reader for async callers.
+ */
 async function readSettingsBackupAsync(): Promise<JsonRecord | null> {
 	try {
 		return await readSettingsRecordAsyncFromPath(UNIFIED_SETTINGS_BACKUP_PATH);
@@ -87,7 +107,40 @@ async function readSettingsBackupAsync(): Promise<JsonRecord | null> {
 	}
 }
 
+/**
+ * Decide whether a primary settings read should fall back to the backup file.
+ *
+ * Missing primaries stay missing so callers do not merge stale backup state.
+ * Corrupt or unreadable primaries may fall back, while transient lock errors
+ * are rethrown so callers can retry.
+ */
+function shouldFallbackToSettingsBackup(
+	primaryExists: boolean,
+	error: unknown,
+): boolean {
+	if (!primaryExists) {
+		return false;
+	}
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	if (code === "ENOENT") {
+		return false;
+	}
+	if (typeof code === "string" && TRANSIENT_READ_FS_CODES.has(code)) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Snapshot the primary settings file into `settings.json.bak` for sync writes.
+ *
+ * When the current in-memory state was recovered from backup, snapshotting is
+ * skipped so a corrupt primary cannot overwrite the only known-good backup.
+ */
 function trySnapshotUnifiedSettingsBackupSync(): void {
+	if (backupDerivedReadPending) {
+		return;
+	}
 	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
 		return;
 	}
@@ -104,7 +157,13 @@ function trySnapshotUnifiedSettingsBackupSync(): void {
 	}
 }
 
+/**
+ * Async variant of `trySnapshotUnifiedSettingsBackupSync`.
+ */
 async function trySnapshotUnifiedSettingsBackupAsync(): Promise<void> {
+	if (backupDerivedReadPending) {
+		return;
+	}
 	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
 		return;
 	}
@@ -132,20 +191,25 @@ async function trySnapshotUnifiedSettingsBackupAsync(): Promise<void> {
  * - Sensitive data: this function performs no token or secret redaction; any sensitive values present in the file are returned as-is and callers are responsible for redaction before logging or external exposure.
  */
 function readSettingsRecordSync(): JsonRecord | null {
+	const primaryExists = existsSync(UNIFIED_SETTINGS_PATH);
 	try {
 		const primaryRecord = readSettingsRecordSyncFromPath(UNIFIED_SETTINGS_PATH);
 		if (primaryRecord) {
 			return primaryRecord;
 		}
 	} catch (error) {
+		if (!shouldFallbackToSettingsBackup(primaryExists, error)) {
+			throw error;
+		}
 		const backupRecord = readSettingsBackupSync();
 		if (backupRecord) {
+			backupDerivedReadPending = true;
 			return backupRecord;
 		}
 		throw error;
 	}
 
-	return readSettingsBackupSync();
+	return null;
 }
 
 /**
@@ -156,6 +220,7 @@ function readSettingsRecordSync(): JsonRecord | null {
  * @returns The parsed settings record as an object clone, or `null` if unavailable or invalid.
  */
 async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
+	const primaryExists = existsSync(UNIFIED_SETTINGS_PATH);
 	try {
 		const primaryRecord = await readSettingsRecordAsyncFromPath(
 			UNIFIED_SETTINGS_PATH,
@@ -164,14 +229,18 @@ async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
 			return primaryRecord;
 		}
 	} catch (error) {
+		if (!shouldFallbackToSettingsBackup(primaryExists, error)) {
+			throw error;
+		}
 		const backupRecord = await readSettingsBackupAsync();
 		if (backupRecord) {
+			backupDerivedReadPending = true;
 			return backupRecord;
 		}
 		throw error;
 	}
 
-	return readSettingsBackupAsync();
+	return null;
 }
 
 /**
@@ -219,6 +288,7 @@ function writeSettingsRecordSync(record: JsonRecord): void {
 			try {
 				renameSync(tempPath, UNIFIED_SETTINGS_PATH);
 				moved = true;
+				backupDerivedReadPending = false;
 				return;
 			} catch (error) {
 				if (!isRetryableFsError(error) || attempt >= 4) {
@@ -271,6 +341,7 @@ async function writeSettingsRecordAsync(record: JsonRecord): Promise<void> {
 			try {
 				await fs.rename(tempPath, UNIFIED_SETTINGS_PATH);
 				moved = true;
+				backupDerivedReadPending = false;
 				return;
 			} catch (error) {
 				if (!isRetryableFsError(error) || attempt >= 4) {

--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -1,4 +1,5 @@
 import {
+	copyFileSync,
 	existsSync,
 	mkdirSync,
 	renameSync,
@@ -16,6 +17,7 @@ type JsonRecord = Record<string, unknown>;
 export const UNIFIED_SETTINGS_VERSION = 1 as const;
 
 const UNIFIED_SETTINGS_PATH = join(getCodexMultiAuthDir(), "settings.json");
+const UNIFIED_SETTINGS_BACKUP_PATH = `${UNIFIED_SETTINGS_PATH}.bak`;
 const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
 let settingsWriteQueue: Promise<void> = Promise.resolve();
 
@@ -45,6 +47,64 @@ function cloneRecord(value: unknown): JsonRecord | null {
 	return { ...value };
 }
 
+function parseSettingsRecord(content: string): JsonRecord {
+	const parsed = cloneRecord(JSON.parse(content));
+	if (!parsed) {
+		throw new Error("Unified settings must contain a JSON object at the root.");
+	}
+	return parsed;
+}
+
+function readSettingsRecordSyncFromPath(filePath: string): JsonRecord | null {
+	if (!existsSync(filePath)) {
+		return null;
+	}
+	return parseSettingsRecord(readFileSync(filePath, "utf8"));
+}
+
+async function readSettingsRecordAsyncFromPath(
+	filePath: string,
+): Promise<JsonRecord | null> {
+	if (!existsSync(filePath)) {
+		return null;
+	}
+	return parseSettingsRecord(await fs.readFile(filePath, "utf8"));
+}
+
+function trySnapshotUnifiedSettingsBackupSync(): void {
+	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
+		return;
+	}
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			copyFileSync(UNIFIED_SETTINGS_PATH, UNIFIED_SETTINGS_BACKUP_PATH);
+			return;
+		} catch (error) {
+			if (!isRetryableFsError(error) || attempt >= 4) {
+				return;
+			}
+			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10 * 2 ** attempt);
+		}
+	}
+}
+
+async function trySnapshotUnifiedSettingsBackupAsync(): Promise<void> {
+	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
+		return;
+	}
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await fs.copyFile(UNIFIED_SETTINGS_PATH, UNIFIED_SETTINGS_BACKUP_PATH);
+			return;
+		} catch (error) {
+			if (!isRetryableFsError(error) || attempt >= 4) {
+				return;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+}
+
 /**
  * Reads and parses the unified settings JSON file from disk.
  *
@@ -56,16 +116,22 @@ function cloneRecord(value: unknown): JsonRecord | null {
  * - Sensitive data: this function performs no token or secret redaction; any sensitive values present in the file are returned as-is and callers are responsible for redaction before logging or external exposure.
  */
 function readSettingsRecordSync(): JsonRecord | null {
-	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
-		return null;
+	try {
+		const primaryRecord = readSettingsRecordSyncFromPath(UNIFIED_SETTINGS_PATH);
+		if (primaryRecord) {
+			return primaryRecord;
+		}
+	} catch (error) {
+		const backupRecord = readSettingsRecordSyncFromPath(
+			UNIFIED_SETTINGS_BACKUP_PATH,
+		);
+		if (backupRecord) {
+			return backupRecord;
+		}
+		throw error;
 	}
 
-	const raw = readFileSync(UNIFIED_SETTINGS_PATH, "utf8");
-	const parsed = cloneRecord(JSON.parse(raw));
-	if (!parsed) {
-		throw new Error("Unified settings must contain a JSON object at the root.");
-	}
-	return parsed;
+	return readSettingsRecordSyncFromPath(UNIFIED_SETTINGS_BACKUP_PATH);
 }
 
 /**
@@ -76,16 +142,24 @@ function readSettingsRecordSync(): JsonRecord | null {
  * @returns The parsed settings record as an object clone, or `null` if unavailable or invalid.
  */
 async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
-	if (!existsSync(UNIFIED_SETTINGS_PATH)) {
-		return null;
+	try {
+		const primaryRecord = await readSettingsRecordAsyncFromPath(
+			UNIFIED_SETTINGS_PATH,
+		);
+		if (primaryRecord) {
+			return primaryRecord;
+		}
+	} catch (error) {
+		const backupRecord = await readSettingsRecordAsyncFromPath(
+			UNIFIED_SETTINGS_BACKUP_PATH,
+		);
+		if (backupRecord) {
+			return backupRecord;
+		}
+		throw error;
 	}
 
-	const raw = await fs.readFile(UNIFIED_SETTINGS_PATH, "utf8");
-	const parsed = cloneRecord(JSON.parse(raw));
-	if (!parsed) {
-		throw new Error("Unified settings must contain a JSON object at the root.");
-	}
-	return parsed;
+	return readSettingsRecordAsyncFromPath(UNIFIED_SETTINGS_BACKUP_PATH);
 }
 
 /**
@@ -125,6 +199,7 @@ function writeSettingsRecordSync(record: JsonRecord): void {
 	const payload = normalizeForWrite(record);
 	const data = `${JSON.stringify(payload, null, 2)}\n`;
 	const tempPath = `${UNIFIED_SETTINGS_PATH}.${process.pid}.${Date.now()}.tmp`;
+	trySnapshotUnifiedSettingsBackupSync();
 	writeFileSync(tempPath, data, "utf8");
 	let moved = false;
 	try {
@@ -176,6 +251,7 @@ async function writeSettingsRecordAsync(record: JsonRecord): Promise<void> {
 	const payload = normalizeForWrite(record);
 	const data = `${JSON.stringify(payload, null, 2)}\n`;
 	const tempPath = `${UNIFIED_SETTINGS_PATH}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+	await trySnapshotUnifiedSettingsBackupAsync();
 	await fs.writeFile(tempPath, data, "utf8");
 	let moved = false;
 	try {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -3085,7 +3085,7 @@ describe("AccountManager", () => {
       expect(getRuntimeTrackerKey(account)).toBe(trackerKey);
       expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
         degradedScore,
-        6,
+        5,
       );
       expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
     });

--- a/test/config-save.test.ts
+++ b/test/config-save.test.ts
@@ -190,6 +190,42 @@ describe("plugin config save paths", () => {
     }
   });
 
+  it("redacts raw values from invalid numeric env override warnings", async () => {
+    process.env.CODEX_AUTH_PARALLEL_PROBING_MAX_CONCURRENCY = "secret-value";
+    vi.resetModules();
+    const logWarnMock = vi.fn();
+
+    vi.doMock("../lib/logger.js", async () => {
+      const actual =
+        await vi.importActual<typeof import("../lib/logger.js")>(
+          "../lib/logger.js",
+        );
+      return {
+        ...actual,
+        logWarn: logWarnMock,
+      };
+    });
+
+    try {
+      const { getParallelProbingMaxConcurrency } = await import(
+        "../lib/config.js"
+      );
+      expect(
+        getParallelProbingMaxConcurrency({ parallelProbingMaxConcurrency: 4 }),
+      ).toBe(4);
+      expect(logWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Ignoring invalid numeric env CODEX_AUTH_PARALLEL_PROBING_MAX_CONCURRENCY.",
+        ),
+      );
+      expect(logWarnMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("secret-value"),
+      );
+    } finally {
+      vi.doUnmock("../lib/logger.js");
+    }
+  });
+
   it("normalizes fallback chain and drops invalid entries", async () => {
     const { getUnsupportedCodexFallbackChain } =
       await import("../lib/config.js");

--- a/test/config-save.test.ts
+++ b/test/config-save.test.ts
@@ -126,20 +126,139 @@ describe("plugin config save paths", () => {
 
   it("writes through unified settings when env path is unset", async () => {
     delete process.env.CODEX_MULTI_AUTH_CONFIG_PATH;
+    const unifiedPath = join(tempDir, "settings.json");
+    await fs.writeFile(
+      unifiedPath,
+      JSON.stringify({
+        version: 1,
+        pluginConfig: {
+          preserved: 1,
+          codexMode: true,
+        },
+      }),
+      "utf8",
+    );
 
-    const { savePluginConfig, loadPluginConfig } =
-      await import("../lib/config.js");
-    await savePluginConfig({
-      codexMode: false,
-      parallelProbing: true,
-      parallelProbingMaxConcurrency: 7,
+    const logWarnMock = vi.fn();
+    vi.doMock("../lib/logger.js", async () => {
+      const actual =
+        await vi.importActual<typeof import("../lib/logger.js")>(
+          "../lib/logger.js",
+        );
+      return {
+        ...actual,
+        logWarn: logWarnMock,
+      };
     });
 
-		const loaded = loadPluginConfig();
-		expect(loaded.codexMode).toBe(false);
-		expect(loaded.parallelProbing).toBe(true);
-		expect(loaded.parallelProbingMaxConcurrency).toBe(2);
+    try {
+      const { savePluginConfig, loadPluginConfig } =
+        await import("../lib/config.js");
+      await savePluginConfig({
+        codexMode: false,
+        parallelProbing: true,
+        parallelProbingMaxConcurrency: 7,
+      });
+
+			const loaded = loadPluginConfig();
+			expect(loaded.codexMode).toBe(false);
+			expect(loaded.parallelProbing).toBe(true);
+			expect(loaded.parallelProbingMaxConcurrency).toBe(2);
+
+      const parsed = JSON.parse(await fs.readFile(unifiedPath, "utf8")) as {
+        pluginConfig?: Record<string, unknown>;
+      };
+      expect(parsed.pluginConfig).toEqual({
+        preserved: 1,
+        codexMode: false,
+        parallelProbing: true,
+      });
+      expect(logWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Ignoring invalid plugin config field(s): parallelProbingMaxConcurrency.",
+        ),
+      );
+    } finally {
+      vi.doUnmock("../lib/logger.js");
+    }
 	});
+
+  it("does not overwrite an unreadable env-path config file", async () => {
+    const configPath = join(tempDir, "plugin-config.json");
+    process.env.CODEX_MULTI_AUTH_CONFIG_PATH = configPath;
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ codexMode: true, preserved: 1 }),
+      "utf8",
+    );
+
+    const originalReadFile = fs.readFile.bind(fs);
+    const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      const [targetPath] = args;
+      if (targetPath === configPath) {
+        const error = new Error("busy") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return originalReadFile(...args);
+    });
+
+    try {
+      const { savePluginConfig } = await import("../lib/config.js");
+      await expect(savePluginConfig({ codexMode: false })).rejects.toThrow(
+        "unreadable",
+      );
+    } finally {
+      readSpy.mockRestore();
+    }
+
+    const parsed = JSON.parse(await fs.readFile(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed).toEqual({ codexMode: true, preserved: 1 });
+  });
+
+  it("does not overwrite an unreadable unified settings file", async () => {
+    delete process.env.CODEX_MULTI_AUTH_CONFIG_PATH;
+    const unifiedPath = join(tempDir, "settings.json");
+    await fs.writeFile(
+      unifiedPath,
+      JSON.stringify({
+        version: 1,
+        pluginConfig: { codexMode: true, preserved: 1 },
+        dashboardDisplaySettings: { uiThemePreset: "green" },
+      }),
+      "utf8",
+    );
+
+    const originalReadFile = fs.readFile.bind(fs);
+    const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      const [targetPath] = args;
+      if (targetPath === unifiedPath) {
+        const error = new Error("busy") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return originalReadFile(...args);
+    });
+
+    try {
+      const { savePluginConfig } = await import("../lib/config.js");
+      await expect(savePluginConfig({ codexMode: false })).rejects.toThrow(
+        "unreadable",
+      );
+    } finally {
+      readSpy.mockRestore();
+    }
+
+    const parsed = JSON.parse(await fs.readFile(unifiedPath, "utf8")) as {
+      pluginConfig?: Record<string, unknown>;
+      dashboardDisplaySettings?: Record<string, unknown>;
+    };
+    expect(parsed.pluginConfig).toEqual({ codexMode: true, preserved: 1 });
+    expect(parsed.dashboardDisplaySettings).toEqual({ uiThemePreset: "green" });
+  });
 
   it("resolves parallel probing settings and clamps concurrency", async () => {
     const { getParallelProbing, getParallelProbingMaxConcurrency } =
@@ -185,6 +304,63 @@ describe("plugin config save paths", () => {
         getParallelProbingMaxConcurrency({ parallelProbingMaxConcurrency: 4 }),
       ).toBe(4);
       expect(logWarnMock).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("../lib/logger.js");
+    }
+  });
+
+  it("does not warn for blank boolean env overrides", async () => {
+    process.env.CODEX_AUTH_PARALLEL_PROBING = "";
+    vi.resetModules();
+    const logWarnMock = vi.fn();
+
+    vi.doMock("../lib/logger.js", async () => {
+      const actual =
+        await vi.importActual<typeof import("../lib/logger.js")>(
+          "../lib/logger.js",
+        );
+      return {
+        ...actual,
+        logWarn: logWarnMock,
+      };
+    });
+
+    try {
+      const { getParallelProbing } = await import("../lib/config.js");
+      expect(getParallelProbing({ parallelProbing: false })).toBe(false);
+      expect(logWarnMock).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("../lib/logger.js");
+    }
+  });
+
+  it("redacts raw values from invalid boolean env override warnings", async () => {
+    process.env.CODEX_AUTH_PARALLEL_PROBING = "secret-bool";
+    vi.resetModules();
+    const logWarnMock = vi.fn();
+
+    vi.doMock("../lib/logger.js", async () => {
+      const actual =
+        await vi.importActual<typeof import("../lib/logger.js")>(
+          "../lib/logger.js",
+        );
+      return {
+        ...actual,
+        logWarn: logWarnMock,
+      };
+    });
+
+    try {
+      const { getParallelProbing } = await import("../lib/config.js");
+      expect(getParallelProbing({ parallelProbing: false })).toBe(false);
+      expect(logWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Ignoring invalid boolean env CODEX_AUTH_PARALLEL_PROBING.",
+        ),
+      );
+      expect(logWarnMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("secret-bool"),
+      );
     } finally {
       vi.doUnmock("../lib/logger.js");
     }

--- a/test/config-save.test.ts
+++ b/test/config-save.test.ts
@@ -161,6 +161,35 @@ describe("plugin config save paths", () => {
     ).toBe(1);
   });
 
+  it("does not warn for blank numeric env overrides", async () => {
+    process.env.CODEX_AUTH_PARALLEL_PROBING_MAX_CONCURRENCY = "";
+    vi.resetModules();
+    const logWarnMock = vi.fn();
+
+    vi.doMock("../lib/logger.js", async () => {
+      const actual =
+        await vi.importActual<typeof import("../lib/logger.js")>(
+          "../lib/logger.js",
+        );
+      return {
+        ...actual,
+        logWarn: logWarnMock,
+      };
+    });
+
+    try {
+      const { getParallelProbingMaxConcurrency } = await import(
+        "../lib/config.js"
+      );
+      expect(
+        getParallelProbingMaxConcurrency({ parallelProbingMaxConcurrency: 4 }),
+      ).toBe(4);
+      expect(logWarnMock).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("../lib/logger.js");
+    }
+  });
+
   it("normalizes fallback chain and drops invalid entries", async () => {
     const { getUnsupportedCodexFallbackChain } =
       await import("../lib/config.js");

--- a/test/config-save.test.ts
+++ b/test/config-save.test.ts
@@ -135,11 +135,11 @@ describe("plugin config save paths", () => {
       parallelProbingMaxConcurrency: 7,
     });
 
-    const loaded = loadPluginConfig();
-    expect(loaded.codexMode).toBe(false);
-    expect(loaded.parallelProbing).toBe(true);
-    expect(loaded.parallelProbingMaxConcurrency).toBe(7);
-  });
+		const loaded = loadPluginConfig();
+		expect(loaded.codexMode).toBe(false);
+		expect(loaded.parallelProbing).toBe(true);
+		expect(loaded.parallelProbingMaxConcurrency).toBe(2);
+	});
 
   it("resolves parallel probing settings and clamps concurrency", async () => {
     const { getParallelProbing, getParallelProbingMaxConcurrency } =

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -663,11 +663,11 @@ describe('Plugin Configuration', () => {
 
 		it('should ignore invalid env values and fall back to config/default', () => {
 			process.env.CODEX_MODE = 'maybe';
-			const config: PluginConfig = { codexMode: true };
+			const config: PluginConfig = { codexMode: false };
 
 			const result = getCodexMode(config);
 
-			expect(result).toBe(true);
+			expect(result).toBe(false);
 		});
 
 		it('should use config codexMode=true when explicitly set', () => {
@@ -1036,6 +1036,7 @@ describe('Plugin Configuration', () => {
 			process.env.CODEX_AUTH_FETCH_TIMEOUT_MS = '';
 			expect(getFetchTimeoutMs({ fetchTimeoutMs: 90000 })).toBe(90000);
 			delete process.env.CODEX_AUTH_FETCH_TIMEOUT_MS;
+			expect(getFetchTimeoutMs({})).toBe(60000);
 		});
 
 		it('should read stream stall timeout from env', () => {

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -661,13 +661,13 @@ describe('Plugin Configuration', () => {
 			expect(result).toBe(false);
 		});
 
-		it('should handle env var with any value other than "1" as false', () => {
-			process.env.CODEX_MODE = 'false';
+		it('should ignore invalid env values and fall back to config/default', () => {
+			process.env.CODEX_MODE = 'maybe';
 			const config: PluginConfig = { codexMode: true };
 
 			const result = getCodexMode(config);
 
-			expect(result).toBe(false);
+			expect(result).toBe(true);
 		});
 
 		it('should use config codexMode=true when explicitly set', () => {
@@ -990,6 +990,23 @@ describe('Plugin Configuration', () => {
 				expect.stringContaining('Plugin config validation warnings')
 			);
 		});
+
+		it('drops invalid persisted values while keeping valid config keys', () => {
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockReturnValue(JSON.stringify({
+				codexMode: 'not-a-boolean',
+				fetchTimeoutMs: 'oops',
+				streamStallTimeoutMs: 30000,
+				backgroundResponses: true,
+			}));
+
+			const config = loadPluginConfig();
+
+			expect(config.codexMode).toBe(true);
+			expect(config.fetchTimeoutMs).toBe(60_000);
+			expect(config.streamStallTimeoutMs).toBe(30000);
+			expect(config.backgroundResponses).toBe(true);
+		});
 	});
 
 	describe('resolveNumberSetting without min option', () => {
@@ -1013,6 +1030,12 @@ describe('Plugin Configuration', () => {
 		it('should read fetch timeout from config', () => {
 			const config: PluginConfig = { fetchTimeoutMs: 120000 };
 			expect(getFetchTimeoutMs(config)).toBe(120000);
+		});
+
+		it('should ignore empty numeric env values and fall back to config/default', () => {
+			process.env.CODEX_AUTH_FETCH_TIMEOUT_MS = '';
+			expect(getFetchTimeoutMs({ fetchTimeoutMs: 90000 })).toBe(90000);
+			delete process.env.CODEX_AUTH_FETCH_TIMEOUT_MS;
 		});
 
 		it('should read stream stall timeout from env', () => {

--- a/test/rotation-integration.test.ts
+++ b/test/rotation-integration.test.ts
@@ -293,6 +293,15 @@ describe("Multi-Account Rotation Integration", () => {
 
 				const saves = Array.from({ length: 10 }, () => manager.saveToDisk());
 				await Promise.all(saves);
+
+				const parsed = JSON.parse(
+					await fs.readFile(testStoragePath, "utf8"),
+				) as AccountStorageV3;
+				expect(parsed.version).toBe(3);
+				expect(parsed.accounts).toHaveLength(3);
+				expect(parsed.accounts.map((account) => account.email)).toEqual(
+					TEST_ACCOUNTS.slice(0, 3).map((account) => account.email),
+				);
 			}, 15_000);
 		});
 

--- a/test/rotation-integration.test.ts
+++ b/test/rotation-integration.test.ts
@@ -286,15 +286,15 @@ describe("Multi-Account Rotation Integration", () => {
     });
   });
 
-  describe("Storage mutex (file locking)", () => {
-    it("concurrent saves complete without corruption", async () => {
-      const storage = createStorageFromTestAccounts(TEST_ACCOUNTS.slice(0, 3));
-      const manager = new AccountManager(undefined, storage);
+		describe("Storage mutex (file locking)", () => {
+			it("concurrent saves complete without corruption", async () => {
+				const storage = createStorageFromTestAccounts(TEST_ACCOUNTS.slice(0, 3));
+				const manager = new AccountManager(undefined, storage);
 
-      const saves = Array.from({ length: 10 }, () => manager.saveToDisk());
-      await Promise.all(saves);
-    });
-  });
+				const saves = Array.from({ length: 10 }, () => manager.saveToDisk());
+				await Promise.all(saves);
+			}, 15_000);
+		});
 
   describe("Debounced save", () => {
     it("saveToDiskDebounced does not throw", () => {

--- a/test/settings-hub-utils.test.ts
+++ b/test/settings-hub-utils.test.ts
@@ -232,7 +232,7 @@ describe("settings-hub utility coverage", () => {
 		expect(() => api.clampBackendNumber("unknown-setting", 5)).toThrow(
 			"Unknown backend numeric setting key",
 		);
-	});
+	}, 15_000);
 
 	it("formats layout mode labels", async () => {
 		const api = await loadSettingsHubTestApi();

--- a/test/storage-flagged.test.ts
+++ b/test/storage-flagged.test.ts
@@ -341,6 +341,43 @@ describe("flagged account storage", () => {
 		readSpy.mockRestore();
 	});
 
+	it("honors the reset marker even when it appears during backup recovery", async () => {
+		const backupPath = `${getFlaggedAccountsPath()}.bak`;
+		const resetMarkerPath = `${getFlaggedAccountsPath()}.reset-intent`;
+		await fs.writeFile(
+			backupPath,
+			JSON.stringify({
+				version: 1,
+				accounts: [
+					{
+						refreshToken: "backup-race",
+						flaggedAt: 1,
+						addedAt: 1,
+						lastUsed: 1,
+					},
+				],
+			}),
+			"utf8",
+		);
+
+		const originalReadFile = fs.readFile.bind(fs);
+		const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+			const [targetPath] = args;
+			const result = await originalReadFile(...args);
+			if (targetPath === backupPath) {
+				await fs.writeFile(resetMarkerPath, "reset", "utf8");
+			}
+			return result;
+		});
+
+		try {
+			const flagged = await loadFlaggedAccounts();
+			expect(flagged.accounts).toHaveLength(0);
+		} finally {
+			readSpy.mockRestore();
+		}
+	});
+
 	it("clears discovered flagged backup artifacts so manual snapshots cannot revive after clear", async () => {
 		await saveFlaggedAccounts({
 			version: 1,

--- a/test/storage-flagged.test.ts
+++ b/test/storage-flagged.test.ts
@@ -451,45 +451,6 @@ describe("flagged account storage", () => {
 		unlinkSpy.mockRestore();
 	});
 
-	it("suppresses flagged accounts when clear cannot delete the primary file after writing the reset marker", async () => {
-		await saveFlaggedAccounts({
-			version: 1,
-			accounts: [
-				{
-					refreshToken: "stale-primary",
-					flaggedAt: 1,
-					addedAt: 1,
-					lastUsed: 1,
-				},
-			],
-		});
-
-		const flaggedPath = getFlaggedAccountsPath();
-		const originalUnlink = fs.unlink.bind(fs);
-		const unlinkSpy = vi
-			.spyOn(fs, "unlink")
-			.mockImplementation(async (targetPath) => {
-				if (targetPath === flaggedPath) {
-					const error = new Error(
-						"EPERM primary delete",
-					) as NodeJS.ErrnoException;
-					error.code = "EPERM";
-					throw error;
-				}
-				return originalUnlink(targetPath);
-			});
-
-		await expect(clearFlaggedAccounts()).rejects.toThrow(
-			"EPERM primary delete",
-		);
-
-		const flagged = await loadFlaggedAccounts();
-		expect(existsSync(flaggedPath)).toBe(true);
-		expect(flagged.accounts).toHaveLength(0);
-
-		unlinkSpy.mockRestore();
-	});
-
 	it("emits snapshot metadata for flagged account backups", async () => {
 		await saveFlaggedAccounts({
 			version: 1,

--- a/test/storage-flagged.test.ts
+++ b/test/storage-flagged.test.ts
@@ -292,7 +292,7 @@ describe("flagged account storage", () => {
 		unlinkSpy.mockRestore();
 	});
 
-	it("does not recover flagged backups when the primary file exists but read fails", async () => {
+	it("recovers flagged backups when the primary file exists but read fails", async () => {
 		await saveFlaggedAccounts({
 			version: 1,
 			accounts: [
@@ -334,7 +334,8 @@ describe("flagged account storage", () => {
 			});
 
 		const flagged = await loadFlaggedAccounts();
-		expect(flagged.accounts).toHaveLength(0);
+		expect(flagged.accounts).toHaveLength(1);
+		expect(flagged.accounts[0]?.refreshToken).toBe("primary-flagged");
 		expect(existsSync(flaggedPath)).toBe(true);
 
 		readSpy.mockRestore();

--- a/test/storage-recovery-paths.test.ts
+++ b/test/storage-recovery-paths.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { promises as fs, existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
@@ -157,6 +157,45 @@ describe("storage recovery paths", () => {
 		const recovered = await loadFlaggedAccounts();
 		expect(recovered.accounts).toHaveLength(1);
 		expect(recovered.accounts[0]?.email).toBe("flagged2@example.com");
+	});
+
+	it("suppresses flagged backup recovery when the reset marker appears mid-read", async () => {
+		const flaggedPath = join(workDir, "openai-codex-flagged-accounts.json");
+		const backupPath = `${flaggedPath}.bak`;
+		const resetMarkerPath = `${flaggedPath}.reset-intent`;
+		await fs.writeFile(
+			backupPath,
+			JSON.stringify({
+				version: 1,
+				accounts: [
+					{
+						refreshToken: "flagged-race-refresh",
+						email: "race@example.com",
+						addedAt: 9,
+						lastUsed: 9,
+						flaggedAt: 9,
+					},
+				],
+			}),
+			"utf-8",
+		);
+
+		const originalReadFile = fs.readFile.bind(fs);
+		const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+			const [targetPath] = args;
+			const result = await originalReadFile(...args);
+			if (targetPath === backupPath) {
+				await fs.writeFile(resetMarkerPath, "reset", "utf-8");
+			}
+			return result;
+		});
+
+		try {
+			const recovered = await loadFlaggedAccounts();
+			expect(recovered.accounts).toHaveLength(0);
+		} finally {
+			readSpy.mockRestore();
+		}
 	});
 
 	it("falls back to historical backup snapshots when the latest backup is unreadable", async () => {

--- a/test/storage-recovery-paths.test.ts
+++ b/test/storage-recovery-paths.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { removeWithRetry } from "./helpers/remove-with-retry.js";
 import {
 	loadAccounts,
+	loadFlaggedAccounts,
 	getBackupMetadata,
 	saveAccounts,
 	setStorageBackupEnabled,
@@ -107,6 +108,55 @@ describe("storage recovery paths", () => {
 			accounts?: Array<{ accountId?: string }>;
 		};
 		expect(persisted.accounts?.[0]?.accountId).toBe("from-backup");
+	});
+
+	it("recovers flagged accounts from backup file when primary storage is missing", async () => {
+		const flaggedPath = join(workDir, "openai-codex-flagged-accounts.json");
+		await fs.writeFile(
+			`${flaggedPath}.bak`,
+			JSON.stringify({
+				version: 1,
+				accounts: [
+					{
+						refreshToken: "flagged-refresh",
+						email: "flagged@example.com",
+						addedAt: 7,
+						lastUsed: 7,
+						flaggedAt: 7,
+					},
+				],
+			}),
+			"utf-8",
+		);
+
+		const recovered = await loadFlaggedAccounts();
+		expect(recovered.accounts).toHaveLength(1);
+		expect(recovered.accounts[0]?.email).toBe("flagged@example.com");
+	});
+
+	it("recovers flagged accounts from backup file when primary storage is unreadable", async () => {
+		const flaggedPath = join(workDir, "openai-codex-flagged-accounts.json");
+		await fs.writeFile(flaggedPath, "{broken-primary", "utf-8");
+		await fs.writeFile(
+			`${flaggedPath}.bak`,
+			JSON.stringify({
+				version: 1,
+				accounts: [
+					{
+						refreshToken: "flagged-refresh-2",
+						email: "flagged2@example.com",
+						addedAt: 8,
+						lastUsed: 8,
+						flaggedAt: 8,
+					},
+				],
+			}),
+			"utf-8",
+		);
+
+		const recovered = await loadFlaggedAccounts();
+		expect(recovered.accounts).toHaveLength(1);
+		expect(recovered.accounts[0]?.email).toBe("flagged2@example.com");
 	});
 
 	it("falls back to historical backup snapshots when the latest backup is unreadable", async () => {

--- a/test/unified-settings.test.ts
+++ b/test/unified-settings.test.ts
@@ -85,6 +85,27 @@ describe("unified settings", () => {
 		expect(await loadUnifiedDashboardSettings()).toBeNull();
 	});
 
+	it("does not load backup settings when the primary file is missing", async () => {
+		const {
+			getUnifiedSettingsPath,
+			loadUnifiedPluginConfigSync,
+			loadUnifiedDashboardSettings,
+		} = await import("../lib/unified-settings.js");
+
+		await fs.writeFile(
+			`${getUnifiedSettingsPath()}.bak`,
+			JSON.stringify({
+				version: 1,
+				pluginConfig: { codexMode: true },
+				dashboardDisplaySettings: { uiThemePreset: "green" },
+			}),
+			"utf8",
+		);
+
+		expect(loadUnifiedPluginConfigSync()).toBeNull();
+		expect(await loadUnifiedDashboardSettings()).toBeNull();
+	});
+
 	it("recovers plugin config from backup when primary settings file is invalid", async () => {
 		const {
 			getUnifiedSettingsPath,
@@ -122,6 +143,88 @@ describe("unified settings", () => {
 		expect(await loadUnifiedDashboardSettings()).toEqual({
 			menuShowLastUsed: true,
 			uiThemePreset: "green",
+		});
+	});
+
+	it("preserves the last good backup when a write fails after a backup-derived read", async () => {
+		const {
+			getUnifiedSettingsPath,
+			loadUnifiedPluginConfigSync,
+			saveUnifiedPluginConfig,
+		} = await import("../lib/unified-settings.js");
+
+		await saveUnifiedPluginConfig({ codexMode: true, fetchTimeoutMs: 45_000 });
+		await saveUnifiedPluginConfig({ codexMode: false, fetchTimeoutMs: 90_000 });
+		await fs.writeFile(getUnifiedSettingsPath(), "{ invalid json", "utf8");
+
+		expect(loadUnifiedPluginConfigSync()).toEqual({
+			codexMode: true,
+			fetchTimeoutMs: 45_000,
+		});
+
+		const backupPath = `${getUnifiedSettingsPath()}.bak`;
+		const copySpy = vi.spyOn(fs, "copyFile");
+		const renameSpy = vi.spyOn(fs, "rename");
+		renameSpy.mockImplementation(async () => {
+			const error = new Error("busy") as NodeJS.ErrnoException;
+			error.code = "EBUSY";
+			throw error;
+		});
+
+		try {
+			await expect(
+				saveUnifiedPluginConfig({ codexMode: true, fetchTimeoutMs: 120_000 }),
+			).rejects.toThrow();
+		} finally {
+			copySpy.mockRestore();
+			renameSpy.mockRestore();
+		}
+
+		expect(copySpy).not.toHaveBeenCalledWith(
+			getUnifiedSettingsPath(),
+			backupPath,
+		);
+		const backupRecord = JSON.parse(
+			await fs.readFile(backupPath, "utf8"),
+		) as { pluginConfig?: Record<string, unknown> };
+		expect(backupRecord.pluginConfig).toEqual({
+			codexMode: true,
+			fetchTimeoutMs: 45_000,
+		});
+	});
+
+	it("resumes snapshotting after a backup-derived write succeeds", async () => {
+		const {
+			getUnifiedSettingsPath,
+			loadUnifiedPluginConfigSync,
+			saveUnifiedPluginConfig,
+		} = await import("../lib/unified-settings.js");
+
+		await saveUnifiedPluginConfig({ codexMode: true, fetchTimeoutMs: 45_000 });
+		await saveUnifiedPluginConfig({ codexMode: false, fetchTimeoutMs: 90_000 });
+		await fs.writeFile(getUnifiedSettingsPath(), "{ invalid json", "utf8");
+
+		expect(loadUnifiedPluginConfigSync()).toEqual({
+			codexMode: true,
+			fetchTimeoutMs: 45_000,
+		});
+
+		await saveUnifiedPluginConfig({ codexMode: true, fetchTimeoutMs: 120_000 });
+		let backupRecord = JSON.parse(
+			await fs.readFile(`${getUnifiedSettingsPath()}.bak`, "utf8"),
+		) as { pluginConfig?: Record<string, unknown> };
+		expect(backupRecord.pluginConfig).toEqual({
+			codexMode: true,
+			fetchTimeoutMs: 45_000,
+		});
+
+		await saveUnifiedPluginConfig({ codexMode: false, fetchTimeoutMs: 150_000 });
+		backupRecord = JSON.parse(
+			await fs.readFile(`${getUnifiedSettingsPath()}.bak`, "utf8"),
+		) as { pluginConfig?: Record<string, unknown> };
+		expect(backupRecord.pluginConfig).toEqual({
+			codexMode: true,
+			fetchTimeoutMs: 120_000,
 		});
 	});
 
@@ -433,7 +536,7 @@ describe("unified settings", () => {
 		});
 	});
 
-	it("preserves settings sections when a primary read fails and backup recovery is available", async () => {
+	it("falls back to backup when the primary settings file is unreadable", async () => {
 		const {
 			saveUnifiedPluginConfig,
 			saveUnifiedDashboardSettings,
@@ -448,8 +551,8 @@ describe("unified settings", () => {
 
 		const readSpy = vi.spyOn(fs, "readFile");
 		readSpy.mockImplementationOnce(async () => {
-			const error = new Error("file locked") as NodeJS.ErrnoException;
-			error.code = "EBUSY";
+			const error = new Error("permission denied") as NodeJS.ErrnoException;
+			error.code = "EACCES";
 			throw error;
 		});
 
@@ -474,6 +577,52 @@ describe("unified settings", () => {
 		expect(parsed.dashboardDisplaySettings).toEqual({
 			menuShowLastUsed: true,
 			uiThemePreset: "yellow",
+		});
+	});
+
+	it("rethrows transient primary read errors instead of falling back to backup", async () => {
+		const {
+			saveUnifiedPluginConfig,
+			saveUnifiedDashboardSettings,
+			getUnifiedSettingsPath,
+		} = await import("../lib/unified-settings.js");
+
+		await saveUnifiedPluginConfig({ codexMode: true, fetchTimeoutMs: 70_000 });
+		await saveUnifiedDashboardSettings({
+			menuShowLastUsed: false,
+			uiThemePreset: "blue",
+		});
+
+		const readSpy = vi.spyOn(fs, "readFile");
+		readSpy.mockImplementationOnce(async () => {
+			const error = new Error("file locked") as NodeJS.ErrnoException;
+			error.code = "EBUSY";
+			throw error;
+		});
+
+		try {
+			await expect(
+				saveUnifiedDashboardSettings({
+					menuShowLastUsed: true,
+					uiThemePreset: "yellow",
+				}),
+			).rejects.toThrow("file locked");
+		} finally {
+			readSpy.mockRestore();
+		}
+
+		const raw = await fs.readFile(getUnifiedSettingsPath(), "utf8");
+		const parsed = JSON.parse(raw) as {
+			pluginConfig?: Record<string, unknown>;
+			dashboardDisplaySettings?: Record<string, unknown>;
+		};
+		expect(parsed.pluginConfig).toEqual({
+			codexMode: true,
+			fetchTimeoutMs: 70_000,
+		});
+		expect(parsed.dashboardDisplaySettings).toEqual({
+			menuShowLastUsed: false,
+			uiThemePreset: "blue",
 		});
 	});
 });

--- a/test/unified-settings.test.ts
+++ b/test/unified-settings.test.ts
@@ -71,6 +71,20 @@ describe("unified settings", () => {
 		expect(await loadUnifiedDashboardSettings()).toBeNull();
 	});
 
+	it("returns null sections when both primary and backup settings files are invalid", async () => {
+		const {
+			getUnifiedSettingsPath,
+			loadUnifiedPluginConfigSync,
+			loadUnifiedDashboardSettings,
+		} = await import("../lib/unified-settings.js");
+
+		await fs.writeFile(getUnifiedSettingsPath(), "{ invalid json", "utf8");
+		await fs.writeFile(`${getUnifiedSettingsPath()}.bak`, "{ invalid backup", "utf8");
+
+		expect(loadUnifiedPluginConfigSync()).toBeNull();
+		expect(await loadUnifiedDashboardSettings()).toBeNull();
+	});
+
 	it("recovers plugin config from backup when primary settings file is invalid", async () => {
 		const {
 			getUnifiedSettingsPath,

--- a/test/unified-settings.test.ts
+++ b/test/unified-settings.test.ts
@@ -71,6 +71,46 @@ describe("unified settings", () => {
 		expect(await loadUnifiedDashboardSettings()).toBeNull();
 	});
 
+	it("recovers plugin config from backup when primary settings file is invalid", async () => {
+		const {
+			getUnifiedSettingsPath,
+			saveUnifiedPluginConfig,
+			loadUnifiedPluginConfigSync,
+		} = await import("../lib/unified-settings.js");
+
+		await saveUnifiedPluginConfig({ codexMode: true, fetchTimeoutMs: 45_000 });
+		await saveUnifiedPluginConfig({ codexMode: false, fetchTimeoutMs: 90_000 });
+		await fs.writeFile(getUnifiedSettingsPath(), "{ invalid json", "utf8");
+
+		expect(loadUnifiedPluginConfigSync()).toEqual({
+			codexMode: true,
+			fetchTimeoutMs: 45_000,
+		});
+	});
+
+	it("recovers dashboard settings from backup when primary settings file is invalid", async () => {
+		const {
+			getUnifiedSettingsPath,
+			saveUnifiedDashboardSettings,
+			loadUnifiedDashboardSettings,
+		} = await import("../lib/unified-settings.js");
+
+		await saveUnifiedDashboardSettings({
+			menuShowLastUsed: true,
+			uiThemePreset: "green",
+		});
+		await saveUnifiedDashboardSettings({
+			menuShowLastUsed: false,
+			uiThemePreset: "blue",
+		});
+		await fs.writeFile(getUnifiedSettingsPath(), "{ invalid json", "utf8");
+
+		expect(await loadUnifiedDashboardSettings()).toEqual({
+			menuShowLastUsed: true,
+			uiThemePreset: "green",
+		});
+	});
+
 	it("returns null when dashboard settings file is missing", async () => {
 		const { loadUnifiedDashboardSettings } = await import(
 			"../lib/unified-settings.js"
@@ -379,7 +419,7 @@ describe("unified settings", () => {
 		});
 	});
 
-	it("refuses overwriting settings sections when a read fails", async () => {
+	it("preserves settings sections when a primary read fails and backup recovery is available", async () => {
 		const {
 			saveUnifiedPluginConfig,
 			saveUnifiedDashboardSettings,
@@ -400,12 +440,10 @@ describe("unified settings", () => {
 		});
 
 		try {
-			await expect(
-				saveUnifiedDashboardSettings({
-					menuShowLastUsed: true,
-					uiThemePreset: "yellow",
-				}),
-			).rejects.toThrow();
+			await saveUnifiedDashboardSettings({
+				menuShowLastUsed: true,
+				uiThemePreset: "yellow",
+			});
 		} finally {
 			readSpy.mockRestore();
 		}
@@ -420,8 +458,8 @@ describe("unified settings", () => {
 			fetchTimeoutMs: 70_000,
 		});
 		expect(parsed.dashboardDisplaySettings).toEqual({
-			menuShowLastUsed: false,
-			uiThemePreset: "blue",
+			menuShowLastUsed: true,
+			uiThemePreset: "yellow",
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- harden plugin config loading so invalid persisted values and invalid env overrides are ignored instead of flowing into runtime behavior
- add settings.json.bak snapshot fallback for unified settings writes and document the new recovery path
- recover flagged-account backups while keeping reset markers authoritative so partial clears cannot revive cleared entries

## What Changed

- tightened lib/config.ts to sanitize persisted config on load, preserve unknown keys on save, and reject invalid boolean and numeric env overrides instead of coercing them into misleading values
- updated lib/unified-settings.ts to snapshot the previous unified settings file before writes and read from that backup when the primary file is unreadable
- updated lib/storage/flagged-storage-io.ts to recover from flagged backup files and to retain the reset marker when backup cleanup is incomplete
- added regression coverage for invalid config inputs, unified-settings backup recovery, flagged backup recovery, and the new clear-marker behavior; updated docs/reference/storage-paths.md for the new backup semantics

## Validation

- [x] 
pm run lint
- [x] 
pm run typecheck
- [x] 
pm test
- [x] 
pm run test -- --run test/documentation.test.ts
- [x] 
pm run build

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] docs/getting-started.md updated (if onboarding flow changed)
- [ ] docs/features.md updated (if capability surface changed)
- [x] relevant docs/reference/* pages updated (if commands/settings/paths changed)
- [ ] docs/upgrade.md updated (if migration behavior changed)
- [ ] SECURITY.md and CONTRIBUTING.md reviewed for alignment

## Risk and Rollback

- Risk level: medium; this changes config ingress and state-store recovery behavior, but it is covered by full test, build, and targeted runtime repros.
- Rollback plan: revert 8403d61, 8de5d2c, and c28c765 in order.

## Additional Notes

- Manual QA on the built branch confirmed that invalid persisted config now falls back to safe values, invalid CODEX_MODE env input is ignored, flagged .bak files recover when the primary is missing, and settings.json.bak restores the last valid unified settings snapshot after primary corruption.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr hardens config ingress (per-field schema validation on load/save, strict boolean/numeric env parsing), adds `settings.json.bak` snapshot-before-write with corrupt-primary fallback, and makes flagged-account backup recovery consistent with the reset-marker authority — all well covered by new regression tests. previous concerns about unguarded backup reads throwing into callers are resolved via `readSettingsBackupSync`/`readSettingsBackupAsync` wrapping the calls in try-catch.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are P2 style/cleanup suggestions that don't affect correctness on the primary paths

prior P1 issues (corrupt backup throwing in sync/async callers) are addressed; no new logic errors found; test coverage is solid across config, unified-settings, and flagged-storage paths; all remaining comments are P2 (depth mismatch in recovery constants, no write-back on flagged backup recovery, no retry in sync path on EBUSY)

lib/storage/flagged-storage-io.ts (recovery depth vs clear depth), lib/unified-settings.ts (no EBUSY retry in sync path)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/config.ts | adds sanitizePluginConfigRecord, sanitizeStoredPluginConfigRecord, readConfigRecordForSave with retry, tighter parseBooleanEnv/parseNumberEnv, and per-field schema validation on load/save; logic is sound and well-tested |
| lib/unified-settings.ts | adds settings.json.bak snapshot-before-write and corrupt-primary fallback; backup corruption is now safely caught; sync path has no retry on transient EBUSY (minor inconsistency with async counterpart in config.ts) |
| lib/storage/flagged-storage-io.ts | adds backup recovery for missing/corrupt primary and defers reset-marker deletion until all files are cleared; recovery depth (3 levels) is one less than the clear/rotation depth (4 levels), and recovered backups aren't written back to primary |
| test/config-save.test.ts | good regression coverage for unreadable env-path and unified-path aborts, dropped-keys warnings, and blank/invalid env override behavior |
| test/storage-recovery-paths.test.ts | adds integration tests for flagged-account backup recovery (missing primary, unreadable primary, mid-read reset-marker race); solid coverage of the new recovery paths |
| test/storage-flagged.test.ts | inverts the does-not-recover assertion to recovers (matching new behavior), adds reset-marker-wins-during-backup-read race test |
| test/unified-settings.test.ts | adds backup-recovery and corrupt-backup handling tests; covers both sync and async paths and the skip-snapshot-when-backup-read guard |
| docs/reference/storage-paths.md | documents new settings.json.bak backup path, flagged reset-marker semantics, and operator validation commands; accurate and complete |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[loadFlaggedAccountsState] --> B{reset marker exists?}
    B -- yes --> Z[return empty]
    B -- no --> C[read primary file]
    C -- success --> D{reset marker now exists?}
    D -- yes --> Z
    D -- no --> E[return loaded]
    C -- ENOENT --> F[loadFlaggedBackup]
    C -- other error --> G[log error + loadFlaggedBackup]
    G -- backup found --> E
    G -- no backup --> Z
    F -- backup found --> H{reset marker appeared mid-read?}
    H -- yes --> Z
    H -- no --> E
    F -- no backup --> I[check legacyPath]
    I -- exists --> J[migrate from legacyPath]
    I -- missing --> Z
    J --> E

    subgraph clearFlaggedAccountsOnDisk
        K[write reset marker] --> L[unlink primary + backups]
        L -- backup unlink fails --> M[keepResetMarker = true]
        L -- primary unlink fails --> N[throw — marker stays]
        M --> O{keepResetMarker?}
        L -- all succeed --> O
        O -- false --> P[unlink reset marker]
        O -- true --> Q[marker retained]
    end

    subgraph settings.json backup
        R[readSettingsRecordInternal] --> S{primary readable?}
        S -- yes --> T[return primary]
        S -- corrupt --> U[readSettingsBackup]
        U -- ok --> V[return backup usedBackup=true]
        U -- corrupt --> W[re-throw original error]
        S -- missing --> X[return null]
        T2[writeSettingsRecord] --> Y{usedBackup?}
        Y -- no --> AA[snapshot primary to .bak then write]
        Y -- yes --> BB[skip snapshot write only]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/config.ts`, line 501-517 ([link](https://github.com/ndycode/codex-multi-auth/blob/8403d6155248a7a373e30b40d5ffaa8ed2cb05ec/lib/config.ts#L501-L517)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Schema-invalid save patch values are silently dropped without a warning**

   `sanitizePluginConfigForSave` now delegates to `sanitizePluginConfigRecord` without `warnOnInvalid: true`. if a caller passes `parallelProbingMaxConcurrency: 7` and the zod schema rejects it, the key is silently stripped and the persisted value reverts to the default — this is exactly what the updated test at `test/config-save.test.ts:141` now asserts (changed from `7` to `2`). callers get no log to indicate their patch was partially dropped. consider passing `warnOnInvalid: true` or logging dropped keys here, consistent with the load-time warning already in `loadPluginConfig`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/config.ts
   Line: 501-517

   Comment:
   **Schema-invalid save patch values are silently dropped without a warning**

   `sanitizePluginConfigForSave` now delegates to `sanitizePluginConfigRecord` without `warnOnInvalid: true`. if a caller passes `parallelProbingMaxConcurrency: 7` and the zod schema rejects it, the key is silently stripped and the persisted value reverts to the default — this is exactly what the updated test at `test/config-save.test.ts:141` now asserts (changed from `7` to `2`). callers get no log to indicate their patch was partially dropped. consider passing `warnOnInvalid: true` or logging dropped keys here, consistent with the load-time warning already in `loadPluginConfig`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fconfig.ts%0ALine%3A%20501-517%0A%0AComment%3A%0A**Schema-invalid%20save%20patch%20values%20are%20silently%20dropped%20without%20a%20warning**%0A%0A%60sanitizePluginConfigForSave%60%20now%20delegates%20to%20%60sanitizePluginConfigRecord%60%20without%20%60warnOnInvalid%3A%20true%60.%20if%20a%20caller%20passes%20%60parallelProbingMaxConcurrency%3A%207%60%20and%20the%20zod%20schema%20rejects%20it%2C%20the%20key%20is%20silently%20stripped%20and%20the%20persisted%20value%20reverts%20to%20the%20default%20%E2%80%94%20this%20is%20exactly%20what%20the%20updated%20test%20at%20%60test%2Fconfig-save.test.ts%3A141%60%20now%20asserts%20%28changed%20from%20%607%60%20to%20%602%60%29.%20callers%20get%20no%20log%20to%20indicate%20their%20patch%20was%20partially%20dropped.%20consider%20passing%20%60warnOnInvalid%3A%20true%60%20or%20logging%20dropped%20keys%20here%2C%20consistent%20with%20the%20load-time%20warning%20already%20in%20%60loadPluginConfig%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fstorage%2Fflagged-storage-io.ts%3A49-76%0A**backup%20recovery%20depth%20mismatches%20load%20vs%20clear**%0A%0A%60getFlaggedBackupPaths%60%20hard-codes%20three%20levels%20%28%60.bak%60%2C%20%60.bak.1%60%2C%20%60.bak.2%60%29%2C%20but%20%60clearFlaggedAccountsOnDisk%60%20is%20called%20from%20%60storage.ts%60%20with%20%60getAccountsBackupRecoveryCandidatesWithDiscovery%60%20at%20%60ACCOUNTS_BACKUP_HISTORY_DEPTH%3D3%60%2C%20which%20generates%20four%20levels%20%28%60.bak%60%20through%20%60.bak.3%60%29.%20a%20%60.bak.3%60%20backup%20left%20from%20a%20previous%20rotation%20isn't%20checked%20during%20recovery%20here%2C%20so%20a%20partial-clear%20scenario%20that%20leaves%20%60.bak.3%60%20alive%20after%20deleting%20%60.bak%60%2F%60.bak.1%60%2F%60.bak.2%60%20could%20leave%20an%20unreachable-but-existing%20backup%20on%20disk.%20not%20a%20safety%20risk%20today%20%28the%20reset%20marker%20guards%20recovery%29%2C%20but%20worth%20aligning%20depths%20so%20the%20recovery%20list%20and%20the%20clear%20list%20are%20always%20in%20sync.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fstorage%2Fflagged-storage-io.ts%3A97-100%0A**backup%20recovery%20runs%20without%20write-back%20to%20primary**%0A%0Athe%20%60loadFlaggedBackup%28%29%60%20call%20at%20line%2097%20is%20reached%20only%20via%20the%20ENOENT%20fall-through%2C%20which%20is%20correct.%20however%2C%20the%20code%20doesn't%20write%20the%20recovered%20backup%20back%20to%20the%20primary%20path%20%E2%80%94%20so%20after%20recovery%20the%20next%20load%20will%20hit%20ENOENT%20again%20and%20recover%20from%20backup%20again%20each%20time.%20this%20is%20pre-existing%20behavior%20%28no%20write-back%20on%20recovery%29%2C%20but%20calling%20%60params.saveFlaggedAccounts%28recoveredBackup%29%60%20here%20%28as%20the%20legacy%20migration%20path%20does%29%20would%20make%20recovery%20self-healing%20and%20consistent%20with%20the%20existing%20pattern.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Funified-settings.ts%3A121-136%0A**transient%20EBUSY%20re-thrown%20in%20sync%20path%20with%20no%20retry**%0A%0A%60shouldFallbackToSettingsBackup%60%20returns%20%60false%60%20for%20%60EBUSY%60%2F%60EAGAIN%60%2C%20causing%20%60readSettingsRecordSyncInternal%60%20to%20re-throw.%20on%20Windows%2C%20%60EBUSY%60%20on%20sync%20file%20reads%20is%20common%20during%20concurrent%20access.%20%60loadUnifiedPluginConfigSync%60%20is%20protected%20by%20its%20own%20try%2Fcatch%20returning%20null%2C%20but%20%60saveUnifiedPluginConfigSync%60%20has%20no%20retry%20loop%20%E2%80%94%20a%20transient%20lock%20will%20propagate%20as%20an%20uncaught%20throw%20to%20callers.%20the%20async%20path%20in%20%60readConfigRecordForSave%60%20%28config.ts%29%20does%20retry%20on%20%60EBUSY%60%3B%20the%20sync%20equivalent%20in%20unified-settings%20doesn't%2C%20which%20is%20an%20inconsistency%20worth%20documenting%20at%20minimum.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/storage/flagged-storage-io.ts
Line: 49-76

Comment:
**backup recovery depth mismatches load vs clear**

`getFlaggedBackupPaths` hard-codes three levels (`.bak`, `.bak.1`, `.bak.2`), but `clearFlaggedAccountsOnDisk` is called from `storage.ts` with `getAccountsBackupRecoveryCandidatesWithDiscovery` at `ACCOUNTS_BACKUP_HISTORY_DEPTH=3`, which generates four levels (`.bak` through `.bak.3`). a `.bak.3` backup left from a previous rotation isn't checked during recovery here, so a partial-clear scenario that leaves `.bak.3` alive after deleting `.bak`/`.bak.1`/`.bak.2` could leave an unreachable-but-existing backup on disk. not a safety risk today (the reset marker guards recovery), but worth aligning depths so the recovery list and the clear list are always in sync.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/storage/flagged-storage-io.ts
Line: 97-100

Comment:
**backup recovery runs without write-back to primary**

the `loadFlaggedBackup()` call at line 97 is reached only via the ENOENT fall-through, which is correct. however, the code doesn't write the recovered backup back to the primary path — so after recovery the next load will hit ENOENT again and recover from backup again each time. this is pre-existing behavior (no write-back on recovery), but calling `params.saveFlaggedAccounts(recoveredBackup)` here (as the legacy migration path does) would make recovery self-healing and consistent with the existing pattern.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/unified-settings.ts
Line: 121-136

Comment:
**transient EBUSY re-thrown in sync path with no retry**

`shouldFallbackToSettingsBackup` returns `false` for `EBUSY`/`EAGAIN`, causing `readSettingsRecordSyncInternal` to re-throw. on Windows, `EBUSY` on sync file reads is common during concurrent access. `loadUnifiedPluginConfigSync` is protected by its own try/catch returning null, but `saveUnifiedPluginConfigSync` has no retry loop — a transient lock will propagate as an uncaught throw to callers. the async path in `readConfigRecordForSave` (config.ts) does retry on `EBUSY`; the sync equivalent in unified-settings doesn't, which is an inconsistency worth documenting at minimum.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix: harden config saves and stabilize r..."](https://github.com/ndycode/codex-multi-auth/commit/5b740f8c716a6efe9bf7678f47bb2f58226d3726) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27244145)</sub>

<!-- /greptile_comment -->