### PR TITLE
fix usage-limit cooldown persistence under concurrent retries

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2152,11 +2152,6 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 																if (!fallbackResponse.ok) {
 																	const { response: handledFallbackResponse, rateLimit: fallbackRateLimit } =
 																		await handleErrorResponse(fallbackResponse);
-																	try {
-																		await fallbackResponse.body?.cancel();
-																	} catch {
-																		// Best effort cleanup before trying next fallback account.
-																	}
 																	if (
 																		fallbackRateLimit ||
 																		handledFallbackResponse.status === 429

--- a/index.ts
+++ b/index.ts
@@ -1865,11 +1865,19 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 														quotaKey,
 														rateLimit.retryAfterMs,
 													);
+													const cooldownMs = Math.max(
+														delayMs,
+														rateLimit.retryAfterMs,
+													);
 													preemptiveQuotaScheduler.markRateLimited(
 														quotaScheduleKey,
-														delayMs,
+														cooldownMs,
 													);
-													const waitLabel = formatWaitTime(delayMs);
+													const waitLabel = formatWaitTime(
+														delayMs <= RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS
+															? delayMs
+															: cooldownMs,
+													);
 
 													if (delayMs <= RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS) {
 														if (
@@ -1894,7 +1902,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 
 													accountManager.markRateLimitedWithReason(
 														account,
-														delayMs,
+														cooldownMs,
 														modelFamily,
 														parseRateLimitReason(rateLimit.code),
 														model,
@@ -2142,16 +2150,19 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 																	);
 																}
 																if (!fallbackResponse.ok) {
+																	const { response: handledFallbackResponse, rateLimit: fallbackRateLimit } =
+																		await handleErrorResponse(fallbackResponse);
 																	try {
 																		await fallbackResponse.body?.cancel();
 																	} catch {
 																		// Best effort cleanup before trying next fallback account.
 																	}
-																	if (fallbackResponse.status === 429) {
+																	if (
+																		fallbackRateLimit ||
+																		handledFallbackResponse.status === 429
+																	) {
 																		const retryAfterMs =
-																			parseRetryAfterHintMs(
-																				fallbackResponse.headers,
-																			) ?? 60_000;
+																			fallbackRateLimit?.retryAfterMs ?? 60_000;
 																		accountManager.markRateLimitedWithReason(
 																			fallbackAccount,
 																			retryAfterMs,

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -783,7 +783,8 @@ export class AccountManager {
 
 		const baseKey = getQuotaKey(family);
 		if (!model || reason === "quota" || reason === "unknown") {
-			account.rateLimitResetTimes[baseKey] = resetAt;
+			const currentResetAt = account.rateLimitResetTimes[baseKey] ?? 0;
+			account.rateLimitResetTimes[baseKey] = Math.max(currentResetAt, resetAt);
 		}
 
 		if (
@@ -791,7 +792,8 @@ export class AccountManager {
 			(reason === "tokens" || reason === "concurrent" || reason === "unknown")
 		) {
 			const modelKey = getQuotaKey(family, model);
-			account.rateLimitResetTimes[modelKey] = resetAt;
+			const currentResetAt = account.rateLimitResetTimes[modelKey] ?? 0;
+			account.rateLimitResetTimes[modelKey] = Math.max(currentResetAt, resetAt);
 		}
 
 		account.lastRateLimitReason = reason;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -68,7 +68,11 @@ const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
 	/model is not supported when using codex with a chatgpt account/i;
 const NORMALIZED_UNSUPPORTED_MODEL_PATTERN =
 	/the model ['"]([^'"]+)['"] is not currently available for this chatgpt account/i;
-const MAX_RETRY_DELAY_MS = 5 * 60 * 1000;
+const MAX_RATE_LIMIT_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
+const RETRY_AFTER_DURATION_PATTERN =
+	/\b(?:try|retry)\s+again\s+in\s+(\d+)\s*(second|minute|hour|day)s?\b/i;
+const RETRY_AFTER_CLOCK_TIME_PATTERN =
+	/\b(?:try|retry)\s+again\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b/i;
 const CREATE_CODEX_HEADERS_PARAM_KEYS = new Set(["init", "accountId", "accessToken", "opts"]);
 const DEFAULT_PROXY_PORTS: Record<string, number> = {
 	"http:": 80,
@@ -1026,7 +1030,7 @@ function extractRateLimitInfoFromBody(
         if (!isRateLimit) return undefined;
 
         const retryAfterMs =
-                parseRetryAfterMs(response, parsed) ?? 60000;
+                parseRetryAfterMs(response, bodyText, parsed) ?? 60000;
 
         return { retryAfterMs, code: parsed?.code };
 }
@@ -1199,6 +1203,7 @@ function ensureJsonErrorResponse(response: Response, payload: ErrorPayload): Res
 
 function parseRetryAfterMs(
 	response: Response,
+	bodyText: string,
 	parsedBody?: { resetsAt?: number; retryAfterMs?: number; retryAfterSeconds?: number },
 ): number | null {
 	if (parsedBody?.retryAfterMs !== undefined) {
@@ -1255,25 +1260,87 @@ function parseRetryAfterMs(
                 if (delta > 0) resetCandidates.push(delta);
         }
 
-        if (resetCandidates.length > 0) {
-                return Math.min(...resetCandidates);
-        }
+	if (resetCandidates.length > 0) {
+		return Math.min(...resetCandidates);
+	}
+
+	const naturalLanguageRetryAfterMs = parseRetryAfterTextMs(bodyText, now);
+	if (naturalLanguageRetryAfterMs !== null) {
+		return naturalLanguageRetryAfterMs;
+	}
 
         return null;
 }
 
-function normalizeRetryAfterMs(value: number): number | null {
+function parseRetryAfterTextMs(bodyText: string, now: number): number | null {
+	if (!bodyText) return null;
+
+	const durationMatch = bodyText.match(RETRY_AFTER_DURATION_PATTERN);
+	if (durationMatch) {
+		const amount = Number.parseInt(durationMatch[1] ?? "", 10);
+		const unit = (durationMatch[2] ?? "").toLowerCase();
+		if (Number.isFinite(amount) && amount > 0) {
+			const multiplier =
+				unit === "second"
+					? 1000
+					: unit === "minute"
+						? 60_000
+						: unit === "hour"
+							? 60 * 60_000
+							: unit === "day"
+								? 24 * 60 * 60_000
+								: 0;
+			if (multiplier > 0) {
+				return clampRateLimitDelayMs(amount * multiplier);
+			}
+		}
+	}
+
+	const clockTimeMatch = bodyText.match(RETRY_AFTER_CLOCK_TIME_PATTERN);
+	if (!clockTimeMatch) return null;
+
+	const hour12 = Number.parseInt(clockTimeMatch[1] ?? "", 10);
+	const minute = Number.parseInt(clockTimeMatch[2] ?? "0", 10);
+	const meridiem = (clockTimeMatch[3] ?? "").toLowerCase();
+	if (
+		!Number.isFinite(hour12) ||
+		hour12 < 1 ||
+		hour12 > 12 ||
+		!Number.isFinite(minute) ||
+		minute < 0 ||
+		minute > 59 ||
+		(meridiem !== "am" && meridiem !== "pm")
+	) {
+		return null;
+	}
+
+	const target = new Date(now);
+	let hour24 = hour12 % 12;
+	if (meridiem === "pm") {
+		hour24 += 12;
+	}
+	target.setHours(hour24, minute, 0, 0);
+	if (target.getTime() <= now) {
+		target.setDate(target.getDate() + 1);
+	}
+
+	return clampRateLimitDelayMs(target.getTime() - now);
+}
+
+function clampRateLimitDelayMs(value: number): number | null {
 	if (!Number.isFinite(value)) return null;
-	const ms = Math.floor(value);
-	if (ms <= 0) return null;
-	return Math.min(ms, MAX_RETRY_DELAY_MS);
+	const normalized = Math.floor(value);
+	if (normalized <= 0) return null;
+	return Math.min(normalized, MAX_RATE_LIMIT_DELAY_MS);
+}
+
+function normalizeRetryAfterMs(value: number): number | null {
+	return clampRateLimitDelayMs(value);
 }
 
 function normalizeRetryAfterSeconds(value: number): number | null {
 	if (!Number.isFinite(value)) return null;
-	const ms = Math.floor(value * 1000);
-	if (ms <= 0) return null;
-	return Math.min(ms, MAX_RETRY_DELAY_MS);
+	return clampRateLimitDelayMs(value * 1000);
 }
 
 function toNumber(value: unknown): number | undefined {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -918,6 +918,33 @@ describe("AccountManager", () => {
       expect(account.rateLimitResetTimes["codex"]).toBeUndefined();
       expect(account.rateLimitResetTimes["codex:gpt-5.2"]).toBeDefined();
     });
+
+    it("does not shorten an existing reset when a later retry window is smaller", () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-04-05T00:00:00.000Z");
+        vi.setSystemTime(now);
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            { refreshToken: "token-1", addedAt: now.getTime(), lastUsed: now.getTime() },
+          ],
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getCurrentAccount()!;
+        manager.markRateLimitedWithReason(account, 90 * 60_000, "codex", "quota");
+
+        const firstResetAt = account.rateLimitResetTimes["codex"];
+
+        manager.markRateLimitedWithReason(account, 60_000, "codex", "quota");
+
+        expect(account.rateLimitResetTimes["codex"]).toBe(firstResetAt);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("cooldown management", () => {

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -1112,13 +1112,26 @@ describe('createEntitlementErrorResponse', () => {
 			expect(rateLimit?.retryAfterMs).toBe(2500);
 		});
 
-	it('caps retryAfterMs at 5 minutes', async () => {
-		const body = { error: { message: 'rate limited', retry_after_ms: 600000 } };
+		it('parses natural-language retry times from usage-limit messages', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date(2026, 2, 22, 4, 0, 0, 0));
+			const response = new Response(
+				"You've hit your usage limit. To get more access now, send a request to your admin or try again at 6:26 AM.",
+				{ status: 429 },
+			);
+
+			const { rateLimit } = await handleErrorResponse(response);
+
+			expect(rateLimit?.retryAfterMs).toBe((2 * 60 + 26) * 60 * 1000);
+		});
+
+	it('caps retryAfterMs at 7 days', async () => {
+		const body = { error: { message: 'rate limited', retry_after_ms: 10 * 24 * 60 * 60 * 1000 } };
 		const response = new Response(JSON.stringify(body), { status: 429 });
 		
 		const { rateLimit } = await handleErrorResponse(response);
 		
-		expect(rateLimit?.retryAfterMs).toBe(300000);
+		expect(rateLimit?.retryAfterMs).toBe(7 * 24 * 60 * 60 * 1000);
 	});
 
 	it('handles invalid retry-after header with default fallback', async () => {

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -1114,15 +1114,19 @@ describe('createEntitlementErrorResponse', () => {
 
 		it('parses natural-language retry times from usage-limit messages', async () => {
 			vi.useFakeTimers();
-			vi.setSystemTime(new Date(2026, 2, 22, 4, 0, 0, 0));
-			const response = new Response(
-				"You've hit your usage limit. To get more access now, send a request to your admin or try again at 6:26 AM.",
-				{ status: 429 },
-			);
+			try {
+				vi.setSystemTime(new Date(2026, 2, 22, 4, 0, 0, 0));
+				const response = new Response(
+					"You've hit your usage limit. To get more access now, send a request to your admin or try again at 6:26 AM.",
+					{ status: 429 },
+				);
 
-			const { rateLimit } = await handleErrorResponse(response);
+				const { rateLimit } = await handleErrorResponse(response);
 
-			expect(rateLimit?.retryAfterMs).toBe((2 * 60 + 26) * 60 * 1000);
+				expect(rateLimit?.retryAfterMs).toBe((2 * 60 + 26) * 60 * 1000);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 	it('caps retryAfterMs at 7 days', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4176,6 +4176,52 @@ describe("OpenAIOAuthPlugin runtime toast forwarding", () => {
 		expect(markToastShown).toHaveBeenCalledWith(0);
 	});
 
+	it("persists the parsed rate-limit cooldown instead of the shorter retry backoff", async () => {
+		const { AccountManager } = await import("../lib/accounts.js");
+		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");
+		const rateLimitBackoffModule = await import("../lib/request/rate-limit-backoff.js");
+
+		const markRateLimitedWithReason = vi.spyOn(
+			AccountManager.prototype,
+			"markRateLimitedWithReason",
+		);
+		vi.mocked(fetchHelpersModule.handleErrorResponse).mockResolvedValueOnce({
+			response: new Response("rate limited", { status: 429 }),
+			rateLimit: {
+				retryAfterMs: 90 * 60 * 1000,
+				code: "usage_limit_reached",
+			},
+			errorBody: "rate limited",
+		} as never);
+		vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValueOnce({
+			attempt: 1,
+			delayMs: 60_000,
+		});
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ content: "ok" }), { status: 200 }),
+			);
+
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
+		const sdk = await plugin.auth.loader(getOAuthAuth, { options: {}, models: {} });
+		await sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5-codex" }),
+		});
+
+		expect(markRateLimitedWithReason).toHaveBeenCalledWith(
+			expect.anything(),
+			90 * 60 * 1000,
+			"codex",
+			expect.any(String),
+			"gpt-5-codex",
+		);
+	});
+
 	it("forwards persistence error toast arguments through manual OAuth flow", async () => {
 		const authModule = await import("../lib/auth/auth.js");
 		const storageModule = await import("../lib/storage.js");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4176,50 +4176,159 @@ describe("OpenAIOAuthPlugin runtime toast forwarding", () => {
 		expect(markToastShown).toHaveBeenCalledWith(0);
 	});
 
-	it("persists the parsed rate-limit cooldown instead of the shorter retry backoff", async () => {
+	it("persists the longer parsed rate-limit cooldown across overlapping requests", async () => {
 		const { AccountManager } = await import("../lib/accounts.js");
 		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");
 		const rateLimitBackoffModule = await import("../lib/request/rate-limit-backoff.js");
-
-		const markRateLimitedWithReason = vi.spyOn(
-			AccountManager.prototype,
-			"markRateLimitedWithReason",
-		);
-		vi.mocked(fetchHelpersModule.handleErrorResponse).mockResolvedValueOnce({
-			response: new Response("rate limited", { status: 429 }),
-			rateLimit: {
-				retryAfterMs: 90 * 60 * 1000,
-				code: "usage_limit_reached",
-			},
-			errorBody: "rate limited",
-		} as never);
-		vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValueOnce({
-			attempt: 1,
-			delayMs: 60_000,
-		});
-		globalThis.fetch = vi
-			.fn()
-			.mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
-			.mockResolvedValueOnce(
-				new Response(JSON.stringify({ content: "ok" }), { status: 200 }),
+		const longCooldownMs = 90 * 60 * 1000;
+		const shortCooldownMs = 60_000;
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-04-05T00:00:00.000Z"));
+			const requestAccount = {
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+				rateLimitResetTimes: {} as Record<string, number>,
+				lastSwitchReason: undefined as string | undefined,
+			};
+			const markRateLimitedWithReason = vi.fn(
+				(
+					account: { rateLimitResetTimes: Record<string, number> },
+					retryAfterMs: number,
+					family: string,
+					reason: string,
+					model?: string | null,
+				) => {
+					const resetAt = Date.now() + retryAfterMs;
+					const baseKey = family;
+					if (!model || reason === "quota" || reason === "unknown") {
+						account.rateLimitResetTimes[baseKey] = Math.max(
+							account.rateLimitResetTimes[baseKey] ?? 0,
+							resetAt,
+						);
+					}
+					if (
+						model &&
+						(reason === "tokens" || reason === "concurrent" || reason === "unknown")
+					) {
+						const modelKey = `${family}:${model}`;
+						account.rateLimitResetTimes[modelKey] = Math.max(
+							account.rateLimitResetTimes[modelKey] ?? 0,
+							resetAt,
+						);
+					}
+				},
 			);
+			const manager = {
+				getAccountCount: () => 1,
+				getCurrentOrNextForFamilyHybrid: () => requestAccount,
+				getCurrentOrNextForFamily: () => requestAccount,
+				getCurrentWorkspace: () => null,
+				getAccountByIndex: () => null,
+				getAccountsSnapshot: () => [requestAccount],
+				isAccountAvailableForFamily: () => true,
+				toAuthDetails: () => ({
+					type: "oauth" as const,
+					access: "access-token",
+					refresh: "refresh-1",
+					expires: Date.now() + 60_000,
+				}),
+				hasRefreshToken: () => true,
+				saveToDiskDebounced: () => {},
+				updateFromAuth: () => {},
+				clearAuthFailures: () => {},
+				incrementAuthFailures: () => 1,
+				saveToDisk: async () => {},
+				markAccountCoolingDown: () => {},
+				markRateLimited: () => {},
+				markRateLimitedWithReason,
+				consumeToken: () => true,
+				refundToken: () => {},
+				syncCodexCliActiveSelectionForIndex: async () => {},
+				markSwitched: () => {},
+				removeAccount: () => {},
+				recordFailure: () => {},
+				recordSuccess: () => {},
+				recordRateLimit: () => {},
+				getMinWaitTimeForFamily: () => 0,
+				shouldShowAccountToast: () => false,
+				markToastShown: () => {},
+				setActiveIndex: () => null,
+			};
+			vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValue(manager as never);
 
-		const mockClient = createMockClient();
-		const { OpenAIOAuthPlugin } = await import("../index.js");
-		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
-		const sdk = await plugin.auth.loader(getOAuthAuth, { options: {}, models: {} });
-		await sdk.fetch!("https://api.openai.com/v1/chat/completions", {
-			method: "POST",
-			body: JSON.stringify({ model: "gpt-5-codex" }),
-		});
+			let releaseSecondResponse!: () => void;
+			const secondResponseReached = new Promise<void>((resolve) => {
+				releaseSecondResponse = resolve;
+			});
+			let rateLimitCallCount = 0;
+			vi.mocked(fetchHelpersModule.handleErrorResponse).mockImplementation(
+				async () => {
+					const callIndex = rateLimitCallCount++;
+					const result = {
+						response: new Response("rate limited", { status: 429 }),
+						rateLimit:
+							callIndex === 0
+								? {
+										retryAfterMs: longCooldownMs,
+										code: "usage_limit_reached",
+									}
+								: {
+										retryAfterMs: shortCooldownMs,
+										code: "usage_limit_reached",
+									},
+						errorBody: "rate limited",
+					};
 
-		expect(markRateLimitedWithReason).toHaveBeenCalledWith(
-			expect.anything(),
-			90 * 60 * 1000,
-			"codex",
-			expect.any(String),
-			"gpt-5-codex",
-		);
+					if (callIndex === 0) {
+						await secondResponseReached;
+						return result as never;
+					}
+
+					releaseSecondResponse();
+					await Promise.resolve();
+					return result as never;
+				},
+			);
+			vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValue({
+				attempt: 1,
+				delayMs: 60_000,
+			});
+
+			let upstreamCallCount = 0;
+			globalThis.fetch = vi.fn(async () => {
+				upstreamCallCount += 1;
+				if (upstreamCallCount <= 2) {
+					return new Response("rate limited", { status: 429 });
+				}
+				return new Response(JSON.stringify({ content: "ok" }), { status: 200 });
+			});
+
+			const mockClient = createMockClient();
+			const { OpenAIOAuthPlugin } = await import("../index.js");
+			const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
+			const sdk = await plugin.auth.loader(getOAuthAuth, { options: {}, models: {} });
+
+			await Promise.all([
+				sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+					method: "POST",
+					body: JSON.stringify({ model: "gpt-5-codex" }),
+				}),
+				sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+					method: "POST",
+					body: JSON.stringify({ model: "gpt-5-codex" }),
+				}),
+			]);
+
+			expect(markRateLimitedWithReason).toHaveBeenCalledTimes(2);
+			expect(requestAccount.rateLimitResetTimes["codex"]).toBe(
+				Date.parse("2026-04-05T01:30:00.000Z"),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("forwards persistence error toast arguments through manual OAuth flow", async () => {


### PR DESCRIPTION
## Summary

- fix usage-limit cooldown persistence when overlapping 429 responses race on the same account
- restore timer cleanup in the natural-language retry test and remove consumed-body cleanup from fallback 429 handling

## What Changed

- preserve the longest stored reset timestamp in `AccountManager.markRateLimitedWithReason`
- add regressions for a shorter follow-up retry window and overlapping `sdk.fetch()` requests
- wrap the natural-language retry test in `try/finally` with `vi.useRealTimers()` and remove the no-op `fallbackResponse.body?.cancel()` after `handleErrorResponse`

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- --run test/fetch-helpers.test.ts test/accounts.test.ts test/index.test.ts test/codex-manager-cli.test.ts`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: Low
- Rollback plan: revert `ce83c9d` and `d950b17`

## Additional Notes

- clean follow-up for the usage-limit fix that was accidentally pushed onto `#347`; that PR will be reset back to its intended scope

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes two related concurrency bugs in the usage-limit cooldown subsystem and adds natural-language rate-limit body parsing.

**core fixes:**
- `lib/accounts.ts`: `markRateLimitedWithReason` now uses `Math.max` so a shorter follow-up 429 can't overwrite a longer existing reset timestamp — the right fix for concurrent retries racing on the same account
- `index.ts`: `cooldownMs = Math.max(delayMs, rateLimit.retryAfterMs)` ensures the preemptive scheduler and account manager both receive the authoritative server-specified cooldown, not just the local backoff estimate
- `index.ts`: fallback 429 handling now routes through `handleErrorResponse` for consistent body-parsed rate-limit info instead of header-only `parseRetryAfterHintMs`

**new feature:**
- `lib/request/fetch-helpers.ts`: `parseRetryAfterTextMs` added with `RETRY_AFTER_DURATION_PATTERN` (\"retry again in N minutes\") and `RETRY_AFTER_CLOCK_TIME_PATTERN` (\"try again at 3:00 PM\"); `MAX_RATE_LIMIT_DELAY_MS` raised from 5 min → 7 days, which silently extends the cap for **all** retry-after sources (headers, body fields, timestamps), not just natural-language text

**concerns:**
- `RETRY_AFTER_DURATION_PATTERN` has no direct vitest coverage; only the clock-time variant is tested
- the 7-day cap change affects all retry-after parsing paths — the cap test was updated but the scope of the change isn't obvious from the test name
- clock-time parsing relies on the node process's local timezone, which can produce wrong deltas on windows machines in a different timezone from the api server
- the concurrent integration test in `test/index.test.ts` duplicates the `Math.max` logic inside its mock rather than delegating to the real implementation

<h3>Confidence Score: 3/5</h3>

safe to merge with caveats — core concurrency fix is correct but natural-language parsing changes are undertested and the cap increase has broader behavioral scope than advertised

the accounts.ts and index.ts fixes are clean and well-reasoned. the fetch-helpers changes introduce untested code paths (RETRY_AFTER_DURATION_PATTERN) and silently change the retry cap from 5 min to 7 days for all sources — including headers and body fields — without proportional test coverage or inline documentation of the rationale

lib/request/fetch-helpers.ts needs duration-pattern tests and a comment on the timezone assumption; test/fetch-helpers.test.ts is missing coverage for the duration branch

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | Math.max guard added to preserve longest cooldown; two-liner fix is correct and well-covered by the new unit test |
| lib/request/fetch-helpers.ts | Natural-language rate-limit parsing added; MAX_RATE_LIMIT_DELAY_MS silently changed from 5 min to 7 days for all sources; clock-time parsing uses local timezone; duration pattern lacks direct test |
| index.ts | cooldownMs = Math.max(delayMs, rateLimit.retryAfterMs) correctly feeds both scheduler and account manager; fallback 429 path now uses handleErrorResponse for consistent body-parsed cooldown |
| test/accounts.test.ts | New unit test properly covers the shorter-follow-up-doesn't-shrink-reset invariant; wrapped in try/finally |
| test/fetch-helpers.test.ts | Clock-time natural-language test added with correct try/finally cleanup; 7-day cap test updated; RETRY_AFTER_DURATION_PATTERN has zero coverage |
| test/index.test.ts | Concurrent overlapping-request integration test added; correctly uses try/finally; mock reimplements markRateLimitedWithReason logic inline |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R1 as Request 1
    participant R2 as Request 2
    participant HE as handleErrorResponse
    participant AM as AccountManager.markRateLimitedWithReason
    participant PQ as preemptiveQuotaScheduler

    Note over R1,R2: Concurrent sdk.fetch() calls hit 429

    R1->>HE: handleErrorResponse(response1)
    R2->>HE: handleErrorResponse(response2)
    HE-->>R1: rateLimit.retryAfterMs = 5400000 (90 min)
    HE-->>R2: rateLimit.retryAfterMs = 60000 (1 min)

    Note over R1: cooldownMs = max(delayMs=60000, 5400000) = 5400000
    Note over R2: cooldownMs = max(delayMs=60000, 60000) = 60000

    R1->>PQ: markRateLimited(key, 5400000)
    R2->>PQ: markRateLimited(key, 60000)

    R1->>AM: markRateLimitedWithReason(account, 5400000)
    Note over AM: currentResetAt=0 → stores max(0, now+5400000)

    R2->>AM: markRateLimitedWithReason(account, 60000)
    Note over AM: currentResetAt=now+5400000 → stores max(now+5400000, now+60000) = now+5400000 ✓
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Atest%2Ffetch-helpers.test.ts%3A1115-1130%0A**missing%20vitest%20coverage%20for%20%60RETRY_AFTER_DURATION_PATTERN%60**%0A%0Athe%20new%20clock-time%20test%20covers%20%60RETRY_AFTER_CLOCK_TIME_PATTERN%60%20%28%22try%20again%20at%206%3A26%20AM%22%29%2C%20but%20%60RETRY_AFTER_DURATION_PATTERN%60%20%28%22retry%20again%20in%205%20minutes%22%2C%20%22try%20again%20in%202%20hours%22%2C%20%22retry%20again%20in%201%20day%22%29%20has%20zero%20direct%20coverage.%20the%20duration%20path%20is%20the%20more%20common%20api%20response%20shape%20and%20is%20now%20completely%20untested.%0A%0Aadd%20at%20minimum%20one%20test%20here%2C%20e.g.%3A%0A%0A%60%60%60ts%0Ait%28'parses%20duration-based%20natural-language%20retry%20hints'%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.useFakeTimers%28%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20vi.setSystemTime%28new%20Date%28'2026-04-05T00%3A00%3A00.000Z'%29%29%3B%0A%20%20%20%20%20%20%20%20const%20response%20%3D%20new%20Response%28%0A%20%20%20%20%20%20%20%20%20%20%20%20'Usage%20limit%20reached.%20Try%20again%20in%2090%20minutes.'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%20status%3A%20429%20%7D%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20const%20%7B%20rateLimit%20%7D%20%3D%20await%20handleErrorResponse%28response%29%3B%0A%20%20%20%20%20%20%20%20expect%28rateLimit%3F.retryAfterMs%29.toBe%2890%20*%2060%20*%201000%29%3B%0A%20%20%20%20%7D%20finally%20%7B%0A%20%20%20%20%20%20%20%20vi.useRealTimers%28%29%3B%0A%20%20%20%20%7D%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Frequest%2Ffetch-helpers.ts%3A71%0A**%60MAX_RATE_LIMIT_DELAY_MS%60%20change%20silently%20re-caps%20ALL%20retry%20sources%2C%20not%20just%20natural-language%20text**%0A%0Athis%20was%20renamed%20from%20%60MAX_RETRY_DELAY_MS%60%20and%20increased%20from%205%20minutes%20to%207%20days.%20it%20now%20caps%20every%20code%20path%20that%20calls%20%60clampRateLimitDelayMs%60%3A%0A-%20%60normalizeRetryAfterMs%60%20%28body%20%60retry_after_ms%60%20field%29%0A-%20%60normalizeRetryAfterSeconds%60%20%28%60retry-after%60%20header%29%0A-%20timestamp%20headers%20%28%60x-codex-primary-reset-at%60%2C%20%60x-ratelimit-reset%60%2C%20etc.%29%0A%0Athe%20old%205-minute%20cap%20was%20almost%20certainly%20too%20short%20%28legit%20usage%20limits%20run%20for%20hours%29.%20the%20new%207-day%20cap%20means%20a%20single%20malformed%20or%20adversarial%20%60retry_after_ms%3A%20864000000%60%20%2810%20days%29%20still%20locks%20the%20account%20out%20for%207%20days.%20the%20updated%20test%20only%20exercises%20the%2010-day%20%E2%86%92%207-day%20clamp%3B%20there%20is%20no%20test%20that%20verifies%20a%20natural-language%20%22retry%20again%20in%2030%20days%22%20message%20is%20also%20clamped%20at%207%20days.%0A%0Aconsider%20documenting%20the%20cap%20choice%20inline%2C%20and%20add%20a%20test%20for%20the%20natural-language%20duration%20path%20hitting%20the%20ceiling%3A%0A%0A%60%60%60ts%0Ait%28'clamps%20natural-language%20duration%20to%207%20days'%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20vi.useFakeTimers%28%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20vi.setSystemTime%28new%20Date%28'2026-04-05T00%3A00%3A00.000Z'%29%29%3B%0A%20%20%20%20%20%20%20%20const%20response%20%3D%20new%20Response%28%0A%20%20%20%20%20%20%20%20%20%20%20%20'Quota%20exceeded.%20Try%20again%20in%2030%20days.'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%20status%3A%20429%20%7D%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20const%20%7B%20rateLimit%20%7D%20%3D%20await%20handleErrorResponse%28response%29%3B%0A%20%20%20%20%20%20%20%20expect%28rateLimit%3F.retryAfterMs%29.toBe%287%20*%2024%20*%2060%20*%2060%20*%201000%29%3B%0A%20%20%20%20%7D%20finally%20%7B%0A%20%20%20%20%20%20%20%20vi.useRealTimers%28%29%3B%0A%20%20%20%20%7D%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Frequest%2Ffetch-helpers.ts%3A1317-1327%0A**clock-time%20parsing%20assumes%20client%20local%20timezone**%0A%0A%60target.setHours%28hour24%2C%20minute%2C%200%2C%200%29%60%20uses%20the%20node%20process's%20local%20timezone.%20if%20a%20usage-limit%20message%20says%20%22try%20again%20at%203%3A00%20PM%22%20the%20computed%20delta%20depends%20on%20%60TZ%60%20at%20runtime%2C%20not%20the%20timezone%20the%20api%20server%20is%20targeting.%20on%20windows%20this%20is%20especially%20unpredictable%20if%20the%20user's%20system%20timezone%20diverges%20from%20utc.%0A%0Aif%20precision%20matters%20here%2C%20a%20comment%20documenting%20the%20local-time%20assumption%20would%20prevent%20future%20confusion%20and%20potential%20misdiagnosis%20on%20windows%20machines.%0A%0A%23%23%23%20Issue%204%20of%204%0Atest%2Findex.test.ts%3A4200-4225%0A**concurrent%20test%20mock%20re-implements%20%60markRateLimitedWithReason%60%20logic%20inline**%0A%0Athe%20mock%20at%20this%20block%20manually%20reproduces%20the%20%60Math.max%60%20guard%20that%20was%20just%20fixed%20in%20%60lib%2Faccounts.ts%60.%20if%20the%20real%20implementation%20changes%20%28e.g.%2C%20adds%20per-model%20key%20handling%20or%20changes%20the%20%60Math.max%60%20semantics%29%2C%20this%20mock%20will%20silently%20diverge%20and%20the%20integration%20test%20will%20keep%20passing%20while%20the%20unit%20behavior%20changes.%0A%0Aconsider%20using%20a%20spy%20that%20delegates%20to%20the%20real%20method%20after%20capturing%20calls%2C%20so%20the%20test%20stays%20coupled%20to%20the%20actual%20implementation%2C%20or%20simply%20assert%20the%20spy%20call%20count%20and%20rely%20on%20the%20%60accounts.test.ts%60%20unit%20test%20for%20the%20%60Math.max%60%20invariant.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/fetch-helpers.test.ts
Line: 1115-1130

Comment:
**missing vitest coverage for `RETRY_AFTER_DURATION_PATTERN`**

the new clock-time test covers `RETRY_AFTER_CLOCK_TIME_PATTERN` ("try again at 6:26 AM"), but `RETRY_AFTER_DURATION_PATTERN` ("retry again in 5 minutes", "try again in 2 hours", "retry again in 1 day") has zero direct coverage. the duration path is the more common api response shape and is now completely untested.

add at minimum one test here, e.g.:

```ts
it('parses duration-based natural-language retry hints', async () => {
    vi.useFakeTimers();
    try {
        vi.setSystemTime(new Date('2026-04-05T00:00:00.000Z'));
        const response = new Response(
            'Usage limit reached. Try again in 90 minutes.',
            { status: 429 },
        );
        const { rateLimit } = await handleErrorResponse(response);
        expect(rateLimit?.retryAfterMs).toBe(90 * 60 * 1000);
    } finally {
        vi.useRealTimers();
    }
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/request/fetch-helpers.ts
Line: 71

Comment:
**`MAX_RATE_LIMIT_DELAY_MS` change silently re-caps ALL retry sources, not just natural-language text**

this was renamed from `MAX_RETRY_DELAY_MS` and increased from 5 minutes to 7 days. it now caps every code path that calls `clampRateLimitDelayMs`:
- `normalizeRetryAfterMs` (body `retry_after_ms` field)
- `normalizeRetryAfterSeconds` (`retry-after` header)
- timestamp headers (`x-codex-primary-reset-at`, `x-ratelimit-reset`, etc.)

the old 5-minute cap was almost certainly too short (legit usage limits run for hours). the new 7-day cap means a single malformed or adversarial `retry_after_ms: 864000000` (10 days) still locks the account out for 7 days. the updated test only exercises the 10-day → 7-day clamp; there is no test that verifies a natural-language "retry again in 30 days" message is also clamped at 7 days.

consider documenting the cap choice inline, and add a test for the natural-language duration path hitting the ceiling:

```ts
it('clamps natural-language duration to 7 days', async () => {
    vi.useFakeTimers();
    try {
        vi.setSystemTime(new Date('2026-04-05T00:00:00.000Z'));
        const response = new Response(
            'Quota exceeded. Try again in 30 days.',
            { status: 429 },
        );
        const { rateLimit } = await handleErrorResponse(response);
        expect(rateLimit?.retryAfterMs).toBe(7 * 24 * 60 * 60 * 1000);
    } finally {
        vi.useRealTimers();
    }
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/request/fetch-helpers.ts
Line: 1317-1327

Comment:
**clock-time parsing assumes client local timezone**

`target.setHours(hour24, minute, 0, 0)` uses the node process's local timezone. if a usage-limit message says "try again at 3:00 PM" the computed delta depends on `TZ` at runtime, not the timezone the api server is targeting. on windows this is especially unpredictable if the user's system timezone diverges from utc.

if precision matters here, a comment documenting the local-time assumption would prevent future confusion and potential misdiagnosis on windows machines.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/index.test.ts
Line: 4200-4225

Comment:
**concurrent test mock re-implements `markRateLimitedWithReason` logic inline**

the mock at this block manually reproduces the `Math.max` guard that was just fixed in `lib/accounts.ts`. if the real implementation changes (e.g., adds per-model key handling or changes the `Math.max` semantics), this mock will silently diverge and the integration test will keep passing while the unit behavior changes.

consider using a spy that delegates to the real method after capturing calls, so the test stays coupled to the actual implementation, or simply assert the spy call count and rely on the `accounts.test.ts` unit test for the `Math.max` invariant.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve longest usage-limit cooldo..."](https://github.com/ndycode/codex-multi-auth/commit/d950b176ac7c1286147c9202beb25b26b4191718) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27363152)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->