### PR TITLE
fix: narrow 404 usage-limit remapping

### DIFF
--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -978,8 +978,8 @@ async function safeReadBody(response: Response): Promise<string> {
 }
 
 function mapUsageLimit404WithBody(response: Response, bodyText: string): Response | null {
-        if (response.status !== HTTP_STATUS.NOT_FOUND) return null;
-        if (!bodyText) return null;
+	if (response.status !== HTTP_STATUS.NOT_FOUND) return null;
+	if (!bodyText) return null;
 
 	let code = "";
 	try {
@@ -994,8 +994,11 @@ function mapUsageLimit404WithBody(response: Response, bodyText: string): Respons
 		return createEntitlementErrorResponse(bodyText);
 	}
 
-	const haystack = `${code} ${bodyText}`.toLowerCase();
-	if (!/usage_limit_reached|rate_limit_exceeded|usage limit/i.test(haystack)) {
+	// Only structured quota-limit codes should be remapped from 404 to 429.
+	// Free-text 404 bodies and generic rate_limit_* codes are too ambiguous and
+	// degrade downstream rate-limit reason classification to "unknown".
+	const normalizedCode = code.toLowerCase();
+	if (!normalizedCode.includes("usage_limit")) {
 		return null;
 	}
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -464,25 +464,40 @@ describe('Fetch Helpers Module', () => {
 	    expect(headers.get('accept')).toBe('text/event-stream');
     });
 
-                it('maps usage-limit 404 errors to 429', async () => {
-                        const body = {
-                                error: {
-                                        code: 'usage_limit_reached',
-                                        message: 'limit reached',
+		it('maps usage-limit 404 errors to 429', async () => {
+			const body = {
+				error: {
+					code: 'usage_limit_reached',
+					message: 'limit reached',
                                 },
                         };
                         const resp = new Response(JSON.stringify(body), { status: 404 });
                         const { response: mapped, rateLimit } = await handleErrorResponse(resp);
                         expect(mapped.status).toBe(429);
                         const json = await mapped.json() as any;
-                        expect(json.error.code).toBe('usage_limit_reached');
-                        expect(rateLimit?.retryAfterMs).toBeGreaterThan(0);
-                });
+			expect(json.error.code).toBe('usage_limit_reached');
+			expect(rateLimit?.retryAfterMs).toBeGreaterThan(0);
+		});
 
-                it('leaves non-usage 404 errors unchanged', async () => {
-                        const body = { error: { code: 'not_found', message: 'nope' } };
-                        const resp = new Response(JSON.stringify(body), { status: 404 });
-                        const { response: result, rateLimit } = await handleErrorResponse(resp);
+		it('maps usage-limit 404 errors to 429 when the signal comes from error.type', async () => {
+			const body = {
+				error: {
+					type: 'usage_limit_reached',
+					message: 'limit reached',
+				},
+			};
+			const resp = new Response(JSON.stringify(body), { status: 404 });
+			const { response: mapped, rateLimit } = await handleErrorResponse(resp);
+			expect(mapped.status).toBe(429);
+			const json = await mapped.json() as { error: { type?: string } };
+			expect(json.error.type).toBe('usage_limit_reached');
+			expect(rateLimit?.retryAfterMs).toBeGreaterThan(0);
+		});
+
+		it('leaves non-usage 404 errors unchanged', async () => {
+			const body = { error: { code: 'not_found', message: 'nope' } };
+			const resp = new Response(JSON.stringify(body), { status: 404 });
+			const { response: result, rateLimit } = await handleErrorResponse(resp);
                         expect(result.status).toBe(404);
                         const json = await result.json() as any;
                         expect(json.error.code).toBe('not_found');
@@ -981,13 +996,30 @@ describe('createEntitlementErrorResponse', () => {
 	});
 
 	describe('handleErrorResponse edge cases', () => {
-		it('handles 404 with non-JSON body containing usage limit text', async () => {
+		it('does not remap 404s with free-text usage-limit messages', async () => {
 			const response = new Response('usage limit exceeded - please try again', { status: 404 });
 			
 			const { response: result, rateLimit } = await handleErrorResponse(response);
 			
-			expect(result.status).toBe(429);
-			expect(rateLimit?.retryAfterMs).toBeGreaterThan(0);
+			expect(result.status).toBe(404);
+			expect(rateLimit).toBeUndefined();
+		});
+
+		it('does not remap 404s with generic rate_limit_exceeded codes', async () => {
+			const response = new Response(
+				JSON.stringify({
+					error: {
+						code: 'rate_limit_exceeded',
+						message: 'upstream overloaded',
+					},
+				}),
+				{ status: 404 },
+			);
+
+			const { response: result, rateLimit } = await handleErrorResponse(response);
+
+			expect(result.status).toBe(404);
+			expect(rateLimit).toBeUndefined();
 		});
 
 		it('does not treat non-429 rate-limit text as a cooldown signal', async () => {


### PR DESCRIPTION
## Problem

The 404 usage-limit remapper was too broad.

It converted 404 responses into 429s when the body merely contained usage-limit text, including plain-text bodies and generic `rate_limit_exceeded` codes. That makes ambiguous not-found errors look like real cooldown signals and pushes weak rate-limit reasons downstream.

## Fix

Tighten the 404 remap so it only fires for structured 404 payloads carrying explicit `usage_limit` codes/types.

This keeps quota-limit signals intact while preserving entitlement handling and avoiding synthetic 429s from ambiguous free-text or generic rate-limit payloads.

## Changes

- `lib/request/fetch-helpers.ts`
  - keep entitlement detection first
  - only remap 404 -> 429 when the parsed structured code/type includes `usage_limit`
  - stop remapping free-text 404 bodies and generic `rate_limit_exceeded` 404 payloads
- `test/fetch-helpers.test.ts`
  - added coverage for `error.type = usage_limit_reached`
  - changed the free-text 404 case to assert it stays 404
  - added a regression test for generic `rate_limit_exceeded` 404 payloads staying 404

## Validation

```text
npx vitest run test/fetch-helpers.test.ts
Test Files  1 passed (1)
Tests      130 passed (130)

npx vitest run
Test Files  222 passed (222)
Tests      3315 passed (3315)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr tightens the `mapUsageLimit404WithBody` function so the 404→429 remap only fires for structured json payloads where `error.code` or `error.type` contains `"usage_limit"`. previously, plain-text 404 bodies and generic `rate_limit_exceeded` codes were also remapped, producing synthetic 429s from ambiguous signals and degrading downstream rate-limit reason classification. the entitlement guard (→403) correctly stays ahead of the remap gate.

**key changes:**
- `lib/request/fetch-helpers.ts`: `mapUsageLimit404WithBody` now requires a parsed, structured `error.code`/`error.type` containing `"usage_limit"` — free-text bodies and generic codes fall through to 404
- `test/fetch-helpers.test.ts`: adds coverage for `error.type = usage_limit_reached`, asserts free-text 404 stays 404, and adds regression test for generic `rate_limit_exceeded` 404s staying 404

**observations:**
- the substring check `normalizedCode.includes("usage_limit")` is slightly broad — a prefix anchor (`startsWith`) would be more defensive
- no test covers alternate real-world codes like `usage_limit_exceeded`; the `includes` gate would handle them correctly but they're unverified
- no concurrency or windows filesystem concerns in the changed paths

<h3>Confidence Score: 4/5</h3>

safe to merge — logic is correct, 3315 tests pass, no concurrency or token safety concerns in the changed paths

narrowly scoped fix with clear intent; entitlement guard is correctly ordered; two minor style/coverage gaps remain but neither affects correctness

`test/fetch-helpers.test.ts` — add a `usage_limit_exceeded` variant test; `lib/request/fetch-helpers.ts` L1001 — consider tightening to `startsWith`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/fetch-helpers.ts | narrows 404→429 remap to structured `usage_limit` codes only; entitlement guard preserved; substring check at L1001 is slightly over-broad |
| test/fetch-helpers.test.ts | adds coverage for `error.type` path, free-text 404 stays-404, and generic `rate_limit_exceeded` stays-404; missing variant test for `usage_limit_exceeded` |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[404 Response received] --> B{bodyText empty?}
    B -- yes --> Z[return null → pass through as 404]
    B -- no --> C[Parse JSON body\nerror.code / error.type → code]
    C -- parse fails --> D[code = empty string]
    C -- parse succeeds --> E{isEntitlementError\ncode + bodyText?}
    D --> E
    E -- yes --> F[createEntitlementErrorResponse\n→ 403 Forbidden]
    F --> G[handleErrorResponse\nreturns response=403\nrateLimit=undefined\nerrorBody=undefined]
    E -- no --> H{normalizedCode\n.includes / .startsWith\nusage_limit?}
    H -- no --> Z
    H -- yes --> I[Rebuild Response\nstatus=429 Too Many Requests]
    I --> J[extractRateLimitInfoFromBody\nretryAfterMs, code]
    J --> K[return response=429\nrateLimit=calculated]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Frequest%2Ffetch-helpers.ts%3A1001%0A**substring%20match%20is%20slightly%20over-broad**%0A%0A%60includes%28%22usage_limit%22%29%60%20would%20also%20match%20hypothetical%20codes%20like%20%60%22no_usage_limit%22%60%20or%20%60%22daily_usage_limit_warning%22%60.%20all%20known%20real%20codes%20%28%60usage_limit_reached%60%2C%20%60usage_limit_exceeded%60%29%20have%20%60usage_limit%60%20as%20a%20strict%20prefix%20%E2%80%94%20%60startsWith%60%20is%20tighter%20and%20signals%20intent%20more%20clearly.%0A%0A%60%60%60suggestion%0A%09if%20%28!normalizedCode.startsWith%28%22usage_limit%22%29%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Ffetch-helpers.test.ts%3A482-495%0A**missing%20vitest%20coverage%20for%20%60usage_limit_exceeded%60%20variant**%0A%0Athe%20remap%20gate%20uses%20%60normalizedCode.includes%28%22usage_limit%22%29%60%20%28or%2C%20per%20the%20suggestion%20above%2C%20%60startsWith%60%29%2C%20but%20the%20only%20exercised%20code%20strings%20are%20%60usage_limit_reached%60%20via%20%60error.code%60%20and%20%60error.type%60.%20a%20real%20backend%20may%20return%20%60usage_limit_exceeded%60%20or%20%60usage_limit_quota_reached%60.%20adding%20one%20test%20for%20an%20alternate%20variant%20would%20lock%20in%20the%20boundary%20and%20prevent%20a%20silent%20regression%20if%20the%20check%20is%20ever%20tightened%3A%0A%0A%60%60%60ts%0Ait%28'maps%20usage_limit_exceeded%20404%20to%20429'%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20const%20body%20%3D%20%7B%20error%3A%20%7B%20code%3A%20'usage_limit_exceeded'%2C%20message%3A%20'quota%20hit'%20%7D%20%7D%3B%0A%20%20%20%20const%20resp%20%3D%20new%20Response%28JSON.stringify%28body%29%2C%20%7B%20status%3A%20404%20%7D%29%3B%0A%20%20%20%20const%20%7B%20response%3A%20mapped%20%7D%20%3D%20await%20handleErrorResponse%28resp%29%3B%0A%20%20%20%20expect%28mapped.status%29.toBe%28429%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/request/fetch-helpers.ts
Line: 1001

Comment:
**substring match is slightly over-broad**

`includes("usage_limit")` would also match hypothetical codes like `"no_usage_limit"` or `"daily_usage_limit_warning"`. all known real codes (`usage_limit_reached`, `usage_limit_exceeded`) have `usage_limit` as a strict prefix — `startsWith` is tighter and signals intent more clearly.

```suggestion
	if (!normalizedCode.startsWith("usage_limit")) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/fetch-helpers.test.ts
Line: 482-495

Comment:
**missing vitest coverage for `usage_limit_exceeded` variant**

the remap gate uses `normalizedCode.includes("usage_limit")` (or, per the suggestion above, `startsWith`), but the only exercised code strings are `usage_limit_reached` via `error.code` and `error.type`. a real backend may return `usage_limit_exceeded` or `usage_limit_quota_reached`. adding one test for an alternate variant would lock in the boundary and prevent a silent regression if the check is ever tightened:

```ts
it('maps usage_limit_exceeded 404 to 429', async () => {
    const body = { error: { code: 'usage_limit_exceeded', message: 'quota hit' } };
    const resp = new Response(JSON.stringify(body), { status: 404 });
    const { response: mapped } = await handleErrorResponse(resp);
    expect(mapped.status).toBe(429);
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: narrow 404 usage-limit remapping"](https://github.com/ndycode/codex-multi-auth/commit/e42de7d6269f84b7240ac0a2999a093d8a3636bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421620)</sub>

<!-- /greptile_comment -->