### PR TITLE
fix: persist report refreshes before mutating state

### DIFF
--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -409,9 +409,6 @@ export async function runReportCommand(
 					email: previousEmail,
 					accountId: previousAccountId,
 				};
-				applyRefreshedAccountPatch(account, refreshPatch);
-				probeAccessToken = refreshResult.access;
-				probeAccountId = account.accountId ?? refreshedAccountId;
 				if (
 					previousRefreshToken !== refreshPatch.refreshToken ||
 					previousAccessToken !== refreshPatch.accessToken ||
@@ -435,7 +432,11 @@ export async function runReportCommand(
 						probeErrors.push(`${formatAccountLabel(account, i)}: ${message}`);
 						continue;
 					}
+					applyRefreshedAccountPatch(account, refreshPatch);
 				}
+				probeAccessToken = refreshResult.access;
+				probeAccountId =
+					refreshPatch.accountId ?? account.accountId ?? refreshedAccountId;
 			}
 
 			if (!probeAccessToken || !probeAccountId) {

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -361,6 +361,60 @@ describe("runReportCommand", () => {
 		);
 	});
 
+	it("does not mutate the in-memory report snapshot when refreshed token persistence fails", async () => {
+		const storage = createStorage([
+			{
+				email: "persist-fail@example.com",
+				accountId: "acct-report",
+				accountIdSource: "org",
+				refreshToken: "refresh-token-1",
+				accessToken: "access-token-1",
+				expiresAt: 10,
+				addedAt: 1,
+				lastUsed: 1,
+				enabled: true,
+			},
+		]);
+		const deps = createDeps({
+			loadAccounts: vi.fn(async () => structuredClone(storage)),
+			saveAccounts: vi.fn(async () => {
+				throw Object.assign(new Error("EPERM write blocked"), {
+					code: "EPERM",
+				});
+			}),
+			queuedRefresh: vi.fn(async () => ({
+				type: "success",
+				access: "access-token-updated",
+				refresh: "refresh-token-updated",
+				expires: 500,
+				idToken: "id-token-updated",
+			})),
+			fetchCodexQuotaSnapshot: vi.fn(async () => ({
+				status: 200,
+				model: "gpt-5-codex",
+				primary: {},
+				secondary: {},
+			})),
+		});
+
+		const result = await runReportCommand(["--live", "--json"], deps);
+
+		expect(result).toBe(0);
+		expect(deps.fetchCodexQuotaSnapshot).not.toHaveBeenCalled();
+		const jsonOutput = JSON.parse(
+			(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? "{}",
+		) as {
+			forecast: { probeErrors: string[]; accounts: Array<{ label: string }> };
+		};
+		expect(jsonOutput.forecast.probeErrors).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("EPERM write blocked"),
+			]),
+		);
+		expect(storage.accounts[0]?.refreshToken).toBe("refresh-token-1");
+		expect(storage.accounts[0]?.accessToken).toBe("access-token-1");
+	});
+
 	it("prints a human-readable report and announces the output path", async () => {
 		const deps = createDeps();
 


### PR DESCRIPTION
## Summary
- persist live report refresh patches before mutating the in-memory account snapshot used to build the report
- keep probe execution blocked when persistence fails so the report cannot drift away from what is actually on disk
- add focused report-command coverage for the persistence-failure path and visible snapshot stability

## Validation
- node_modules/.bin/vitest.cmd run test/codex-manager-report-command.test.ts
- node_modules/.bin/tsc.cmd --noEmit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr correctly fixes the persist-before-mutate ordering — `applyRefreshedAccountPatch` now only runs after `persistRefreshedAccountPatch` succeeds, and a persistence failure causes `continue` so the probe is blocked. the fix prevents token drift between disk and the in-memory report snapshot. two issues need attention before merging.

- **dead condition branches** (`report.ts` lines 416-417): moving the patch application after the `if` condition renders `previousEmail !== account.email` and `previousAccountId !== account.accountId` permanently false. `previousEmail` and `account.email` are the same unmutated value — the comparison never fires. in the old code, `applyRefreshedAccountPatch` ran before the check so `account.email`/`account.accountId` could actually differ. the fix is to compare against `refreshPatch.email`/`refreshPatch.accountId` instead.
- **trivially-true snapshot assertion** (`test` lines 414-415): `loadAccounts` returns `structuredClone(storage)`, so the original `storage` object can never be mutated by the code under test. asserting `storage.accounts[0]?.refreshToken === "refresh-token-1"` passes regardless of the fix. the test should capture and assert on the clone itself to provide real signal.
- **no windows filesystem or concurrency regressions** introduced; the eperm retry path and the load-clone-save pattern in `persistRefreshedAccountPatch` are intact.
- **missing vitest coverage** for the case where tokens are unchanged but email or accountId changes — the now-dead branches aren't exercised and won't catch a regression here.

<h3>Confidence Score: 3/5</h3>

not safe to merge as-is — logic regression in the change-detection condition and a misleading test assertion both need to be fixed first

the core ordering fix is correct and meaningful, but the deferral introduces dead condition branches (email/accountId comparisons always false) that silently skip persistence for a narrow but real class of refresh responses. the test assertion providing 'mutation safety' evidence is trivially true. these are correctness concerns, not style.

lib/codex-manager/commands/report.ts lines 413-418 (dead condition branches); test/codex-manager-report-command.test.ts lines 414-415 (trivially-true snapshot assertions)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/report.ts | persist-before-mutate ordering is correctly fixed, but the move introduces dead condition branches on lines 416-417 where email/accountId comparisons are always false against the unmutated account object |
| test/codex-manager-report-command.test.ts | adds useful eperm-on-persist coverage and verifies probe is blocked; snapshot mutation assertions on lines 414-415 are trivially true because loadAccounts returns a structuredClone |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as runReportCommand
    participant Q as queuedRefresh
    participant P as persistRefreshedAccountPatch
    participant S as saveAccountsWithRetry
    participant A as applyRefreshedAccountPatch
    participant F as fetchCodexQuotaSnapshot

    loop for each enabled account
        alt hasUsableAccessToken → false
            R->>Q: queuedRefresh(account.refreshToken)
            Q-->>R: refreshResult
            alt type !== success
                R->>R: record refreshFailure, continue
            else refresh succeeded
                R->>R: build refreshPatch
                alt tokens or identity changed
                    R->>P: persistRefreshedAccountPatch(...)
                    P->>P: loadAccounts (latest)
                    P->>S: saveAccountsWithRetry(nextStorage)
                    S-->>P: saved or EPERM retry
                    alt persist failure
                        R->>R: push error → probeErrors, continue
                    else persist success
                        R->>A: applyRefreshedAccountPatch(account, patch)
                        A-->>R: in-memory account mutated
                    end
                end
                R->>R: set probeAccessToken, probeAccountId
            end
        end
        alt missing probeAccessToken or probeAccountId
            R->>R: push error → probeErrors, continue
        else
            R->>F: fetchCodexQuotaSnapshot(accountId, accessToken, model)
            F-->>R: liveQuota or error → probeErrors
        end
    end
    R-->>R: build and return report
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/codex-manager/commands/report.ts`, line 413-418 ([link](https://github.com/ndycode/codex-multi-auth/blob/31e2590d6d5d2b5326330bd5775690dfc53fee4f/lib/codex-manager/commands/report.ts#L413-L418)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **dead condition branches after deferring the patch**

   `previousEmail` is captured as `account.email` (line 393) and `previousAccountId` as `account.accountId` (line 394). since `applyRefreshedAccountPatch` is no longer called before this `if` block, neither `account.email` nor `account.accountId` has been mutated — so `previousEmail !== account.email` and `previousAccountId !== account.accountId` are structurally always `false`. in the old code these worked because the patch was applied first.

   if a refresh returns a new email or accountId with unchanged tokens/expiry, the persistence won't be triggered. fix: compare against the patch values instead.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/codex-manager/commands/report.ts
   Line: 413-418

   Comment:
   **dead condition branches after deferring the patch**

   `previousEmail` is captured as `account.email` (line 393) and `previousAccountId` as `account.accountId` (line 394). since `applyRefreshedAccountPatch` is no longer called before this `if` block, neither `account.email` nor `account.accountId` has been mutated — so `previousEmail !== account.email` and `previousAccountId !== account.accountId` are structurally always `false`. in the old code these worked because the patch was applied first.

   if a refresh returns a new email or accountId with unchanged tokens/expiry, the persistence won't be triggered. fix: compare against the patch values instead.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fcodex-manager%2Fcommands%2Freport.ts%0ALine%3A%20413-418%0A%0AComment%3A%0A**dead%20condition%20branches%20after%20deferring%20the%20patch**%0A%0A%60previousEmail%60%20is%20captured%20as%20%60account.email%60%20%28line%20393%29%20and%20%60previousAccountId%60%20as%20%60account.accountId%60%20%28line%20394%29.%20since%20%60applyRefreshedAccountPatch%60%20is%20no%20longer%20called%20before%20this%20%60if%60%20block%2C%20neither%20%60account.email%60%20nor%20%60account.accountId%60%20has%20been%20mutated%20%E2%80%94%20so%20%60previousEmail%20!%3D%3D%20account.email%60%20and%20%60previousAccountId%20!%3D%3D%20account.accountId%60%20are%20structurally%20always%20%60false%60.%20in%20the%20old%20code%20these%20worked%20because%20the%20patch%20was%20applied%20first.%0A%0Aif%20a%20refresh%20returns%20a%20new%20email%20or%20accountId%20with%20unchanged%20tokens%2Fexpiry%2C%20the%20persistence%20won't%20be%20triggered.%20fix%3A%20compare%20against%20the%20patch%20values%20instead.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09if%20%28%0A%09%09%09%09%09%09previousRefreshToken%20!%3D%3D%20refreshPatch.refreshToken%20%7C%7C%0A%09%09%09%09%09%09previousAccessToken%20!%3D%3D%20refreshPatch.accessToken%20%7C%7C%0A%09%09%09%09%09%09previousExpiresAt%20!%3D%3D%20refreshPatch.expiresAt%20%7C%7C%0A%09%09%09%09%09%09previousEmail%20!%3D%3D%20refreshPatch.email%20%7C%7C%0A%09%09%09%09%09%09previousAccountId%20!%3D%3D%20refreshPatch.accountId%0A%09%09%09%09%09%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fcodex-manager%2Fcommands%2Freport.ts%3A413-418%0A**dead%20condition%20branches%20after%20deferring%20the%20patch**%0A%0A%60previousEmail%60%20is%20captured%20as%20%60account.email%60%20%28line%20393%29%20and%20%60previousAccountId%60%20as%20%60account.accountId%60%20%28line%20394%29.%20since%20%60applyRefreshedAccountPatch%60%20is%20no%20longer%20called%20before%20this%20%60if%60%20block%2C%20neither%20%60account.email%60%20nor%20%60account.accountId%60%20has%20been%20mutated%20%E2%80%94%20so%20%60previousEmail%20!%3D%3D%20account.email%60%20and%20%60previousAccountId%20!%3D%3D%20account.accountId%60%20are%20structurally%20always%20%60false%60.%20in%20the%20old%20code%20these%20worked%20because%20the%20patch%20was%20applied%20first.%0A%0Aif%20a%20refresh%20returns%20a%20new%20email%20or%20accountId%20with%20unchanged%20tokens%2Fexpiry%2C%20the%20persistence%20won't%20be%20triggered.%20fix%3A%20compare%20against%20the%20patch%20values%20instead.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09if%20%28%0A%09%09%09%09%09%09previousRefreshToken%20!%3D%3D%20refreshPatch.refreshToken%20%7C%7C%0A%09%09%09%09%09%09previousAccessToken%20!%3D%3D%20refreshPatch.accessToken%20%7C%7C%0A%09%09%09%09%09%09previousExpiresAt%20!%3D%3D%20refreshPatch.expiresAt%20%7C%7C%0A%09%09%09%09%09%09previousEmail%20!%3D%3D%20refreshPatch.email%20%7C%7C%0A%09%09%09%09%09%09previousAccountId%20!%3D%3D%20refreshPatch.accountId%0A%09%09%09%09%09%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fcodex-manager-report-command.test.ts%3A414-415%0A**snapshot%20mutation%20assertion%20is%20trivially%20true**%0A%0A%60loadAccounts%60%20is%20mocked%20as%20%60vi.fn%28async%20%28%29%20%3D%3E%20structuredClone%28storage%29%29%60%20%28line%20379%29%2C%20so%20%60runReportCommand%60%20operates%20on%20a%20deep%20clone%20%E2%80%94%20the%20original%20%60storage%60%20object%20is%20structurally%20unreachable%20by%20the%20code%20under%20test.%20these%20assertions%20pass%20regardless%20of%20whether%20the%20fix%20is%20correct%2C%20giving%20false%20confidence.%0A%0Acapture%20the%20clone%20returned%20by%20the%20mock%20and%20assert%20on%20it%20post-run%20to%20get%20real%20signal%3A%0A%0A%60%60%60typescript%0Alet%20capturedClone%3A%20AccountStorageV3%20%7C%20undefined%3B%0AloadAccounts%3A%20vi.fn%28async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20capturedClone%20%3D%20structuredClone%28storage%29%3B%0A%20%20%20%20return%20capturedClone%3B%0A%7D%29%2C%0A%2F%2F%20...%20after%20runReportCommand%3A%0Aexpect%28capturedClone%3F.accounts%5B0%5D%3F.refreshToken%29.toBe%28%22refresh-token-1%22%29%3B%0Aexpect%28capturedClone%3F.accounts%5B0%5D%3F.accessToken%29.toBe%28%22access-token-1%22%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager/commands/report.ts
Line: 413-418

Comment:
**dead condition branches after deferring the patch**

`previousEmail` is captured as `account.email` (line 393) and `previousAccountId` as `account.accountId` (line 394). since `applyRefreshedAccountPatch` is no longer called before this `if` block, neither `account.email` nor `account.accountId` has been mutated — so `previousEmail !== account.email` and `previousAccountId !== account.accountId` are structurally always `false`. in the old code these worked because the patch was applied first.

if a refresh returns a new email or accountId with unchanged tokens/expiry, the persistence won't be triggered. fix: compare against the patch values instead.

```suggestion
					if (
						previousRefreshToken !== refreshPatch.refreshToken ||
						previousAccessToken !== refreshPatch.accessToken ||
						previousExpiresAt !== refreshPatch.expiresAt ||
						previousEmail !== refreshPatch.email ||
						previousAccountId !== refreshPatch.accountId
					) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-report-command.test.ts
Line: 414-415

Comment:
**snapshot mutation assertion is trivially true**

`loadAccounts` is mocked as `vi.fn(async () => structuredClone(storage))` (line 379), so `runReportCommand` operates on a deep clone — the original `storage` object is structurally unreachable by the code under test. these assertions pass regardless of whether the fix is correct, giving false confidence.

capture the clone returned by the mock and assert on it post-run to get real signal:

```typescript
let capturedClone: AccountStorageV3 | undefined;
loadAccounts: vi.fn(async () => {
    capturedClone = structuredClone(storage);
    return capturedClone;
}),
// ... after runReportCommand:
expect(capturedClone?.accounts[0]?.refreshToken).toBe("refresh-token-1");
expect(capturedClone?.accounts[0]?.accessToken).toBe("access-token-1");
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: persist report refreshes before mut..."](https://github.com/ndycode/codex-multi-auth/commit/31e2590d6d5d2b5326330bd5775690dfc53fee4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421674)</sub>

<!-- /greptile_comment -->