### PR TITLE
fix usage-limit cooldown persistence

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1865,13 +1865,17 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 														quotaKey,
 														rateLimit.retryAfterMs,
 													);
+													const cooldownMs = Math.max(
+														delayMs,
+														rateLimit.retryAfterMs,
+													);
 													preemptiveQuotaScheduler.markRateLimited(
 														quotaScheduleKey,
-														delayMs,
+														cooldownMs,
 													);
-													const waitLabel = formatWaitTime(delayMs);
+													const waitLabel = formatWaitTime(cooldownMs);
 
-													if (delayMs <= RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS) {
+													if (cooldownMs <= RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS) {
 														if (
 															accountManager.shouldShowAccountToast(
 																account.index,
@@ -1887,14 +1891,14 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 														}
 
 														await sleep(
-															addJitter(Math.max(MIN_BACKOFF_MS, delayMs), 0.2),
+															addJitter(Math.max(MIN_BACKOFF_MS, cooldownMs), 0.2),
 														);
 														continue;
 													}
 
 													accountManager.markRateLimitedWithReason(
 														account,
-														delayMs,
+														cooldownMs,
 														modelFamily,
 														parseRateLimitReason(rateLimit.code),
 														model,
@@ -2142,19 +2146,29 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 																	);
 																}
 																if (!fallbackResponse.ok) {
-																	try {
-																		await fallbackResponse.body?.cancel();
-																	} catch {
-																		// Best effort cleanup before trying next fallback account.
-																	}
-																	if (fallbackResponse.status === 429) {
+																	const { response: handledFallbackResponse, rateLimit: fallbackRateLimit } =
+																		await handleErrorResponse(fallbackResponse);
+																	if (handledFallbackResponse.status === 429) {
 																		const retryAfterMs =
-																			parseRetryAfterHintMs(
-																				fallbackResponse.headers,
-																			) ?? 60_000;
+																			fallbackRateLimit?.retryAfterMs ?? 60_000;
+																		const fallbackQuotaKey =
+																			model ? `${modelFamily}:${model}` : modelFamily;
+																		const { delayMs } = getRateLimitBackoff(
+																			fallbackAccount.index,
+																			fallbackQuotaKey,
+																			retryAfterMs,
+																		);
+																		const cooldownMs = Math.max(
+																			delayMs,
+																			retryAfterMs,
+																		);
+																		preemptiveQuotaScheduler.markRateLimited(
+																			`${fallbackEntitlementAccountKey}:${model ?? modelFamily}`,
+																			cooldownMs,
+																		);
 																		accountManager.markRateLimitedWithReason(
 																			fallbackAccount,
-																			retryAfterMs,
+																			cooldownMs,
 																			modelFamily,
 																			"quota",
 																			model,

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -783,7 +783,8 @@ export class AccountManager {
 
 		const baseKey = getQuotaKey(family);
 		if (!model || reason === "quota" || reason === "unknown") {
-			account.rateLimitResetTimes[baseKey] = resetAt;
+			const currentResetAt = account.rateLimitResetTimes[baseKey] ?? 0;
+			account.rateLimitResetTimes[baseKey] = Math.max(currentResetAt, resetAt);
 		}
 
 		if (
@@ -791,7 +792,8 @@ export class AccountManager {
 			(reason === "tokens" || reason === "concurrent" || reason === "unknown")
 		) {
 			const modelKey = getQuotaKey(family, model);
-			account.rateLimitResetTimes[modelKey] = resetAt;
+			const currentResetAt = account.rateLimitResetTimes[modelKey] ?? 0;
+			account.rateLimitResetTimes[modelKey] = Math.max(currentResetAt, resetAt);
 		}
 
 		account.lastRateLimitReason = reason;

--- a/lib/preemptive-quota-scheduler.ts
+++ b/lib/preemptive-quota-scheduler.ts
@@ -212,14 +212,20 @@ export class PreemptiveQuotaScheduler {
 	markRateLimited(key: string, retryAfterMs: number, now = Date.now()): void {
 		if (!key) return;
 		const waitMs = Number.isFinite(retryAfterMs) ? Math.max(0, Math.floor(retryAfterMs)) : 0;
+		const existing = this.snapshots.get(key);
+		const existingResetAtMs = Math.max(
+			existing?.primary.resetAtMs ?? 0,
+			existing?.secondary.resetAtMs ?? 0,
+		);
+		const nextResetAtMs = Math.max(existingResetAtMs, now + waitMs);
 		this.snapshots.set(key, {
 			status: 429,
 			primary: {
 				usedPercent: 100,
-				resetAtMs: now + waitMs,
+				resetAtMs: nextResetAtMs,
 			},
 			secondary: {},
-			updatedAt: now,
+			updatedAt: Math.max(existing?.updatedAt ?? 0, now),
 		});
 	}
 

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -68,7 +68,11 @@ const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
 	/model is not supported when using codex with a chatgpt account/i;
 const NORMALIZED_UNSUPPORTED_MODEL_PATTERN =
 	/the model ['"]([^'"]+)['"] is not currently available for this chatgpt account/i;
-const MAX_RETRY_DELAY_MS = 5 * 60 * 1000;
+const MAX_RATE_LIMIT_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
+const RETRY_AFTER_DURATION_PATTERN =
+	/\b(?:try|retry)\s+again\s+in\s+(\d+)\s*(second|minute|hour|day)s?\b/i;
+const RETRY_AFTER_CLOCK_TIME_PATTERN =
+	/\b(?:try|retry)\s+again\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b/i;
 const CREATE_CODEX_HEADERS_PARAM_KEYS = new Set(["init", "accountId", "accessToken", "opts"]);
 const DEFAULT_PROXY_PORTS: Record<string, number> = {
 	"http:": 80,
@@ -1010,23 +1014,16 @@ function extractRateLimitInfoFromBody(
         const isStatusRateLimit =
                 response.status === HTTP_STATUS.TOO_MANY_REQUESTS;
         const parsed = parseRateLimitBody(bodyText);
-
-        const haystack = `${parsed?.code ?? ""} ${bodyText}`.toLowerCase();
         
         // Entitlement errors should not be treated as rate limits
         if (isEntitlementError(parsed?.code ?? "", bodyText)) {
                 return undefined;
         }
-        
-        const isRateLimit =
-                isStatusRateLimit ||
-                /usage_limit_reached|rate_limit_exceeded|rate_limit|usage limit/i.test(
-                        haystack,
-                );
-        if (!isRateLimit) return undefined;
+
+        if (!isStatusRateLimit) return undefined;
 
         const retryAfterMs =
-                parseRetryAfterMs(response, parsed) ?? 60000;
+                parseRetryAfterMs(response, bodyText, parsed) ?? 60000;
 
         return { retryAfterMs, code: parsed?.code };
 }
@@ -1197,8 +1194,24 @@ function ensureJsonErrorResponse(response: Response, payload: ErrorPayload): Res
 	});
 }
 
+function parseResetTimestampMs(rawValue: string): number | null {
+	const trimmed = rawValue.trim();
+	if (trimmed.length === 0) return null;
+
+	if (/^\d+$/.test(trimmed)) {
+		const parsed = Number.parseInt(trimmed, 10);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return parsed < 10_000_000_000 ? parsed * 1000 : parsed;
+		}
+	}
+
+	const parsedDate = Date.parse(trimmed);
+	return Number.isFinite(parsedDate) ? parsedDate : null;
+}
+
 function parseRetryAfterMs(
 	response: Response,
+	bodyText: string,
 	parsedBody?: { resetsAt?: number; retryAfterMs?: number; retryAfterSeconds?: number },
 ): number | null {
 	if (parsedBody?.retryAfterMs !== undefined) {
@@ -1211,69 +1224,144 @@ function parseRetryAfterMs(
 		if (normalized !== null) return normalized;
 	}
 
-        const retryAfterMsHeader = response.headers.get("retry-after-ms");
-        if (retryAfterMsHeader) {
-                const parsed = Number.parseInt(retryAfterMsHeader, 10);
-                if (!Number.isNaN(parsed) && parsed > 0) {
-                        return parsed;
-                }
-        }
+	const retryAfterMsHeader = response.headers.get("retry-after-ms");
+	if (retryAfterMsHeader) {
+		const parsed = Number.parseInt(retryAfterMsHeader, 10);
+		const normalized = normalizeRetryAfterMs(parsed);
+		if (normalized !== null) {
+			return normalized;
+		}
+	}
 
-        const retryAfterHeader = response.headers.get("retry-after");
-        if (retryAfterHeader) {
-                const parsed = Number.parseInt(retryAfterHeader, 10);
-                if (!Number.isNaN(parsed) && parsed > 0) {
-                        return parsed * 1000;
-                }
-        }
+	const retryAfterHeader = response.headers.get("retry-after");
+	if (retryAfterHeader) {
+		const parsed = Number.parseInt(retryAfterHeader, 10);
+		const normalized = normalizeRetryAfterSeconds(parsed);
+		if (normalized !== null) {
+			return normalized;
+		}
+	}
 
-        const resetAtHeaders = [
-                "x-codex-primary-reset-at",
-                "x-codex-secondary-reset-at",
-                "x-ratelimit-reset",
-        ];
-        const now = Date.now();
-        const resetCandidates: number[] = [];
-        for (const header of resetAtHeaders) {
-                const value = response.headers.get(header);
-                if (!value) continue;
-                const parsed = Number.parseInt(value, 10);
-                if (!Number.isNaN(parsed) && parsed > 0) {
-                        const timestamp =
-                                parsed < 10_000_000_000 ? parsed * 1000 : parsed;
-                        const delta = timestamp - now;
-                        if (delta > 0) resetCandidates.push(delta);
-                }
-        }
+	const resetAfterSecondsHeaders = [
+		"x-codex-primary-reset-after-seconds",
+		"x-codex-secondary-reset-after-seconds",
+	];
+	const resetCandidates: number[] = [];
+	for (const header of resetAfterSecondsHeaders) {
+		const value = response.headers.get(header);
+		if (!value) continue;
+		const parsed = Number.parseInt(value, 10);
+		const normalized = normalizeRetryAfterSeconds(parsed);
+		if (normalized !== null) {
+			resetCandidates.push(normalized);
+		}
+	}
 
-        if (parsedBody?.resetsAt) {
-                const timestamp =
-                        parsedBody.resetsAt < 10_000_000_000
-                                ? parsedBody.resetsAt * 1000
-                                : parsedBody.resetsAt;
-                const delta = timestamp - now;
-                if (delta > 0) resetCandidates.push(delta);
-        }
+	const resetAtHeaders = [
+		"x-codex-primary-reset-at",
+		"x-codex-secondary-reset-at",
+		"x-ratelimit-reset",
+	];
+	const now = Date.now();
+	for (const header of resetAtHeaders) {
+		const value = response.headers.get(header);
+		if (!value) continue;
+		const timestamp = parseResetTimestampMs(value);
+		if (timestamp === null) continue;
+		const delta = normalizeRetryAfterMs(timestamp - now);
+		if (delta !== null) resetCandidates.push(delta);
+	}
 
-        if (resetCandidates.length > 0) {
-                return Math.min(...resetCandidates);
-        }
+	if (parsedBody?.resetsAt) {
+		const timestamp =
+			parsedBody.resetsAt < 10_000_000_000
+				? parsedBody.resetsAt * 1000
+				: parsedBody.resetsAt;
+		const delta = normalizeRetryAfterMs(timestamp - now);
+		if (delta !== null) resetCandidates.push(delta);
+	}
 
-        return null;
+	if (resetCandidates.length > 0) {
+		return Math.max(...resetCandidates);
+	}
+
+	const naturalLanguageRetryAfterMs = parseRetryAfterTextMs(bodyText, now);
+	if (naturalLanguageRetryAfterMs !== null) {
+		return naturalLanguageRetryAfterMs;
+	}
+
+	return null;
+}
+
+function parseRetryAfterTextMs(bodyText: string, now: number): number | null {
+	if (!bodyText) return null;
+
+	const durationMatch = bodyText.match(RETRY_AFTER_DURATION_PATTERN);
+	if (durationMatch) {
+		const amount = Number.parseInt(durationMatch[1] ?? "", 10);
+		const unit = (durationMatch[2] ?? "").toLowerCase();
+		if (Number.isFinite(amount) && amount > 0) {
+			const multiplier =
+				unit === "second"
+					? 1000
+					: unit === "minute"
+						? 60_000
+						: unit === "hour"
+							? 60 * 60_000
+							: unit === "day"
+								? 24 * 60 * 60_000
+								: 0;
+			if (multiplier > 0) {
+				return clampRateLimitDelayMs(amount * multiplier);
+			}
+		}
+	}
+
+	const clockTimeMatch = bodyText.match(RETRY_AFTER_CLOCK_TIME_PATTERN);
+	if (!clockTimeMatch) return null;
+
+	const hour12 = Number.parseInt(clockTimeMatch[1] ?? "", 10);
+	const minute = Number.parseInt(clockTimeMatch[2] ?? "0", 10);
+	const meridiem = (clockTimeMatch[3] ?? "").toLowerCase();
+	if (
+		!Number.isFinite(hour12) ||
+		hour12 < 1 ||
+		hour12 > 12 ||
+		!Number.isFinite(minute) ||
+		minute < 0 ||
+		minute > 59 ||
+		(meridiem !== "am" && meridiem !== "pm")
+	) {
+		return null;
+	}
+
+	const target = new Date(now);
+	let hour24 = hour12 % 12;
+	if (meridiem === "pm") {
+		hour24 += 12;
+	}
+	target.setHours(hour24, minute, 0, 0);
+	if (target.getTime() <= now) {
+		target.setDate(target.getDate() + 1);
+	}
+
+	return clampRateLimitDelayMs(target.getTime() - now);
+}
+
+function clampRateLimitDelayMs(value: number): number | null {
+	if (!Number.isFinite(value)) return null;
+	const normalized = Math.floor(value);
+	if (normalized <= 0) return null;
+	return Math.min(normalized, MAX_RATE_LIMIT_DELAY_MS);
 }
 
 function normalizeRetryAfterMs(value: number): number | null {
-	if (!Number.isFinite(value)) return null;
-	const ms = Math.floor(value);
-	if (ms <= 0) return null;
-	return Math.min(ms, MAX_RETRY_DELAY_MS);
+	return clampRateLimitDelayMs(value);
 }
 
 function normalizeRetryAfterSeconds(value: number): number | null {
 	if (!Number.isFinite(value)) return null;
-	const ms = Math.floor(value * 1000);
-	if (ms <= 0) return null;
-	return Math.min(ms, MAX_RETRY_DELAY_MS);
+	return clampRateLimitDelayMs(value * 1000);
 }
 
 function toNumber(value: unknown): number | undefined {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -918,6 +918,76 @@ describe("AccountManager", () => {
       expect(account.rateLimitResetTimes["codex"]).toBeUndefined();
       expect(account.rateLimitResetTimes["codex:gpt-5.2"]).toBeDefined();
     });
+
+    it("does not shorten an existing reset when a later retry window is smaller", () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-04-05T00:00:00.000Z");
+        vi.setSystemTime(now);
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            { refreshToken: "token-1", addedAt: now.getTime(), lastUsed: now.getTime() },
+          ],
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getCurrentAccount()!;
+        manager.markRateLimitedWithReason(account, 90 * 60_000, "codex", "quota");
+
+        const expectedResetAt = now.getTime() + 90 * 60_000;
+
+        vi.advanceTimersByTime(30 * 60_000);
+
+        manager.markRateLimitedWithReason(account, 60_000, "codex", "quota");
+
+        expect(account.rateLimitResetTimes["codex"]).toBe(expectedResetAt);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not shorten an existing model-scoped reset when a later retry window is smaller", () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date("2026-04-05T00:00:00.000Z");
+        vi.setSystemTime(now);
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            { refreshToken: "token-1", addedAt: now.getTime(), lastUsed: now.getTime() },
+          ],
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getCurrentAccount()!;
+        manager.markRateLimitedWithReason(
+          account,
+          90 * 60_000,
+          "codex",
+          "tokens",
+          "gpt-5.2",
+        );
+
+        const expectedResetAt = now.getTime() + 90 * 60_000;
+
+        vi.advanceTimersByTime(30 * 60_000);
+
+        manager.markRateLimitedWithReason(
+          account,
+          60_000,
+          "codex",
+          "tokens",
+          "gpt-5.2",
+        );
+
+        expect(account.rateLimitResetTimes["codex:gpt-5.2"]).toBe(expectedResetAt);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("cooldown management", () => {
@@ -3004,91 +3074,103 @@ describe("AccountManager", () => {
 
     it("keeps refresh-only tracker state stable when the refresh token rotates", () => {
       const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(now);
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            { refreshToken: "token-1", addedAt: now, lastUsed: now },
+          ],
+        };
 
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const healthTracker = getHealthTracker();
-      const tokenTracker = getTokenTracker();
-      const trackerKey = getRuntimeTrackerKey(account);
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getCurrentAccount()!;
+        const healthTracker = getHealthTracker();
+        const tokenTracker = getTokenTracker();
+        const trackerKey = getRuntimeTrackerKey(account);
 
-      manager.recordFailure(account, "codex", "gpt-5.1");
-      const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
-      expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
+        manager.recordFailure(account, "codex", "gpt-5.1");
+        const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+        expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
 
-      account.refreshToken = "token-1-rotated";
+        account.refreshToken = "token-1-rotated";
 
-      const rotatedAccount = manager.getCurrentAccount()!;
-      expect(getRuntimeTrackerKey(rotatedAccount)).toBe(trackerKey);
-      expect(getRuntimeAccountIdentityKey(rotatedAccount)).toBe(trackerKey);
-      expect(getAccountIdentityKey(rotatedAccount)).not.toBe(`${trackerKey}`);
-      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
-        degradedScore,
-        6,
-      );
-      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
+        const rotatedAccount = manager.getCurrentAccount()!;
+        expect(getRuntimeTrackerKey(rotatedAccount)).toBe(trackerKey);
+        expect(getRuntimeAccountIdentityKey(rotatedAccount)).toBe(trackerKey);
+        expect(getAccountIdentityKey(rotatedAccount)).not.toBe(`${trackerKey}`);
+        expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
+          degradedScore,
+          6,
+        );
+        expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("keeps pinned runtime tracker state stable after updateFromAuth enriches identity", () => {
       const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          {
-            refreshToken: "token-2",
-            email: "healthy@example.com",
-            addedAt: now,
-            lastUsed: now,
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(now);
+        const stored = {
+          version: 3 as const,
+          activeIndex: 0,
+          accounts: [
+            { refreshToken: "token-1", addedAt: now, lastUsed: now },
+            {
+              refreshToken: "token-2",
+              email: "healthy@example.com",
+              addedAt: now,
+              lastUsed: now,
+            },
+          ],
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getAccountByIndex(0)!;
+        const healthTracker = getHealthTracker();
+        const tokenTracker = getTokenTracker();
+        const trackerKey = getRuntimeTrackerKey(account);
+
+        manager.recordFailure(account, "codex", "gpt-5.1");
+        const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+        expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
+
+        const payload = Buffer.from(JSON.stringify({
+          email: "enriched@example.com",
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "account-enriched",
           },
-        ],
-      };
+          exp: Math.floor((now + 3600000) / 1000),
+        })).toString("base64url");
+        const accessToken = `header.${payload}.signature`;
 
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getAccountByIndex(0)!;
-      const healthTracker = getHealthTracker();
-      const tokenTracker = getTokenTracker();
-      const trackerKey = getRuntimeTrackerKey(account);
+        manager.updateFromAuth(account, {
+          type: "oauth",
+          access: accessToken,
+          refresh: "token-1-rotated",
+          expires: now + 3600000,
+        });
 
-      manager.recordFailure(account, "codex", "gpt-5.1");
-      const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
-      expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
-
-      const payload = Buffer.from(JSON.stringify({
-        email: "enriched@example.com",
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "account-enriched",
-        },
-        exp: Math.floor((now + 3600000) / 1000),
-      })).toString("base64url");
-      const accessToken = `header.${payload}.signature`;
-
-      manager.updateFromAuth(account, {
-        type: "oauth",
-        access: accessToken,
-        refresh: "token-1-rotated",
-        expires: now + 3600000,
-      });
-
-      expect(account.accountId).toBe("account-enriched");
-      expect(account.email).toBe("enriched@example.com");
-      expect(getRuntimeAccountIdentityKey(account)).toBe(
-        "account:account-enriched::email:enriched@example.com",
-      );
-      expect(getRuntimeTrackerKey(account)).toBe(trackerKey);
-      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
-        degradedScore,
-        6,
-      );
-      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
-    });
+        expect(account.accountId).toBe("account-enriched");
+        expect(account.email).toBe("enriched@example.com");
+        expect(getRuntimeAccountIdentityKey(account)).toBe(
+          "account:account-enriched::email:enriched@example.com",
+        );
+        expect(getRuntimeTrackerKey(account)).toBe(trackerKey);
+        expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
+          degradedScore,
+          6,
+        );
+        expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
+      } finally {
+        vi.useRealTimers();
+      }
+	});
 
     it("preserves tracker state when account indexes shift", () => {
       const now = Date.now();

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -990,6 +990,17 @@ describe('createEntitlementErrorResponse', () => {
 			expect(rateLimit?.retryAfterMs).toBeGreaterThan(0);
 		});
 
+		it('does not treat non-429 rate-limit text as a cooldown signal', async () => {
+			const response = new Response('rate_limit_exceeded - upstream overloaded', {
+				status: 500,
+			});
+
+			const { response: result, rateLimit } = await handleErrorResponse(response);
+
+			expect(result.status).toBe(500);
+			expect(rateLimit).toBeUndefined();
+		});
+
 		it('handles 429 with entitlement error code (should not be rate limit)', async () => {
 			const body = { error: { code: 'usage_not_included', message: 'Not included' } };
 			const response = new Response(JSON.stringify(body), { status: 429 });
@@ -1084,6 +1095,27 @@ describe('createEntitlementErrorResponse', () => {
 			expect(rateLimit?.retryAfterMs).toBeGreaterThan(0);
 		});
 
+		it('prefers the longest reset hint across reset-after-seconds and date-form reset-at headers', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.setSystemTime(new Date('2026-04-05T00:00:00.000Z'));
+				const headers = new Headers({
+					'x-codex-primary-reset-after-seconds': '60',
+					'x-codex-secondary-reset-at': new Date('2026-04-05T01:30:00.000Z').toUTCString(),
+				});
+				const response = new Response(
+					JSON.stringify({ error: { message: 'rate limited' } }),
+					{ status: 429, headers },
+				);
+
+				const { rateLimit } = await handleErrorResponse(response);
+
+				expect(rateLimit?.retryAfterMs).toBe(90 * 60 * 1000);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it('keeps retry_after_ms values in milliseconds', async () => {
 			const body = { error: { message: 'rate limited', retry_after_ms: 5 } };
 			const response = new Response(JSON.stringify(body), { status: 429 });
@@ -1112,14 +1144,84 @@ describe('createEntitlementErrorResponse', () => {
 			expect(rateLimit?.retryAfterMs).toBe(2500);
 		});
 
-	it('caps retryAfterMs at 5 minutes', async () => {
-		const body = { error: { message: 'rate limited', retry_after_ms: 600000 } };
+		it('parses natural-language retry times from usage-limit messages', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.setSystemTime(new Date(2026, 2, 22, 4, 0, 0, 0));
+				const response = new Response(
+					"You've hit your usage limit. To get more access now, send a request to your admin or try again at 6:26 AM.",
+					{ status: 429 },
+				);
+
+				const { rateLimit } = await handleErrorResponse(response);
+
+				expect(rateLimit?.retryAfterMs).toBe((2 * 60 + 26) * 60 * 1000);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('parses natural-language retry durations from usage-limit messages', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.setSystemTime(new Date('2026-04-05T00:00:00.000Z'));
+				const response = new Response(
+					"You've hit your usage limit. Please try again in 2 hours.",
+					{ status: 429 },
+				);
+
+				const { rateLimit } = await handleErrorResponse(response);
+
+				expect(rateLimit?.retryAfterMs).toBe(2 * 60 * 60 * 1000);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+	it('caps retryAfterMs at 7 days', async () => {
+		const body = { error: { message: 'rate limited', retry_after_ms: 10 * 24 * 60 * 60 * 1000 } };
 		const response = new Response(JSON.stringify(body), { status: 429 });
 		
 		const { rateLimit } = await handleErrorResponse(response);
 		
-		expect(rateLimit?.retryAfterMs).toBe(300000);
+		expect(rateLimit?.retryAfterMs).toBe(7 * 24 * 60 * 60 * 1000);
 	});
+
+		it('caps retry-after-ms header values at 7 days', async () => {
+			const headers = new Headers({
+				'retry-after-ms': String(10 * 24 * 60 * 60 * 1000),
+			});
+			const response = new Response(
+				JSON.stringify({ error: { message: 'rate limited' } }),
+				{ status: 429, headers },
+			);
+
+			const { rateLimit } = await handleErrorResponse(response);
+
+			expect(rateLimit?.retryAfterMs).toBe(7 * 24 * 60 * 60 * 1000);
+		});
+
+		it('caps reset timestamp hints at 7 days', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.setSystemTime(new Date('2026-04-05T00:00:00.000Z'));
+				const resetAtSeconds =
+					Math.floor(Date.now() / 1000) + 10 * 24 * 60 * 60;
+				const headers = new Headers({
+					'x-ratelimit-reset': String(resetAtSeconds),
+				});
+				const response = new Response(
+					JSON.stringify({ error: { message: 'rate limited' } }),
+					{ status: 429, headers },
+				);
+
+				const { rateLimit } = await handleErrorResponse(response);
+
+				expect(rateLimit?.retryAfterMs).toBe(7 * 24 * 60 * 60 * 1000);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
 
 	it('handles invalid retry-after header with default fallback', async () => {
 		const headers = new Headers({ 'retry-after': 'invalid' });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -454,10 +454,6 @@ vi.mock("../lib/accounts.js", async () => {
 
 		markToastShown() {}
 
-		getCurrentWorkspace() {
-			return null;
-		}
-
 		disableCurrentWorkspace() {
 			return false;
 		}
@@ -2902,7 +2898,6 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 				getMinWaitTimeForFamily: () => 0,
 				shouldShowAccountToast: () => false,
 				markToastShown: () => {},
-				getCurrentWorkspace: () => null,
 				disableCurrentWorkspace: () => false,
 				rotateToNextWorkspace: () => null,
 				hasEnabledWorkspaces: () => true,
@@ -4140,7 +4135,10 @@ describe("OpenAIOAuthPlugin runtime toast forwarding", () => {
 		vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValue(manager as never);
 		vi.mocked(fetchHelpersModule.handleErrorResponse).mockResolvedValueOnce({
 			response: new Response("rate limited", { status: 429 }),
-			rateLimit: true,
+			rateLimit: {
+				retryAfterMs: 1000,
+				code: "usage_limit_reached",
+			},
 			errorBody: "rate limited",
 		} as never);
 		vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValueOnce({
@@ -4174,6 +4172,379 @@ describe("OpenAIOAuthPlugin runtime toast forwarding", () => {
 			{ duration: 5000 },
 		);
 		expect(markToastShown).toHaveBeenCalledWith(0);
+	});
+
+	it("does not short-retry the same account when the parsed cooldown exceeds the retry floor", async () => {
+		const { AccountManager } = await import("../lib/accounts.js");
+		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");
+		const rateLimitBackoffModule = await import("../lib/request/rate-limit-backoff.js");
+
+		const markRateLimitedWithReason = vi.fn();
+		const manager = {
+			getAccountCount: () => 1,
+			getCurrentOrNextForFamilyHybrid: () => ({
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+			}),
+			getCurrentOrNextForFamily: () => ({
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+			}),
+			getCurrentWorkspace: () => null,
+			getAccountByIndex: () => null,
+			getAccountsSnapshot: () => [],
+			isAccountAvailableForFamily: () => true,
+			toAuthDetails: () => ({
+				type: "oauth" as const,
+				access: "access-token",
+				refresh: "refresh-1",
+				expires: Date.now() + 60_000,
+			}),
+			hasRefreshToken: () => true,
+			saveToDiskDebounced: () => {},
+			updateFromAuth: () => {},
+			clearAuthFailures: () => {},
+			incrementAuthFailures: () => 1,
+			saveToDisk: async () => {},
+			markAccountCoolingDown: () => {},
+			markRateLimited: () => {},
+			markRateLimitedWithReason,
+			consumeToken: () => true,
+			refundToken: () => {},
+			syncCodexCliActiveSelectionForIndex: async () => {},
+			markSwitched: () => {},
+			removeAccount: () => {},
+			recordFailure: () => {},
+			recordSuccess: () => {},
+			recordRateLimit: () => {},
+			getMinWaitTimeForFamily: () => 0,
+			shouldShowAccountToast: () => true,
+			markToastShown: () => {},
+			setActiveIndex: () => null,
+		};
+		vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValue(manager as never);
+		vi.mocked(fetchHelpersModule.handleErrorResponse).mockResolvedValueOnce({
+			response: new Response("rate limited", { status: 429 }),
+			rateLimit: {
+				retryAfterMs: 2 * 60 * 60 * 1000,
+				code: "usage_limit_reached",
+			},
+			errorBody: "rate limited",
+		} as never);
+		vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValueOnce({
+			attempt: 2,
+			delayMs: 1000,
+		});
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+			.mockResolvedValueOnce(new Response(JSON.stringify({ content: "ok" }), { status: 200 }));
+
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
+		const sdk = await plugin.auth.loader(getOAuthAuth, { options: {}, models: {} });
+		showRuntimeToastMock.mockClear();
+		const response = await sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+
+		expect(response.status).toBe(503);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(markRateLimitedWithReason.mock.calls[0]?.[1]).toBe(2 * 60 * 60 * 1000);
+		expect(showRuntimeToastMock).not.toHaveBeenCalled();
+	});
+
+	it("persists the longer parsed rate-limit cooldown across overlapping requests", async () => {
+		const { AccountManager } = await import("../lib/accounts.js");
+		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");
+		const rateLimitBackoffModule = await import("../lib/request/rate-limit-backoff.js");
+		const longCooldownMs = 90 * 60 * 1000;
+		const shortCooldownMs = 60_000;
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date("2026-04-05T00:00:00.000Z"));
+			const requestAccount = {
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+				rateLimitResetTimes: {} as Record<string, number>,
+				lastSwitchReason: undefined as string | undefined,
+			};
+			let observedBaseResetAt: number | undefined;
+			const markRateLimitedWithReason = vi.fn(
+				(
+					account: { rateLimitResetTimes: Record<string, number> },
+					retryAfterMs: number,
+					family: string,
+					reason: string,
+					model?: string | null,
+				) => {
+					const resetAt = Date.now() + retryAfterMs;
+					const baseKey = family;
+					if (!model || reason === "quota" || reason === "unknown") {
+						account.rateLimitResetTimes[baseKey] = Math.max(
+							account.rateLimitResetTimes[baseKey] ?? 0,
+							resetAt,
+						);
+						observedBaseResetAt = account.rateLimitResetTimes[baseKey];
+					}
+					if (
+						model &&
+						(reason === "tokens" || reason === "concurrent" || reason === "unknown")
+					) {
+						const modelKey = `${family}:${model}`;
+						account.rateLimitResetTimes[modelKey] = Math.max(
+							account.rateLimitResetTimes[modelKey] ?? 0,
+							resetAt,
+						);
+					}
+				},
+			);
+			const manager = {
+				getAccountCount: () => 1,
+				getCurrentOrNextForFamilyHybrid: () => requestAccount,
+				getCurrentOrNextForFamily: () => requestAccount,
+				getCurrentWorkspace: () => null,
+				getAccountByIndex: () => null,
+				getAccountsSnapshot: () => [requestAccount],
+				isAccountAvailableForFamily: () => true,
+				toAuthDetails: () => ({
+					type: "oauth" as const,
+					access: "access-token",
+					refresh: "refresh-1",
+					expires: Date.now() + 60_000,
+				}),
+				hasRefreshToken: () => true,
+				saveToDiskDebounced: () => {},
+				updateFromAuth: () => {},
+				clearAuthFailures: () => {},
+				incrementAuthFailures: () => 1,
+				saveToDisk: async () => {},
+				markAccountCoolingDown: () => {},
+				markRateLimited: () => {},
+				markRateLimitedWithReason,
+				consumeToken: () => true,
+				refundToken: () => {},
+				syncCodexCliActiveSelectionForIndex: async () => {},
+				markSwitched: () => {},
+				removeAccount: () => {},
+				recordFailure: () => {},
+				recordSuccess: () => {},
+				recordRateLimit: () => {},
+				getMinWaitTimeForFamily: () => 0,
+				shouldShowAccountToast: () => false,
+				markToastShown: () => {},
+				setActiveIndex: () => null,
+			};
+			vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValue(manager as never);
+
+			let rateLimitCallCount = 0;
+			const waitForSecondRateLimitCall = async () => {
+				for (let spin = 0; spin < 200; spin += 1) {
+					if (rateLimitCallCount > 1) {
+						return;
+					}
+					await Promise.resolve();
+				}
+				throw new Error(
+					"second overlapping request never reached the rate-limit handler",
+				);
+			};
+			vi.mocked(fetchHelpersModule.handleErrorResponse).mockImplementation(
+				async () => {
+					const callIndex = rateLimitCallCount++;
+					const result = {
+						response: new Response("rate limited", { status: 429 }),
+						rateLimit:
+							callIndex === 0
+								? {
+										retryAfterMs: longCooldownMs,
+										code: "usage_limit_reached",
+									}
+								: {
+										retryAfterMs: shortCooldownMs,
+										code: "usage_limit_reached",
+									},
+						errorBody: "rate limited",
+					};
+
+					if (callIndex === 0) {
+						await waitForSecondRateLimitCall();
+						return result as never;
+					}
+
+					await Promise.resolve();
+					return result as never;
+				},
+			);
+			vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValue({
+				attempt: 1,
+				delayMs: 60_000,
+			});
+
+			let upstreamCallCount = 0;
+			globalThis.fetch = vi.fn(async () => {
+				upstreamCallCount += 1;
+				if (upstreamCallCount <= 2) {
+					return new Response("rate limited", { status: 429 });
+				}
+				return new Response(JSON.stringify({ content: "ok" }), { status: 200 });
+			});
+
+			const mockClient = createMockClient();
+			const { OpenAIOAuthPlugin } = await import("../index.js");
+			const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
+			const sdk = await plugin.auth.loader(getOAuthAuth, { options: {}, models: {} });
+
+			await Promise.all([
+				sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+					method: "POST",
+					body: JSON.stringify({ model: "gpt-5-codex" }),
+				}),
+				sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+					method: "POST",
+					body: JSON.stringify({ model: "gpt-5-codex" }),
+				}),
+			]);
+
+			expect(markRateLimitedWithReason).toHaveBeenCalledTimes(2);
+			expect(observedBaseResetAt).toBe(
+				Date.parse("2026-04-05T01:30:00.000Z"),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("uses the floored cooldown for stream failover 429s", async () => {
+		const { AccountManager } = await import("../lib/accounts.js");
+		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");
+		const rateLimitBackoffModule = await import("../lib/request/rate-limit-backoff.js");
+		const streamFailoverModule = await import("../lib/request/stream-failover.js");
+		const currentAccount = {
+			index: 0,
+			accountId: "acc-1",
+			email: "alpha@example.com",
+			refreshToken: "refresh-1",
+			accessToken: "access-alpha",
+		};
+		const fallbackAccount = {
+			index: 1,
+			accountId: "acc-2",
+			email: "beta@example.com",
+			refreshToken: "refresh-2",
+			accessToken: "access-beta",
+		};
+		const markRateLimitedWithReason = vi.fn();
+		const recordRateLimit = vi.fn();
+		const pendingFailovers: Array<Promise<unknown>> = [];
+		const manager = {
+			getAccountCount: () => 2,
+			getCurrentOrNextForFamilyHybrid: () => currentAccount,
+			getCurrentOrNextForFamily: () => currentAccount,
+			getCurrentWorkspace: () => null,
+			getAccountByIndex: (index: number) =>
+				index === fallbackAccount.index ? fallbackAccount : currentAccount,
+			getAccountsSnapshot: () => [currentAccount, fallbackAccount],
+			isAccountAvailableForFamily: (index: number) => index === fallbackAccount.index,
+			toAuthDetails: (account: typeof currentAccount | typeof fallbackAccount) => ({
+				type: "oauth" as const,
+				access: account.accessToken,
+				refresh: account.refreshToken,
+				expires: Date.now() + 60_000,
+			}),
+			hasRefreshToken: () => true,
+			saveToDiskDebounced: () => {},
+			updateFromAuth: () => {},
+			clearAuthFailures: () => {},
+			incrementAuthFailures: () => 1,
+			saveToDisk: async () => {},
+			markAccountCoolingDown: () => {},
+			markRateLimited: () => {},
+			markRateLimitedWithReason,
+			consumeToken: () => true,
+			refundToken: () => {},
+			syncCodexCliActiveSelectionForIndex: async () => {},
+			markSwitched: () => {},
+			removeAccount: () => {},
+			recordFailure: () => {},
+			recordSuccess: () => {},
+			recordRateLimit,
+			getMinWaitTimeForFamily: () => 0,
+			shouldShowAccountToast: () => false,
+			markToastShown: () => {},
+			setActiveIndex: () => null,
+		};
+		vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValueOnce(manager as never);
+		vi.mocked(fetchHelpersModule.handleErrorResponse).mockImplementation(
+			async (response: Response) =>
+				({
+					response,
+					rateLimit:
+						response.status === 429
+							? { retryAfterMs: 4_000, code: "usage_limit_reached" }
+							: undefined,
+					errorBody: "rate limited",
+				}) as never,
+		);
+		vi.mocked(fetchHelpersModule.transformRequestForCodex).mockImplementation(
+			async (init, _url, _userConfig, _codexMode, body) => ({
+				updatedInit: {
+					...(init as RequestInit),
+					body: JSON.stringify(body ?? {}),
+				},
+				body: (body ?? {
+					model: "gpt-5.1",
+					stream: true,
+				}) as {
+					model: string;
+					stream?: boolean;
+				},
+			}),
+		);
+		vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValue({
+			attempt: 3,
+			delayMs: 15_000,
+		});
+		vi.spyOn(streamFailoverModule, "withStreamingFailover").mockImplementation(
+			(initialResponse, getFallbackResponse) => {
+				pendingFailovers.push(getFallbackResponse(1, 0));
+				return initialResponse;
+			},
+		);
+		let fetchCount = 0;
+		globalThis.fetch = vi.fn().mockImplementation(async () => {
+			fetchCount += 1;
+			if (fetchCount === 1) {
+				return new Response("data: ok\n\n", { status: 200 });
+			}
+			return new Response("rate limited", { status: 429 });
+		});
+
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
+		const sdk = await plugin.auth.loader(getOAuthAuth, { options: {}, models: {} });
+		const response = await sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1", stream: true }),
+		});
+		await Promise.all(pendingFailovers);
+
+		expect(response.status).toBe(200);
+		expect(markRateLimitedWithReason.mock.calls[0]?.[1]).toBe(15_000);
+		expect(recordRateLimit).toHaveBeenCalledWith(
+			fallbackAccount,
+			"gpt-5.1",
+			"gpt-5.1",
+		);
 	});
 
 	it("forwards persistence error toast arguments through manual OAuth flow", async () => {

--- a/test/preemptive-quota-scheduler.test.ts
+++ b/test/preemptive-quota-scheduler.test.ts
@@ -70,6 +70,23 @@ describe("preemptive quota scheduler", () => {
 		expect(decision.waitMs).toBeGreaterThan(0);
 	});
 
+	it("preserves the longest known rate-limit reset across overlapping updates", () => {
+		const scheduler = new PreemptiveQuotaScheduler();
+		scheduler.markRateLimited("acc:model", 30_000, 1_000);
+		scheduler.update("acc:model", {
+			status: 429,
+			primary: {},
+			secondary: { resetAtMs: 31_000 },
+			updatedAt: 1_000,
+		});
+		scheduler.markRateLimited("acc:model", 10_000, 5_000);
+
+		const decision = scheduler.getDeferral("acc:model", 6_000);
+		expect(decision.defer).toBe(true);
+		expect(decision.reason).toBe("rate-limit");
+		expect(decision.waitMs).toBe(25_000);
+	});
+
 	it("sanitizes non-finite retry-after values", () => {
 		const scheduler = new PreemptiveQuotaScheduler();
 		scheduler.markRateLimited("acc:model", Number.NaN, 1_000);


### PR DESCRIPTION
## Summary
- Split the usage-limit cooldown fixes out of #350 into its own reviewable PR.

## What Changed
- Tightened usage-limit handling across request/error classification and quota scheduling so cooldown state persists and propagates correctly instead of bouncing accounts back into ready selection too early.
- Added focused regression coverage across account state, fetch helpers, scheduler behavior, and the plugin entrypoint.

## Validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- test/accounts.test.ts test/fetch-helpers.test.ts test/index.test.ts test/preemptive-quota-scheduler.test.ts`

## Docs and Governance Checklist
- No docs updates were needed; this is cooldown/state handling only.

## Risk and Rollback
- Risk level: medium
- Rollback plan: revert `00bbcba`

## Additional Notes
- Split from #350.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr tightens usage-limit cooldown propagation across three layers: `accounts.ts` and `preemptive-quota-scheduler.ts` now use `Math.max` to preserve the longest reset time instead of blindly overwriting it, and the `index.ts` fallback 429 path is fully wired into the same backoff/scheduler pipeline as the primary path. the retry-after cap is raised from 5 minutes to 7 days, and natural-language usage-limit messages are parsed for both clock-time ("try again at 6:26 AM") and duration ("try again in 2 hours") hints.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are P2 style/cleanup concerns with no correctness impact

the core Math.max fix in accounts.ts and preemptive-quota-scheduler.ts is correct and well-tested; the fallback 429 path is now consistent with the primary path; no P0/P1 issues found

lib/preemptive-quota-scheduler.ts (secondary slot data loss is benign but worth tracking); test/fetch-helpers.test.ts (indentation inconsistency on one migrated test)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | markRateLimitedWithReason now uses Math.max to preserve the longest reset time — correct and minimal fix |
| lib/preemptive-quota-scheduler.ts | markRateLimited preserves max reset across overlapping calls; secondary.usedPercent is silently cleared on each invocation |
| lib/request/fetch-helpers.ts | retry-after cap raised from 5 min to 7 days; clock-time and duration natural-language parsing added with correct 12-hour AM/PM handling |
| index.ts | fallback 429 path gains full scheduler/backoff propagation; explicit body stream cancel removed from fallback cleanup |
| test/accounts.test.ts | regression coverage for Math.max cooldown preservation added; clean vitest structure |
| test/fetch-helpers.test.ts | good coverage for natural-language parsing and cap increase; one migrated test has inconsistent indentation |
| test/index.test.ts | getCurrentWorkspace mock removed cleanly; fallback 429 coverage updated |
| test/preemptive-quota-scheduler.test.ts | markRateLimited persistence across overlapping updates well-covered with deterministic fake-timer assertions |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant P as Plugin fetch handler
    participant B as getRateLimitBackoff
    participant S as PreemptiveQuotaScheduler
    participant A as AccountManager

    C->>P: request
    P->>P: primary account fetch → 429
    P->>B: getRateLimitBackoff(index, quotaKey, retryAfterMs)
    B-->>P: { delayMs }
    P->>P: cooldownMs = max(delayMs, retryAfterMs)
    P->>S: markRateLimited(quotaScheduleKey, cooldownMs)
    Note over S: nextReset = max(existingReset, now+cooldownMs)
    P->>A: markRateLimitedWithReason(account, cooldownMs, ...)
    Note over A: resetAt = max(currentResetAt, now+cooldownMs)

    alt cooldownMs ≤ short retry threshold
        P->>P: sleep(addJitter(cooldownMs)) then retry
    else
        P-->>C: propagate 429 with cooldownMs wait
    end

    Note over P: fallback account path (new)
    P->>P: fallback fetch → 429
    P->>P: handleErrorResponse(fallbackResponse)
    P->>B: getRateLimitBackoff(fallbackIndex, fallbackQuotaKey, retryAfterMs)
    B-->>P: { delayMs }
    P->>P: cooldownMs = max(delayMs, retryAfterMs)
    P->>S: markRateLimited(fallbackScheduleKey, cooldownMs)
    P->>A: markRateLimitedWithReason(fallbackAccount, cooldownMs, 'quota', ...)
    P->>P: continue to next fallback
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atest%2Ffetch-helpers.test.ts%3A1181-1188%0A**test%20indented%20at%20wrong%20describe%20scope**%0A%0Athis%20test%20was%20migrated%20from%20the%20old%20top-level%20%60it%28'caps%20retryAfterMs%20at%205%20minutes'%60%20but%20its%20indentation%20%281%20tab%29%20was%20not%20updated%20to%20match%20the%20surrounding%20nested%20group%20%283%20tabs%2C%20lines%201147%E2%80%931179%20and%201190%2B%29.%20it%20still%20runs%20and%20passes%2C%20but%20it%20is%20not%20inside%20the%20same%20%60describe%60%20block%20as%20the%20other%20cap%20tests%2C%20so%20grouping%20and%20scoping%20are%20inconsistent.%0A%0A%60%60%60suggestion%0A%09%09%09it%28'caps%20retryAfterMs%20at%207%20days'%2C%20async%20%28%29%20%3D%3E%20%7B%0A%09%09%09%09const%20body%20%3D%20%7B%20error%3A%20%7B%20message%3A%20'rate%20limited'%2C%20retry_after_ms%3A%2010%20*%2024%20*%2060%20*%2060%20*%201000%20%7D%20%7D%3B%0A%09%09%09%09const%20response%20%3D%20new%20Response%28JSON.stringify%28body%29%2C%20%7B%20status%3A%20429%20%7D%29%3B%0A%09%09%09%09%0A%09%09%09%09const%20%7B%20rateLimit%20%7D%20%3D%20await%20handleErrorResponse%28response%29%3B%0A%09%09%09%09%0A%09%09%09%09expect%28rateLimit%3F.retryAfterMs%29.toBe%287%20*%2024%20*%2060%20*%2060%20*%201000%29%3B%0A%09%09%09%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fpreemptive-quota-scheduler.ts%3A221-228%0A**secondary%20slot%20usedPercent%20silently%20dropped%20on%20markRateLimited**%0A%0A%60secondary%3A%20%7B%7D%60%20wipes%20any%20existing%20%60secondary.usedPercent%60%20from%20a%20prior%20%60update%28%29%60%20call.%20the%20secondary%20reset%20timestamp%20is%20correctly%20folded%20into%20%60nextResetAtMs%60%20on%20the%20primary%20slot%2C%20so%20deferral%20is%20preserved%20during%20the%20active%20429%20window.%20however%2C%20once%20the%20cooldown%20expires%20and%20the%20snapshot%20is%20pruned%2C%20the%20near-exhaustion%20signal%20on%20the%20secondary%20quota%20is%20gone%20until%20the%20next%20successful%20response%20restores%20it%20via%20%60update%28%29%60.%20this%20is%20benign%20in%20the%20common%20path%20but%20worth%20noting%20for%20observability%3A%20a%20request%20that%20lands%20between%20cooldown%20expiry%20and%20the%20next%20successful%20header%20could%20skip%20the%20%60quota-near-exhaustion%60%20deferral%20branch.%0A%0A%23%23%23%20Issue%203%20of%203%0Aindex.ts%3A2148-2150%0A**original%20fallback%20response%20body%20stream%20not%20cancelled**%0A%0Athe%20old%20code%20explicitly%20called%20%60fallbackResponse.body%3F.cancel%28%29%60%20%28best-effort%20cleanup%29%20before%20moving%20to%20the%20next%20account.%20the%20replacement%20%60handleErrorResponse%28fallbackResponse%29%60%20calls%20%60safeReadBody%60%20via%20%60response.clone%28%29.text%28%29%60%2C%20which%20consumes%20the%20*clone's*%20body%20but%20leaves%20the%20original%20undici%20stream%20open.%20on%20long-lived%20http%2F2%20connections%20this%20can%20delay%20socket%20reuse%20until%20gc.%20adding%20an%20explicit%20cancel%20after%20the%20read%20would%20restore%20the%20original%20safety%20net%3A%0A%0A%60%60%60typescript%0Aconst%20%7B%20response%3A%20handledFallbackResponse%2C%20rateLimit%3A%20fallbackRateLimit%20%7D%20%3D%0A%20%20%20%20await%20handleErrorResponse%28fallbackResponse%29%3B%0Atry%20%7B%20await%20fallbackResponse.body%3F.cancel%28%29%3B%20%7D%20catch%20%7B%20%2F*%20best%20effort%20*%2F%20%7D%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/fetch-helpers.test.ts
Line: 1181-1188

Comment:
**test indented at wrong describe scope**

this test was migrated from the old top-level `it('caps retryAfterMs at 5 minutes'` but its indentation (1 tab) was not updated to match the surrounding nested group (3 tabs, lines 1147–1179 and 1190+). it still runs and passes, but it is not inside the same `describe` block as the other cap tests, so grouping and scoping are inconsistent.

```suggestion
			it('caps retryAfterMs at 7 days', async () => {
				const body = { error: { message: 'rate limited', retry_after_ms: 10 * 24 * 60 * 60 * 1000 } };
				const response = new Response(JSON.stringify(body), { status: 429 });
				
				const { rateLimit } = await handleErrorResponse(response);
				
				expect(rateLimit?.retryAfterMs).toBe(7 * 24 * 60 * 60 * 1000);
			});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/preemptive-quota-scheduler.ts
Line: 221-228

Comment:
**secondary slot usedPercent silently dropped on markRateLimited**

`secondary: {}` wipes any existing `secondary.usedPercent` from a prior `update()` call. the secondary reset timestamp is correctly folded into `nextResetAtMs` on the primary slot, so deferral is preserved during the active 429 window. however, once the cooldown expires and the snapshot is pruned, the near-exhaustion signal on the secondary quota is gone until the next successful response restores it via `update()`. this is benign in the common path but worth noting for observability: a request that lands between cooldown expiry and the next successful header could skip the `quota-near-exhaustion` deferral branch.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: index.ts
Line: 2148-2150

Comment:
**original fallback response body stream not cancelled**

the old code explicitly called `fallbackResponse.body?.cancel()` (best-effort cleanup) before moving to the next account. the replacement `handleErrorResponse(fallbackResponse)` calls `safeReadBody` via `response.clone().text()`, which consumes the *clone's* body but leaves the original undici stream open. on long-lived http/2 connections this can delay socket reuse until gc. adding an explicit cancel after the read would restore the original safety net:

```typescript
const { response: handledFallbackResponse, rateLimit: fallbackRateLimit } =
    await handleErrorResponse(fallbackResponse);
try { await fallbackResponse.body?.cancel(); } catch { /* best effort */ }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix usage-limit cooldown persistence"](https://github.com/ndycode/codex-multi-auth/commit/00bbcba2f809e3048e1eca303371d0e2a7e947dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27372835)</sub>

<!-- /greptile_comment -->