### PR TITLE
fix: make account clear reset atomic

### DIFF
--- a/lib/storage/account-clear.ts
+++ b/lib/storage/account-clear.ts
@@ -7,32 +7,43 @@ export async function clearAccountStorageArtifacts(params: {
 	backupPaths: string[];
 	logError: (message: string, details: Record<string, unknown>) => void;
 }): Promise<void> {
+	const clearPath = async (
+		targetPath: string,
+		required: boolean,
+	): Promise<void> => {
+		try {
+			await fs.unlink(targetPath);
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code === "ENOENT") {
+				return;
+			}
+			if (required) {
+				params.logError("Failed to clear account storage artifact", {
+					path: targetPath,
+					error: String(error),
+				});
+				throw error;
+			}
+			params.logError("Failed to clear account storage artifact", {
+				path: targetPath,
+				error: String(error),
+			});
+		}
+	};
+
+	await clearPath(params.path, true);
+	await clearPath(params.walPath, true);
 	await fs.writeFile(
 		params.resetMarkerPath,
 		JSON.stringify({ version: 1, createdAt: Date.now() }),
 		{ encoding: "utf-8", mode: 0o600 },
 	);
-	const clearPath = async (targetPath: string): Promise<void> => {
+	for (const backupPath of params.backupPaths) {
 		try {
-			await fs.unlink(targetPath);
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException).code;
-			if (code !== "ENOENT") {
-				params.logError("Failed to clear account storage artifact", {
-					path: targetPath,
-					error: String(error),
-				});
-			}
+			await clearPath(backupPath, false);
+		} catch {
+			// Non-critical artifacts are already logged best-effort.
 		}
-	};
-
-	try {
-		await Promise.all([
-			clearPath(params.path),
-			clearPath(params.walPath),
-			...params.backupPaths.map(clearPath),
-		]);
-	} catch {
-		// Individual path cleanup is already best-effort with per-artifact logging.
 	}
 }

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -2961,14 +2961,24 @@ describe("storage", () => {
 			await fs.rm(testWorkDir, { recursive: true, force: true });
 		});
 
-		it("logs but does not throw on non-ENOENT errors", async () => {
-			const readOnlyDir = join(testWorkDir, "readonly");
-			await fs.mkdir(readOnlyDir, { recursive: true });
-			const readOnlyFile = join(readOnlyDir, "accounts.json");
-			await fs.writeFile(readOnlyFile, "{}");
-			setStoragePathDirect(readOnlyFile);
+		it("throws and does not write reset marker when the primary storage file cannot be removed", async () => {
+			await fs.writeFile(testStoragePath, "{}", "utf-8");
+			const resetMarkerPath = getIntentionalResetMarkerPath(testStoragePath);
+			const unlinkSpy = vi
+				.spyOn(fs, "unlink")
+				.mockImplementation(async (targetPath) => {
+					if (String(targetPath) === testStoragePath) {
+						const error = Object.assign(new Error("locked"), { code: "EPERM" });
+						throw error;
+					}
+					return Promise.resolve();
+				});
 
-			await expect(clearAccounts()).resolves.not.toThrow();
+			await expect(clearAccounts()).rejects.toMatchObject({ code: "EPERM" });
+			expect(existsSync(testStoragePath)).toBe(true);
+			expect(existsSync(resetMarkerPath)).toBe(false);
+
+			unlinkSpy.mockRestore();
 		});
 	});
 
@@ -4122,7 +4132,7 @@ describe("storage", () => {
 					Object.assign(new Error("EACCES error"), { code: "EACCES" }),
 				);
 
-			await clearAccounts();
+			await expect(clearAccounts()).rejects.toMatchObject({ code: "EACCES" });
 
 			expect(unlinkSpy).toHaveBeenCalled();
 			unlinkSpy.mockRestore();


### PR DESCRIPTION
## Summary
- delete the primary storage file and WAL before writing the intentional reset marker so account clears stay truthful
- fail loudly when critical account artifacts cannot be removed instead of hiding them behind an empty-state marker
- add regression coverage for the new strict clear behavior and retained reset-marker guarantees

## Validation
- node_modules/.bin/vitest.cmd run test/storage.test.ts
- node_modules/.bin/tsc.cmd --noEmit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

reorders the clear sequence so the primary file and WAL are deleted before the reset marker is written, and makes those two deletions fail-loud. the atomicity fix is correct: callers in `index.ts` and `auth-commands.ts` correctly propagate errors to the user on failure. all remaining findings are p2 cleanup: a dead `try/catch` around the non-throwing best-effort backup loop, a gap in WAL-only failure test coverage, and `fs.unlink` on required paths lacking the windows eperm/ebusy retry the project uses elsewhere.

<h3>Confidence Score: 5/5</h3>

safe to merge; all findings are p2 style and coverage items that do not affect correctness

atomicity fix is sound, required-path error propagation is correct, and the primary regression path is covered. remaining issues (dead catch block, missing wal failure test, no windows retry) are cleanup-level and do not affect the correctness of the new behaviour.

lib/storage/account-clear.ts — dead try/catch in backup loop; consider windows eperm/ebusy retry for required unlink paths on windows hosts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage/account-clear.ts | reorders delete-then-mark for atomicity and adds required-throw semantics; dead try/catch in backup loop and no Windows EPERM retry on required unlink paths |
| test/storage.test.ts | adds EPERM primary-path regression and updates EACCES test to expect rejection; WAL-only failure path not independently covered |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant clearFn as clearAccountStorageArtifacts
    participant FS

    Caller->>clearFn: invoke
    clearFn->>FS: unlink(path) [required=true]
    alt non-ENOENT error (e.g. EPERM/EBUSY)
        FS-->>clearFn: error
        clearFn->>clearFn: logError + throw
        clearFn-->>Caller: throws — reset marker NOT written
    else ok or ENOENT
        FS-->>clearFn: ok
        clearFn->>FS: unlink(walPath) [required=true]
        alt non-ENOENT error
            FS-->>clearFn: error
            clearFn->>clearFn: logError + throw
            clearFn-->>Caller: throws — reset marker NOT written
        else ok or ENOENT
            FS-->>clearFn: ok
            clearFn->>FS: writeFile(resetMarkerPath)
            FS-->>clearFn: ok
            loop backupPaths (best-effort, required=false)
                clearFn->>FS: unlink(backupPath)
                FS-->>clearFn: ok or error (logged, never thrown)
            end
            clearFn-->>Caller: resolves
        end
    end
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fstorage%2Faccount-clear.ts%3A43-47%0A**dead%20%60try%2Fcatch%60%20around%20non-throwing%20helper**%0A%0A%60clearPath%28backupPath%2C%20false%29%60%20never%20throws%20%E2%80%94%20when%20%60required%3Dfalse%60%2C%20every%20error%20branch%20either%20returns%20early%20%28%60ENOENT%60%29%20or%20logs%20and%20returns%20without%20re-throwing.%20the%20outer%20%60try%2Fcatch%60%20is%20unreachable%20dead%20code%20that%20misleads%20readers%20into%20thinking%20the%20helper%20can%20surface%20errors%20from%20this%20path.%0A%0A%60%60%60suggestion%0A%09for%20%28const%20backupPath%20of%20params.backupPaths%29%20%7B%0A%09%09await%20clearPath%28backupPath%2C%20false%29%3B%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fstorage.test.ts%3A2977-2982%0A**WAL-only%20deletion%20failure%20path%20not%20covered**%0A%0Athe%20new%20test%20covers%20primary-path%20EPERM%20%E2%86%92%20throw%20%2B%20reset%20marker%20not%20written.%20the%20symmetric%20case%20%E2%80%94%20WAL%20deletion%20fails%20while%20primary%20succeeds%20%E2%80%94%20is%20untested%2C%20even%20though%20it%20hits%20the%20same%20%60required%3Dtrue%60%20throw%20path%20%28%60clearPath%28walPath%2C%20true%29%60%29%20and%20the%20PR%20description%20specifically%20calls%20out%20regression%20coverage%20for%20the%20strict%20clear%20behaviour.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fstorage%2Faccount-clear.ts%3A35-36%0A**no%20Windows%20EPERM%2FEBUSY%20retry%20on%20required%20%60unlink%60%20calls**%0A%0AAGENTS.md%20explicitly%20flags%3A%20*%22never%20use%20bare%20%60fs.rm%60%20without%20retry%20logic%20%28Windows%20antivirus%20locks%29%22*.%20the%20same%20transient-lock%20risk%20applies%20to%20%60fs.unlink%60%20on%20%60required%3Dtrue%60%20paths.%20a%20momentary%20antivirus%20or%20Explorer%20hold%20on%20%60accounts.json%60%20or%20its%20WAL%20will%20now%20hard-throw%20and%20propagate%20to%20both%20unguarded%20call%20sites%20%28%60index.ts%60%20and%20%60auth-commands.ts%60%29%2C%20which%20is%20the%20exact%20failure%20mode%20the%20project%20defends%20against%20elsewhere%20with%20%60removeWithRetry%60.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/storage/account-clear.ts
Line: 43-47

Comment:
**dead `try/catch` around non-throwing helper**

`clearPath(backupPath, false)` never throws — when `required=false`, every error branch either returns early (`ENOENT`) or logs and returns without re-throwing. the outer `try/catch` is unreachable dead code that misleads readers into thinking the helper can surface errors from this path.

```suggestion
	for (const backupPath of params.backupPaths) {
		await clearPath(backupPath, false);
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/storage.test.ts
Line: 2977-2982

Comment:
**WAL-only deletion failure path not covered**

the new test covers primary-path EPERM → throw + reset marker not written. the symmetric case — WAL deletion fails while primary succeeds — is untested, even though it hits the same `required=true` throw path (`clearPath(walPath, true)`) and the PR description specifically calls out regression coverage for the strict clear behaviour.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/storage/account-clear.ts
Line: 35-36

Comment:
**no Windows EPERM/EBUSY retry on required `unlink` calls**

AGENTS.md explicitly flags: *"never use bare `fs.rm` without retry logic (Windows antivirus locks)"*. the same transient-lock risk applies to `fs.unlink` on `required=true` paths. a momentary antivirus or Explorer hold on `accounts.json` or its WAL will now hard-throw and propagate to both unguarded call sites (`index.ts` and `auth-commands.ts`), which is the exact failure mode the project defends against elsewhere with `removeWithRetry`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make account clear reset atomic"](https://github.com/ndycode/codex-multi-auth/commit/a11299024530583bacf5adffb7756bbf2c5652a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421675)</sub>

<!-- /greptile_comment -->