### PR TITLE
fix: stop quota scheduler cooldown drift

### DIFF
--- a/lib/preemptive-quota-scheduler.ts
+++ b/lib/preemptive-quota-scheduler.ts
@@ -238,14 +238,27 @@ export class PreemptiveQuotaScheduler {
 		const snapshot = this.snapshots.get(key);
 		if (!snapshot) return { defer: false, waitMs: 0 };
 
+		const primaryWait =
+			typeof snapshot.primary.resetAtMs === "number" &&
+			Number.isFinite(snapshot.primary.resetAtMs) &&
+			snapshot.primary.resetAtMs > now
+				? snapshot.primary.resetAtMs - now
+				: 0;
+		const secondaryWait =
+			typeof snapshot.secondary.resetAtMs === "number" &&
+			Number.isFinite(snapshot.secondary.resetAtMs) &&
+			snapshot.secondary.resetAtMs > now
+				? snapshot.secondary.resetAtMs - now
+				: 0;
+
 		const waitCandidates = [snapshot.primary.resetAtMs, snapshot.secondary.resetAtMs]
 			.filter((value): value is number => typeof value === "number" && Number.isFinite(value) && value > now)
 			.map((value) => value - now)
 			.filter((value) => value > 0);
-		const nearestWait = waitCandidates.length > 0 ? Math.min(...waitCandidates) : 0;
+		const longestWait = waitCandidates.length > 0 ? Math.max(...waitCandidates) : 0;
 
-		if (snapshot.status === 429 && nearestWait > 0) {
-			const bounded = Math.min(nearestWait, this.maxDeferralMs);
+		if (snapshot.status === 429 && longestWait > 0) {
+			const bounded = Math.min(longestWait, this.maxDeferralMs);
 			if (bounded > 0) {
 				return { defer: true, waitMs: bounded, reason: "rate-limit" };
 			}
@@ -259,9 +272,12 @@ export class PreemptiveQuotaScheduler {
 			typeof snapshot.secondary.usedPercent === "number" &&
 			Number.isFinite(snapshot.secondary.usedPercent) &&
 			snapshot.secondary.usedPercent >= 100 - this.secondaryRemainingPercentThreshold;
-		const nearExhausted = primaryNearExhausted || secondaryNearExhausted;
-		if (nearExhausted && nearestWait > 0) {
-			const bounded = Math.min(nearestWait, this.maxDeferralMs);
+		const nearExhaustedWait = Math.max(
+			primaryNearExhausted ? primaryWait : 0,
+			secondaryNearExhausted ? secondaryWait : 0,
+		);
+		if (nearExhaustedWait > 0) {
+			const bounded = Math.min(nearExhaustedWait, this.maxDeferralMs);
 			if (bounded > 0) {
 				return { defer: true, waitMs: bounded, reason: "quota-near-exhaustion" };
 			}

--- a/test/preemptive-quota-scheduler.test.ts
+++ b/test/preemptive-quota-scheduler.test.ts
@@ -87,6 +87,21 @@ describe("preemptive quota scheduler", () => {
 		expect(decision.waitMs).toBe(25_000);
 	});
 
+	it("uses the longest active reset window for 429 deferrals", () => {
+		const scheduler = new PreemptiveQuotaScheduler();
+		scheduler.update("acc:model", {
+			status: 429,
+			primary: { resetAtMs: 31_000 },
+			secondary: { resetAtMs: 61_000 },
+			updatedAt: 1_000,
+		});
+
+		const decision = scheduler.getDeferral("acc:model", 6_000);
+		expect(decision.defer).toBe(true);
+		expect(decision.reason).toBe("rate-limit");
+		expect(decision.waitMs).toBe(55_000);
+	});
+
 	it("preserves secondary near-exhaustion state when marking a quota key rate-limited", () => {
 		const scheduler = new PreemptiveQuotaScheduler({
 			remainingPercentThresholdSecondary: 5,
@@ -139,6 +154,24 @@ describe("preemptive quota scheduler", () => {
 		const decision = scheduler.getDeferral("acc:model", 20_000);
 		expect(decision.defer).toBe(true);
 		expect(decision.reason).toBe("quota-near-exhaustion");
+	});
+
+	it("uses the longest near-exhausted reset window for quota deferrals", () => {
+		const scheduler = new PreemptiveQuotaScheduler({
+			remainingPercentThresholdPrimary: 5,
+			remainingPercentThresholdSecondary: 5,
+		});
+		scheduler.update("acc:model", {
+			status: 200,
+			primary: { usedPercent: 96, resetAtMs: 70_000 },
+			secondary: { usedPercent: 97, resetAtMs: 120_000 },
+			updatedAt: 10_000,
+		});
+
+		const decision = scheduler.getDeferral("acc:model", 20_000);
+		expect(decision.defer).toBe(true);
+		expect(decision.reason).toBe("quota-near-exhaustion");
+		expect(decision.waitMs).toBe(100_000);
 	});
 
 	it("prunes expired snapshots", () => {


### PR DESCRIPTION
## Problem

`PreemptiveQuotaScheduler.getDeferral()` was computing cooldowns from the nearest reset window.

That causes cooldown drift when a later primary or secondary quota window is still active: the scheduler can resume traffic early even though another active quota window has not reset yet.

## Fix

Use the longest relevant reset window instead of the nearest one.

- For `429` snapshots, defer until the latest active reset across primary and secondary windows.
- For quota-near-exhaustion snapshots, defer until the latest reset among the windows that are actually near exhaustion.

## Changes

- `lib/preemptive-quota-scheduler.ts`
  - compute per-window waits once
  - use the longest active wait for `429` deferrals
  - use the longest near-exhausted wait for quota deferrals
- `test/preemptive-quota-scheduler.test.ts`
  - added regression coverage for 429 cooldowns using the longer reset window
  - added regression coverage for near-exhaustion cooldowns using the longer reset window

## Validation

```text
npx vitest run test/preemptive-quota-scheduler.test.ts
Test Files  1 passed (1)
Tests      16 passed (16)

npx vitest run
Test Files  222 passed (222)
Tests      3315 passed (3315)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

replaces nearest-window cooldown selection with longest-window in `getDeferral()`, fixing premature quota resumption when a longer secondary reset window is still active. both the 429 and near-exhaustion paths now correctly defer until all relevant windows have reset, backed by two new regression tests.

<h3>Confidence Score: 5/5</h3>

safe to merge — the fix is correct, all 16 tests pass, and the change is well-scoped

both findings are p2 style/coverage; the core logic correctly uses Math.max across windows for both the 429 and near-exhaustion paths, which is exactly the stated intent. no concurrency issues — all scheduler methods are synchronous with no async gaps in the map mutations. no filesystem or token handling touched.

no files require special attention; redundancy in getDeferral is cosmetic only

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/preemptive-quota-scheduler.ts | fixes cooldown drift by using Math.max across windows for both 429 and near-exhaustion paths; minor redundancy between waitCandidates and primaryWait/secondaryWait is cosmetic only |
| test/preemptive-quota-scheduler.test.ts | adds two targeted regression tests for the new longest-window logic; missing edge case for expired 429 snapshots before prune fires |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getDeferral(key, now)"] --> B{scheduler enabled?}
    B -- no --> Z[defer: false, waitMs: 0]
    B -- yes --> C{snapshot exists?}
    C -- no --> Z
    C -- yes --> D["compute primaryWait = max(0, primary.resetAtMs - now)\ncompute secondaryWait = max(0, secondary.resetAtMs - now)\nlongestWait = max(primaryWait, secondaryWait)"]
    D --> E{status === 429\nAND longestWait > 0?}
    E -- yes --> F["bounded = min(longestWait, maxDeferralMs)\ndefer: true, reason: rate-limit"]
    E -- no --> G{primaryNearExhausted\nOR secondaryNearExhausted?}
    G -- yes --> H["nearExhaustedWait = max(\n  primaryNearExhausted ? primaryWait : 0,\n  secondaryNearExhausted ? secondaryWait : 0\n)"]
    H --> I{nearExhaustedWait > 0?}
    I -- yes --> J["bounded = min(nearExhaustedWait, maxDeferralMs)\ndefer: true, reason: quota-near-exhaustion"]
    I -- no --> Z
    G -- no --> Z
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fpreemptive-quota-scheduler.ts%3A254-258%0A**redundant%20%60waitCandidates%60%20array**%0A%0A%60longestWait%60%20is%20equivalent%20to%20%60Math.max%28primaryWait%2C%20secondaryWait%29%60%20%E2%80%94%20both%20values%20are%20already%20computed%20with%20identical%20semantics%20above.%20the%20%60waitCandidates%60%20intermediate%20array%20and%20the%20second%20%60.filter%28v%20%3D%3E%20v%20%3E%200%29%60%20are%20redundant%20%28the%20first%20filter%20already%20guarantees%20%60v%20%3E%20now%60%2C%20so%20%60v%20-%20now%20%3E%200%60%20is%20always%20true%29.%0A%0A%60%60%60suggestion%0A%09%09const%20longestWait%20%3D%20Math.max%28primaryWait%2C%20secondaryWait%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fpreemptive-quota-scheduler.test.ts%3A63-71%0A**missing%20vitest%20regression%3A%20expired%20429%20cooldown**%0A%0Athere's%20no%20test%20asserting%20%60getDeferral%60%20returns%20%60%7B%20defer%3A%20false%20%7D%60%20once%20both%20reset%20windows%20on%20a%20429%20snapshot%20have%20elapsed%20but%20before%20%60prune%28%29%60%20runs.%20a%20future%20regression%20dropping%20the%20%60%3E%20now%60%20guard%20would%20silently%20defer%20on%20a%20stale%20snapshot%20and%20this%20would%20go%20undetected.%0A%0A%60%60%60ts%0Ait%28%22does%20not%20defer%20after%20429%20reset%20windows%20have%20elapsed%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20const%20scheduler%20%3D%20new%20PreemptiveQuotaScheduler%28%29%3B%0A%20%20scheduler.update%28%22acc%3Amodel%22%2C%20%7B%0A%20%20%20%20status%3A%20429%2C%0A%20%20%20%20primary%3A%20%7B%20resetAtMs%3A%205_000%20%7D%2C%0A%20%20%20%20secondary%3A%20%7B%20resetAtMs%3A%208_000%20%7D%2C%0A%20%20%20%20updatedAt%3A%201_000%2C%0A%20%20%7D%29%3B%0A%20%20%2F%2F%20both%20windows%20are%20now%20in%20the%20past%0A%20%20expect%28scheduler.getDeferral%28%22acc%3Amodel%22%2C%2010_000%29.defer%29.toBe%28false%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/preemptive-quota-scheduler.ts
Line: 254-258

Comment:
**redundant `waitCandidates` array**

`longestWait` is equivalent to `Math.max(primaryWait, secondaryWait)` — both values are already computed with identical semantics above. the `waitCandidates` intermediate array and the second `.filter(v => v > 0)` are redundant (the first filter already guarantees `v > now`, so `v - now > 0` is always true).

```suggestion
		const longestWait = Math.max(primaryWait, secondaryWait);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/preemptive-quota-scheduler.test.ts
Line: 63-71

Comment:
**missing vitest regression: expired 429 cooldown**

there's no test asserting `getDeferral` returns `{ defer: false }` once both reset windows on a 429 snapshot have elapsed but before `prune()` runs. a future regression dropping the `> now` guard would silently defer on a stale snapshot and this would go undetected.

```ts
it("does not defer after 429 reset windows have elapsed", () => {
  const scheduler = new PreemptiveQuotaScheduler();
  scheduler.update("acc:model", {
    status: 429,
    primary: { resetAtMs: 5_000 },
    secondary: { resetAtMs: 8_000 },
    updatedAt: 1_000,
  });
  // both windows are now in the past
  expect(scheduler.getDeferral("acc:model", 10_000).defer).toBe(false);
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop quota scheduler cooldown drift"](https://github.com/ndycode/codex-multi-auth/commit/e70a2ed1a522a0164dcacd8b67f7e2da145ba2ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421743)</sub>

<!-- /greptile_comment -->