### PR TITLE
fix codex wrapper compatibility handling

### DIFF
--- a/scripts/codex-bin-resolver.js
+++ b/scripts/codex-bin-resolver.js
@@ -1,0 +1,97 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+function defaultResolvePackageBin(moduleUrl) {
+	try {
+		const require = createRequire(moduleUrl);
+		return require.resolve("@openai/codex/bin/codex.js");
+	} catch {
+		return null;
+	}
+}
+
+function resolveWindowsCmdPath(env) {
+	const comSpec = (env.ComSpec ?? env.COMSPEC ?? "").trim();
+	if (comSpec.length > 0) return comSpec;
+
+	const systemRoot = (env.SystemRoot ?? env.SYSTEMROOT ?? "").trim();
+	if (systemRoot.length > 0) {
+		return `${systemRoot.replace(/[\\/]+$/, "")}\\System32\\cmd.exe`;
+	}
+
+	return "cmd.exe";
+}
+
+export function resolveRealCodexBin(options = {}) {
+	const {
+		env = process.env,
+		argv = process.argv,
+		platform = process.platform,
+		moduleUrl = import.meta.url,
+		existsSyncImpl = existsSync,
+		spawnSyncImpl = spawnSync,
+		resolvePackageBin = defaultResolvePackageBin,
+	} = options;
+
+	const override = (env.CODEX_MULTI_AUTH_REAL_CODEX_BIN ?? "").trim();
+	if (override.length > 0) {
+		if (existsSyncImpl(override)) return override;
+		return null;
+	}
+
+	const resolved = resolvePackageBin(moduleUrl);
+	if (typeof resolved === "string" && resolved.length > 0 && existsSyncImpl(resolved)) {
+		return resolved;
+	}
+
+	const searchRoots = [];
+	const scriptDir = dirname(fileURLToPath(moduleUrl));
+	searchRoots.push(join(scriptDir, "..", ".."));
+
+	const invokedScript = argv[1];
+	if (typeof invokedScript === "string" && invokedScript.length > 0) {
+		searchRoots.push(join(dirname(invokedScript), "..", ".."));
+	}
+
+	const npmPrefix = (env.npm_config_prefix ?? env.PREFIX ?? "").trim();
+	if (npmPrefix.length > 0) {
+		searchRoots.push(join(npmPrefix, "node_modules"));
+		searchRoots.push(join(npmPrefix, "lib", "node_modules"));
+	}
+
+	for (const root of searchRoots) {
+		const candidate = join(root, "@openai", "codex", "bin", "codex.js");
+		if (existsSyncImpl(candidate)) return candidate;
+	}
+
+	try {
+		const rootResult =
+			platform === "win32"
+				? spawnSyncImpl(resolveWindowsCmdPath(env), ["/d", "/s", "/c", "npm root -g"], {
+						encoding: "utf8",
+						env,
+						stdio: ["ignore", "pipe", "ignore"],
+						windowsHide: true,
+					})
+				: spawnSyncImpl("npm", ["root", "-g"], {
+						encoding: "utf8",
+						env,
+						stdio: ["ignore", "pipe", "ignore"],
+					});
+		if (rootResult.status === 0) {
+			const globalRoot = rootResult.stdout.trim();
+			if (globalRoot.length > 0) {
+				const globalBin = join(globalRoot, "@openai", "codex", "bin", "codex.js");
+				if (existsSyncImpl(globalBin)) return globalBin;
+			}
+		}
+	} catch {
+		// Ignore and fall through to null.
+	}
+
+	return null;
+}

--- a/scripts/codex-bin-resolver.js
+++ b/scripts/codex-bin-resolver.js
@@ -75,12 +75,14 @@ export function resolveRealCodexBin(options = {}) {
 						encoding: "utf8",
 						env,
 						stdio: ["ignore", "pipe", "ignore"],
+						timeout: 5000,
 						windowsHide: true,
 					})
 				: spawnSyncImpl("npm", ["root", "-g"], {
 						encoding: "utf8",
 						env,
 						stdio: ["ignore", "pipe", "ignore"],
+						timeout: 5000,
 					});
 		if (rootResult.status === 0) {
 			const globalRoot = rootResult.stdout.trim();

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -2,6 +2,7 @@
 
 import { spawn } from "node:child_process";
 import {
+	chmodSync,
 	copyFileSync,
 	existsSync,
 	mkdirSync,
@@ -510,12 +511,23 @@ function createCompatibilityCodexHome(rawArgs, baseEnv = process.env) {
 			// Best-effort cleanup only.
 		}
 	};
+	const tightenShadowHomePermissions = (path) => {
+		try {
+			chmodSync(path, 0o600);
+		} catch {
+			// Best-effort only; permission semantics vary by platform.
+		}
+	};
 	try {
-		writeFileSync(join(shadowCodexHome, "config.toml"), compatConfig, "utf8");
+		const compatConfigPath = join(shadowCodexHome, "config.toml");
+		writeFileSync(compatConfigPath, compatConfig, "utf8");
+		tightenShadowHomePermissions(compatConfigPath);
 		for (const name of ["auth.json", "accounts.json", ".codex-global-state.json"]) {
 			const sourcePath = join(originalCodexHome, name);
 			if (existsSync(sourcePath)) {
-				copyFileSync(sourcePath, join(shadowCodexHome, name));
+				const destinationPath = join(shadowCodexHome, name);
+				copyFileSync(sourcePath, destinationPath);
+				tightenShadowHomePermissions(destinationPath);
 			}
 		}
 	} catch (error) {

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1,12 +1,54 @@
 #!/usr/bin/env node
 
-import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { createRequire } from "node:module";
+import { homedir, tmpdir } from "node:os";
 import { basename, delimiter, dirname, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { resolveRealCodexBin as resolveRealCodexBinFromEnvironment } from "./codex-bin-resolver.js";
 import { normalizeAuthAlias, shouldHandleMultiAuthAuth } from "./codex-routing.js";
+
+const RETRYABLE_SHADOW_HOME_CLEANUP_CODES = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
+const SHADOW_HOME_CLEANUP_BACKOFF_MS = [20, 60, 120];
+
+function isRetryableShadowHomeCleanupError(error) {
+	const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+	return typeof code === "string" && RETRYABLE_SHADOW_HOME_CLEANUP_CODES.has(code);
+}
+
+function sleepSync(ms) {
+	if (!Number.isFinite(ms) || ms <= 0) {
+		return;
+	}
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function removeDirectoryWithRetry(targetPath) {
+	for (let attempt = 0; attempt <= SHADOW_HOME_CLEANUP_BACKOFF_MS.length; attempt += 1) {
+		try {
+			rmSync(targetPath, { recursive: true, force: true });
+			return;
+		} catch (error) {
+			if (
+				!isRetryableShadowHomeCleanupError(error) ||
+				attempt === SHADOW_HOME_CLEANUP_BACKOFF_MS.length
+			) {
+				throw error;
+			}
+			sleepSync(SHADOW_HOME_CLEANUP_BACKOFF_MS[attempt]);
+		}
+	}
+}
 
 function hydrateCliVersionEnv() {
 	try {
@@ -74,73 +116,37 @@ function resolveRealCodexBin() {
 		return null;
 	}
 
-	try {
-		const require = createRequire(import.meta.url);
-		const resolved = require.resolve("@openai/codex/bin/codex.js");
-		if (existsSync(resolved)) return resolved;
-	} catch {
-		// Fall through to sibling lookup.
-	}
-
-	const searchRoots = [];
-	const scriptDir = dirname(fileURLToPath(import.meta.url));
-	searchRoots.push(join(scriptDir, "..", ".."));
-
-	const invokedScript = process.argv[1];
-	if (typeof invokedScript === "string" && invokedScript.length > 0) {
-		searchRoots.push(join(dirname(invokedScript), "..", ".."));
-	}
-
-	const npmPrefix = (process.env.npm_config_prefix ?? process.env.PREFIX ?? "").trim();
-	if (npmPrefix.length > 0) {
-		searchRoots.push(join(npmPrefix, "node_modules"));
-		searchRoots.push(join(npmPrefix, "lib", "node_modules"));
-	}
-
-	for (const root of searchRoots) {
-		const candidate = join(root, "@openai", "codex", "bin", "codex.js");
-		if (existsSync(candidate)) return candidate;
-	}
-
-	const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-	try {
-		const rootResult = spawnSync(npmCmd, ["root", "-g"], {
-			encoding: "utf8",
-			stdio: ["ignore", "pipe", "ignore"],
-		});
-		if (rootResult.status === 0) {
-			const globalRoot = rootResult.stdout.trim();
-			if (globalRoot.length > 0) {
-				const globalBin = join(globalRoot, "@openai", "codex", "bin", "codex.js");
-				if (existsSync(globalBin)) return globalBin;
-			}
-		}
-	} catch {
-		// Ignore and fall through to null.
-	}
-
-	return null;
+	return resolveRealCodexBinFromEnvironment({ moduleUrl: import.meta.url });
 }
 
-function forwardToRealCodex(codexBin, args) {
+function forwardToRealCodex(codexBin, args, env = process.env, cleanup) {
 	return new Promise((resolve) => {
+		const finalize = (exitCode) => {
+			try {
+				cleanup?.();
+			} catch {
+				// Best-effort cleanup only.
+			}
+			resolve(exitCode);
+		};
+
 		const child = spawn(process.execPath, [codexBin, ...args], {
 			stdio: "inherit",
-			env: process.env,
+			env,
 		});
 
 		child.once("error", (error) => {
 			console.error(`Failed to launch real Codex CLI: ${String(error)}`);
-			resolve(1);
+			finalize(1);
 		});
 
 		child.once("exit", (code, signal) => {
 			if (signal) {
 				const signalNumber = signal === "SIGINT" ? 130 : 1;
-				resolve(signalNumber);
+				finalize(signalNumber);
 				return;
 			}
-			resolve(typeof code === "number" ? code : 1);
+			finalize(typeof code === "number" ? code : 1);
 		});
 	});
 }
@@ -168,13 +174,379 @@ function hasCliAuthCredentialsStoreOverride(args) {
 	return false;
 }
 
+// IMPORTANT: Keep this mapping in sync with
+// `lib/request/helpers/model-map.ts` `MODEL_PROFILES`.
+// This wrapper runs before the TypeScript build, so it cannot import that source.
+const SUPPORTED_REASONING_EFFORTS_BY_MODEL = {
+	"gpt-5-codex": ["low", "medium", "high", "xhigh"],
+	"gpt-5.1-codex-max": ["medium", "high", "xhigh"],
+	"gpt-5.1-codex-mini": ["medium", "high"],
+	"gpt-5.4": ["none", "low", "medium", "high", "xhigh"],
+	"gpt-5.4-pro": ["medium", "high", "xhigh"],
+	"gpt-5.2-pro": ["medium", "high", "xhigh"],
+	"gpt-5-pro": ["high"],
+	"gpt-5.2": ["none", "low", "medium", "high", "xhigh"],
+	"gpt-5.1": ["none", "low", "medium", "high"],
+	"gpt-5": ["minimal", "low", "medium", "high"],
+	"gpt-5-mini": ["medium"],
+	"gpt-5-nano": ["medium"],
+};
+
+const REASONING_FALLBACKS = {
+	none: ["none", "low", "minimal", "medium", "high", "xhigh"],
+	minimal: ["minimal", "low", "none", "medium", "high", "xhigh"],
+	low: ["low", "minimal", "none", "medium", "high", "xhigh"],
+	medium: ["medium", "low", "high", "minimal", "none", "xhigh"],
+	high: ["high", "medium", "xhigh", "low", "minimal", "none"],
+	xhigh: ["xhigh", "high", "medium", "low", "minimal", "none"],
+};
+
+const KNOWN_REASONING_EFFORTS = new Set(Object.keys(REASONING_FALLBACKS));
+
+function stripProviderPrefix(model) {
+	return typeof model === "string" && model.includes("/")
+		? model.split("/").pop() ?? model
+		: model;
+}
+
+function normalizeRequestedModel(model) {
+	const stripped = stripProviderPrefix(model ?? "");
+	const normalized = stripped.trim().toLowerCase();
+	if (normalized.length === 0) return "";
+
+	if (
+		normalized.includes("gpt-5.1-codex-max") ||
+		normalized.includes("gpt 5.1 codex max") ||
+		normalized.includes("codex-max")
+	) {
+		return "gpt-5.1-codex-max";
+	}
+	if (
+		normalized.includes("gpt-5.1-codex-mini") ||
+		normalized.includes("gpt 5.1 codex mini") ||
+		normalized.includes("gpt-5-codex-mini") ||
+		normalized.includes("gpt 5 codex mini") ||
+		normalized.includes("codex-mini-latest")
+	) {
+		return "gpt-5.1-codex-mini";
+	}
+	if (
+		normalized.includes("gpt-5.3-codex-spark") ||
+		normalized.includes("gpt 5.3 codex spark") ||
+		normalized.includes("gpt-5.3-codex") ||
+		normalized.includes("gpt 5.3 codex") ||
+		normalized.includes("gpt-5.2-codex") ||
+		normalized.includes("gpt 5.2 codex") ||
+		normalized.includes("gpt-5.1-codex") ||
+		normalized.includes("gpt 5.1 codex") ||
+		normalized.includes("gpt-5-codex") ||
+		normalized.includes("gpt 5 codex") ||
+		normalized === "codex"
+	) {
+		return "gpt-5-codex";
+	}
+	if (normalized.includes("gpt-5.4-pro") || normalized.includes("gpt 5.4 pro")) {
+		return "gpt-5.4-pro";
+	}
+	if (normalized.includes("gpt-5.2-pro") || normalized.includes("gpt 5.2 pro")) {
+		return "gpt-5.2-pro";
+	}
+	if (normalized.includes("gpt-5-pro") || normalized.includes("gpt 5 pro")) {
+		return "gpt-5-pro";
+	}
+	if (
+		normalized.includes("gpt-5.4-mini") ||
+		normalized.includes("gpt 5.4 mini") ||
+		normalized.includes("gpt-5-mini") ||
+		normalized.includes("gpt 5 mini")
+	) {
+		return "gpt-5-mini";
+	}
+	if (
+		normalized.includes("gpt-5.4-nano") ||
+		normalized.includes("gpt 5.4 nano") ||
+		normalized.includes("gpt-5-nano") ||
+		normalized.includes("gpt 5 nano")
+	) {
+		return "gpt-5-nano";
+	}
+	if (normalized.includes("gpt-5.4") || normalized.includes("gpt 5.4")) {
+		return "gpt-5.4";
+	}
+	if (normalized.includes("gpt-5.2") || normalized.includes("gpt 5.2")) {
+		return "gpt-5.2";
+	}
+	if (
+		normalized.includes("gpt-5.1-chat-latest") ||
+		normalized.includes("gpt-5.1") ||
+		normalized.includes("gpt 5.1")
+	) {
+		return "gpt-5.1";
+	}
+	if (
+		normalized === "gpt-5-chat-latest" ||
+		normalized === "gpt-5" ||
+		normalized.includes("gpt 5")
+	) {
+		return "gpt-5";
+	}
+	return "";
+}
+
+function coerceReasoningEffortForModel(model, effort) {
+	if (typeof effort !== "string") return effort;
+	const normalizedEffort = effort.trim().toLowerCase();
+	if (!KNOWN_REASONING_EFFORTS.has(normalizedEffort)) {
+		return effort;
+	}
+
+	const normalizedModel = normalizeRequestedModel(model);
+	const supportedEfforts =
+		SUPPORTED_REASONING_EFFORTS_BY_MODEL[normalizedModel] ?? null;
+	if (!supportedEfforts || supportedEfforts.includes(normalizedEffort)) {
+		return normalizedEffort;
+	}
+
+	const fallbackOrder = REASONING_FALLBACKS[normalizedEffort] ?? [normalizedEffort];
+	for (const candidate of fallbackOrder) {
+		if (supportedEfforts.includes(candidate)) {
+			return candidate;
+		}
+	}
+
+	return normalizedEffort;
+}
+
+function extractRequestedModel(args) {
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (arg === "--model") {
+			const next = args[i + 1];
+			if (typeof next === "string" && next.trim().length > 0) {
+				return next.trim();
+			}
+			continue;
+		}
+		if (typeof arg === "string" && arg.startsWith("--model=")) {
+			const value = arg.slice("--model=".length).trim();
+			if (value.length > 0) {
+				return value;
+			}
+		}
+	}
+	return null;
+}
+
+function parseConfigAssignment(value) {
+	if (typeof value !== "string") return null;
+	const separatorIndex = value.indexOf("=");
+	if (separatorIndex < 0) return null;
+	return {
+		key: value.slice(0, separatorIndex).trim(),
+		value: value.slice(separatorIndex + 1).trim(),
+	};
+}
+
+function parseQuotedValue(value) {
+	if (typeof value !== "string") {
+		return { quote: '"', inner: "" };
+	}
+	const trimmed = value.trim();
+	const first = trimmed[0];
+	const last = trimmed.at(-1);
+	if ((first === '"' || first === "'") && last === first) {
+		return {
+			quote: first,
+			inner: trimmed.slice(1, -1),
+		};
+	}
+	return { quote: '"', inner: trimmed };
+}
+
+function rewriteReasoningConfigAssignment(assignment, requestedModel) {
+	const parsed = parseConfigAssignment(assignment);
+	if (!parsed || parsed.key !== "model_reasoning_effort") {
+		return assignment;
+	}
+
+	const { quote, inner } = parseQuotedValue(parsed.value);
+	const coercedEffort = coerceReasoningEffortForModel(requestedModel, inner);
+	if (coercedEffort === inner) {
+		return assignment;
+	}
+
+	return `${parsed.key}=${quote}${coercedEffort}${quote}`;
+}
+
+function rewriteReasoningConfigArgs(rawArgs) {
+	const requestedModel = extractRequestedModel(rawArgs);
+	if (!requestedModel) {
+		return {
+			args: [...rawArgs],
+			requestedModel: null,
+		};
+	}
+
+	const nextArgs = [...rawArgs];
+	for (let i = 0; i < nextArgs.length; i += 1) {
+		const arg = nextArgs[i];
+		if ((arg === "-c" || arg === "--config") && typeof nextArgs[i + 1] === "string") {
+			nextArgs[i + 1] = rewriteReasoningConfigAssignment(
+				nextArgs[i + 1],
+				requestedModel,
+			);
+			i += 1;
+			continue;
+		}
+		if (typeof arg === "string" && arg.startsWith("--config=")) {
+			const assignment = arg.slice("--config=".length);
+			nextArgs[i] = `--config=${rewriteReasoningConfigAssignment(
+				assignment,
+				requestedModel,
+			)}`;
+		}
+	}
+
+	return {
+		args: nextArgs,
+		requestedModel,
+	};
+}
+
+function resolveCodexHomeDir(env = process.env) {
+	const override = (env.CODEX_HOME ?? "").trim();
+	if (override.length > 0) return override;
+	if (process.platform === "win32") {
+		const homeDir = resolveWindowsUserHomeDir();
+		if (homeDir) {
+			return join(homeDir, ".codex");
+		}
+	}
+	return join(env.HOME ?? homedir(), ".codex");
+}
+
+function ensureTrailingNewline(value) {
+	return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+function rewriteConfigTomlReasoningEffort(rawConfig, requestedModel) {
+	const lineEnding = rawConfig.includes("\r\n") ? "\r\n" : "\n";
+	let changed = false;
+	const nextLines = rawConfig.split(/\r?\n/).map((line) => {
+		const quotedMatch = line.match(
+			/^(\s*model_reasoning_effort\s*=\s*)(["'])([^"']+)(\2.*)$/,
+		);
+		const bareMatch = quotedMatch
+			? null
+			: line.match(
+					/^(\s*model_reasoning_effort\s*=\s*)([^\s#]+)(\s*(?:#.*)?)$/,
+				);
+		if (!quotedMatch && !bareMatch) return line;
+
+		const prefix = quotedMatch?.[1] ?? bareMatch?.[1] ?? "";
+		const openingQuote = quotedMatch?.[2] ?? "";
+		const currentEffort = quotedMatch?.[3] ?? bareMatch?.[2] ?? "";
+		const suffix = quotedMatch?.[4] ?? bareMatch?.[3] ?? "";
+		const coercedEffort = coerceReasoningEffortForModel(
+			requestedModel,
+			currentEffort,
+		);
+		if (coercedEffort === currentEffort) {
+			return line;
+		}
+
+		changed = true;
+		return quotedMatch
+			? `${prefix}${openingQuote}${coercedEffort}${suffix}`
+			: `${prefix}${coercedEffort}${suffix}`;
+	});
+
+	if (!changed) {
+		return rawConfig;
+	}
+
+	return ensureTrailingNewline(nextLines.join(lineEnding));
+}
+
+function resolveOriginalMultiAuthDir(env) {
+	const explicit = (env.CODEX_MULTI_AUTH_DIR ?? "").trim();
+	if (explicit.length > 0) {
+		return explicit;
+	}
+	return undefined;
+}
+
+function createCompatibilityCodexHome(rawArgs, baseEnv = process.env) {
+	const { args: nextArgs, requestedModel } = rewriteReasoningConfigArgs(rawArgs);
+	if (!requestedModel) {
+		return { args: nextArgs, env: baseEnv, cleanup: undefined };
+	}
+
+	const xhighCompatEffort = coerceReasoningEffortForModel(requestedModel, "xhigh");
+	if (xhighCompatEffort === "xhigh") {
+		return { args: nextArgs, env: baseEnv, cleanup: undefined };
+	}
+
+	const originalCodexHome = resolveCodexHomeDir(baseEnv);
+	const configPath = join(originalCodexHome, "config.toml");
+	if (!existsSync(configPath)) {
+		return { args: nextArgs, env: baseEnv, cleanup: undefined };
+	}
+
+	const rawConfig = readFileSync(configPath, "utf8");
+	const compatConfig = rewriteConfigTomlReasoningEffort(
+		rawConfig,
+		requestedModel,
+	);
+	if (compatConfig === rawConfig) {
+		return { args: nextArgs, env: baseEnv, cleanup: undefined };
+	}
+
+	const shadowCodexHome = mkdtempSync(join(tmpdir(), "codex-multi-auth-home-"));
+	const cleanup = () => {
+		try {
+			removeDirectoryWithRetry(shadowCodexHome);
+		} catch {
+			// Best-effort cleanup only.
+		}
+	};
+	try {
+		writeFileSync(join(shadowCodexHome, "config.toml"), compatConfig, "utf8");
+		for (const name of ["auth.json", "accounts.json", ".codex-global-state.json"]) {
+			const sourcePath = join(originalCodexHome, name);
+			if (existsSync(sourcePath)) {
+				copyFileSync(sourcePath, join(shadowCodexHome, name));
+			}
+		}
+	} catch (error) {
+		cleanup();
+		throw error;
+	}
+
+	const forwardedEnv = {
+		...baseEnv,
+		CODEX_HOME: shadowCodexHome,
+	};
+	const originalMultiAuthDir = resolveOriginalMultiAuthDir(baseEnv);
+	if (originalMultiAuthDir) {
+		forwardedEnv.CODEX_MULTI_AUTH_DIR = originalMultiAuthDir;
+	}
+
+	return {
+		args: nextArgs,
+		env: forwardedEnv,
+		cleanup,
+	};
+}
+
 function buildForwardArgs(rawArgs) {
+	const { args: compatibilityArgs } = rewriteReasoningConfigArgs(rawArgs);
 	const forceFileAuthStore = (process.env.CODEX_MULTI_AUTH_FORCE_FILE_AUTH_STORE ?? "1").trim() !== "0";
-	if (!forceFileAuthStore) return [...rawArgs];
-	if (hasCliAuthCredentialsStoreOverride(rawArgs)) return [...rawArgs];
+	if (!forceFileAuthStore) return compatibilityArgs;
+	if (hasCliAuthCredentialsStoreOverride(compatibilityArgs)) return compatibilityArgs;
 
 	return [
-		...rawArgs,
+		...compatibilityArgs,
 		"-c",
 		'cli_auth_credentials_store="file"',
 	];
@@ -536,7 +908,13 @@ async function main() {
 
 	await autoSyncManagerActiveSelectionIfEnabled();
 	const forwardArgs = buildForwardArgs(rawArgs);
-	return forwardToRealCodex(realCodexBin, forwardArgs);
+	const compatibility = createCompatibilityCodexHome(forwardArgs);
+	return forwardToRealCodex(
+		realCodexBin,
+		compatibility.args,
+		compatibility.env,
+		compatibility.cleanup,
+	);
 }
 
 const exitCode = await main();

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -347,9 +347,13 @@ describe("codex bin wrapper", () => {
 			'const configPath = path.join(process.env.CODEX_HOME ?? "", "config.toml");',
 			'const authPath = path.join(process.env.CODEX_HOME ?? "", "auth.json");',
 			'console.log(`AUTH_EXISTS:${fs.existsSync(authPath)}`);',
-			'if (fs.existsSync(authPath)) console.log(`AUTH_JSON:${fs.readFileSync(authPath, "utf8").trim()}`);',
+			'if (fs.existsSync(authPath)) {',
+			'  console.log(`AUTH_JSON:${fs.readFileSync(authPath, "utf8").trim()}`);',
+			'  console.log(`AUTH_MODE:${(fs.statSync(authPath).mode & 0o777).toString(8)}`);',
+			'}',
 			'console.log("CONFIG_START");',
 			'console.log(fs.readFileSync(configPath, "utf8").trim());',
+			'console.log(`CONFIG_MODE:${(fs.statSync(configPath).mode & 0o777).toString(8)}`);',
 			'console.log("CONFIG_END");',
 			"process.exit(0);",
 		]);
@@ -382,8 +386,14 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("CODEX_MULTI_AUTH_DIR_JSON:null");
 		expect(output).toContain("AUTH_EXISTS:true");
 		expect(output).toContain("AUTH_JSON:{}");
+		expect(output).toContain("AUTH_MODE:");
 		expect(output).toContain('model_reasoning_effort = "high"');
+		expect(output).toContain("CONFIG_MODE:");
 		expect(output).not.toContain('model_reasoning_effort = "xhigh"');
+		if (process.platform !== "win32") {
+			expect(output).toContain("AUTH_MODE:600");
+			expect(output).toContain("CONFIG_MODE:600");
+		}
 	});
 
 	it("cleans up compatibility shadow homes when staging fails", () => {
@@ -410,6 +420,7 @@ describe("codex bin wrapper", () => {
 				CODEX_HOME: originalHome,
 				TMP: controlledTmp,
 				TEMP: controlledTmp,
+				TMPDIR: controlledTmp,
 			},
 		);
 
@@ -935,6 +946,7 @@ describe("codex bin wrapper", () => {
 				npm_config_prefix: "",
 			},
 			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 5000,
 			windowsHide: true,
 		});
 	});
@@ -983,6 +995,7 @@ describe("codex bin wrapper", () => {
 				npm_config_prefix: "",
 			},
 			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 5000,
 			windowsHide: true,
 		});
 	});
@@ -1022,6 +1035,9 @@ describe("codex bin wrapper", () => {
 		expect(spawnCalls).toHaveLength(1);
 		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			timeout: 5000,
+		});
 	});
 
 	it("derives cmd.exe from uppercase SYSTEMROOT when ComSpec is unavailable", () => {
@@ -1062,6 +1078,9 @@ describe("codex bin wrapper", () => {
 		expect(spawnCalls).toHaveLength(1);
 		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			timeout: 5000,
+		});
 	});
 
 	it("falls back to bare cmd.exe when no Windows shell env vars are set", () => {
@@ -1104,6 +1123,7 @@ describe("codex bin wrapper", () => {
 				npm_config_prefix: "",
 			},
 			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 5000,
 			windowsHide: true,
 		});
 	});
@@ -1150,6 +1170,7 @@ describe("codex bin wrapper", () => {
 				npm_config_prefix: "",
 			},
 			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 5000,
 		});
 		expect(spawnCalls[0]?.options).not.toHaveProperty("windowsHide");
 	});

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -3,6 +3,7 @@ import {
 	copyFileSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
 	writeFileSync,
@@ -10,9 +11,10 @@ import {
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { sleep } from "../lib/utils.js";
+import { resolveRealCodexBin } from "../scripts/codex-bin-resolver.js";
 
 const createdDirs: string[] = [];
 const testFileDir = dirname(fileURLToPath(import.meta.url));
@@ -57,6 +59,10 @@ function createWrapperFixture(): string {
 		join(repoRootDir, "scripts", "codex-routing.js"),
 		join(scriptDir, "codex-routing.js"),
 	);
+	copyFileSync(
+		join(repoRootDir, "scripts", "codex-bin-resolver.js"),
+		join(scriptDir, "codex-bin-resolver.js"),
+	);
 	return fixtureRoot;
 }
 
@@ -80,6 +86,75 @@ function createCustomFakeCodexBin(rootDir: string, lines: string[]): string {
 	return fakeBin;
 }
 
+function injectShadowCleanupBusyFailures(
+	fixtureRoot: string,
+	failuresBeforeSuccess = 2,
+): void {
+	const wrapperPath = join(fixtureRoot, "scripts", "codex.js");
+	const originalSource = readFileSync(wrapperPath, "utf8");
+	const instrumentedSource = originalSource
+		.replace(
+			'const SHADOW_HOME_CLEANUP_BACKOFF_MS = [20, 60, 120];',
+			[
+				'const SHADOW_HOME_CLEANUP_BACKOFF_MS = [20, 60, 120];',
+				`globalThis.__cleanupBusyFailuresRemaining = ${failuresBeforeSuccess};`,
+			].join("\n"),
+		)
+		.replace(
+			"rmSync(targetPath, { recursive: true, force: true });",
+			[
+				"if (globalThis.__cleanupBusyFailuresRemaining > 0) {",
+				"\tglobalThis.__cleanupBusyFailuresRemaining -= 1;",
+				'\tconst error = new Error("simulated busy cleanup");',
+				'\terror.code = "EBUSY";',
+				"\tthrow error;",
+				"}",
+				"rmSync(targetPath, { recursive: true, force: true });",
+			].join("\n"),
+		);
+	writeFileSync(wrapperPath, instrumentedSource, "utf8");
+}
+
+function createFakeGlobalCodexInstall(rootDir: string): string {
+	const fakeBin = join(rootDir, "@openai", "codex", "bin", "codex.js");
+	mkdirSync(dirname(fakeBin), { recursive: true });
+	writeFileSync(
+		fakeBin,
+		[
+			"#!/usr/bin/env node",
+			'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
+			"process.exit(0);",
+		].join("\n"),
+		"utf8",
+	);
+	return fakeBin;
+}
+
+function createSpawnSyncSuccess(stdout: string): SpawnSyncReturns<string> {
+	return {
+		output: ["", stdout, ""],
+		pid: 1,
+		signal: null,
+		status: 0,
+		stderr: "",
+		stdout,
+	};
+}
+
+function buildWrapperEnv(extraEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		CODEX_MULTI_AUTH_FORCE_FILE_AUTH_STORE: "1",
+		...extraEnv,
+	};
+	for (const [key, value] of Object.entries(env)) {
+		if (value === undefined) {
+			delete env[key];
+		}
+	}
+	return env;
+}
+
 function runWrapper(
 	fixtureRoot: string,
 	args: string[],
@@ -90,10 +165,7 @@ function runWrapper(
 		[join(fixtureRoot, "scripts", "codex.js"), ...args],
 		{
 			encoding: "utf8",
-			env: {
-				...process.env,
-				...extraEnv,
-			},
+			env: buildWrapperEnv(extraEnv),
 		},
 	);
 }
@@ -105,10 +177,7 @@ function runWrapperScript(
 ): SpawnSyncReturns<string> {
 	return spawnSync(process.execPath, [scriptPath, ...args], {
 		encoding: "utf8",
-		env: {
-			...process.env,
-			...extraEnv,
-		},
+		env: buildWrapperEnv(extraEnv),
 	});
 }
 
@@ -129,10 +198,7 @@ function runWrapperAsync(
 			process.execPath,
 			[join(fixtureRoot, "scripts", "codex.js"), ...args],
 			{
-				env: {
-					...process.env,
-					...extraEnv,
-				},
+				env: buildWrapperEnv(extraEnv),
 				stdio: ["ignore", "pipe", "pipe"],
 			},
 		);
@@ -267,6 +333,232 @@ describe("codex bin wrapper", () => {
 
 		expect(result.status).toBe(13);
 		expect(combinedOutput(result)).toContain("EPERM: locked auth store");
+	});
+
+	it("creates a compatibility CODEX_HOME shadow when the requested model cannot accept xhigh defaults", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
+			'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
+			'console.log(`CODEX_HOME:${process.env.CODEX_HOME ?? ""}`);',
+			'console.log(`CODEX_MULTI_AUTH_DIR_JSON:${JSON.stringify(process.env.CODEX_MULTI_AUTH_DIR ?? null)}`);',
+			'const configPath = path.join(process.env.CODEX_HOME ?? "", "config.toml");',
+			'const authPath = path.join(process.env.CODEX_HOME ?? "", "auth.json");',
+			'console.log(`AUTH_EXISTS:${fs.existsSync(authPath)}`);',
+			'if (fs.existsSync(authPath)) console.log(`AUTH_JSON:${fs.readFileSync(authPath, "utf8").trim()}`);',
+			'console.log("CONFIG_START");',
+			'console.log(fs.readFileSync(configPath, "utf8").trim());',
+			'console.log("CONFIG_END");',
+			"process.exit(0);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "auth.json"), "{}\n", "utf8");
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			[
+				'model_reasoning_effort = "xhigh"',
+				'profile = "legacy-full-access"',
+				"",
+				'[profiles."legacy-full-access"]',
+				'model_reasoning_effort = "xhigh"',
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		const result = runWrapper(fixtureRoot, ["exec", "status", "--model", "gpt-5.1"], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_HOME: originalHome,
+			CODEX_MULTI_AUTH_DIR: undefined,
+		});
+
+		expect(result.status).toBe(0);
+		const output = combinedOutput(result);
+		expect(output).toContain('FORWARDED:exec status --model gpt-5.1 -c cli_auth_credentials_store="file"');
+		expect(output).not.toContain(`CODEX_HOME:${originalHome}`);
+		expect(output).toContain("CODEX_MULTI_AUTH_DIR_JSON:null");
+		expect(output).toContain("AUTH_EXISTS:true");
+		expect(output).toContain("AUTH_JSON:{}");
+		expect(output).toContain('model_reasoning_effort = "high"');
+		expect(output).not.toContain('model_reasoning_effort = "xhigh"');
+	});
+
+	it("cleans up compatibility shadow homes when staging fails", () => {
+		const fixtureRoot = createWrapperFixture();
+		injectShadowCleanupBusyFailures(fixtureRoot);
+		const fakeBin = createFakeCodexBin(fixtureRoot);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const controlledTmp = join(fixtureRoot, "tmp");
+		mkdirSync(originalHome, { recursive: true });
+		mkdirSync(controlledTmp, { recursive: true });
+		writeFileSync(join(originalHome, "auth.json"), "{}\n", "utf8");
+		mkdirSync(join(originalHome, "accounts.json"), { recursive: true });
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			'model_reasoning_effort = "xhigh"\n',
+			"utf8",
+		);
+
+		const result = runWrapper(
+			fixtureRoot,
+			["exec", "status", "--model", "gpt-5.1"],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				TMP: controlledTmp,
+				TEMP: controlledTmp,
+			},
+		);
+
+		expect(result.status).toBe(1);
+		expect(
+			readdirSync(controlledTmp).filter((entry) =>
+				entry.startsWith("codex-multi-auth-home-"),
+			),
+		).toEqual([]);
+	});
+
+	it("rewrites unquoted config reasoning effort values for mini compatibility models", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
+			'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
+			'const configPath = path.join(process.env.CODEX_HOME ?? "", "config.toml");',
+			'console.log("CONFIG_START");',
+			'console.log(fs.readFileSync(configPath, "utf8").trim());',
+			'console.log("CONFIG_END");',
+			"process.exit(0);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "auth.json"), "{}\n", "utf8");
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			[
+				"model_reasoning_effort = xhigh",
+				'profile = "legacy-full-access"',
+				"",
+				'[profiles."legacy-full-access"]',
+				"model_reasoning_effort = xhigh # keep comment",
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		const result = runWrapper(
+			fixtureRoot,
+			["exec", "status", "--model", "gpt-5.1-codex-mini"],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+			},
+		);
+
+		expect(result.status).toBe(0);
+		const output = combinedOutput(result);
+		expect(output).toContain(
+			'FORWARDED:exec status --model gpt-5.1-codex-mini -c cli_auth_credentials_store="file"',
+		);
+		expect(output).toContain("model_reasoning_effort = high");
+		expect(output).toContain("model_reasoning_effort = high # keep comment");
+		expect(output).not.toContain("model_reasoning_effort = xhigh");
+	});
+
+	it("downgrades explicit unsupported reasoning overrides before forwarding", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createFakeCodexBin(fixtureRoot);
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "auth.json"), "{}\n", "utf8");
+		writeFileSync(join(originalHome, "config.toml"), "", "utf8");
+
+		const result = runWrapper(
+			fixtureRoot,
+			[
+				"exec",
+				"status",
+				"--model",
+				"gpt-5.1",
+				"-c",
+				'model_reasoning_effort="xhigh"',
+			],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+			},
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain(
+			'FORWARDED:exec status --model gpt-5.1 -c model_reasoning_effort="high" -c cli_auth_credentials_store="file"',
+		);
+		expect(result.stdout).not.toContain('model_reasoning_effort="xhigh"');
+	});
+
+	it("downgrades explicit unsupported reasoning overrides for codex mini variants", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createFakeCodexBin(fixtureRoot);
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "auth.json"), "{}\n", "utf8");
+		writeFileSync(join(originalHome, "config.toml"), "", "utf8");
+
+		const result = runWrapper(
+			fixtureRoot,
+			[
+				"exec",
+				"status",
+				"--model",
+				"gpt-5.1-codex-mini",
+				"-c",
+				'model_reasoning_effort="xhigh"',
+			],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+			},
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain(
+			'FORWARDED:exec status --model gpt-5.1-codex-mini -c model_reasoning_effort="high" -c cli_auth_credentials_store="file"',
+		);
+		expect(result.stdout).not.toContain('model_reasoning_effort="xhigh"');
+	});
+
+	it("preserves explicit xhigh overrides for models that support them", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createFakeCodexBin(fixtureRoot);
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "auth.json"), "{}\n", "utf8");
+		writeFileSync(join(originalHome, "config.toml"), "", "utf8");
+
+		const result = runWrapper(
+			fixtureRoot,
+			[
+				"exec",
+				"status",
+				"--model",
+				"gpt-5.4",
+				"-c",
+				'model_reasoning_effort="xhigh"',
+			],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+			},
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain(
+			'FORWARDED:exec status --model gpt-5.4 -c model_reasoning_effort="xhigh" -c cli_auth_credentials_store="file"',
+		);
 	});
 
 	it.skipIf(process.platform !== "win32")(
@@ -467,6 +759,10 @@ describe("codex bin wrapper", () => {
 				join(repoRootDir, "scripts", "codex-routing.js"),
 				join(scriptDir, "codex-routing.js"),
 			);
+			copyFileSync(
+				join(repoRootDir, "scripts", "codex-bin-resolver.js"),
+				join(scriptDir, "codex-bin-resolver.js"),
+			);
 			writeFileSync(
 				join(globalShimDir, "codex-multi-auth.cmd"),
 				"@ECHO OFF\r\nREM real shim\r\n",
@@ -593,6 +889,290 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain(
 			"Install it globally: npm install -g @openai/codex",
 		);
+	});
+
+	it("discovers the real codex bin via npm root fallback for direct script runs on Windows", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules");
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				ComSpec: "C:\\Windows\\System32\\cmd.exe",
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\r\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			encoding: "utf8",
+			env: {
+				ComSpec: "C:\\Windows\\System32\\cmd.exe",
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
+		});
+	});
+
+	it("honors uppercase COMSPEC when resolving the Windows npm root fallback", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules-uppercase");
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\r\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			encoding: "utf8",
+			env: {
+				COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
+		});
+	});
+
+	it("derives cmd.exe from SystemRoot when ComSpec is unavailable", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules-systemroot");
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				SystemRoot: "C:\\Windows\\",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\r\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+	});
+
+	it("derives cmd.exe from uppercase SYSTEMROOT when ComSpec is unavailable", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(
+			fixtureRoot,
+			"fake-global-node_modules-systemroot-uppercase",
+		);
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				SYSTEMROOT: "C:\\Windows\\",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\r\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+	});
+
+	it("falls back to bare cmd.exe when no Windows shell env vars are set", () => {
+		const fixtureRoot = createWrapperFixture();
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+
+		resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: () => false,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "win32",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess("");
+			},
+		});
+
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("cmd.exe");
+		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			encoding: "utf8",
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
+		});
+	});
+
+	it("discovers the real codex bin via npm root fallback on POSIX", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeGlobalRoot = join(fixtureRoot, "fake-global-node_modules-posix");
+		const fakeGlobalBin = createFakeGlobalCodexInstall(fakeGlobalRoot);
+		const spawnCalls: Array<{
+			args: string[];
+			command: string;
+			options: Record<string, unknown>;
+		}> = [];
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: (candidatePath) => candidatePath === fakeGlobalBin,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "linux",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({
+					args,
+					command,
+					options: options as Record<string, unknown>,
+				});
+				return createSpawnSyncSuccess(`${fakeGlobalRoot}\n`);
+			},
+		});
+
+		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command).toBe("npm");
+		expect(spawnCalls[0]?.args).toEqual(["root", "-g"]);
+		expect(spawnCalls[0]?.options).toMatchObject({
+			encoding: "utf8",
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		expect(spawnCalls[0]?.options).not.toHaveProperty("windowsHide");
+	});
+
+	it("returns null when npm root lookup throws", () => {
+		const fixtureRoot = createWrapperFixture();
+		const resolvedBin = resolveRealCodexBin({
+			argv: ["node", join(fixtureRoot, "scripts", "codex.js")],
+			env: {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: "",
+				PREFIX: "",
+				npm_config_prefix: "",
+			},
+			existsSyncImpl: () => false,
+			moduleUrl: pathToFileURL(join(fixtureRoot, "scripts", "codex.js")).href,
+			platform: "linux",
+			resolvePackageBin: () => null,
+			spawnSyncImpl: () => {
+				throw new Error("ENOENT: npm not found");
+			},
+		});
+
+		expect(resolvedBin).toBeNull();
 	});
 
 	it("handles concurrent wrapper invocations without module-load regressions", async () => {


### PR DESCRIPTION
## Summary
- Split the Codex wrapper compatibility work out of #350 into its own reviewable PR.

## What Changed
- Added a dedicated resolver for the real Codex binary and tightened the wrapper fallback path so compatibility staging, shell-guard install, and direct-script resolution behave consistently.
- Expanded wrapper regression coverage around unsupported reasoning overrides, Windows shell guard setup, and npm-root fallback discovery.

## Validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- test/codex-bin-wrapper.test.ts`

## Docs and Governance Checklist
- No docs updates were needed; this is wrapper/runtime compatibility handling only.

## Risk and Rollback
- Risk level: medium
- Rollback plan: revert `6c9aea9`

## Additional Notes
- Split from #350.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr extracts binary resolution into a dedicated `codex-bin-resolver.js` module with fully injectable dependencies, adds compatibility shadow-home staging that rewrites `config.toml` reasoning-effort values for mini models and copies auth files with `chmod 0o600`, and implements retry-with-backoff cleanup via `Atomics.wait`. it also adds reasoning-effort downgrade in cli args (`rewriteReasoningConfigArgs`), tightens windows shell-guard installs, and widens test coverage with posix/windows npm-root fallback unit tests, cleanup-failure integration tests, and concurrent-invocation regression tests.

all three issues flagged in prior review threads are resolved:
- `spawnSync` timeout: `timeout: 5000` is present on both the win32 and posix call sites in `codex-bin-resolver.js` lines 74–86
- auth file permissions: `chmodSync(dest, 0o600)` is applied to every copied file via `tightenShadowHomePermissions` in `codex.js` lines 514–519
- `TMPDIR` vs `TMP`/`TEMP`: `TMPDIR: controlledTmp` is now included in the cleanup test env (line 423)

key findings:
- **P2 — double `rewriteReasoningConfigArgs` call**: `buildForwardArgs` rewrites `-c model_reasoning_effort=...` args, then `main()` passes its output to `createCompatibilityCodexHome` which calls `rewriteReasoningConfigArgs` again. currently harmless (idempotent), but `createCompatibilityCodexHome` is designed around `rawArgs` semantics while receiving pre-processed args — a future change that breaks idempotency would silently produce wrong forwarded args
- posix npm-root unit test is present and complete at line 1131 (asserts `command === "npm"`, args `["root", "-g"]`, `timeout: 5000`, and absence of `windowsHide`)
- concurrency test at line 1199 runs 10 parallel subprocess invocations and confirms no module-load races

<h3>Confidence Score: 5/5</h3>

safe to merge — all prior p1 concerns resolved, sole remaining finding is a p2 design smell around double arg-rewrite

the three p1 issues from prior review threads (missing spawnSync timeout, missing chmodSync, wrong tmpdir env var) are all addressed. posix npm-root unit test coverage is complete. the only new finding is the redundant rewriteReasoningConfigArgs call which is currently idempotent and carries no present-tense defect.

no files require special attention; optional follow-up: rename createCompatibilityCodexHome's rawArgs parameter or extract requestedModel to eliminate the double-rewrite pattern

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/codex-bin-resolver.js | new injectable resolver: override env → require.resolve → sibling search → npm-prefix → npm root -g with timeout:5000 on both posix and win32 paths; windows cmd.exe derivation from ComSpec/COMSPEC/SystemRoot fully unit-tested |
| scripts/codex.js | adds shadow-home compat staging with chmod 0o600, atomics-based retry cleanup, reasoning-effort downgrade in args and config.toml, and windows shim guard install; delegates binary resolution to new module; all prior token-safety and timeout concerns addressed |
| test/codex-bin-wrapper.test.ts | comprehensive new coverage: shadow home creation and cleanup-on-failure, posix and windows npm-root spawnSyncImpl unit tests, reasoning rewrite (quoted and unquoted toml), windows shell guard installs, and 10-way concurrent invocation regression |

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fcodex.js%3A554-565%0A**redundant%20%60rewriteReasoningConfigArgs%60%20double-call**%0A%0A%60buildForwardArgs%60%20calls%20%60rewriteReasoningConfigArgs%28rawArgs%29%60%20internally%20and%20returns%20the%20rewritten%20args.%20%60main%28%29%60%20then%20passes%20that%20output%20directly%20into%20%60createCompatibilityCodexHome%60%2C%20which%20calls%20%60rewriteReasoningConfigArgs%60%20again.%20the%20rewrite%20is%20idempotent%20today%20so%20there%20is%20no%20present%20bug%2C%20but%20%60createCompatibilityCodexHome%60%20parameter%20is%20named%20%60rawArgs%60%20and%20its%20logic%20assumes%20unprocessed%20input.%20if%20the%20rewrite%20ever%20becomes%20non-idempotent%2C%20%60compatibility.args%60%20would%20silently%20diverge%20from%20%60forwardArgs%60%20with%20no%20test%20to%20catch%20it.%0A%0Aconsider%20extracting%20model%20detection%20so%20%60createCompatibilityCodexHome%60%20receives%20the%20resolved%20model%20directly%2C%20or%20at%20minimum%20rename%20the%20parameter%20from%20%60rawArgs%60%20to%20%60processedArgs%60%20to%20accurately%20signal%20the%20contract.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/codex.js
Line: 554-565

Comment:
**redundant `rewriteReasoningConfigArgs` double-call**

`buildForwardArgs` calls `rewriteReasoningConfigArgs(rawArgs)` internally and returns the rewritten args. `main()` then passes that output directly into `createCompatibilityCodexHome`, which calls `rewriteReasoningConfigArgs` again. the rewrite is idempotent today so there is no present bug, but `createCompatibilityCodexHome` parameter is named `rawArgs` and its logic assumes unprocessed input. if the rewrite ever becomes non-idempotent, `compatibility.args` would silently diverge from `forwardArgs` with no test to catch it.

consider extracting model detection so `createCompatibilityCodexHome` receives the resolved model directly, or at minimum rename the parameter from `rawArgs` to `processedArgs` to accurately signal the contract.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>**[Greploops](https://www.greptile.com/docs/mcp-v2/skills#greploop)** — Automatically fix all review issues by running `/greploops` in [Claude Code](https://claude.ai/download). It iterates: fix, push, re-review, repeat until 5/5 confidence.<br>Use the **[Greptile plugin for Claude Code](https://www.greptile.com/docs/integrations/claude-code#claude-code-plugin)** to query reviews, search comments, and manage custom context directly from your terminal.</sub>

<sub>Reviews (2): Last reviewed commit: ["fix: harden codex wrapper fallbacks"](https://github.com/ndycode/codex-multi-auth/commit/24f503fbc7fc3a94419b1db39db9fccb74b6dedc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27372833)</sub>

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->