### PR TITLE
test: add mixed retry failure regression

### DIFF
--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -521,6 +521,105 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 		);
 	});
 
+	it("keeps the total request cap when empty-response retries and server-error rotation combine", async () => {
+		const logger = await import("../lib/logger.js");
+		const logWarnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
+
+		const accounts = Array.from({ length: 6 }, (_, index) =>
+			createMockAccount({
+				index,
+				accountId: `account-${index + 1}`,
+				email: `user${index + 1}@example.com`,
+				refreshToken: `refresh-token-${index + 1}`,
+				access: `access-token-account-${index + 1}`,
+			}),
+		);
+		accountManagerState.accounts = accounts;
+		accountManagerState.accountSelections = [...accounts];
+
+		const serverErrorResponse = () =>
+			new Response(
+				JSON.stringify({
+					error: { code: "server_error", message: "temporary outage" },
+				}),
+				{
+					status: 500,
+					headers: { "content-type": "application/json" },
+				},
+			);
+
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response("{}", {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+			)
+			.mockResolvedValueOnce(serverErrorResponse())
+			.mockResolvedValueOnce(serverErrorResponse())
+			.mockResolvedValueOnce(serverErrorResponse())
+			.mockResolvedValueOnce(serverErrorResponse())
+			.mockResolvedValueOnce(serverErrorResponse());
+		globalThis.fetch = fetchMock as any;
+
+		const { OpenAIAuthPlugin } = await import("../index.js");
+		const client = {
+			tui: { showToast: vi.fn() },
+			auth: { set: vi.fn() },
+		} as any;
+		const plugin = await OpenAIAuthPlugin({ client });
+
+		const getAuth = async () => ({
+			type: "oauth" as const,
+			access: "a",
+			refresh: "r",
+			expires: Date.now() + 60_000,
+			multiAccount: true,
+		});
+
+		const sdk = (await plugin.auth.loader(getAuth, { options: {}, models: {} })) as any;
+		const fetchPromise = sdk.fetch("https://example.com", {});
+
+		await vi.advanceTimersByTimeAsync(1500);
+
+		const response = await fetchPromise;
+		const payload = await response.json();
+
+		expect(fetchMock).toHaveBeenCalledTimes(6);
+		expect(
+			fetchMock.mock.calls.map(
+				(call) => (call[1]?.headers as Headers).get("x-account-id"),
+			),
+		).toEqual([
+			"account-1",
+			"account-1",
+			"account-2",
+			"account-3",
+			"account-4",
+			"account-5",
+		]);
+		expect(response.status).toBe(503);
+		expect(payload).toEqual({
+			error: {
+				message:
+					"Request attempt budget exhausted after 6 outbound request(s). Try again after the current retries settle.",
+			},
+		});
+		expect(logWarnSpy).toHaveBeenCalledWith(
+			"Empty response received (attempt 1/2). Retrying...",
+		);
+		expect(logWarnSpy).toHaveBeenCalledWith(
+			"Request attempt budget exhausted.",
+			expect.objectContaining({
+				reason: "primary",
+				accountIndex: 5,
+				budget: 6,
+				consumed: 6,
+			}),
+		);
+	});
+
 	it("rebuilds request headers after rotating to the next workspace", async () => {
 		const account = createMockAccount({
 			workspaces: [


### PR DESCRIPTION
## Summary
- add one higher-level retry regression that combines an empty-response retry with repeated server-error rotations in a single request lifecycle
- assert the request still stops at the bounded outbound fetch budget instead of walking the full remaining account pool
- verify the actual account header sequence to prove the same-account retry and cross-account rotation paths both participate before exhaustion

## Validation
- npm test -- --run test/index-retry.test.ts test/runtime-metrics.test.ts
- npm run typecheck

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds a regression test that exercises the combined empty-response retry (same-account) and server-error cross-account rotation paths in a single request lifecycle, verifying the outbound fetch budget cap holds across both retry modes. one minor gap: `logDebug` is not suppressed in the new test, causing the "Configured outbound request attempt budget." debug line to leak into test output unlike the adjacent test.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are style-only (P2), no logic or correctness issues

the new test is logically correct: call count, header sequence, accountIndex value, budget-exhausted payload, and timer advancement are all consistent with existing test patterns and production-code contracts. the only gap is a missing logDebugSpy suppression which does not affect test correctness or ci reliability.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/index-retry.test.ts | adds mixed empty-response + server-error rotation regression test; logic and assertions are correct, missing logDebug spy is a style-only gap |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SDK as sdk.fetch
    participant PM as fetchMock
    participant Budget as RequestBudget

    Note over SDK,Budget: budget = 6, accounts = 6
    SDK->>PM: call 1 (account-1)
    PM-->>SDK: 200 {} (empty body)
    Note over SDK: empty-response retry (attempt 1/2), same account
    SDK->>PM: call 2 (account-1)
    PM-->>SDK: 500 server_error
    Note over SDK: rotate to account-2
    SDK->>PM: call 3 (account-2)
    PM-->>SDK: 500 server_error
    Note over SDK: rotate to account-3
    SDK->>PM: call 4 (account-3)
    PM-->>SDK: 500 server_error
    Note over SDK: rotate to account-4
    SDK->>PM: call 5 (account-4)
    PM-->>SDK: 500 server_error
    Note over SDK: rotate to account-5
    SDK->>PM: call 6 (account-5)
    PM-->>SDK: 500 server_error
    Budget-->>SDK: 503 budget exhausted (consumed=6)
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Findex-retry.test.ts%3A526-527%0A**missing%20%60logDebugSpy%60%20suppression**%0A%0Athe%20adjacent%20test%20at%20line%20446%20silences%20%60logDebug%60%20alongside%20%60logWarn%60%20because%20the%20production%20code%20emits%20an%20unconditional%20%22Configured%20outbound%20request%20attempt%20budget.%22%20debug%20log%20on%20every%20exercised%20fetch%20path.%20without%20the%20suppression%20that%20message%20surfaces%20in%20test%20output%20and%20the%20new%20test%20diverges%20from%20the%20established%20pattern%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%09%09const%20logWarnSpy%20%3D%20vi.spyOn%28logger%2C%20%22logWarn%22%29.mockImplementation%28%28%29%20%3D%3E%20%7B%7D%29%3B%0A%09%09vi.spyOn%28logger%2C%20%22logDebug%22%29.mockImplementation%28%28%29%20%3D%3E%20%7B%7D%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/index-retry.test.ts
Line: 526-527

Comment:
**missing `logDebugSpy` suppression**

the adjacent test at line 446 silences `logDebug` alongside `logWarn` because the production code emits an unconditional "Configured outbound request attempt budget." debug log on every exercised fetch path. without the suppression that message surfaces in test output and the new test diverges from the established pattern in this file.

```suggestion
		const logWarnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
		vi.spyOn(logger, "logDebug").mockImplementation(() => {});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test: cover mixed retry failure chains"](https://github.com/ndycode/codex-multi-auth/commit/a4ee02d3ba2fcf403197eb9556e6948b4c95a22d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27417664)</sub>

<!-- /greptile_comment -->