### PR TITLE
fix: bound short-429 retry loop to MAX_SHORT_RETRY_ATTEMPTS

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -167,6 +167,7 @@ import {
 } from "./lib/request/fetch-helpers.js";
 import {
 	getRateLimitBackoff,
+	MAX_SHORT_RETRY_ATTEMPTS,
 	RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS,
 	resetRateLimitBackoff,
 } from "./lib/request/rate-limit-backoff.js";
@@ -1877,26 +1878,29 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 													);
 													const waitLabel = formatWaitTime(cooldownMs);
 
-													if (cooldownMs <= RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS) {
-														if (
-															accountManager.shouldShowAccountToast(
-																account.index,
-																rateLimitToastDebounceMs,
-															)
-														) {
-															await showRuntimeToast(client, 
-																`Rate limited. Retrying in ${waitLabel} (attempt ${attempt})...`,
-																"warning",
-																{ duration: toastDurationMs },
-															);
-															accountManager.markToastShown(account.index);
-														}
+								if (
+									cooldownMs <= RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS &&
+									attempt < MAX_SHORT_RETRY_ATTEMPTS
+								) {
+									if (
+										accountManager.shouldShowAccountToast(
+											account.index,
+											rateLimitToastDebounceMs,
+										)
+									) {
+										await showRuntimeToast(client, 
+											`Rate limited. Retrying in ${waitLabel} (attempt ${attempt})...`,
+											"warning",
+											{ duration: toastDurationMs },
+										);
+										accountManager.markToastShown(account.index);
+									}
 
-														await sleep(
-															addJitter(Math.max(MIN_BACKOFF_MS, cooldownMs), 0.2),
-														);
-														continue;
-													}
+									await sleep(
+										addJitter(Math.max(MIN_BACKOFF_MS, cooldownMs), 0.2),
+									);
+									continue;
+								}
 
 													accountManager.markRateLimitedWithReason(
 														account,

--- a/lib/request/rate-limit-backoff.ts
+++ b/lib/request/rate-limit-backoff.ts
@@ -20,6 +20,16 @@ const MAX_BACKOFF_MS = 60_000;
 
 export const RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS = 5000;
 
+/**
+ * Maximum number of consecutive short-cooldown 429 retries before
+ * falling through to the long-cooldown rotation path.
+ *
+ * Without this bound, an upstream that perpetually returns short
+ * Retry-After values (≤ RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS) would
+ * keep the request loop spinning on the same account indefinitely.
+ */
+export const MAX_SHORT_RETRY_ATTEMPTS = 3;
+
 interface RateLimitState {
 	consecutive429: number;
 	lastAt: number;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -206,6 +206,7 @@ vi.mock("../lib/recovery.js", () => ({
 vi.mock("../lib/request/rate-limit-backoff.js", () => ({
 	getRateLimitBackoff: vi.fn(() => ({ attempt: 1, delayMs: 1000 })),
 	RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS: 5000,
+	MAX_SHORT_RETRY_ATTEMPTS: 3,
 	resetRateLimitBackoff: vi.fn(),
 }));
 
@@ -4343,6 +4344,195 @@ describe("OpenAIOAuthPlugin runtime toast forwarding", () => {
 			"unknown",
 			"gpt-5.1",
 		);
+	});
+
+	it("falls through to rotation when short-retry attempt count reaches MAX_SHORT_RETRY_ATTEMPTS", async () => {
+		const { AccountManager } = await import("../lib/accounts.js");
+		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");
+		const rateLimitBackoffModule = await import("../lib/request/rate-limit-backoff.js");
+
+		const markRateLimitedWithReason = vi.fn();
+		const recordRateLimit = vi.fn();
+		const manager = {
+			getAccountCount: () => 1,
+			getCurrentOrNextForFamilyHybrid: () => ({
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+			}),
+			getCurrentOrNextForFamily: () => ({
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+			}),
+			getCurrentWorkspace: () => null,
+			getAccountByIndex: () => null,
+			getAccountsSnapshot: () => [],
+			isAccountAvailableForFamily: () => true,
+			toAuthDetails: () => ({
+				type: "oauth" as const,
+				access: "access-token",
+				refresh: "refresh-1",
+				expires: Date.now() + 60_000,
+			}),
+			hasRefreshToken: () => true,
+			saveToDiskDebounced: () => {},
+			updateFromAuth: () => {},
+			clearAuthFailures: () => {},
+			incrementAuthFailures: () => 1,
+			saveToDisk: async () => {},
+			markAccountCoolingDown: () => {},
+			markRateLimited: () => {},
+			markRateLimitedWithReason,
+			consumeToken: () => true,
+			refundToken: () => {},
+			syncCodexCliActiveSelectionForIndex: async () => {},
+			markSwitched: () => {},
+			removeAccount: () => {},
+			recordFailure: () => {},
+			recordSuccess: () => {},
+			recordRateLimit,
+			getMinWaitTimeForFamily: () => 0,
+			shouldShowAccountToast: () => true,
+			markToastShown: () => {},
+			setActiveIndex: () => null,
+		};
+		vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValue(manager as never);
+
+		// Return a short cooldown (1s) but attempt=3, which is >= MAX_SHORT_RETRY_ATTEMPTS (3).
+		// This should fall through to rotation instead of short-retrying.
+		vi.mocked(fetchHelpersModule.handleErrorResponse).mockResolvedValueOnce({
+			response: new Response("rate limited", { status: 429 }),
+			rateLimit: {
+				retryAfterMs: 1000,
+				code: "rate_limit_exceeded",
+			},
+			errorBody: "rate limited",
+		} as never);
+		vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValueOnce({
+			attempt: 3,
+			delayMs: 1000,
+		});
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("rate limited", { status: 429 }));
+
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
+		const sdk = await plugin.auth.loader(getOAuthAuth, { options: {}, models: {} });
+		const response = await sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+
+		// Should have rotated (503 returned as single-account pool exhausted)
+		// rather than short-retrying
+		expect(response.status).toBe(503);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(markRateLimitedWithReason).toHaveBeenCalledWith(
+			expect.objectContaining({ index: 0 }),
+			1000,
+			"gpt-5.1",
+			expect.any(String),
+			"gpt-5.1",
+		);
+		expect(recordRateLimit).toHaveBeenCalled();
+	});
+
+	it("short-retries the same account when attempt is below MAX_SHORT_RETRY_ATTEMPTS", async () => {
+		const { AccountManager } = await import("../lib/accounts.js");
+		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");
+		const rateLimitBackoffModule = await import("../lib/request/rate-limit-backoff.js");
+
+		const markRateLimitedWithReason = vi.fn();
+		const manager = {
+			getAccountCount: () => 1,
+			getCurrentOrNextForFamilyHybrid: () => ({
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+			}),
+			getCurrentOrNextForFamily: () => ({
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+			}),
+			getCurrentWorkspace: () => null,
+			getAccountByIndex: () => null,
+			getAccountsSnapshot: () => [],
+			isAccountAvailableForFamily: () => true,
+			toAuthDetails: () => ({
+				type: "oauth" as const,
+				access: "access-token",
+				refresh: "refresh-1",
+				expires: Date.now() + 60_000,
+			}),
+			hasRefreshToken: () => true,
+			saveToDiskDebounced: () => {},
+			updateFromAuth: () => {},
+			clearAuthFailures: () => {},
+			incrementAuthFailures: () => 1,
+			saveToDisk: async () => {},
+			markAccountCoolingDown: () => {},
+			markRateLimited: () => {},
+			markRateLimitedWithReason,
+			consumeToken: () => true,
+			refundToken: () => {},
+			syncCodexCliActiveSelectionForIndex: async () => {},
+			markSwitched: () => {},
+			removeAccount: () => {},
+			recordFailure: () => {},
+			recordSuccess: () => {},
+			recordRateLimit: () => {},
+			getMinWaitTimeForFamily: () => 0,
+			shouldShowAccountToast: () => true,
+			markToastShown: () => {},
+			setActiveIndex: () => null,
+		};
+		vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValue(manager as never);
+
+		// First request: 429 with attempt=2 (below MAX_SHORT_RETRY_ATTEMPTS=3) → short retry
+		// Second request: 200 OK
+		vi.mocked(fetchHelpersModule.handleErrorResponse).mockResolvedValueOnce({
+			response: new Response("rate limited", { status: 429 }),
+			rateLimit: {
+				retryAfterMs: 1000,
+				code: "rate_limit_exceeded",
+			},
+			errorBody: "rate limited",
+		} as never);
+		vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValueOnce({
+			attempt: 2,
+			delayMs: 1000,
+		});
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+			.mockResolvedValueOnce(new Response(JSON.stringify({ content: "ok" }), { status: 200 }));
+
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
+		const sdk = await plugin.auth.loader(getOAuthAuth, { options: {}, models: {} });
+
+		vi.useFakeTimers();
+		const responsePromise = sdk.fetch!("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+		await vi.advanceTimersByTimeAsync(2000);
+		const response = await responsePromise;
+
+		// Should have short-retried and succeeded
+		expect(response.status).toBe(200);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+		// markRateLimitedWithReason should NOT have been called (no rotation)
+		expect(markRateLimitedWithReason).not.toHaveBeenCalled();
 	});
 
 	it("persists the longer parsed rate-limit cooldown across overlapping requests", async () => {


### PR DESCRIPTION
## Summary

When an upstream perpetually returns short `Retry-After` values (≤ 5 s), the short-retry path loops indefinitely on the same account — burning tokens and stalling the request.

This PR adds a `MAX_SHORT_RETRY_ATTEMPTS` (3) bound so that after 3 consecutive short-cooldown 429s the request falls through to the existing long-cooldown rotation path, which marks the account rate-limited and rotates to the next one.

## Changes

| File | What |
|---|---|
| `lib/request/rate-limit-backoff.ts` | Add `MAX_SHORT_RETRY_ATTEMPTS = 3` constant with JSDoc |
| `index.ts` | Import `MAX_SHORT_RETRY_ATTEMPTS`; add `&& attempt < MAX_SHORT_RETRY_ATTEMPTS` guard to the short-retry condition (line 1881) |
| `test/index.test.ts` | 2 new test cases: (1) at-limit rotates, (2) below-limit retries. Updated mock to include the new export. |

## Design

Uses the existing `attempt` count returned by `getRateLimitBackoff()` (which already tracks consecutive 429s per account+quota key) rather than introducing new state. When `attempt >= 3`, the short-retry `if` block is skipped and the existing rotation logic at lines 1901-1937 handles it (`markRateLimitedWithReason` -> `recordRateLimit` -> rotate).

## Test results

Full suite passing: **222 files, 3315 tests, 0 failures** (15.59 s).

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

This PR correctly bounds the perpetual short-cooldown 429 retry loop by adding `MAX_SHORT_RETRY_ATTEMPTS = 3` and guarding the short-retry path with `attempt < MAX_SHORT_RETRY_ATTEMPTS`. One P2 naming point worth considering: the strict `<` comparison means only 2 actual short-retries occur (at `attempt=1` and `attempt=2`), not 3 as the constant name implies — at `attempt=3` the condition is false and falls through to rotation. The tests are self-consistent with this behavior, but the constant name could mislead future maintainers.

<h3>Confidence Score: 5/5</h3>

safe to merge; the infinite short-retry loop is correctly bounded and all 3315 tests pass

all findings are p2 naming/style — no correctness or logic bugs; the fix directly and cleanly addresses the stated problem

index.ts line 1883 naming question is the only item worth a follow-up

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/rate-limit-backoff.ts | adds MAX_SHORT_RETRY_ATTEMPTS=3 export with well-scoped JSDoc; no issues |
| index.ts | applies attempt < MAX_SHORT_RETRY_ATTEMPTS guard at line 1883; strict < means 2 actual retries occur, not 3 as name implies |
| test/index.test.ts | new tests cover fallthrough at attempt=3 and short-retry at attempt=2; mock exports constant as literal value |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant L as fetch loop (index.ts)
    participant B as getRateLimitBackoff
    C->>L: POST /v1/chat/completions
    L->>L: upstream 429 retryAfterMs=1000
    L->>B: getRateLimitBackoff(idx, key, 1000)
    B-->>L: attempt=1 delayMs=1000
    Note over L: cooldown<=5000 AND attempt(1)<3 short-retry
    L->>L: sleep + continue
    L->>L: upstream 429 again
    L->>B: getRateLimitBackoff
    B-->>L: attempt=2 delayMs=1000
    Note over L: attempt(2)<3 short-retry
    L->>L: sleep + continue
    L->>L: upstream 429 again
    L->>B: getRateLimitBackoff
    B-->>L: attempt=3 delayMs=1000
    Note over L: attempt(3)<3 is FALSE fall through to rotation
    L->>L: markRateLimitedWithReason + recordRateLimit
    L-->>C: rotate or 503 pool exhausted
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aindex.ts%3A1883%0A**%60%3C%60%20yields%202%20actual%20short-retries%2C%20but%20constant%20name%20implies%203**%0A%0AWith%20%60MAX_SHORT_RETRY_ATTEMPTS%20%3D%203%60%20and%20strict%20%60%3C%60%2C%20the%20short-retry%20path%20runs%20at%20%60attempt%3D1%60%20and%20%60attempt%3D2%60%20only%20%E2%80%94%202%20retries%20total.%20At%20%60attempt%3D3%60%20the%20condition%20is%20%60false%60%20and%20falls%20through%20to%20rotation.%20The%20tests%20confirm%20this%20is%20intentional%20%28attempt%3D3%20%E2%86%92%20rotate%29%2C%20but%20the%20constant%20name%20conventionally%20reads%20as%20%22allow%20up%20to%203%20retries%22%2C%20which%20would%20require%20%60%3C%3D%60.%20A%20future%20maintainer%20reading%20the%20constant%20may%20introduce%20a%20silent%20regression%20by%20adjusting%20the%20value%20without%20realizing%20the%20semantics.%20Either%20rename%20to%20%60SHORT_RETRY_FALLTHROUGH_AT_ATTEMPT%60%20to%20document%20the%20exclusive%20bound%2C%20or%20change%20the%20operator%20if%203%20actual%20retries%20were%20intended.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09%09%09%09attempt%20%3C%3D%20MAX_SHORT_RETRY_ATTEMPTS%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: index.ts
Line: 1883

Comment:
**`<` yields 2 actual short-retries, but constant name implies 3**

With `MAX_SHORT_RETRY_ATTEMPTS = 3` and strict `<`, the short-retry path runs at `attempt=1` and `attempt=2` only — 2 retries total. At `attempt=3` the condition is `false` and falls through to rotation. The tests confirm this is intentional (attempt=3 → rotate), but the constant name conventionally reads as "allow up to 3 retries", which would require `<=`. A future maintainer reading the constant may introduce a silent regression by adjusting the value without realizing the semantics. Either rename to `SHORT_RETRY_FALLTHROUGH_AT_ATTEMPT` to document the exclusive bound, or change the operator if 3 actual retries were intended.

```suggestion
								attempt <= MAX_SHORT_RETRY_ATTEMPTS
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bound short-429 retry loop to MAX\_S..."](https://github.com/ndycode/codex-multi-auth/commit/42628669d268a3c53640fa2703989100d1d3c00d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27420607)</sub>

<!-- /greptile_comment -->