### PR TITLE
fix: stop stream failover replay after output

### DIFF
--- a/lib/request/stream-failover.ts
+++ b/lib/request/stream-failover.ts
@@ -105,7 +105,11 @@ async function readChunkWithSoftHardTimeout(
  *
  * The returned Response streams bytes from the initialResponse body and, when the stream stalls or errors, will attempt up to `maxFailovers` failovers by calling `getFallbackResponse(attempt, emittedBytes)`. On each successful failover a textual marker is injected into the stream identifying the failover attempt (and `requestInstanceId` when provided). The function performs best-effort cleanup of underlying readers and enforces soft/hard read timeouts as configured via `options`.
  *
- * Concurrency assumptions: the implementation expects a single consumer reading the returned Response body; callers must not concurrently read the same stream body from multiple consumers. Filesystem/platform note: behavior is platform-agnostic; no filesystem access is performed (Windows-specific filesystem semantics do not apply). Token redaction: any request identifiers embedded in the injected marker are limited to the normalized `requestInstanceId` (trimmed and truncated to 64 chars) to avoid leaking long tokens.
+	 * Concurrency assumptions: the implementation expects a single consumer reading the returned Response body; callers must not concurrently read the same stream body from multiple consumers. Filesystem/platform note: behavior is platform-agnostic; no filesystem access is performed (Windows-specific filesystem semantics do not apply). Token redaction: any request identifiers embedded in the injected marker are limited to the normalized `requestInstanceId` (trimmed and truncated to 64 chars) to avoid leaking long tokens.
+	 *
+	 * Failover safety: once the wrapper has already emitted bytes from the primary stream,
+	 * it will stop attempting fallback replays. Reissuing the upstream request after partial
+	 * output can duplicate streamed text and any side-effectful tool activity.
  *
  * @param initialResponse - The original Response whose body will be streamed and monitored for stalls/errors.
  * @param getFallbackResponse - Async function invoked for each failover attempt with the 1-based attempt number and total emitted bytes; should return a Response with a streaming body to switch to, or `null`/a Response without a body to indicate no fallback.
@@ -160,6 +164,9 @@ export function withStreamingFailover(
 
 			const tryFailover = async (): Promise<boolean> => {
 				if (failoverAttempt >= maxFailovers) {
+					return false;
+				}
+				if (emittedBytes > 0) {
 					return false;
 				}
 				failoverAttempt += 1;

--- a/test/stream-failover.test.ts
+++ b/test/stream-failover.test.ts
@@ -18,6 +18,21 @@ function makeStallingResponse(): Response {
 	);
 }
 
+function makeIdleResponse(): Response {
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start() {
+				// Intentionally idle until timeout.
+			},
+		}),
+		{
+			headers: {
+				"content-type": "text/event-stream",
+			},
+		},
+	);
+}
+
 function makeSseResponse(payload: string): Response {
 	return new Response(
 		new ReadableStream<Uint8Array>({
@@ -52,7 +67,7 @@ describe("stream failover", () => {
 	it("switches to fallback stream when primary stalls", async () => {
 		vi.useFakeTimers();
 		const fallback = vi.fn(async () => makeSseResponse("data: second\n\n"));
-		const response = withStreamingFailover(makeStallingResponse(), fallback, {
+		const response = withStreamingFailover(makeIdleResponse(), fallback, {
 			maxFailovers: 1,
 			stallTimeoutMs: 10,
 		});
@@ -60,7 +75,6 @@ describe("stream failover", () => {
 		const textPromise = response.text();
 		await vi.advanceTimersByTimeAsync(1_200);
 		const text = await textPromise;
-		expect(text).toContain("data: first");
 		expect(text).toContain("codex-multi-auth failover 1");
 		expect(text).toContain("data: second");
 		expect(fallback).toHaveBeenCalledTimes(1);
@@ -69,7 +83,7 @@ describe("stream failover", () => {
 	it("includes request id marker when provided", async () => {
 		vi.useFakeTimers();
 		const response = withStreamingFailover(
-			makeStallingResponse(),
+			makeIdleResponse(),
 			async () => makeSseResponse("data: fallback\n\n"),
 			{
 				maxFailovers: 1,
@@ -87,7 +101,7 @@ describe("stream failover", () => {
 	it("errors when fallback is unavailable", async () => {
 		vi.useFakeTimers();
 		const response = withStreamingFailover(
-			makeStallingResponse(),
+			makeIdleResponse(),
 			async () => null,
 			{ maxFailovers: 1, stallTimeoutMs: 10 },
 		);
@@ -101,7 +115,7 @@ describe("stream failover", () => {
 	it("propagates fallback provider exceptions deterministically", async () => {
 		vi.useFakeTimers();
 		const response = withStreamingFailover(
-			makeStallingResponse(),
+			makeIdleResponse(),
 			async () => {
 				throw new Error("fallback exploded");
 			},
@@ -114,7 +128,7 @@ describe("stream failover", () => {
 		await assertion;
 	});
 
-	it("calls fallback exactly once when read-error and timeout race", async () => {
+	it("does not trigger fallback when read-error and timeout race after bytes emitted", async () => {
 		vi.useFakeTimers();
 		const raceResponse = new Response(
 			new ReadableStream<Uint8Array>({
@@ -139,13 +153,27 @@ describe("stream failover", () => {
 		});
 
 		const textPromise = response.text();
+		const assertion = expect(textPromise).rejects.toThrow("primary read failure");
 		await vi.advanceTimersByTimeAsync(1_200);
-		const text = await textPromise;
+		await assertion;
 
-		expect(fallback).toHaveBeenCalledTimes(1);
-		expect((text.match(/codex-multi-auth failover 1/g) ?? []).length).toBe(1);
-		expect(text).toContain("data: first");
-		expect(text).toContain("data: fallback");
+		expect(fallback).not.toHaveBeenCalled();
+	});
+
+	it("does not replay after bytes have already been emitted", async () => {
+		vi.useFakeTimers();
+		const fallback = vi.fn(async () => makeSseResponse("data: fallback\n\n"));
+		const response = withStreamingFailover(makeStallingResponse(), fallback, {
+			maxFailovers: 1,
+			stallTimeoutMs: 10,
+		});
+
+		const textPromise = response.text();
+		const assertion = expect(textPromise).rejects.toThrow("SSE stream stalled");
+		await vi.advanceTimersByTimeAsync(1_200);
+		await assertion;
+
+		expect(fallback).not.toHaveBeenCalled();
 	});
 
 	it("releases underlying reader when wrapped stream is cancelled", async () => {


### PR DESCRIPTION
## Summary
- stop streaming failover from replaying upstream requests after any bytes have already been emitted
- preserve failover for pre-output stalls only, which keeps safe recovery for idle streams without duplicating streamed output or tool side effects
- update stream failover coverage for both the safe replay path and the new no-replay-after-output guard

## Validation
- node_modules/.bin/vitest.cmd run test/stream-failover.test.ts
- node_modules/.bin/tsc.cmd --noEmit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds a one-line `emittedBytes > 0` guard in `tryFailover()` that stops failover replay once any bytes have been sent downstream, preventing duplicate streamed output and side-effectful tool re-execution. tests are migrated to `makeIdleResponse()` for pre-output stall coverage and a new test validates the post-output guard directly.

<h3>Confidence Score: 5/5</h3>

safe to merge — guard logic is correct, no data loss or runtime errors introduced

single guard added at the right place, no P0/P1 findings; only a missing test scenario for maxFailovers > 1 which is P2

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/stream-failover.ts | adds emittedBytes > 0 guard in tryFailover() to block failover replay after partial output; logic and placement are correct |
| test/stream-failover.test.ts | adds makeIdleResponse() helper, migrates stalling tests, adds no-replay-after-output test; coverage for maxFailovers > 1 + partial output scenario is absent |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[error or stall in pump] --> B{tryFailover}
    B --> C{failoverAttempt >= maxFailovers?}
    C -- yes --> D[return false → controller.error]
    C -- no --> E{emittedBytes > 0?}
    E -- yes --> F[return false → controller.error]
    E -- no --> G[failoverAttempt += 1]
    G --> H[getFallbackResponse]
    H --> I{fallback?.body?}
    I -- no --> J[return false → controller.error]
    I -- yes --> K[releaseCurrentReader]
    K --> L[enqueue marker bytes]
    L --> M[currentReader = fallback.body.getReader]
    M --> N[return true → continue pump loop]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fstream-failover.test.ts%3A163-177%0A**missing%20%60maxFailovers%20%3E%201%60%20coverage**%0A%0Athe%20new%20guard%20is%20tested%20only%20with%20%60maxFailovers%3A%201%60%2C%20so%20there's%20no%20case%20that%20verifies%20the%20guard%20also%20fires%20on%20a%20second%20failover%20attempt%20when%20bytes%20were%20emitted%20from%20a%20successful%20first%20fallback%20stream.%20given%20the%2080%25%20coverage%20threshold%2C%20consider%20adding%20a%20companion%20test.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/stream-failover.test.ts
Line: 163-177

Comment:
**missing `maxFailovers > 1` coverage**

the new guard is tested only with `maxFailovers: 1`, so there's no case that verifies the guard also fires on a second failover attempt when bytes were emitted from a successful first fallback stream. given the 80% coverage threshold, consider adding a companion test.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop stream failover replay after o..."](https://github.com/ndycode/codex-multi-auth/commit/b5701622cbfd1f96a303e8cc5d8d96f1306dc5e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421676)</sub>

<!-- /greptile_comment -->