### PR TITLE
fix: cap request retries and stream failover

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -148,6 +148,11 @@ import {
 	parseFailoverMode,
 } from "./lib/request/failover-config.js";
 import {
+	buildStreamFailoverCandidateOrder,
+	capStreamFailoverMax,
+	computeOutboundRequestAttemptBudget,
+} from "./lib/request/request-attempt-budget.js";
+import {
 	evaluateFailurePolicy,
 	type FailoverMode,
 } from "./lib/request/failure-policy.js";
@@ -713,8 +718,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 					);
 					const streamFailoverMax = Math.max(
 						0,
-						parseEnvInt(process.env.CODEX_AUTH_STREAM_FAILOVER_MAX) ??
-							STREAM_FAILOVER_MAX_BY_MODE[failoverMode],
+						capStreamFailoverMax(
+							parseEnvInt(process.env.CODEX_AUTH_STREAM_FAILOVER_MAX) ??
+								STREAM_FAILOVER_MAX_BY_MODE[failoverMode],
+						),
 					);
 					const streamFailoverSoftTimeoutMs = Math.max(
 						1_000,
@@ -898,11 +905,36 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								);
 								runtimeMetrics.lastRequestAt = Date.now();
 
-								const abortSignal = requestInit?.signal ?? init?.signal ?? null;
-								const sleep = createAbortableSleep(abortSignal);
+							const abortSignal = requestInit?.signal ?? init?.signal ?? null;
+							const sleep = createAbortableSleep(abortSignal);
+							const maxOutboundRequestAttempts =
+								computeOutboundRequestAttemptBudget({
+									accountCount: accountManager.getAccountCount(),
+									maxSameAccountRetries,
+									emptyResponseMaxRetries,
+									streamFailoverMax,
+								});
+							let outboundRequestAttemptsRemaining =
+								maxOutboundRequestAttempts;
+							const tryConsumeOutboundRequestAttempt = (
+								reason: "primary" | "stream-failover",
+								accountIndex: number,
+							): boolean => {
+								if (outboundRequestAttemptsRemaining <= 0) {
+									runtimeMetrics.lastError =
+										`Request attempt budget exhausted after ${maxOutboundRequestAttempts} outbound request(s)`;
+									logWarn(
+										`Stopping ${reason} replay after exhausting ${maxOutboundRequestAttempts} outbound request(s) on account ${accountIndex + 1}.`,
+									);
+									return false;
+								}
 
-								let allRateLimitedRetries = 0;
-								let emptyResponseRetries = 0;
+								outboundRequestAttemptsRemaining -= 1;
+								return true;
+							};
+
+							let allRateLimitedRetries = 0;
+							let emptyResponseRetries = 0;
 								const attemptedUnsupportedFallbackModels = new Set<string>();
 								if (model) {
 									attemptedUnsupportedFallbackModels.add(model);
@@ -1271,6 +1303,28 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 										let successAccountForResponse = account;
 										let successEntitlementAccountKey = entitlementAccountKey;
 										while (true) {
+											if (
+												!tryConsumeOutboundRequestAttempt(
+													"primary",
+													account.index,
+												)
+											) {
+												runtimeMetrics.failedRequests++;
+												const lastErrorDetail = runtimeMetrics.lastError;
+												const message = lastErrorDetail
+													? `${lastErrorDetail}. Try again after the current retries settle.`
+													: "Request attempt budget exhausted. Try again shortly.";
+												return new Response(
+													JSON.stringify({ error: { message } }),
+													{
+														status: 503,
+														headers: {
+															"content-type": "application/json; charset=utf-8",
+														},
+													},
+												);
+											}
+
 											let response: Response;
 											const fetchStart = performance.now();
 
@@ -1955,13 +2009,13 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 											runtimeMetrics.cumulativeLatencyMs += fetchLatencyMs;
 											let responseForSuccess = response;
 											if (isStreaming) {
-												const streamFallbackCandidateOrder = [
-													account.index,
-													...accountManager
-														.getAccountsSnapshot()
-														.map((candidate) => candidate.index)
-														.filter((index) => index !== account.index),
-												];
+												const streamFallbackCandidateOrder =
+													buildStreamFailoverCandidateOrder(
+														account.index,
+														accountSnapshotList.map(
+															(candidate) => candidate.index,
+														),
+													);
 												responseForSuccess = withStreamingFailover(
 													response,
 													async (failoverAttempt, emittedBytes) => {
@@ -2077,6 +2131,14 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 																)
 															) {
 																continue;
+															}
+															if (
+																!tryConsumeOutboundRequestAttempt(
+																	"stream-failover",
+																	fallbackAccount.index,
+																)
+															) {
+																return null;
 															}
 															fallbackAccount.accountId = fallbackAccountId;
 															if (

--- a/index.ts
+++ b/index.ts
@@ -2124,6 +2124,14 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 															}
 
 															if (
+																!tryConsumeOutboundRequestAttempt(
+																	"stream-failover",
+																	fallbackAccount.index,
+																)
+															) {
+																return null;
+															}
+															if (
 																!accountManager.consumeToken(
 																	fallbackAccount,
 																	modelFamily,
@@ -2131,14 +2139,6 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 																)
 															) {
 																continue;
-															}
-															if (
-																!tryConsumeOutboundRequestAttempt(
-																	"stream-failover",
-																	fallbackAccount.index,
-																)
-															) {
-																return null;
 															}
 															fallbackAccount.accountId = fallbackAccountId;
 															if (

--- a/lib/request/request-attempt-budget.ts
+++ b/lib/request/request-attempt-budget.ts
@@ -1,0 +1,58 @@
+const MAX_TOTAL_OUTBOUND_REQUEST_ATTEMPTS = 6;
+const MAX_STREAM_FAILOVERS = 1;
+const MAX_STREAM_FAILOVER_CANDIDATES = 2;
+
+export function capStreamFailoverMax(value: number): number {
+	return Math.max(
+		0,
+		Math.min(MAX_STREAM_FAILOVERS, Math.floor(Number.isFinite(value) ? value : 0)),
+	);
+}
+
+export function computeOutboundRequestAttemptBudget(params: {
+	accountCount: number;
+	maxSameAccountRetries: number;
+	emptyResponseMaxRetries: number;
+	streamFailoverMax: number;
+}): number {
+	const accountCount = Math.max(1, Math.floor(params.accountCount));
+	const maxSameAccountRetries = Math.max(
+		0,
+		Math.floor(params.maxSameAccountRetries),
+	);
+	const emptyResponseMaxRetries = Math.max(
+		0,
+		Math.floor(params.emptyResponseMaxRetries),
+	);
+	const streamFailoverMax = capStreamFailoverMax(params.streamFailoverMax);
+
+	return Math.max(
+		1,
+		Math.min(
+			accountCount +
+				maxSameAccountRetries +
+				emptyResponseMaxRetries +
+				streamFailoverMax,
+			MAX_TOTAL_OUTBOUND_REQUEST_ATTEMPTS,
+		),
+	);
+}
+
+export function buildStreamFailoverCandidateOrder(
+	primaryIndex: number,
+	accountIndices: number[],
+): number[] {
+	const order: number[] = [primaryIndex];
+
+	for (const index of accountIndices) {
+		if (!Number.isFinite(index) || index === primaryIndex || order.includes(index)) {
+			continue;
+		}
+		order.push(index);
+		if (order.length >= MAX_STREAM_FAILOVER_CANDIDATES) {
+			break;
+		}
+	}
+
+	return order;
+}

--- a/lib/request/request-attempt-budget.ts
+++ b/lib/request/request-attempt-budget.ts
@@ -2,6 +2,9 @@ const MAX_TOTAL_OUTBOUND_REQUEST_ATTEMPTS = 6;
 const MAX_STREAM_FAILOVERS = 1;
 const MAX_STREAM_FAILOVER_CANDIDATES = 2;
 
+/**
+ * Clamp configured stream failover retries to the conservative runtime cap.
+ */
 export function capStreamFailoverMax(value: number): number {
 	return Math.max(
 		0,
@@ -9,6 +12,11 @@ export function capStreamFailoverMax(value: number): number {
 	);
 }
 
+/**
+ * Compute a finite per-request budget that bounds all outbound Responses API
+ * fetches across account rotation, same-account retries, empty-response
+ * retries, and stream failover.
+ */
 export function computeOutboundRequestAttemptBudget(params: {
 	accountCount: number;
 	maxSameAccountRetries: number;
@@ -49,6 +57,13 @@ export function computeOutboundRequestAttemptBudget(params: {
 	);
 }
 
+/**
+ * Build the ordered stream-failover candidate list for a request.
+ *
+ * The caller is expected to pass a valid primary account index from the
+ * current account snapshot. This helper keeps the primary first and adds at
+ * most one alternate account to avoid broad replay fan-out.
+ */
 export function buildStreamFailoverCandidateOrder(
 	primaryIndex: number,
 	accountIndices: number[],

--- a/lib/request/request-attempt-budget.ts
+++ b/lib/request/request-attempt-budget.ts
@@ -15,14 +15,25 @@ export function computeOutboundRequestAttemptBudget(params: {
 	emptyResponseMaxRetries: number;
 	streamFailoverMax: number;
 }): number {
-	const accountCount = Math.max(1, Math.floor(params.accountCount));
+	const accountCount = Math.max(
+		1,
+		Math.floor(Number.isFinite(params.accountCount) ? params.accountCount : 1),
+	);
 	const maxSameAccountRetries = Math.max(
 		0,
-		Math.floor(params.maxSameAccountRetries),
+		Math.floor(
+			Number.isFinite(params.maxSameAccountRetries)
+				? params.maxSameAccountRetries
+				: 0,
+		),
 	);
 	const emptyResponseMaxRetries = Math.max(
 		0,
-		Math.floor(params.emptyResponseMaxRetries),
+		Math.floor(
+			Number.isFinite(params.emptyResponseMaxRetries)
+				? params.emptyResponseMaxRetries
+				: 0,
+		),
 	);
 	const streamFailoverMax = capStreamFailoverMax(params.streamFailoverMax);
 

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -441,6 +441,63 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 		expect(response.status).toBe(200);
 	});
 
+	it("stops after the bounded outbound request budget even when more accounts are available", async () => {
+		const accounts = Array.from({ length: 8 }, (_, index) =>
+			createMockAccount({
+				index,
+				accountId: `account-${index + 1}`,
+				email: `user${index + 1}@example.com`,
+				refreshToken: `refresh-token-${index + 1}`,
+				access: `access-token-account-${index + 1}`,
+			}),
+		);
+		accountManagerState.accounts = accounts;
+		accountManagerState.accountSelections = [...accounts];
+
+		const fetchMock = vi.fn().mockImplementation(() =>
+			Promise.resolve(
+				new Response(
+					JSON.stringify({
+						error: { code: "server_error", message: "temporary outage" },
+					}),
+					{
+						status: 500,
+						headers: { "content-type": "application/json" },
+					},
+				),
+			),
+		);
+		globalThis.fetch = fetchMock as any;
+
+		const { OpenAIAuthPlugin } = await import("../index.js");
+		const client = {
+			tui: { showToast: vi.fn() },
+			auth: { set: vi.fn() },
+		} as any;
+		const plugin = await OpenAIAuthPlugin({ client });
+
+		const getAuth = async () => ({
+			type: "oauth" as const,
+			access: "a",
+			refresh: "r",
+			expires: Date.now() + 60_000,
+			multiAccount: true,
+		});
+
+		const sdk = (await plugin.auth.loader(getAuth, { options: {}, models: {} })) as any;
+		const response = await sdk.fetch("https://example.com", {});
+		const payload = await response.json();
+
+		expect(fetchMock).toHaveBeenCalledTimes(6);
+		expect(response.status).toBe(503);
+		expect(payload).toEqual({
+			error: {
+				message:
+					"Request attempt budget exhausted after 6 outbound request(s). Try again after the current retries settle.",
+			},
+		});
+	});
+
 	it("rebuilds request headers after rotating to the next workspace", async () => {
 		const account = createMockAccount({
 			workspaces: [

--- a/test/request-attempt-budget.test.ts
+++ b/test/request-attempt-budget.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildStreamFailoverCandidateOrder,
+	capStreamFailoverMax,
+	computeOutboundRequestAttemptBudget,
+} from "../lib/request/request-attempt-budget.js";
+
+describe("request attempt budget", () => {
+	it("caps stream failover to a single retry", () => {
+		expect(capStreamFailoverMax(0)).toBe(0);
+		expect(capStreamFailoverMax(1)).toBe(1);
+		expect(capStreamFailoverMax(3)).toBe(1);
+	});
+
+	it("caps outbound request budgets for large account pools", () => {
+		expect(
+			computeOutboundRequestAttemptBudget({
+				accountCount: 12,
+				maxSameAccountRetries: 2,
+				emptyResponseMaxRetries: 2,
+				streamFailoverMax: 3,
+			}),
+		).toBe(6);
+	});
+
+	it("keeps the primary stream account plus at most one alternate", () => {
+		expect(
+			buildStreamFailoverCandidateOrder(2, [2, 5, 2, 7, 9]),
+		).toEqual([2, 5]);
+	});
+});

--- a/test/request-attempt-budget.test.ts
+++ b/test/request-attempt-budget.test.ts
@@ -23,6 +23,17 @@ describe("request attempt budget", () => {
 		).toBe(6);
 	});
 
+	it("sanitizes non-finite retry inputs to deterministic defaults", () => {
+		expect(
+			computeOutboundRequestAttemptBudget({
+				accountCount: Number.NaN,
+				maxSameAccountRetries: Number.POSITIVE_INFINITY,
+				emptyResponseMaxRetries: Number.NEGATIVE_INFINITY,
+				streamFailoverMax: Number.NaN,
+			}),
+		).toBe(1);
+	});
+
 	it("keeps the primary stream account plus at most one alternate", () => {
 		expect(
 			buildStreamFailoverCandidateOrder(2, [2, 5, 2, 7, 9]),


### PR DESCRIPTION
## Summary
- add a hard outbound request-attempt budget so one active session request cannot keep replaying across a large account pool
- cap stream failover to a single failover attempt and keep the candidate list to the current account plus at most one alternate account
- add regression coverage for the bounded request budget and pure helper coverage for the failover caps

## Validation
- npm test -- --run test/index-retry.test.ts test/request-attempt-budget.test.ts
- npm run typecheck

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds a hard per-request outbound attempt budget (`MAX_TOTAL_OUTBOUND_REQUEST_ATTEMPTS = 6`) and caps stream failover to a single attempt (`MAX_STREAM_FAILOVERS = 1`), backed by three new pure helpers in `lib/request/request-attempt-budget.ts`. the budget counter is initialized per-request inside the `sdk.fetch` closure and consumed by both the primary retry loop and the stream-failover callback via `tryConsumeOutboundRequestAttempt`. the candidate list for stream failover is now bounded to the current account plus at most one alternate via `buildStreamFailoverCandidateOrder`.

- **new module** `lib/request/request-attempt-budget.ts` — exports `capStreamFailoverMax`, `computeOutboundRequestAttemptBudget`, and `buildStreamFailoverCandidateOrder`; all helpers are pure with non-finite input guards, no windows filesystem or token storage touches
- **`index.ts`** — imports and wires up the three helpers; budget is computed once at the top of each request and consumed atomically (single-threaded js, no actual concurrency hazard between primary loop and failover callback)
- **`test/request-attempt-budget.test.ts`** — new unit file covering all three helpers including `NaN`/`Infinity` sanitization edge cases
- **`test/index-retry.test.ts`** — adds a regression test confirming the budget cap fires after exactly 6 outbound requests when 8 accounts are available
- **minor concern**: `STREAM_FAILOVER_MAX_BY_MODE` in `index.ts` declares `balanced: 2` and `conservative: 2`, but `capStreamFailoverMax` silently clamps both to `1` at runtime — all three failover modes are effectively equivalent for stream failover count; the table values should be updated to `1` or annotated to avoid misleading maintainers

<h3>Confidence Score: 5/5</h3>

safe to merge — one P2 style finding (misleading config table), no logic bugs, data-loss paths, or concurrency issues

all helpers are pure with correct non-finite guards; the budget counter lives inside the per-request closure so there is no shared mutable state across concurrent requests; the regression test validates the 6-attempt hard cap end-to-end; the only remaining finding is a misleading constant that has zero runtime effect

index.ts lines 332-336 (STREAM_FAILOVER_MAX_BY_MODE balanced/conservative values)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/request-attempt-budget.ts | new pure-helper module — non-finite guards correct, cap/budget math verified, candidate-list dedup logic sound |
| index.ts | wires up budget and candidate-list helpers correctly; STREAM_FAILOVER_MAX_BY_MODE balanced/conservative=2 are always overridden to 1 by capStreamFailoverMax |
| test/request-attempt-budget.test.ts | solid unit coverage for all three helpers including NaN/Infinity sanitization and large-pool capping |
| test/index-retry.test.ts | regression test confirms budget fires after exactly 6 attempts with 8-account pool; existing workspace-rotation tests untouched |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SDK as sdk.fetch()
    participant Budget as tryConsumeAttempt
    participant Primary as primary retry loop
    participant Failover as withStreamingFailover
    participant Candidates as buildFailoverCandidates

    SDK->>Budget: init budget = min(acctCount+retries+failovers, 6)
    loop primary attempts
        Primary->>Budget: consume(primary, accountIndex)
        Budget-->>Primary: true OR false → 503 if exhausted
        Primary->>SDK: outbound fetch() → response
        alt streaming response stalls or errors
            SDK->>Candidates: buildStreamFailoverCandidateOrder(primary, allIndices)
            Candidates-->>SDK: [primary, altAccount] capped at 2
            loop up to capStreamFailoverMax(1) = 1 failover
                Failover->>Budget: consume(stream-failover, fallbackIndex)
                Budget-->>Failover: true OR false → abandon stream
                Failover->>SDK: fetch() with fallback auth
                SDK-->>Failover: resumed stream or error
            end
        end
    end
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aindex.ts%3A332-336%0A**dead%20mode%20differentiation%20in%20%60STREAM_FAILOVER_MAX_BY_MODE%60**%0A%0A%60balanced%3A%202%60%20and%20%60conservative%3A%202%60%20are%20both%20silently%20clamped%20to%20%601%60%20by%20%60capStreamFailoverMax%28%29%60%20because%20%60MAX_STREAM_FAILOVERS%20%3D%201%60%20in%20%60lib%2Frequest%2Frequest-attempt-budget.ts%60.%20at%20runtime%20all%20three%20modes%20resolve%20to%20%60streamFailoverMax%20%3D%201%60%2C%20so%20the%20per-mode%20differentiation%20in%20this%20table%20is%20currently%20dead.%20update%20both%20values%20to%20%601%60%20to%20match%20the%20enforced%20cap%2C%20or%20add%20a%20comment%20explaining%20these%20are%20aspirational%20values%20reserved%20for%20when%20the%20cap%20is%20raised.%0A%0A%60%60%60suggestion%0A%09const%20STREAM_FAILOVER_MAX_BY_MODE%3A%20Record%3CFailoverMode%2C%20number%3E%20%3D%20%7B%0A%09%09aggressive%3A%201%2C%0A%09%09balanced%3A%201%2C%0A%09%09conservative%3A%201%2C%0A%09%7D%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: index.ts
Line: 332-336

Comment:
**dead mode differentiation in `STREAM_FAILOVER_MAX_BY_MODE`**

`balanced: 2` and `conservative: 2` are both silently clamped to `1` by `capStreamFailoverMax()` because `MAX_STREAM_FAILOVERS = 1` in `lib/request/request-attempt-budget.ts`. at runtime all three modes resolve to `streamFailoverMax = 1`, so the per-mode differentiation in this table is currently dead. update both values to `1` to match the enforced cap, or add a comment explaining these are aspirational values reserved for when the cap is raised.

```suggestion
	const STREAM_FAILOVER_MAX_BY_MODE: Record<FailoverMode, number> = {
		aggressive: 1,
		balanced: 1,
		conservative: 1,
	};
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: document request attempt budget he..."](https://github.com/ndycode/codex-multi-auth/commit/6fa23ab612bc642fae999c746eeb518050d58b73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27417076)</sub>

<!-- /greptile_comment -->