### PR TITLE
fix ready-first account ordering regressions

### DIFF
--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -2574,6 +2574,11 @@ async function runAuthLogin(args: string[]): Promise<number> {
 	let pendingMenuQuotaRefresh: Promise<void> | null = null;
 	let menuQuotaRefreshStatus: string | undefined;
 	let skipNextMenuQuotaAutoRefresh = false;
+	let menuQuotaRefreshGeneration = 0;
+	const clearMenuQuotaAutoRefreshSkip = () => {
+		skipNextMenuQuotaAutoRefresh = false;
+		menuQuotaRefreshGeneration += 1;
+	};
 	loginFlow: while (true) {
 		let existingStorage = await loadAccounts();
 		if (existingStorage && existingStorage.accounts.length > 0) {
@@ -2610,6 +2615,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 						if (showFetchStatus) {
 							menuQuotaRefreshStatus = `${UI_COPY.mainMenu.loadingLimits} [0/${staleCount}]`;
 						}
+						const refreshGeneration = menuQuotaRefreshGeneration;
 						pendingMenuQuotaRefresh = refreshQuotaCacheForMenu(
 							currentStorage,
 							quotaCache,
@@ -2620,7 +2626,9 @@ async function runAuthLogin(args: string[]): Promise<number> {
 							},
 						)
 							.then(() => {
-								skipNextMenuQuotaAutoRefresh = true;
+								if (refreshGeneration === menuQuotaRefreshGeneration) {
+									skipNextMenuQuotaAutoRefresh = true;
+								}
 								return undefined;
 							})
 							.catch(() => undefined)
@@ -2647,7 +2655,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					return 0;
 				}
 				if (menuResult.mode === "check") {
-					skipNextMenuQuotaAutoRefresh = false;
+					clearMenuQuotaAutoRefreshSkip();
 					await runActionPanel(
 						"Quick Check",
 						"Checking local session + live status",
@@ -2659,7 +2667,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "deep-check") {
-					skipNextMenuQuotaAutoRefresh = false;
+					clearMenuQuotaAutoRefreshSkip();
 					await runActionPanel(
 						"Deep Check",
 						"Refreshing and testing all accounts",
@@ -2671,7 +2679,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "forecast") {
-					skipNextMenuQuotaAutoRefresh = false;
+					clearMenuQuotaAutoRefreshSkip();
 					await runActionPanel(
 						"Best Account",
 						"Comparing accounts",
@@ -2683,7 +2691,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "fix") {
-					skipNextMenuQuotaAutoRefresh = false;
+					clearMenuQuotaAutoRefreshSkip();
 					await runActionPanel(
 						"Auto-Fix",
 						"Checking and fixing common issues",
@@ -2695,12 +2703,12 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "settings") {
-					skipNextMenuQuotaAutoRefresh = false;
+					clearMenuQuotaAutoRefreshSkip();
 					await configureUnifiedSettings(displaySettings);
 					continue;
 				}
 				if (menuResult.mode === "verify-flagged") {
-					skipNextMenuQuotaAutoRefresh = false;
+					clearMenuQuotaAutoRefreshSkip();
 					await runActionPanel(
 						"Problem Account Check",
 						"Checking problem accounts",
@@ -2712,7 +2720,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "fresh" && menuResult.deleteAll) {
-					skipNextMenuQuotaAutoRefresh = false;
+					clearMenuQuotaAutoRefreshSkip();
 					await runActionPanel(
 						"Reset Accounts",
 						"Deleting all saved accounts",
@@ -2727,6 +2735,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "manage") {
+					clearMenuQuotaAutoRefreshSkip();
 					const requiresInteractiveOAuth =
 						typeof menuResult.refreshAccountIndex === "number";
 					if (requiresInteractiveOAuth) {

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -79,6 +79,10 @@ import {
 	resolveNormalizedModel,
 } from "./request/helpers/model-map.js";
 import {
+	formatRateLimitEntry as formatAccountRateLimitEntry,
+	resolveActiveIndex,
+} from "./runtime/account-status.js";
+import {
 	loadQuotaCache,
 	type QuotaCacheData,
 	type QuotaCacheEntry,
@@ -439,50 +443,12 @@ const IMPLEMENTED_FEATURES: ImplementedFeature[] = [
 	{ id: 41, name: "Auto-switch to best account command" },
 ];
 
-function resolveActiveIndex(
-	storage: AccountStorageV3,
-	family: ModelFamily = "codex",
-): number {
-	const total = storage.accounts.length;
-	if (total === 0) return 0;
-	const rawCandidate =
-		storage.activeIndexByFamily?.[family] ?? storage.activeIndex;
-	const raw = Number.isFinite(rawCandidate) ? rawCandidate : 0;
-	return Math.max(0, Math.min(raw, total - 1));
-}
-
-function getRateLimitResetTimeForFamily(
-	account: { rateLimitResetTimes?: Record<string, number | undefined> },
-	now: number,
-	family: ModelFamily,
-): number | null {
-	const times = account.rateLimitResetTimes;
-	if (!times) return null;
-
-	let minReset: number | null = null;
-	const prefix = `${family}:`;
-	for (const [key, value] of Object.entries(times)) {
-		if (typeof value !== "number") continue;
-		if (value <= now) continue;
-		if (key !== family && !key.startsWith(prefix)) continue;
-		if (minReset === null || value < minReset) {
-			minReset = value;
-		}
-	}
-
-	return minReset;
-}
-
 function formatRateLimitEntry(
 	account: { rateLimitResetTimes?: Record<string, number | undefined> },
 	now: number,
 	family: ModelFamily = "codex",
 ): string | null {
-	const resetAt = getRateLimitResetTimeForFamily(account, now, family);
-	if (typeof resetAt !== "number") return null;
-	const remaining = resetAt - now;
-	if (remaining <= 0) return null;
-	return `resets in ${formatWaitTime(remaining)}`;
+	return formatAccountRateLimitEntry(account, now, formatWaitTime, family);
 }
 
 function normalizeQuotaEmail(email: string | undefined): string | null {
@@ -983,6 +949,13 @@ function readQuotaLeftPercent(
 	return parseLeftPercentFromQuotaSummary(account.quotaSummary, windowLabel);
 }
 
+function readQuotaFloorPercent(account: ExistingAccountInfo): number {
+	return Math.min(
+		readQuotaLeftPercent(account, "5h"),
+		readQuotaLeftPercent(account, "7d"),
+	);
+}
+
 function accountStatusSortBucket(
 	status: ExistingAccountInfo["status"],
 ): number {
@@ -1004,10 +977,25 @@ function accountStatusSortBucket(
 	}
 }
 
+function accountReadinessSortBucket(account: ExistingAccountInfo): number {
+	const statusBucket = accountStatusSortBucket(account.status);
+	if (statusBucket >= 2) return statusBucket;
+	return account.quotaRateLimited ? 2 : statusBucket;
+}
+
 function compareReadyFirstAccounts(
 	left: ExistingAccountInfo,
 	right: ExistingAccountInfo,
 ): number {
+	const bucketDelta =
+		accountReadinessSortBucket(left) -
+		accountReadinessSortBucket(right);
+	if (bucketDelta !== 0) return bucketDelta;
+
+	const leftFloor = readQuotaFloorPercent(left);
+	const rightFloor = readQuotaFloorPercent(right);
+	if (leftFloor !== rightFloor) return rightFloor - leftFloor;
+
 	const left5h = readQuotaLeftPercent(left, "5h");
 	const right5h = readQuotaLeftPercent(right, "5h");
 	if (left5h !== right5h) return right5h - left5h;
@@ -1015,11 +1003,6 @@ function compareReadyFirstAccounts(
 	const left7d = readQuotaLeftPercent(left, "7d");
 	const right7d = readQuotaLeftPercent(right, "7d");
 	if (left7d !== right7d) return right7d - left7d;
-
-	const bucketDelta =
-		accountStatusSortBucket(left.status) -
-		accountStatusSortBucket(right.status);
-	if (bucketDelta !== 0) return bucketDelta;
 
 	const leftLastUsed = left.lastUsed ?? 0;
 	const rightLastUsed = right.lastUsed ?? 0;
@@ -2590,6 +2573,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 	setStoragePath(null);
 	let pendingMenuQuotaRefresh: Promise<void> | null = null;
 	let menuQuotaRefreshStatus: string | undefined;
+	let skipNextMenuQuotaAutoRefresh = false;
 	loginFlow: while (true) {
 		let existingStorage = await loadAccounts();
 		if (existingStorage && existingStorage.accounts.length > 0) {
@@ -2607,7 +2591,16 @@ async function runAuthLogin(args: string[]): Promise<number> {
 				const showFetchStatus = displaySettings.menuShowFetchStatus ?? true;
 				const quotaTtlMs =
 					displaySettings.menuQuotaTtlMs ?? DEFAULT_MENU_QUOTA_REFRESH_TTL_MS;
-				if (shouldAutoFetchLimits && !pendingMenuQuotaRefresh) {
+				const shouldSkipAutoFetchThisPass =
+					!pendingMenuQuotaRefresh && skipNextMenuQuotaAutoRefresh;
+				if (shouldSkipAutoFetchThisPass) {
+					skipNextMenuQuotaAutoRefresh = false;
+				}
+				if (
+					shouldAutoFetchLimits
+					&& !pendingMenuQuotaRefresh
+					&& !shouldSkipAutoFetchThisPass
+				) {
 					const staleCount = countMenuQuotaRefreshTargets(
 						currentStorage,
 						quotaCache,
@@ -2626,7 +2619,10 @@ async function runAuthLogin(args: string[]): Promise<number> {
 								menuQuotaRefreshStatus = `${UI_COPY.mainMenu.loadingLimits} [${current}/${total}]`;
 							},
 						)
-							.then(() => undefined)
+							.then(() => {
+								skipNextMenuQuotaAutoRefresh = true;
+								return undefined;
+							})
 							.catch(() => undefined)
 							.finally(() => {
 								menuQuotaRefreshStatus = undefined;
@@ -2651,6 +2647,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					return 0;
 				}
 				if (menuResult.mode === "check") {
+					skipNextMenuQuotaAutoRefresh = false;
 					await runActionPanel(
 						"Quick Check",
 						"Checking local session + live status",
@@ -2662,6 +2659,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "deep-check") {
+					skipNextMenuQuotaAutoRefresh = false;
 					await runActionPanel(
 						"Deep Check",
 						"Refreshing and testing all accounts",
@@ -2673,6 +2671,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "forecast") {
+					skipNextMenuQuotaAutoRefresh = false;
 					await runActionPanel(
 						"Best Account",
 						"Comparing accounts",
@@ -2684,6 +2683,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "fix") {
+					skipNextMenuQuotaAutoRefresh = false;
 					await runActionPanel(
 						"Auto-Fix",
 						"Checking and fixing common issues",
@@ -2695,10 +2695,12 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "settings") {
+					skipNextMenuQuotaAutoRefresh = false;
 					await configureUnifiedSettings(displaySettings);
 					continue;
 				}
 				if (menuResult.mode === "verify-flagged") {
+					skipNextMenuQuotaAutoRefresh = false;
 					await runActionPanel(
 						"Problem Account Check",
 						"Checking problem accounts",
@@ -2710,6 +2712,7 @@ async function runAuthLogin(args: string[]): Promise<number> {
 					continue;
 				}
 				if (menuResult.mode === "fresh" && menuResult.deleteAll) {
+					skipNextMenuQuotaAutoRefresh = false;
 					await runActionPanel(
 						"Reset Accounts",
 						"Deleting all saved accounts",

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -1,5 +1,6 @@
 import { formatAccountLabel, formatWaitTime } from "./accounts.js";
 import type { CodexQuotaSnapshot } from "./quota-probe.js";
+import { getRateLimitResetTimeForFamily } from "./runtime/account-status.js";
 import type { AccountMetadataV3 } from "./storage.js";
 import type { TokenFailure } from "./types.js";
 
@@ -105,27 +106,6 @@ function getRiskLevel(score: number): ForecastRiskLevel {
 	if (score >= 75) return "high";
 	if (score >= 40) return "medium";
 	return "low";
-}
-
-function getRateLimitResetTimeForFamily(
-	account: AccountMetadataV3,
-	now: number,
-	family = "codex",
-): number | null {
-	const times = account.rateLimitResetTimes;
-	if (!times) return null;
-
-	let minReset: number | null = null;
-	const prefix = `${family}:`;
-	for (const [key, value] of Object.entries(times)) {
-		if (typeof value !== "number") continue;
-		if (value <= now) continue;
-		if (key !== family && !key.startsWith(prefix)) continue;
-		if (minReset === null || value < minReset) {
-			minReset = value;
-		}
-	}
-	return minReset;
 }
 
 function getLiveQuotaWaitMs(snapshot: CodexQuotaSnapshot, now: number): number {

--- a/lib/runtime/account-state.ts
+++ b/lib/runtime/account-state.ts
@@ -1,52 +1,5 @@
-import { formatWaitTime } from "../accounts.js";
-import type { ModelFamily } from "../prompts/codex.js";
-
-export function resolveActiveIndex(
-	storage: {
-		activeIndex: number;
-		activeIndexByFamily?: Partial<Record<ModelFamily, number>>;
-		accounts: unknown[];
-	},
-	family: ModelFamily = "codex",
-): number {
-	const total = storage.accounts.length;
-	if (total === 0) return 0;
-	const rawCandidate =
-		storage.activeIndexByFamily?.[family] ?? storage.activeIndex;
-	const raw = Number.isFinite(rawCandidate) ? rawCandidate : 0;
-	return Math.max(0, Math.min(raw, total - 1));
-}
-
-export function getRateLimitResetTimeForFamily(
-	account: { rateLimitResetTimes?: Record<string, number | undefined> },
-	now: number,
-	family: ModelFamily,
-): number | null {
-	const times = account.rateLimitResetTimes;
-	if (!times) return null;
-
-	let minReset: number | null = null;
-	const prefix = `${family}:`;
-	for (const [key, value] of Object.entries(times)) {
-		if (typeof value !== "number") continue;
-		if (value <= now) continue;
-		if (key !== family && !key.startsWith(prefix)) continue;
-		if (minReset === null || value < minReset) {
-			minReset = value;
-		}
-	}
-
-	return minReset;
-}
-
-export function formatRateLimitEntry(
-	account: { rateLimitResetTimes?: Record<string, number | undefined> },
-	now: number,
-	family: ModelFamily = "codex",
-): string | null {
-	const resetAt = getRateLimitResetTimeForFamily(account, now, family);
-	if (typeof resetAt !== "number") return null;
-	const remaining = resetAt - now;
-	if (remaining <= 0) return null;
-	return `resets in ${formatWaitTime(remaining)}`;
-}
+export {
+	formatRateLimitEntry,
+	getRateLimitResetTimeForFamily,
+	resolveActiveIndex,
+} from "./account-status.js";

--- a/test/account-status.test.ts
+++ b/test/account-status.test.ts
@@ -4,6 +4,11 @@ import {
 	getRateLimitResetTimeForFamily,
 	resolveActiveIndex,
 } from "../lib/runtime/account-status.js";
+import {
+	formatRateLimitEntry as formatRateLimitEntryFromBarrel,
+	getRateLimitResetTimeForFamily as getRateLimitResetTimeForFamilyFromBarrel,
+	resolveActiveIndex as resolveActiveIndexFromBarrel,
+} from "../lib/runtime/account-state.js";
 
 describe("account status helpers", () => {
 	it("resolves active index using family overrides and clamps bounds", () => {
@@ -60,5 +65,39 @@ describe("account status helpers", () => {
 				() => "x",
 			),
 		).toBeNull();
+	});
+
+	it("re-exports account status helpers through the account-state barrel", () => {
+		expect(resolveActiveIndexFromBarrel).toBe(resolveActiveIndex);
+		expect(getRateLimitResetTimeForFamilyFromBarrel).toBe(
+			getRateLimitResetTimeForFamily,
+		);
+		expect(formatRateLimitEntryFromBarrel).toBe(formatRateLimitEntry);
+
+		expect(
+			resolveActiveIndexFromBarrel(
+				{
+					activeIndex: 4,
+					activeIndexByFamily: { codex: 1 },
+					accounts: [1, 2, 3],
+				},
+				"codex",
+			),
+		).toBe(1);
+		expect(
+			getRateLimitResetTimeForFamilyFromBarrel(
+				{ rateLimitResetTimes: { codex: 4_000 } },
+				1_000,
+				"codex",
+			),
+		).toBe(4_000);
+		expect(
+			formatRateLimitEntryFromBarrel(
+				{ rateLimitResetTimes: { codex: 5_000 } },
+				1_000,
+				(ms) => `${ms}ms`,
+				"codex",
+			),
+		).toBe("resets in 4000ms");
 	});
 });

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -7320,38 +7320,44 @@ describe("codex manager cli commands", () => {
 		saveQuotaCacheMock.mockImplementation(async (nextCache) => {
 			quotaCacheState = structuredClone(nextCache);
 		});
-		fetchCodexQuotaSnapshotMock
-			.mockImplementationOnce(async () => {
-				await releaseFirstRefresh.promise;
-				return {
-					status: 429,
-					model: "gpt-5-codex",
-					primary: {
-						usedPercent: 0,
-						windowMinutes: 300,
-						resetAtMs: now + 3_000,
-					},
-					secondary: {
-						usedPercent: 0,
-						windowMinutes: 10080,
-						resetAtMs: now + 4_000,
-					},
-				};
-			})
-			.mockResolvedValueOnce({
-				status: 200,
-				model: "gpt-5-codex",
-				primary: {
-					usedPercent: 20,
-					windowMinutes: 300,
-					resetAtMs: now + 5_000,
-				},
-				secondary: {
-					usedPercent: 20,
-					windowMinutes: 10080,
-					resetAtMs: now + 6_000,
-				},
-			});
+		fetchCodexQuotaSnapshotMock.mockImplementation(
+			async ({ accountId }: { accountId?: string }) => {
+				if (accountId === "acc_becomes_degraded") {
+					await releaseFirstRefresh.promise;
+					return {
+						status: 429,
+						model: "gpt-5-codex",
+						primary: {
+							usedPercent: 0,
+							windowMinutes: 300,
+							resetAtMs: now + 3_000,
+						},
+						secondary: {
+							usedPercent: 0,
+							windowMinutes: 10080,
+							resetAtMs: now + 4_000,
+						},
+					};
+				}
+				if (accountId === "acc_becomes_healthy") {
+					return {
+						status: 200,
+						model: "gpt-5-codex",
+						primary: {
+							usedPercent: 20,
+							windowMinutes: 300,
+							resetAtMs: now + 5_000,
+						},
+						secondary: {
+							usedPercent: 20,
+							windowMinutes: 10080,
+							resetAtMs: now + 6_000,
+						},
+					};
+				}
+				throw new Error(`unexpected probe target: ${String(accountId)}`);
+			},
+		);
 
 		let promptCallCount = 0;
 		promptLoginModeMock
@@ -7396,8 +7402,351 @@ describe("codex manager cli commands", () => {
 		expect(exitCode).toBe(0);
 		expect(promptLoginModeMock).toHaveBeenCalledTimes(2);
 		expect(promptCallCount).toBe(2);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
+		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not let stale refresh completions re-enable the next menu auto-fetch skip", async () => {
+		const now = Date.now();
+		let storageState = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "becomes-degraded@example.com",
+					accountId: "acc_becomes_degraded",
+					refreshToken: "refresh-becomes-degraded",
+					accessToken: "access-becomes-degraded",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					enabled: true,
+				},
+				{
+					email: "becomes-healthy@example.com",
+					accountId: "acc_becomes_healthy",
+					refreshToken: "refresh-becomes-healthy",
+					accessToken: "access-becomes-healthy",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		};
+		loadAccountsMock.mockImplementation(async () => structuredClone(storageState));
+		saveAccountsMock.mockImplementation(async (nextStorage) => {
+			storageState = structuredClone(nextStorage);
+		});
+
+		loadDashboardDisplaySettingsMock.mockResolvedValue(
+			createReadyFirstMenuSettings({
+				menuAutoFetchLimits: true,
+				menuQuotaTtlMs: 0,
+				menuShowFetchStatus: true,
+			}),
+		);
+
+		let quotaCacheState = {
+			byAccountId: {},
+			byEmail: {
+				"becomes-degraded@example.com": {
+					updatedAt: now - 10_000,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 10,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 10,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+				"becomes-healthy@example.com": {
+					updatedAt: now - 10_000,
+					status: 429,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 0,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 0,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+			},
+		};
+		loadQuotaCacheMock.mockImplementation(async () => structuredClone(quotaCacheState));
+
+		const releaseFirstRefresh = createDeferred<void>();
+		const releaseSecondRefresh = createDeferred<void>();
+		saveQuotaCacheMock.mockImplementation(async (nextCache) => {
+			quotaCacheState = structuredClone(nextCache);
+		});
+
+		let degradedProbeCount = 0;
+		let healthyProbeCount = 0;
+		fetchCodexQuotaSnapshotMock.mockImplementation(
+			async ({ accountId }: { accountId?: string }) => {
+				if (accountId === "acc_becomes_degraded") {
+					degradedProbeCount += 1;
+					if (degradedProbeCount === 1) {
+						await releaseFirstRefresh.promise;
+					} else if (degradedProbeCount === 2) {
+						await releaseSecondRefresh.promise;
+					}
+					return {
+						status: 429,
+						model: "gpt-5-codex",
+						primary: {
+							usedPercent: 0,
+							windowMinutes: 300,
+							resetAtMs: now + 3_000 + degradedProbeCount,
+						},
+						secondary: {
+							usedPercent: 0,
+							windowMinutes: 10080,
+							resetAtMs: now + 4_000 + degradedProbeCount,
+						},
+					};
+				}
+				if (accountId === "acc_becomes_healthy") {
+					healthyProbeCount += 1;
+					return {
+						status: 200,
+						model: "gpt-5-codex",
+						primary: {
+							usedPercent: 20,
+							windowMinutes: 300,
+							resetAtMs: now + 5_000 + healthyProbeCount,
+						},
+						secondary: {
+							usedPercent: 20,
+							windowMinutes: 10080,
+							resetAtMs: now + 6_000 + healthyProbeCount,
+						},
+					};
+				}
+				throw new Error(`unexpected probe target: ${String(accountId)}`);
+			},
+		);
+
+		let promptCallCount = 0;
+		promptLoginModeMock
+			.mockImplementationOnce(async (accounts) => {
+				promptCallCount += 1;
+				expect(promptCallCount).toBe(1);
+				expect(accounts.map((account: { email?: string }) => account.email)).toEqual([
+					"becomes-degraded@example.com",
+					"becomes-healthy@example.com",
+				]);
+
+				queueMicrotask(() => {
+					releaseFirstRefresh.resolve();
+				});
+				return { mode: "manage", deleteAccountIndex: 99 };
+			})
+			.mockImplementationOnce(async (accounts, options) => {
+				promptCallCount += 1;
+				expect(promptCallCount).toBe(2);
+				expect(accounts.map((account: { email?: string }) => account.email)).toEqual([
+					"becomes-healthy@example.com",
+					"becomes-degraded@example.com",
+				]);
+				expect(typeof options?.statusMessage?.()).toBe("string");
+				expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(3);
+
+				releaseSecondRefresh.resolve();
+				await vi.waitFor(() => {
+					expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
+				});
+				return { mode: "cancel" };
+			});
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+
+		expect(exitCode).toBe(0);
+		expect(promptLoginModeMock).toHaveBeenCalledTimes(2);
+		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
+		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not get stuck skipping menu auto-fetch when quota cache saves fail with EBUSY", async () => {
+		const now = Date.now();
+		let storageState = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "becomes-degraded@example.com",
+					accountId: "acc_becomes_degraded",
+					refreshToken: "refresh-becomes-degraded",
+					accessToken: "access-becomes-degraded",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					enabled: true,
+				},
+				{
+					email: "becomes-healthy@example.com",
+					accountId: "acc_becomes_healthy",
+					refreshToken: "refresh-becomes-healthy",
+					accessToken: "access-becomes-healthy",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		};
+		loadAccountsMock.mockImplementation(async () => structuredClone(storageState));
+		saveAccountsMock.mockImplementation(async (nextStorage) => {
+			storageState = structuredClone(nextStorage);
+		});
+
+		loadDashboardDisplaySettingsMock.mockResolvedValue(
+			createReadyFirstMenuSettings({
+				menuAutoFetchLimits: true,
+				menuQuotaTtlMs: 0,
+				menuShowFetchStatus: true,
+			}),
+		);
+
+		let quotaCacheState = {
+			byAccountId: {},
+			byEmail: {
+				"becomes-degraded@example.com": {
+					updatedAt: now - 10_000,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 10,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 10,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+				"becomes-healthy@example.com": {
+					updatedAt: now - 10_000,
+					status: 429,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 0,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 0,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+			},
+		};
+		loadQuotaCacheMock.mockImplementation(async () => structuredClone(quotaCacheState));
+
+		const releaseFirstRefresh = createDeferred<void>();
+		const releaseSecondRefresh = createDeferred<void>();
+		let saveAttemptCount = 0;
+		saveQuotaCacheMock.mockImplementation(async (nextCache) => {
+			saveAttemptCount += 1;
+			if (saveAttemptCount === 1) {
+				throw makeErrnoError("quota cache busy", "EBUSY");
+			}
+			quotaCacheState = structuredClone(nextCache);
+		});
+
+		let degradedProbeCount = 0;
+		let healthyProbeCount = 0;
+		fetchCodexQuotaSnapshotMock.mockImplementation(
+			async ({ accountId }: { accountId?: string }) => {
+				if (accountId === "acc_becomes_degraded") {
+					degradedProbeCount += 1;
+					if (degradedProbeCount === 1) {
+						await releaseFirstRefresh.promise;
+					} else if (degradedProbeCount === 2) {
+						await releaseSecondRefresh.promise;
+					}
+					return {
+						status: 429,
+						model: "gpt-5-codex",
+						primary: {
+							usedPercent: 0,
+							windowMinutes: 300,
+							resetAtMs: now + 3_000 + degradedProbeCount,
+						},
+						secondary: {
+							usedPercent: 0,
+							windowMinutes: 10080,
+							resetAtMs: now + 4_000 + degradedProbeCount,
+						},
+					};
+				}
+				if (accountId === "acc_becomes_healthy") {
+					healthyProbeCount += 1;
+					return {
+						status: 200,
+						model: "gpt-5-codex",
+						primary: {
+							usedPercent: 20,
+							windowMinutes: 300,
+							resetAtMs: now + 5_000 + healthyProbeCount,
+						},
+						secondary: {
+							usedPercent: 20,
+							windowMinutes: 10080,
+							resetAtMs: now + 6_000 + healthyProbeCount,
+						},
+					};
+				}
+				throw new Error(`unexpected probe target: ${String(accountId)}`);
+			},
+		);
+
+		let promptCallCount = 0;
+		promptLoginModeMock
+			.mockImplementationOnce(async () => {
+				promptCallCount += 1;
+				expect(promptCallCount).toBe(1);
+
+				queueMicrotask(() => {
+					releaseFirstRefresh.resolve();
+				});
+				return { mode: "manage", deleteAccountIndex: 99 };
+			})
+			.mockImplementationOnce(async (_accounts, options) => {
+				promptCallCount += 1;
+				expect(promptCallCount).toBe(2);
+				expect(typeof options?.statusMessage?.()).toBe("string");
+				expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(3);
+
+				releaseSecondRefresh.resolve();
+				await vi.waitFor(() => {
+					expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
+				});
+				return { mode: "cancel" };
+			});
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+
+		expect(exitCode).toBe(0);
+		expect(promptLoginModeMock).toHaveBeenCalledTimes(2);
+		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
+		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(2);
 	});
 
 	it("prefers email-scoped quota cache entries for shared workspace accounts", async () => {

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -323,6 +323,39 @@ function createDeferred<T>(): {
 	return { promise, resolve, reject };
 }
 
+type ReadyFirstMenuSettings = {
+	showPerAccountRows: boolean;
+	showQuotaDetails: boolean;
+	showForecastReasons: boolean;
+	showRecommendations: boolean;
+	showLiveProbeNotes: boolean;
+	menuAutoFetchLimits: boolean;
+	menuSortEnabled: boolean;
+	menuSortMode: "ready-first";
+	menuSortPinCurrent: boolean;
+	menuSortQuickSwitchVisibleRow: boolean;
+	menuQuotaTtlMs?: number;
+	menuShowFetchStatus?: boolean;
+};
+
+function createReadyFirstMenuSettings(
+	overrides: Partial<ReadyFirstMenuSettings> = {},
+): ReadyFirstMenuSettings {
+	return {
+		showPerAccountRows: true,
+		showQuotaDetails: true,
+		showForecastReasons: true,
+		showRecommendations: true,
+		showLiveProbeNotes: true,
+		menuAutoFetchLimits: false,
+		menuSortEnabled: true,
+		menuSortMode: "ready-first",
+		menuSortPinCurrent: false,
+		menuSortQuickSwitchVisibleRow: true,
+		...overrides,
+	};
+}
+
 function cloneValue<T>(value: T): T {
 	return structuredClone(value);
 }
@@ -6770,6 +6803,601 @@ describe("codex manager cli commands", () => {
 		).toEqual([1, 2, 3]);
 		expect(firstCallAccounts[0]?.isCurrentAccount).toBe(false);
 		expect(firstCallAccounts[1]?.isCurrentAccount).toBe(true);
+	});
+
+	it("keeps ready accounts ahead of degraded limit rows in ready-first sorting", async () => {
+		const now = Date.now();
+		loadAccountsMock.mockResolvedValue({
+			version: 3,
+			activeIndex: 3,
+			activeIndexByFamily: { codex: 3 },
+			accounts: [
+				{
+					email: "cached-limit@example.com",
+					accountId: "acc_cached_limit",
+					refreshToken: "refresh-cached-limit",
+					accessToken: "access-cached-limit",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 5_000,
+					lastUsed: now - 5_000,
+					enabled: true,
+				},
+				{
+					email: "cooldown@example.com",
+					accountId: "acc_cooldown",
+					refreshToken: "refresh-cooldown",
+					accessToken: "access-cooldown",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 4_000,
+					lastUsed: now - 4_000,
+					enabled: true,
+					coolingDownUntil: now + 90_000,
+				},
+				{
+					email: "healthy-low@example.com",
+					accountId: "acc_healthy_low",
+					refreshToken: "refresh-healthy-low",
+					accessToken: "access-healthy-low",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 3_000,
+					lastUsed: now - 3_000,
+					enabled: true,
+				},
+				{
+					email: "healthy-high@example.com",
+					accountId: "acc_healthy_high",
+					refreshToken: "refresh-healthy-high",
+					accessToken: "access-healthy-high",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					enabled: true,
+				},
+				{
+					email: "rate-limited@example.com",
+					accountId: "acc_rate_limited",
+					refreshToken: "refresh-rate-limited",
+					accessToken: "access-rate-limited",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+					rateLimitResetTimes: { codex: now + 60_000 },
+				},
+			],
+		});
+		loadDashboardDisplaySettingsMock.mockResolvedValue(
+			createReadyFirstMenuSettings(),
+		);
+		loadQuotaCacheMock.mockResolvedValue({
+			byAccountId: {},
+			byEmail: {
+				"cached-limit@example.com": {
+					updatedAt: now,
+					status: 429,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 0,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 0,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+				"cooldown@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 20,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 20,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+				"healthy-low@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 75,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 75,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+				"healthy-high@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 10,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 10,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+				"rate-limited@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 5,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 5,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+			},
+		});
+		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+
+		expect(exitCode).toBe(0);
+		const firstCallAccounts = promptLoginModeMock.mock.calls[0]?.[0] as Array<{
+			email?: string;
+			sourceIndex?: number;
+			quotaRateLimited?: boolean;
+		}>;
+		expect(firstCallAccounts.map((account) => account.email)).toEqual([
+			"healthy-high@example.com",
+			"healthy-low@example.com",
+			"cached-limit@example.com",
+			"rate-limited@example.com",
+			"cooldown@example.com",
+		]);
+		expect(firstCallAccounts.map((account) => account.sourceIndex)).toEqual([
+			3, 2, 0, 4, 1,
+		]);
+		expect(firstCallAccounts[2]?.quotaRateLimited).toBe(true);
+	});
+
+	it("keeps exhausted weekly quota below balanced ready accounts in ready-first sorting", async () => {
+		const now = Date.now();
+		loadAccountsMock.mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "weekly-empty@example.com",
+					accountId: "acc_weekly_empty",
+					refreshToken: "refresh-weekly-empty",
+					accessToken: "access-weekly-empty",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					enabled: true,
+				},
+				{
+					email: "balanced@example.com",
+					accountId: "acc_balanced",
+					refreshToken: "refresh-balanced",
+					accessToken: "access-balanced",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		});
+		loadDashboardDisplaySettingsMock.mockResolvedValue(
+			createReadyFirstMenuSettings(),
+		);
+		loadQuotaCacheMock.mockResolvedValue({
+			byAccountId: {},
+			byEmail: {
+				"weekly-empty@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 0,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 100,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+				"balanced@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 20,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 20,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+			},
+		});
+		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+
+		expect(exitCode).toBe(0);
+		const firstCallAccounts = promptLoginModeMock.mock.calls[0]?.[0] as Array<{
+			email?: string;
+			quota5hLeftPercent?: number;
+			quota7dLeftPercent?: number;
+		}>;
+		expect(firstCallAccounts.map((account) => account.email)).toEqual([
+			"balanced@example.com",
+			"weekly-empty@example.com",
+		]);
+		expect(firstCallAccounts.map((account) => account.quota5hLeftPercent)).toEqual([
+			80, 100,
+		]);
+		expect(firstCallAccounts.map((account) => account.quota7dLeftPercent)).toEqual([
+			80, 0,
+		]);
+	});
+
+	it("treats missing quota windows as the lowest ready-first floor", async () => {
+		const now = Date.now();
+		loadAccountsMock.mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "partial-window@example.com",
+					accountId: "acc_partial_window",
+					refreshToken: "refresh-partial-window",
+					accessToken: "access-partial-window",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					enabled: true,
+				},
+				{
+					email: "balanced-window@example.com",
+					accountId: "acc_balanced_window",
+					refreshToken: "refresh-balanced-window",
+					accessToken: "access-balanced-window",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		});
+		loadDashboardDisplaySettingsMock.mockResolvedValue(
+			createReadyFirstMenuSettings(),
+		);
+		loadQuotaCacheMock.mockResolvedValue({
+			byAccountId: {},
+			byEmail: {
+				"partial-window@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 10,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {},
+				},
+				"balanced-window@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 20,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 20,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+			},
+		});
+		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+
+		expect(exitCode).toBe(0);
+		const firstCallAccounts = promptLoginModeMock.mock.calls[0]?.[0] as Array<{
+			email?: string;
+			quota5hLeftPercent?: number;
+			quota7dLeftPercent?: number;
+			quotaSummary?: string;
+		}>;
+		expect(firstCallAccounts.map((account) => account.email)).toEqual([
+			"balanced-window@example.com",
+			"partial-window@example.com",
+		]);
+		expect(firstCallAccounts.map((account) => account.quota5hLeftPercent)).toEqual([
+			80, 90,
+		]);
+		expect(firstCallAccounts.map((account) => account.quota7dLeftPercent)).toEqual([
+			80,
+			undefined,
+		]);
+		expect(firstCallAccounts[1]?.quotaSummary).toBe("5h 90%");
+	});
+
+	it("treats accounts with no quota windows as the lowest ready-first floor", async () => {
+		const now = Date.now();
+		loadAccountsMock.mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "missing-window@example.com",
+					accountId: "acc_missing_window",
+					refreshToken: "refresh-missing-window",
+					accessToken: "access-missing-window",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					enabled: true,
+				},
+				{
+					email: "full-window@example.com",
+					accountId: "acc_full_window",
+					refreshToken: "refresh-full-window",
+					accessToken: "access-full-window",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		});
+		loadDashboardDisplaySettingsMock.mockResolvedValue(
+			createReadyFirstMenuSettings(),
+		);
+		loadQuotaCacheMock.mockResolvedValue({
+			byAccountId: {},
+			byEmail: {
+				"missing-window@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {},
+					secondary: {},
+				},
+				"full-window@example.com": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 20,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 20,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+			},
+		});
+		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+
+		expect(exitCode).toBe(0);
+		const firstCallAccounts = promptLoginModeMock.mock.calls[0]?.[0] as Array<{
+			email?: string;
+			quota5hLeftPercent?: number;
+			quota7dLeftPercent?: number;
+			quotaSummary?: string;
+		}>;
+		expect(firstCallAccounts.map((account) => account.email)).toEqual([
+			"full-window@example.com",
+			"missing-window@example.com",
+		]);
+		expect(firstCallAccounts.map((account) => account.quota5hLeftPercent)).toEqual([
+			80,
+			undefined,
+		]);
+		expect(firstCallAccounts.map((account) => account.quota7dLeftPercent)).toEqual([
+			80,
+			undefined,
+		]);
+	});
+
+	it("re-sorts ready-first rows after async menu quota refresh changes which row is degraded", async () => {
+		const now = Date.now();
+		let storageState = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "becomes-degraded@example.com",
+					accountId: "acc_becomes_degraded",
+					refreshToken: "refresh-becomes-degraded",
+					accessToken: "access-becomes-degraded",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					enabled: true,
+				},
+				{
+					email: "becomes-healthy@example.com",
+					accountId: "acc_becomes_healthy",
+					refreshToken: "refresh-becomes-healthy",
+					accessToken: "access-becomes-healthy",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		};
+		loadAccountsMock.mockImplementation(async () => structuredClone(storageState));
+		saveAccountsMock.mockImplementation(async (nextStorage) => {
+			storageState = structuredClone(nextStorage);
+		});
+
+		loadDashboardDisplaySettingsMock.mockResolvedValue(
+			createReadyFirstMenuSettings({
+				menuAutoFetchLimits: true,
+				menuQuotaTtlMs: 1,
+				menuShowFetchStatus: true,
+			}),
+		);
+
+		let quotaCacheState = {
+			byAccountId: {},
+			byEmail: {
+				"becomes-degraded@example.com": {
+					updatedAt: now - 10_000,
+					status: 200,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 10,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 10,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+				"becomes-healthy@example.com": {
+					updatedAt: now - 10_000,
+					status: 429,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 0,
+						windowMinutes: 300,
+						resetAtMs: now + 1_000,
+					},
+					secondary: {
+						usedPercent: 0,
+						windowMinutes: 10080,
+						resetAtMs: now + 2_000,
+					},
+				},
+			},
+		};
+		loadQuotaCacheMock.mockImplementation(async () => structuredClone(quotaCacheState));
+
+		const releaseFirstRefresh = createDeferred<void>();
+		saveQuotaCacheMock.mockImplementation(async (nextCache) => {
+			quotaCacheState = structuredClone(nextCache);
+		});
+		fetchCodexQuotaSnapshotMock
+			.mockImplementationOnce(async () => {
+				await releaseFirstRefresh.promise;
+				return {
+					status: 429,
+					model: "gpt-5-codex",
+					primary: {
+						usedPercent: 0,
+						windowMinutes: 300,
+						resetAtMs: now + 3_000,
+					},
+					secondary: {
+						usedPercent: 0,
+						windowMinutes: 10080,
+						resetAtMs: now + 4_000,
+					},
+				};
+			})
+			.mockResolvedValueOnce({
+				status: 200,
+				model: "gpt-5-codex",
+				primary: {
+					usedPercent: 20,
+					windowMinutes: 300,
+					resetAtMs: now + 5_000,
+				},
+				secondary: {
+					usedPercent: 20,
+					windowMinutes: 10080,
+					resetAtMs: now + 6_000,
+				},
+			});
+
+		let promptCallCount = 0;
+		promptLoginModeMock
+			.mockImplementationOnce(async (accounts, options) => {
+				promptCallCount += 1;
+				expect(promptCallCount).toBe(1);
+				expect(accounts.map((account: { email?: string }) => account.email)).toEqual([
+					"becomes-degraded@example.com",
+					"becomes-healthy@example.com",
+				]);
+				expect(
+					accounts.map(
+						(account: { quotaRateLimited?: boolean }) => account.quotaRateLimited,
+					),
+				).toEqual([false, true]);
+				expect(typeof options?.statusMessage?.()).toBe("string");
+
+				releaseFirstRefresh.resolve();
+				await vi.waitFor(() => {
+					expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+				});
+				return { mode: "manage", deleteAccountIndex: 99 };
+			})
+			.mockImplementationOnce(async (accounts) => {
+				promptCallCount += 1;
+				expect(promptCallCount).toBe(2);
+				expect(accounts.map((account: { email?: string }) => account.email)).toEqual([
+					"becomes-healthy@example.com",
+					"becomes-degraded@example.com",
+				]);
+				expect(
+					accounts.map(
+						(account: { quotaRateLimited?: boolean }) => account.quotaRateLimited,
+					),
+				).toEqual([false, true]);
+				return { mode: "cancel" };
+			});
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+
+		expect(exitCode).toBe(0);
+		expect(promptLoginModeMock).toHaveBeenCalledTimes(2);
+		expect(promptCallCount).toBe(2);
+		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
+		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("prefers email-scoped quota cache entries for shared workspace accounts", async () => {


### PR DESCRIPTION
## Summary
- Split the ready-first ordering fix out of #350 into its own reviewable PR.

## What Changed
- Reworked the ready/waiting forecast and runtime account ordering flow so healthy ready accounts stay ahead of accounts that are still effectively blocked by rate-limit state.
- Added focused CLI and account-status regression coverage around the ordering cases that were surfacing the wrong top-ranked account.

## Validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- test/codex-manager-cli.test.ts test/account-status.test.ts`

## Docs and Governance Checklist
- No docs updates were needed; this is an internal ranking/forecast fix.

## Risk and Rollback
- Risk level: medium
- Rollback plan: revert `fe0aac2`

## Additional Notes
- Split from #350.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes the ready-first ordering regression by moving the readiness bucket check before quota percentages in `compareReadyFirstAccounts`, so `quotaRateLimited` accounts (bucket 2) never float ahead of healthy accounts regardless of stale quota numbers stored in cache. the extraction of `resolveActiveIndex`, `getRateLimitResetTimeForFamily`, and `formatRateLimitEntry` into `lib/runtime/account-status.ts` is clean; the new `skipNextMenuQuotaAutoRefresh`/`menuQuotaRefreshGeneration` generation guard correctly prevents stale async completions from re-enabling the auto-fetch skip after a user action.

- `npm test` (full suite) is unchecked; `lib/forecast.ts` had its import path changed but `test/forecast.test.ts` was not in the targeted run — worth running the full suite before merge.
- `readQuotaFloorPercent` and `accountReadinessSortBucket` have no isolated unit tests; the `-1` sentinel from `parseLeftPercentFromQuotaSummary` (no-data path) is only covered implicitly via the `full-window/missing-window` integration test.

<h3>Confidence Score: 5/5</h3>

safe to merge; all remaining findings are P2 style/coverage notes with no blocking defects

core ordering bug correctly fixed by bucket-first comparison; extraction refactor is clean; new tests cover the regression cases; no P0 or P1 issues found

lib/codex-manager.ts sort logic looks correct — run full npm test suite to confirm forecast.ts import change before merge

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime/account-status.ts | new module extracting resolveActiveIndex, getRateLimitResetTimeForFamily, formatRateLimitEntry with injected formatWaitTime; clean extraction, no logic change |
| lib/runtime/account-state.ts | reduced to barrel re-exporting all three symbols from account-status.ts |
| lib/forecast.ts | import path updated to account-status.ts; no logic change |
| lib/codex-manager.ts | bucket-first sort fix with quotaRateLimited awareness; generation guard prevents stale async completions from re-enabling skip flag |
| test/account-status.test.ts | new vitest suite covering extracted helpers and barrel re-export reference identity |
| test/codex-manager-cli.test.ts | new integration tests for ready-first ordering, quotaRateLimited sort position, async re-sort, and generation guard |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Loop as auth login loop
    participant Sort as compareReadyFirstAccounts
    participant Refresh as refreshQuotaCacheForMenu

    Loop->>Sort: applyAccountMenuOrdering(accounts)
    Sort->>Sort: accountReadinessSortBucket (quotaRateLimited → bucket 2)
    Sort->>Sort: readQuotaFloorPercent (min of 5h/7d left%)
    Sort->>Sort: readQuotaLeftPercent 5h, then 7d
    Sort-->>Loop: sorted accounts (healthy always ahead)

    Loop->>Refresh: start async refresh (stale & !skip & !pending)
    Note over Refresh: captures refreshGeneration
    Refresh-->>Loop: .then(): set skip=true only if gen matches
    Loop->>Loop: next pass — skip one auto-fetch
    Loop->>Loop: clearMenuQuotaAutoRefreshSkip() on user action (gen++)
    Note over Loop: stale .then() sees gen mismatch → skip stays false
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fforecast.ts%3A3%0A**%60forecast.test.ts%60%20not%20in%20targeted%20run**%0A%0Athe%20import%20of%20%60getRateLimitResetTimeForFamily%60%20was%20moved%20to%20%60.%2Fruntime%2Faccount-status.js%60%20but%20%60test%2Fforecast.test.ts%60%20wasn't%20included%20in%20the%20targeted%20%60npm%20test%60%20run.%20%60npm%20test%60%20%28full%20suite%29%20is%20also%20unchecked%20in%20the%20pr%20description%20%E2%80%94%20run%20the%20full%20suite%20before%20merge%20to%20confirm%20this%20import%20path%20change%20doesn't%20silently%20break%20the%20forecast%20evaluation%20path.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fcodex-manager.ts%3A952-957%0A**no%20isolated%20vitest%20coverage%20for%20%60-1%60%20sentinel%20path**%0A%0A%60readQuotaFloorPercent%60%20delegates%20to%20%60readQuotaLeftPercent%60%2C%20which%20falls%20through%20to%20%60parseLeftPercentFromQuotaSummary%60%20%E2%80%94%20that%20returns%20%60-1%60%20when%20there's%20no%20quota%20summary%20data.%20so%20accounts%20with%20a%20completely%20empty%20quota%20cache%20get%20%60floor%20%3D%20-1%60%20and%20sort%20below%20every%20account%20that%20has%20any%20real%20quota%20data.%20the%20behavior%20is%20exercised%20implicitly%20by%20the%20%60full-window%2Fmissing-window%60%20integration%20test%2C%20but%20there's%20no%20direct%20unit%20test%20asserting%20this%20sentinel%20value%20and%20its%20effect%20on%20sort%20order.%20add%20a%20focused%20test%20for%20%60accountReadinessSortBucket%60%20and%20%60readQuotaFloorPercent%60%20%28missing-data%20input%20%E2%86%92%20-1%2C%20sort%20consequence%29%20to%20lock%20in%20the%20contract.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/forecast.ts
Line: 3

Comment:
**`forecast.test.ts` not in targeted run**

the import of `getRateLimitResetTimeForFamily` was moved to `./runtime/account-status.js` but `test/forecast.test.ts` wasn't included in the targeted `npm test` run. `npm test` (full suite) is also unchecked in the pr description — run the full suite before merge to confirm this import path change doesn't silently break the forecast evaluation path.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager.ts
Line: 952-957

Comment:
**no isolated vitest coverage for `-1` sentinel path**

`readQuotaFloorPercent` delegates to `readQuotaLeftPercent`, which falls through to `parseLeftPercentFromQuotaSummary` — that returns `-1` when there's no quota summary data. so accounts with a completely empty quota cache get `floor = -1` and sort below every account that has any real quota data. the behavior is exercised implicitly by the `full-window/missing-window` integration test, but there's no direct unit test asserting this sentinel value and its effect on sort order. add a focused test for `accountReadinessSortBucket` and `readQuotaFloorPercent` (missing-data input → -1, sort consequence) to lock in the contract.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: clear ready-first auto-refresh skip..."](https://github.com/ndycode/codex-multi-auth/commit/32e9af47162c028eb1386b4619b4626cec24ebd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27372831)</sub>

<!-- /greptile_comment -->