### PR TITLE
fix: notify quota scheduler on 502/503/529 overload responses

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1801,16 +1801,32 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 													const serverRetryAfterMs = parseRetryAfterHintMs(
 														response.headers,
 													);
-													const policy = evaluateFailurePolicy(
-														{
-															kind: "server",
-															failoverMode,
-															serverRetryAfterMs:
-																serverRetryAfterMs ?? undefined,
-														},
-														{ serverCooldownMs: serverErrorCooldownMs },
-													);
-													if (policy.refundToken) {
+							const policy = evaluateFailurePolicy(
+								{
+									kind: "server",
+									failoverMode,
+									serverRetryAfterMs:
+										serverRetryAfterMs ?? undefined,
+								},
+								{ serverCooldownMs: serverErrorCooldownMs },
+							);
+							// Overload-type server errors (502 Bad Gateway, 503 Service
+							// Unavailable, 529 Overloaded) signal upstream capacity
+							// pressure. Notify the quota scheduler so it can proactively
+							// defer subsequent requests for this quota key, mirroring the
+							// 429 handler's scheduler awareness.
+							if (
+								(response.status === 502 ||
+									response.status === 503 ||
+									response.status === 529) &&
+								typeof policy.cooldownMs === "number"
+							) {
+								preemptiveQuotaScheduler.markRateLimited(
+									quotaScheduleKey,
+									policy.cooldownMs,
+								);
+							}
+							if (policy.refundToken) {
 														accountManager.refundToken(
 															account,
 															modelFamily,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2655,6 +2655,94 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 		dateNowSpy.mockRestore();
 	});
 
+	it("notifies preemptive quota scheduler on 503 overload responses", async () => {
+		const { PreemptiveQuotaScheduler } = await import(
+			"../lib/preemptive-quota-scheduler.js"
+		);
+		const schedulerSpy = vi.spyOn(
+			PreemptiveQuotaScheduler.prototype,
+			"markRateLimited",
+		);
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response("service unavailable", { status: 503 }),
+		);
+
+		const { sdk } = await setupPlugin();
+		await sdk.fetch!("https://api.openai.com/v1/chat", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+
+		expect(schedulerSpy).toHaveBeenCalled();
+		schedulerSpy.mockRestore();
+	});
+
+	it("notifies preemptive quota scheduler on 502 overload responses", async () => {
+		const { PreemptiveQuotaScheduler } = await import(
+			"../lib/preemptive-quota-scheduler.js"
+		);
+		const schedulerSpy = vi.spyOn(
+			PreemptiveQuotaScheduler.prototype,
+			"markRateLimited",
+		);
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response("bad gateway", { status: 502 }),
+		);
+
+		const { sdk } = await setupPlugin();
+		await sdk.fetch!("https://api.openai.com/v1/chat", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+
+		expect(schedulerSpy).toHaveBeenCalled();
+		schedulerSpy.mockRestore();
+	});
+
+	it("notifies preemptive quota scheduler on 529 overload responses", async () => {
+		const { PreemptiveQuotaScheduler } = await import(
+			"../lib/preemptive-quota-scheduler.js"
+		);
+		const schedulerSpy = vi.spyOn(
+			PreemptiveQuotaScheduler.prototype,
+			"markRateLimited",
+		);
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response("overloaded", { status: 529 }),
+		);
+
+		const { sdk } = await setupPlugin();
+		await sdk.fetch!("https://api.openai.com/v1/chat", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+
+		expect(schedulerSpy).toHaveBeenCalled();
+		schedulerSpy.mockRestore();
+	});
+
+	it("does not notify preemptive quota scheduler on generic 500 server errors", async () => {
+		const { PreemptiveQuotaScheduler } = await import(
+			"../lib/preemptive-quota-scheduler.js"
+		);
+		const schedulerSpy = vi.spyOn(
+			PreemptiveQuotaScheduler.prototype,
+			"markRateLimited",
+		);
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response("internal server error", { status: 500 }),
+		);
+
+		const { sdk } = await setupPlugin();
+		await sdk.fetch!("https://api.openai.com/v1/chat", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+
+		expect(schedulerSpy).not.toHaveBeenCalled();
+		schedulerSpy.mockRestore();
+	});
+
 	it("falls back from gpt-5.3-codex to gpt-5.2-codex when unsupported fallback is enabled", async () => {
 		const configModule = await import("../lib/config.js");
 		const fetchHelpers = await import("../lib/request/fetch-helpers.js");


### PR DESCRIPTION
## Problem

The 5xx handler (`index.ts:1793`) rotates accounts and applies failure policy when receiving server errors, but does **not** notify the `preemptiveQuotaScheduler`. This means the scheduler stays blind to upstream capacity pressure and keeps sending requests into an overloaded backend.

Meanwhile, the 429 handler (`index.ts:1877`) already calls `preemptiveQuotaScheduler.markRateLimited()` — so the scheduler has awareness of rate-limit pressure but not overload pressure.

## Fix

After `evaluateFailurePolicy()` returns inside the 5xx handler, check for overload-specific status codes (502 Bad Gateway, 503 Service Unavailable, 529 Overloaded) and call `preemptiveQuotaScheduler.markRateLimited(quotaScheduleKey, policy.cooldownMs)`.

This mirrors the 429 handler's scheduler awareness. Generic 500 Internal Server Errors are intentionally excluded since they do not indicate capacity pressure.

## Changes

- **`index.ts`** (lines 1813–1828): Added overload quota scheduler notification after `evaluateFailurePolicy()` in the 5xx handler
- **`test/index.test.ts`**: Added 4 test cases:
  1. Notifies scheduler on 503 responses
  2. Notifies scheduler on 502 responses
  3. Notifies scheduler on 529 responses
  4. Does NOT notify scheduler on generic 500 errors

## Test results

```
Test Files  222 passed (222)
     Tests  3317 passed (3317)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr correctly mirrors the 429 handler's `preemptiveQuotaScheduler.markRateLimited()` call for overload-class 5xx codes (502/503/529) in the main request path, with four matching vitest cases. however, the equivalent fallback path (used for stream failover) has the same blind spot and was not updated.

- **P1**: the `else` branch at `index.ts:2205–2215` handles non-429 fallback errors including 502/503/529 but never calls `markRateLimited()`, so the scheduler remains blind to overload pressure on the fallback account — the stated problem this pr intends to solve.

<h3>Confidence Score: 4/5</h3>

hold for P1 fix — fallback path still blind to overload pressure

the main path fix and tests are correct, but the fallback path at lines 2205-2215 has the same scheduler blindness this PR set out to fix. one P1 finding keeps this at 4/5.

index.ts lines 2205-2215 (fallback else branch missing markRateLimited for 502/503/529)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.ts | adds overload scheduler notification in main 5xx path (lines 1813-1828) but the equivalent fallback 5xx path (lines 2205-2215) is not updated, leaving the fallback account blind to overload pressure |
| test/index.test.ts | 4 new vitest cases for 502/503/529/500 scheduler behavior; all pass but assertions only check toHaveBeenCalled() without verifying the key or cooldownMs arguments |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Loop as request loop
    participant FP as evaluateFailurePolicy
    participant Sched as preemptiveQuotaScheduler
    participant AM as accountManager

    Loop->>Loop: response.status >= 500
    Loop->>FP: evaluateFailurePolicy({kind:"server", ...})
    FP-->>Loop: policy (cooldownMs, retrySameAccount, ...)
    alt status 502/503/529 AND cooldownMs is number
        Loop->>Sched: markRateLimited(quotaScheduleKey, cooldownMs) ✅ NEW
    end
    alt policy.retrySameAccount (conservative mode)
        Loop->>Loop: sleep + continue (same account)
        Loop->>Sched: getDeferral(quotaScheduleKey)
        Sched-->>Loop: defer=true (⚠️ scheduler fires before retry check)
        Loop->>AM: markRateLimitedWithReason → rotates account
    else rotate account
        Loop->>AM: markAccountCoolingDown
        Loop->>Loop: break
    end

    Note over Loop,Sched: fallback path else-branch (lines 2205-2215):
    Note over Loop,Sched: 502/503/529 → recordFailure only, NO markRateLimited ❌
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `index.ts`, line 2205-2215 ([link](https://github.com/ndycode/codex-multi-auth/blob/ec654b1fee0fd41dd1eb1a33f818f681fbc613da/index.ts#L2205-L2215)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Fallback path missing overload scheduler notification**

   This `else` branch handles all non-429 errors from the fallback account — including 502/503/529 — but never calls `preemptiveQuotaScheduler.markRateLimited()`. The main 5xx handler was just fixed (lines 1818-1828), but the fallback path retains the same blind spot: capacity pressure on the fallback account is invisible to the scheduler, so subsequent requests keep hitting an overloaded backend. Fix should mirror the main path:

   ```typescript
   } else {
       if (
           handledFallbackResponse.status === 502 ||
           handledFallbackResponse.status === 503 ||
           handledFallbackResponse.status === 529
       ) {
           preemptiveQuotaScheduler.markRateLimited(
               `${fallbackEntitlementAccountKey}:${model ?? modelFamily}`,
               serverErrorCooldownMs > 0 ? serverErrorCooldownMs : 4_000,
           );
       }
       accountManager.recordFailure(
           fallbackAccount,
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: index.ts
   Line: 2205-2215

   Comment:
   **Fallback path missing overload scheduler notification**

   This `else` branch handles all non-429 errors from the fallback account — including 502/503/529 — but never calls `preemptiveQuotaScheduler.markRateLimited()`. The main 5xx handler was just fixed (lines 1818-1828), but the fallback path retains the same blind spot: capacity pressure on the fallback account is invisible to the scheduler, so subsequent requests keep hitting an overloaded backend. Fix should mirror the main path:

   ```typescript
   } else {
       if (
           handledFallbackResponse.status === 502 ||
           handledFallbackResponse.status === 503 ||
           handledFallbackResponse.status === 529
       ) {
           preemptiveQuotaScheduler.markRateLimited(
               `${fallbackEntitlementAccountKey}:${model ?? modelFamily}`,
               serverErrorCooldownMs > 0 ? serverErrorCooldownMs : 4_000,
           );
       }
       accountManager.recordFailure(
           fallbackAccount,
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20index.ts%0ALine%3A%202205-2215%0A%0AComment%3A%0A**Fallback%20path%20missing%20overload%20scheduler%20notification**%0A%0AThis%20%60else%60%20branch%20handles%20all%20non-429%20errors%20from%20the%20fallback%20account%20%E2%80%94%20including%20502%2F503%2F529%20%E2%80%94%20but%20never%20calls%20%60preemptiveQuotaScheduler.markRateLimited%28%29%60.%20The%20main%205xx%20handler%20was%20just%20fixed%20%28lines%201818-1828%29%2C%20but%20the%20fallback%20path%20retains%20the%20same%20blind%20spot%3A%20capacity%20pressure%20on%20the%20fallback%20account%20is%20invisible%20to%20the%20scheduler%2C%20so%20subsequent%20requests%20keep%20hitting%20an%20overloaded%20backend.%20Fix%20should%20mirror%20the%20main%20path%3A%0A%0A%60%60%60typescript%0A%7D%20else%20%7B%0A%20%20%20%20if%20%28%0A%20%20%20%20%20%20%20%20handledFallbackResponse.status%20%3D%3D%3D%20502%20%7C%7C%0A%20%20%20%20%20%20%20%20handledFallbackResponse.status%20%3D%3D%3D%20503%20%7C%7C%0A%20%20%20%20%20%20%20%20handledFallbackResponse.status%20%3D%3D%3D%20529%0A%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20preemptiveQuotaScheduler.markRateLimited%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%60%24%7BfallbackEntitlementAccountKey%7D%3A%24%7Bmodel%20%3F%3F%20modelFamily%7D%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20serverErrorCooldownMs%20%3E%200%20%3F%20serverErrorCooldownMs%20%3A%204_000%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20accountManager.recordFailure%28%0A%20%20%20%20%20%20%20%20fallbackAccount%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aindex.ts%3A2205-2215%0A**Fallback%20path%20missing%20overload%20scheduler%20notification**%0A%0AThis%20%60else%60%20branch%20handles%20all%20non-429%20errors%20from%20the%20fallback%20account%20%E2%80%94%20including%20502%2F503%2F529%20%E2%80%94%20but%20never%20calls%20%60preemptiveQuotaScheduler.markRateLimited%28%29%60.%20The%20main%205xx%20handler%20was%20just%20fixed%20%28lines%201818-1828%29%2C%20but%20the%20fallback%20path%20retains%20the%20same%20blind%20spot%3A%20capacity%20pressure%20on%20the%20fallback%20account%20is%20invisible%20to%20the%20scheduler%2C%20so%20subsequent%20requests%20keep%20hitting%20an%20overloaded%20backend.%20Fix%20should%20mirror%20the%20main%20path%3A%0A%0A%60%60%60typescript%0A%7D%20else%20%7B%0A%20%20%20%20if%20%28%0A%20%20%20%20%20%20%20%20handledFallbackResponse.status%20%3D%3D%3D%20502%20%7C%7C%0A%20%20%20%20%20%20%20%20handledFallbackResponse.status%20%3D%3D%3D%20503%20%7C%7C%0A%20%20%20%20%20%20%20%20handledFallbackResponse.status%20%3D%3D%3D%20529%0A%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20preemptiveQuotaScheduler.markRateLimited%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%60%24%7BfallbackEntitlementAccountKey%7D%3A%24%7Bmodel%20%3F%3F%20modelFamily%7D%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20serverErrorCooldownMs%20%3E%200%20%3F%20serverErrorCooldownMs%20%3A%204_000%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20accountManager.recordFailure%28%0A%20%20%20%20%20%20%20%20fallbackAccount%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aindex.ts%3A1813-1828%0A**Scheduler%20notification%20fires%20before%20%60retrySameAccount%60%20decision**%0A%0AIn%20conservative%20failover%20mode%2C%20%60evaluateFailurePolicy%60%20returns%20%60retrySameAccount%3A%20true%60%20for%20502%2F503%2F529%20when%20no%20%60Retry-After%60%20header%20is%20present.%20The%20notification%20at%20lines%201818-1828%20marks%20the%20quota%20key%20rate-limited%20*before*%20the%20retry%20decision%20at%20line%201847.%20On%20the%20next%20loop%20iteration%2C%20%60getDeferral%60%20sees%20%60status%3A%20429%60%20with%20a%20live%20%60resetAtMs%60%2C%20triggering%20the%20quota-deferral%20path%20%28line%201231-1247%29%20%E2%80%94%20which%20marks%20the%20account%20rate-limited%20and%20rotates%20to%20a%20new%20account%2C%20silently%20bypassing%20the%20conservative%20same-account%20retry%20intent.%20this%20is%20an%20edge%20case%20%28conservative%20mode%20is%20non-default%29%20and%20the%20behavior%20change%20may%20be%20acceptable%2C%20but%20it's%20undocumented.%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Findex.test.ts%3A2676%0A**Assertions%20don't%20verify%20key%20or%20cooldown%20arguments**%0A%0A%60expect%28schedulerSpy%29.toHaveBeenCalled%28%29%60%20passes%20regardless%20of%20what%20%60quotaScheduleKey%60%20or%20%60cooldownMs%60%20was%20passed.%20if%20the%20key%20is%20wrong%20or%20cooldown%20is%200%2C%20the%20test%20still%20passes.%20prefer%20%60toHaveBeenCalledWith%28expect.any%28String%29%2C%20expect.any%28Number%29%29%60%20at%20minimum%2C%20or%20pin%20the%20exact%20cooldown%20to%20guard%20against%20regressions.%20same%20pattern%20applies%20to%20the%20502%20%28line%202698%29%20and%20529%20%28line%202720%29%20tests.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: index.ts
Line: 2205-2215

Comment:
**Fallback path missing overload scheduler notification**

This `else` branch handles all non-429 errors from the fallback account — including 502/503/529 — but never calls `preemptiveQuotaScheduler.markRateLimited()`. The main 5xx handler was just fixed (lines 1818-1828), but the fallback path retains the same blind spot: capacity pressure on the fallback account is invisible to the scheduler, so subsequent requests keep hitting an overloaded backend. Fix should mirror the main path:

```typescript
} else {
    if (
        handledFallbackResponse.status === 502 ||
        handledFallbackResponse.status === 503 ||
        handledFallbackResponse.status === 529
    ) {
        preemptiveQuotaScheduler.markRateLimited(
            `${fallbackEntitlementAccountKey}:${model ?? modelFamily}`,
            serverErrorCooldownMs > 0 ? serverErrorCooldownMs : 4_000,
        );
    }
    accountManager.recordFailure(
        fallbackAccount,
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: index.ts
Line: 1813-1828

Comment:
**Scheduler notification fires before `retrySameAccount` decision**

In conservative failover mode, `evaluateFailurePolicy` returns `retrySameAccount: true` for 502/503/529 when no `Retry-After` header is present. The notification at lines 1818-1828 marks the quota key rate-limited *before* the retry decision at line 1847. On the next loop iteration, `getDeferral` sees `status: 429` with a live `resetAtMs`, triggering the quota-deferral path (line 1231-1247) — which marks the account rate-limited and rotates to a new account, silently bypassing the conservative same-account retry intent. this is an edge case (conservative mode is non-default) and the behavior change may be acceptable, but it's undocumented.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/index.test.ts
Line: 2676

Comment:
**Assertions don't verify key or cooldown arguments**

`expect(schedulerSpy).toHaveBeenCalled()` passes regardless of what `quotaScheduleKey` or `cooldownMs` was passed. if the key is wrong or cooldown is 0, the test still passes. prefer `toHaveBeenCalledWith(expect.any(String), expect.any(Number))` at minimum, or pin the exact cooldown to guard against regressions. same pattern applies to the 502 (line 2698) and 529 (line 2720) tests.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: notify quota scheduler on 502/503/5..."](https://github.com/ndycode/codex-multi-auth/commit/ec654b1fee0fd41dd1eb1a33f818f681fbc613da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421194)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->