### PR TITLE
fix: flag malformed codex auth payloads in doctor

### DIFF
--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -1687,7 +1687,14 @@ export async function runDoctor(
 		try {
 			const raw = await fs.readFile(codexAuthPath, "utf-8");
 			const parsed = JSON.parse(raw) as unknown;
-			if (parsed && typeof parsed === "object") {
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				addCheck({
+					key: "codex-auth-readable",
+					severity: "error",
+					message: "Codex auth file has invalid structure",
+					details: codexAuthPath,
+				});
+			} else {
 				const payload = parsed as Record<string, unknown>;
 				const tokens = payload.tokens && typeof payload.tokens === "object"
 					? payload.tokens as Record<string, unknown>
@@ -1708,19 +1715,19 @@ export async function runDoctor(
 					emailFromFile ?? extractAccountEmail(accessToken, idToken),
 				);
 				codexAuthAccountId = accountIdFromFile ?? extractAccountId(accessToken);
+				addCheck({
+					key: "codex-auth-readable",
+					severity: "ok",
+					message: "Codex auth file is readable",
+					details:
+						codexAuthEmail || codexAuthAccountId
+							? formatDoctorIdentitySummary({
+								email: codexAuthEmail,
+								accountId: codexAuthAccountId,
+							})
+							: undefined,
+				});
 			}
-			addCheck({
-				key: "codex-auth-readable",
-				severity: "ok",
-				message: "Codex auth file is readable",
-				details:
-					codexAuthEmail || codexAuthAccountId
-						? formatDoctorIdentitySummary({
-							email: codexAuthEmail,
-							accountId: codexAuthAccountId,
-						})
-						: undefined,
-			});
 		} catch (error) {
 			addCheck({
 				key: "codex-auth-readable",

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -751,6 +751,25 @@ describe("repair-commands direct deps coverage", () => {
 		);
 	});
 
+	it("runDoctor marks malformed codex auth payloads as invalid instead of healthy", async () => {
+		existsSyncMock.mockImplementation((path) => path === "/mock/auth.json");
+		readFileMock.mockResolvedValueOnce("[]");
+		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const exitCode = await runDoctor(["--json"], createDeps());
+
+		expect(exitCode).toBe(1);
+		expect(
+			JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")).checks,
+		).toContainEqual(
+			expect.objectContaining({
+				key: "codex-auth-readable",
+				severity: "error",
+				message: "Codex auth file has invalid structure",
+			}),
+		);
+	});
+
 	it("runDoctor derives auto-fix state from the final action set", async () => {
 		const now = Date.now();
 		let persistedAccountStorage: unknown;


### PR DESCRIPTION
## Summary
- treat malformed `auth.json` payload shapes as invalid in the active `doctor` implementation instead of reporting them as healthy
- keep readable-object auth files on the existing healthy path while surfacing invalid structure as a real error
- add direct repair-command coverage for malformed auth payloads in the dispatched doctor path

## Validation
- node_modules/.bin/vitest.cmd run test/repair-commands.test.ts
- node_modules/.bin/tsc.cmd --noEmit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

moves the `codex-auth-readable` ok-check inside the valid-object branch and adds `Array.isArray` to catch array-shaped payloads that the original `typeof === 'object'` check passed silently — previously `[]` would enter the `if (parsed && typeof parsed === "object")` branch (arrays are truthy objects), extract no tokens, then unconditionally report healthy. test wiring is correct: mock isolation via `existsSyncMock.mockImplementation` and a single `readFileMock.mockResolvedValueOnce` matches the one `readFile` call made in the malformed-payload path, and the exit-code assertion follows from `summary.error > 0 ? 1 : 0`.

<h3>Confidence Score: 5/5</h3>

safe to merge — logic is correct, test wiring is sound, no windows filesystem or token-safety regressions

no P0/P1 issues; Array.isArray guard is correct, ok-check relocation is correct, test validates the primary new error path with proper mock isolation. only remaining finding is P2 coverage breadth.

no files need special attention beyond the noted P2 coverage suggestion in test/repair-commands.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/repair-commands.ts | inverts guard to error on null/array auth payloads and moves ok-check inside the valid-object branch — logic is correct |
| test/repair-commands.test.ts | adds vitest case for array-shaped auth.json; mock wiring is correct; null/primitive shapes lack dedicated coverage (P2) |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant D as runDoctor
    participant FS as fs.readFile
    participant C as checks[]

    D->>FS: readFile(codexAuthPath, utf-8)
    FS-->>D: raw JSON string

    alt malformed payload (null / array / primitive)
        D->>C: addCheck(codex-auth-readable, severity=error)
        Note over D: exitCode = 1
    else valid plain object
        D->>D: extract tokens / email / accountId
        D->>C: addCheck(codex-auth-readable, severity=ok)
        Note over D: exitCode = 0 (unless other errors)
    end
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Frepair-commands.test.ts%3A756%0A**missing%20coverage%20for%20null%2Fprimitive%20shapes**%0A%0Athe%20test%20exercises%20the%20%60%5B%5D%60%20%28array%29%20path%2C%20but%20the%20new%20guard%20also%20catches%20%60null%60%2C%20%6042%60%2C%20and%20string-valued%20JSON%20%E2%80%94%20none%20of%20which%20have%20a%20dedicated%20case.%20since%20%60null%60%20was%20silently%20reported%20healthy%20before%20this%20fix%2C%20a%20parameterised%20loop%20over%20%60%5B%22null%22%2C%20%2242%22%2C%20%22%5C%22str%5C%22%22%2C%20%22%5B%7B%7D%5D%22%5D%60%20would%20give%20full%20branch%20coverage%20for%20%60!parsed%60%2C%20%60typeof%20!%3D%3D%20'object'%60%2C%20and%20the%20array%20check%20in%20one%20shot.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/repair-commands.test.ts
Line: 756

Comment:
**missing coverage for null/primitive shapes**

the test exercises the `[]` (array) path, but the new guard also catches `null`, `42`, and string-valued JSON — none of which have a dedicated case. since `null` was silently reported healthy before this fix, a parameterised loop over `["null", "42", "\"str\"", "[{}]"]` would give full branch coverage for `!parsed`, `typeof !== 'object'`, and the array check in one shot.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: flag malformed codex auth payloads ..."](https://github.com/ndycode/codex-multi-auth/commit/95ebd98162d63b7af048458b6d969c5740d0729e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421677)</sub>

<!-- /greptile_comment -->