### PR TITLE
fix windows codex bin fallback resolution

### DIFF
--- a/scripts/codex-bin-resolver.js
+++ b/scripts/codex-bin-resolver.js
@@ -1,0 +1,85 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+function defaultResolvePackageBin(moduleUrl) {
+	try {
+		const require = createRequire(moduleUrl);
+		return require.resolve("@openai/codex/bin/codex.js");
+	} catch {
+		return null;
+	}
+}
+
+export function resolveRealCodexBin(options = {}) {
+	const {
+		env = process.env,
+		argv = process.argv,
+		platform = process.platform,
+		moduleUrl = import.meta.url,
+		existsSyncImpl = existsSync,
+		spawnSyncImpl = spawnSync,
+		resolvePackageBin = defaultResolvePackageBin,
+	} = options;
+
+	const override = (env.CODEX_MULTI_AUTH_REAL_CODEX_BIN ?? "").trim();
+	if (override.length > 0) {
+		if (existsSyncImpl(override)) return override;
+		return null;
+	}
+
+	const resolved = resolvePackageBin(moduleUrl);
+	if (typeof resolved === "string" && resolved.length > 0 && existsSyncImpl(resolved)) {
+		return resolved;
+	}
+
+	const searchRoots = [];
+	const scriptDir = dirname(fileURLToPath(moduleUrl));
+	searchRoots.push(join(scriptDir, "..", ".."));
+
+	const invokedScript = argv[1];
+	if (typeof invokedScript === "string" && invokedScript.length > 0) {
+		searchRoots.push(join(dirname(invokedScript), "..", ".."));
+	}
+
+	const npmPrefix = (env.npm_config_prefix ?? env.PREFIX ?? "").trim();
+	if (npmPrefix.length > 0) {
+		searchRoots.push(join(npmPrefix, "node_modules"));
+		searchRoots.push(join(npmPrefix, "lib", "node_modules"));
+	}
+
+	for (const root of searchRoots) {
+		const candidate = join(root, "@openai", "codex", "bin", "codex.js");
+		if (existsSyncImpl(candidate)) return candidate;
+	}
+
+	try {
+		const rootResult =
+			platform === "win32"
+				? spawnSyncImpl(env.ComSpec || "cmd.exe", ["/d", "/s", "/c", "npm root -g"], {
+						encoding: "utf8",
+						env,
+						stdio: ["ignore", "pipe", "ignore"],
+						windowsHide: true,
+					})
+				: spawnSyncImpl("npm", ["root", "-g"], {
+						encoding: "utf8",
+						env,
+						stdio: ["ignore", "pipe", "ignore"],
+					});
+		if (rootResult.status === 0) {
+			const globalRoot = rootResult.stdout.trim();
+			if (globalRoot.length > 0) {
+				const globalBin = join(globalRoot, "@openai", "codex", "bin", "codex.js");
+				if (existsSyncImpl(globalBin)) return globalBin;
+			}
+		}
+	} catch {
+		// Ignore and fall through to null.
+	}
+
+	return null;
+}

--- a/scripts/codex-bin-resolver.js
+++ b/scripts/codex-bin-resolver.js
@@ -14,6 +14,18 @@ function defaultResolvePackageBin(moduleUrl) {
 	}
 }
 
+function resolveWindowsCmdPath(env) {
+	const comSpec = (env.ComSpec ?? env.COMSPEC ?? "").trim();
+	if (comSpec.length > 0) return comSpec;
+
+	const systemRoot = (env.SystemRoot ?? env.SYSTEMROOT ?? "").trim();
+	if (systemRoot.length > 0) {
+		return `${systemRoot.replace(/[\\/]+$/, "")}\\System32\\cmd.exe`;
+	}
+
+	return "cmd.exe";
+}
+
 export function resolveRealCodexBin(options = {}) {
 	const {
 		env = process.env,
@@ -59,7 +71,7 @@ export function resolveRealCodexBin(options = {}) {
 	try {
 		const rootResult =
 			platform === "win32"
-				? spawnSyncImpl(env.ComSpec || "cmd.exe", ["/d", "/s", "/c", "npm root -g"], {
+				? spawnSyncImpl(resolveWindowsCmdPath(env), ["/d", "/s", "/c", "npm root -g"], {
 						encoding: "utf8",
 						env,
 						stdio: ["ignore", "pipe", "ignore"],

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { basename, delimiter, dirname, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { resolveRealCodexBin as resolveRealCodexBinFromEnvironment } from "./codex-bin-resolver.js";
 import { normalizeAuthAlias, shouldHandleMultiAuthAuth } from "./codex-routing.js";
 
 function hydrateCliVersionEnv() {
@@ -74,52 +75,7 @@ function resolveRealCodexBin() {
 		return null;
 	}
 
-	try {
-		const require = createRequire(import.meta.url);
-		const resolved = require.resolve("@openai/codex/bin/codex.js");
-		if (existsSync(resolved)) return resolved;
-	} catch {
-		// Fall through to sibling lookup.
-	}
-
-	const searchRoots = [];
-	const scriptDir = dirname(fileURLToPath(import.meta.url));
-	searchRoots.push(join(scriptDir, "..", ".."));
-
-	const invokedScript = process.argv[1];
-	if (typeof invokedScript === "string" && invokedScript.length > 0) {
-		searchRoots.push(join(dirname(invokedScript), "..", ".."));
-	}
-
-	const npmPrefix = (process.env.npm_config_prefix ?? process.env.PREFIX ?? "").trim();
-	if (npmPrefix.length > 0) {
-		searchRoots.push(join(npmPrefix, "node_modules"));
-		searchRoots.push(join(npmPrefix, "lib", "node_modules"));
-	}
-
-	for (const root of searchRoots) {
-		const candidate = join(root, "@openai", "codex", "bin", "codex.js");
-		if (existsSync(candidate)) return candidate;
-	}
-
-	const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-	try {
-		const rootResult = spawnSync(npmCmd, ["root", "-g"], {
-			encoding: "utf8",
-			stdio: ["ignore", "pipe", "ignore"],
-		});
-		if (rootResult.status === 0) {
-			const globalRoot = rootResult.stdout.trim();
-			if (globalRoot.length > 0) {
-				const globalBin = join(globalRoot, "@openai", "codex", "bin", "codex.js");
-				if (existsSync(globalBin)) return globalBin;
-			}
-		}
-	} catch {
-		// Ignore and fall through to null.
-	}
-
-	return null;
+	return resolveRealCodexBinFromEnvironment({ moduleUrl: import.meta.url });
 }
 
 function forwardToRealCodex(codexBin, args) {

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -10,9 +10,10 @@ import {
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { sleep } from "../lib/utils.js";
+import { resolveRealCodexBin } from "../scripts/codex-bin-resolver.js";
 
 const createdDirs: string[] = [];
 const testFileDir = dirname(fileURLToPath(import.meta.url));
@@ -57,6 +58,10 @@ function createWrapperFixture(): string {
 		join(repoRootDir, "scripts", "codex-routing.js"),
 		join(scriptDir, "codex-routing.js"),
 	);
+	copyFileSync(
+		join(repoRootDir, "scripts", "codex-bin-resolver.js"),
+		join(scriptDir, "codex-bin-resolver.js"),
+	);
 	return fixtureRoot;
 }
 
@@ -77,6 +82,21 @@ function createFakeCodexBin(rootDir: string): string {
 function createCustomFakeCodexBin(rootDir: string, lines: string[]): string {
 	const fakeBin = join(rootDir, `fake-codex-${createdDirs.length}.js`);
 	writeFileSync(fakeBin, lines.join("\n"), "utf8");
+	return fakeBin;
+}
+
+function createFakeGlobalCodexInstall(rootDir: string): string {
+	const fakeBin = join(rootDir, "@openai", "codex", "bin", "codex.js");
+	mkdirSync(dirname(fakeBin), { recursive: true });
+	writeFileSync(
+		fakeBin,
+		[
+			"#!/usr/bin/env node",
+			'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
+			"process.exit(0);",
+		].join("\n"),
+		"utf8",
+	);
 	return fakeBin;
 }
 
@@ -467,6 +487,10 @@ describe("codex bin wrapper", () => {
 				join(repoRootDir, "scripts", "codex-routing.js"),
 				join(scriptDir, "codex-routing.js"),
 			);
+			copyFileSync(
+				join(repoRootDir, "scripts", "codex-bin-resolver.js"),
+				join(scriptDir, "codex-bin-resolver.js"),
+			);
 			writeFileSync(
 				join(globalShimDir, "codex-multi-auth.cmd"),
 				"@ECHO OFF\r\nREM real shim\r\n",
@@ -593,6 +617,61 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain(
 			"Install it globally: npm install -g @openai/codex",
 		);
+	});
+
+	it("discovers the real codex bin via npm root fallback for direct script runs on Windows", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules");
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				ComSpec: "C:\\Windows\\System32\\cmd.exe",
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return {
+					output: ["", `${fakeGlobalRoot}\r\n`, ""],
+					pid: 1,
+					signal: null,
+					status: 0,
+					stderr: "",
+					stdout: `${fakeGlobalRoot}\r\n`,
+				};
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			encoding: "utf8",
+			env: {
+				ComSpec: "C:\\Windows\\System32\\cmd.exe",
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
+		});
 	});
 
 	it("handles concurrent wrapper invocations without module-load regressions", async () => {

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -890,6 +890,7 @@ describe("codex bin wrapper", () => {
 			},
 			stdio: ["ignore", "pipe", "ignore"],
 		});
+		expect(spawnCalls[0]?.options).not.toHaveProperty("windowsHide");
 	});
 
 	it("handles concurrent wrapper invocations without module-load regressions", async () => {

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -763,6 +763,50 @@ describe("codex bin wrapper", () => {
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
 	});
 
+	it("falls back to bare cmd.exe when no Windows shell env vars are set", () => {
+		const fixtureRoot = createWrapperFixture();
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+
+		resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: () => false,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess("");
+			},
+		});
+
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			encoding: "utf8",
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
+		});
+	});
+
 	it("discovers the real codex bin via npm root fallback on POSIX", () => {
 		const fixtureRoot = createWrapperFixture();
 		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules-posix");

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -100,6 +100,17 @@ function createFakeGlobalCodexInstall(rootDir: string): string {
 	return fakeBin;
 }
 
+function createSpawnSyncSuccess(stdout: string): SpawnSyncReturns<string> {
+	return {
+		output: ["", stdout, ""],
+		pid: 1,
+		signal: null,
+		status: 0,
+		stderr: "",
+		stdout,
+	};
+}
+
 function runWrapper(
 	fixtureRoot: string,
 	args: string[],
@@ -646,14 +657,7 @@ describe("codex bin wrapper", () => {
 					command,
 					options: options as Record<string, unknown>,
 				});
-				return {
-					output: ["", `${fakeGlobalRoot}\r\n`, ""],
-					pid: 1,
-					signal: null,
-					status: 0,
-					stderr: "",
-					stdout: `${fakeGlobalRoot}\r\n`,
-				};
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\r\n`);
 			},
 		});
 
@@ -671,6 +675,136 @@ describe("codex bin wrapper", () => {
 			},
 			stdio: ["ignore", "pipe", "ignore"],
 			windowsHide: true,
+		});
+	});
+
+	it("honors uppercase COMSPEC when resolving the Windows npm root fallback", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules-uppercase");
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\r\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			encoding: "utf8",
+			env: {
+				COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
+		});
+	});
+
+	it("derives cmd.exe from SystemRoot when ComSpec is unavailable", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules-systemroot");
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				SystemRoot: "C:\\Windows\\",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\r\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+	});
+
+	it("discovers the real codex bin via npm root fallback on POSIX", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules-posix");
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "linux",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("npm");
+		expect(spawnCalls[0]?.args).toEqual(["root", "-g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			encoding: "utf8",
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			stdio: ["ignore", "pipe", "ignore"],
 		});
 	});
 

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -763,6 +763,46 @@ describe("codex bin wrapper", () => {
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
 	});
 
+	it("derives cmd.exe from uppercase SYSTEMROOT when ComSpec is unavailable", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(
+			fixtureRoot,
+			"fake-global-node_modules-systemroot-uppercase",
+		);
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				SYSTEMROOT: "C:\\Windows\\",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\r\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+	});
+
 	it("falls back to bare cmd.exe when no Windows shell env vars are set", () => {
 		const fixtureRoot = createWrapperFixture();
 		const spawnCalls: Array<{


### PR DESCRIPTION
## Summary

- fix direct `scripts/codex.js` wrapper resolution on Windows when the global Codex lookup must go through the shell
- honor `ComSpec`, `COMSPEC`, `SystemRoot`, and `SYSTEMROOT` fallback paths for the Windows `npm root -g` lookup
- add regression coverage for the Windows and POSIX resolver fallback paths, including the uppercase `SYSTEMROOT` branch

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run test/codex-bin-wrapper.test.ts`
- `npm run build`
- `node scripts/codex.js --version`

## Notes

- cleaned replacement for the Windows-specific slice split out of `#346`
- follow-up reviewer coverage landed in `79f7ad4`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr extracts the codex bin resolution logic from `scripts/codex.js` into a new injectable module `scripts/codex-bin-resolver.js`, fixing the windows fallback that previously used `npm.cmd` directly (which fails when npm is not on PATH as a `.cmd` shim). the fix introduces `resolveWindowsCmdPath(env)` to properly honor `ComSpec`/`COMSPEC` and `SystemRoot`/`SYSTEMROOT` env var precedence, then invokes npm via `cmd.exe /d /s /c "npm root -g"` — the correct windows pattern. the refactor also makes every dependency injectable, enabling the new vitest unit tests that cover all four windows env-var branches and the posix fallback path without spawning real processes.

- new `scripts/codex-bin-resolver.js` with fully injectable `resolveRealCodexBin(options)`, `resolveWindowsCmdPath(env)`, and `defaultResolvePackageBin`
- `scripts/codex.js` removes ~45 lines of inline resolver logic; local wrapper retains the user-facing error message for a missing `CODEX_MULTI_AUTH_REAL_CODEX_BIN` override before delegating to the new module
- five new unit tests added: windows `ComSpec`, windows `SystemRoot`, windows `SYSTEMROOT` (uppercase), bare `cmd.exe` fallback, and posix `npm root -g` path
- `windowsHide: true` on the windows spawn prevents a stray cmd.exe console window from flashing — good windows ux hygiene
- full `process.env` (including any auth tokens) is passed to the npm subprocess on windows — unavoidable for npm global prefix resolution but worth being aware of on shared or ci windows environments

<h3>Confidence Score: 5/5</h3>

safe to merge — all changed paths are stateless, well-tested via injected dependencies, and the windows cmd.exe invocation pattern is standard and correct

five new unit tests cover every new branch; no concurrency issues (resolver is purely functional); no data-loss, auth-boundary, or token-safety bugs found; the one notable behavior (full env passed to subprocess) is unavoidable and pre-existing in spirit

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/codex-bin-resolver.js | new injectable resolver module — correctly handles ComSpec/COMSPEC/SystemRoot/SYSTEMROOT precedence and uses cmd.exe /d /s /c for safe Windows npm invocation |
| scripts/codex.js | cleanly delegates to codex-bin-resolver; retains user-facing error log for missing CODEX_MULTI_AUTH_REAL_CODEX_BIN override; no regressions |
| test/codex-bin-wrapper.test.ts | adds five targeted unit tests covering all new Windows and POSIX resolver branches via full dependency injection — no real processes spawned |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as codex.js wrapper
    participant R as codex-bin-resolver.js
    participant FS as filesystem
    participant NM as npm subprocess

    W->>W: check CODEX_MULTI_AUTH_REAL_CODEX_BIN override
    alt override set
        W->>FS: existsSync(override)
        FS-->>W: exists / missing
        W-->>W: return path or null + console.error
    else no override
        W->>R: resolveRealCodexBin({ moduleUrl })
        R->>R: resolvePackageBin via createRequire
        alt resolved by require
            R->>FS: existsSync(resolved)
            FS-->>R: true
            R-->>W: return resolved path
        else not resolved
            R->>R: search scriptDir / argv[1] / npm_config_prefix roots
            alt found in search roots
                R-->>W: return candidate path
            else not found
                alt platform === win32
                    R->>R: resolveWindowsCmdPath(env)
                    Note right of R: ComSpec → COMSPEC → SystemRoot\System32\cmd.exe → cmd.exe
                    R->>NM: cmd.exe /d /s /c npm root -g
                else POSIX
                    R->>NM: npm root -g
                end
                NM-->>R: global node_modules root stdout
                R->>FS: existsSync(globalRoot/@openai/codex/bin/codex.js)
                FS-->>R: true / false
                R-->>W: return path or null
            end
        end
    end
```

<sub>Reviews (6): Last reviewed commit: ["test: pin posix fallback spawn options"](https://github.com/ndycode/codex-multi-auth/commit/e05bad94d3d13155268ea3d12bfa59c31b282b48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27355455)</sub>

<!-- /greptile_comment -->