### PR TITLE
fix: prevent stale prompt cache session overwrites

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -314,8 +314,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 	let refreshGuardian: RefreshGuardian | null = null;
 	let refreshGuardianConfigKey: string | null = null;
 	let refreshGuardianCleanupRegistered = false;
-	let sessionAffinityStore: SessionAffinityStore | null =
-		new SessionAffinityStore();
+let sessionAffinityStore: SessionAffinityStore | null =
+	new SessionAffinityStore();
+let sessionAffinityWriteVersion = 0;
 	let sessionAffinityConfigKey: string | null = null;
 	const entitlementCache = new EntitlementCache();
 	const preemptiveQuotaScheduler = new PreemptiveQuotaScheduler();
@@ -862,6 +863,8 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 										.trim() || undefined;
 								const sessionAffinityKey =
 									threadIdCandidate ?? promptCacheKey ?? null;
+								const sessionAffinityVersion =
+									(sessionAffinityWriteVersion += 1);
 								const effectivePromptCacheKey =
 									(sessionAffinityKey ?? promptCacheKey ?? "")
 										.toString()
@@ -2273,15 +2276,19 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 												isStreaming,
 												{
 													onResponseId: (responseId) => {
-														if (!responseContinuationEnabled) return;
-														sessionAffinityStore?.remember(
-															sessionAffinityKey,
-															successAccountForResponse.index,
-														);
-														sessionAffinityStore?.updateLastResponseId(
-															sessionAffinityKey,
-															responseId,
-														);
+												if (!responseContinuationEnabled) return;
+												sessionAffinityStore?.rememberWithVersion(
+													sessionAffinityKey,
+													successAccountForResponse.index,
+													Date.now(),
+													sessionAffinityVersion,
+												);
+												sessionAffinityStore?.updateLastResponseId(
+													sessionAffinityKey,
+													responseId,
+													Date.now(),
+													sessionAffinityVersion,
+												);
 														storedResponseIdForSuccess = true;
 													},
 													streamStallTimeoutMs,

--- a/lib/session-affinity.ts
+++ b/lib/session-affinity.ts
@@ -12,6 +12,7 @@ interface SessionAffinityEntry {
 	expiresAt: number;
 	lastResponseId?: string;
 	updatedAt: number;
+	writeVersion: number;
 }
 
 const DEFAULT_TTL_MS = 20 * 60 * 1000;
@@ -62,17 +63,34 @@ export class SessionAffinityStore {
 	}
 
 	remember(sessionKey: string | null | undefined, accountIndex: number, now = Date.now()): void {
+		this.rememberWithVersion(sessionKey, accountIndex, now, now);
+	}
+
+	rememberWithVersion(
+		sessionKey: string | null | undefined,
+		accountIndex: number,
+		now = Date.now(),
+		writeVersion = now,
+	): void {
 		const key = normalizeSessionKey(sessionKey);
 		if (!key) return;
 		if (!Number.isFinite(accountIndex) || accountIndex < 0) return;
 
 		const existingEntry = this.entries.get(key);
+		if (
+			existingEntry &&
+			existingEntry.expiresAt > now &&
+			existingEntry.writeVersion > writeVersion
+		) {
+			return;
+		}
 
 		this.setEntry(key, {
 			accountIndex,
 			expiresAt: now + this.ttlMs,
 			lastResponseId: existingEntry?.lastResponseId,
 			updatedAt: now,
+			writeVersion,
 		});
 	}
 
@@ -110,6 +128,7 @@ export class SessionAffinityStore {
 		sessionKey: string | null | undefined,
 		responseId: string | null | undefined,
 		now = Date.now(),
+		writeVersion = now,
 	): void {
 		const key = normalizeSessionKey(sessionKey);
 		const normalizedResponseId = typeof responseId === "string" ? responseId.trim() : "";
@@ -121,12 +140,16 @@ export class SessionAffinityStore {
 			this.entries.delete(key);
 			return;
 		}
+		if (entry.writeVersion > writeVersion) {
+			return;
+		}
 
 		this.setEntry(key, {
 			...entry,
 			expiresAt: now + this.ttlMs,
 			lastResponseId: normalizedResponseId,
 			updatedAt: now,
+			writeVersion,
 		});
 	}
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1642,7 +1642,7 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 		expect(secondBody?.previous_response_id).toBe("resp_standalone_789");
 	});
 
-	it("keeps account and previous_response_id aligned across overlapping same-session streams", async () => {
+	it("keeps the newest account and previous_response_id across overlapping same-session streams", async () => {
 		const { AccountManager } = await import("../lib/accounts.js");
 		const configModule = await import("../lib/config.js");
 		const fetchHelpers = await import("../lib/request/fetch-helpers.js");
@@ -1748,9 +1748,9 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 			previous_response_id?: string;
 		};
 		const thirdHeaders = new Headers(thirdInit.headers);
-		expect(thirdBody.previous_response_id).toBe("resp_first_123");
-		expect(thirdHeaders.get("x-test-account-id")).toBe("acc-1");
-		expect(thirdHeaders.get("x-test-access-token")).toBe("access-alpha");
+		expect(thirdBody.previous_response_id).toBe("resp_second_456");
+		expect(thirdHeaders.get("x-test-account-id")).toBe("acc-2");
+		expect(thirdHeaders.get("x-test-access-token")).toBe("access-beta");
 	});
 	it("compacts fast-session input before sending the upstream request when compaction succeeds", async () => {
 		const fetchHelpers = await import("../lib/request/fetch-helpers.js");

--- a/test/session-affinity.test.ts
+++ b/test/session-affinity.test.ts
@@ -143,4 +143,18 @@ describe("SessionAffinityStore", () => {
 		expect(store.getLastResponseId("session-a", 3_500)).toBe("resp_123");
 		expect(store.getPreferredAccountIndex("session-a", 3_500)).toBe(2);
 	});
+
+	it("ignores stale response-id writes from older overlapping requests", () => {
+		const store = new SessionAffinityStore({ ttlMs: 10_000, maxEntries: 4 });
+		store.rememberWithVersion("session-a", 1, 1_000, 1);
+		store.updateLastResponseId("session-a", "resp_first", 2_000, 1);
+		store.rememberWithVersion("session-a", 2, 3_000, 2);
+		store.updateLastResponseId("session-a", "resp_second", 4_000, 2);
+
+		store.rememberWithVersion("session-a", 1, 5_000, 1);
+		store.updateLastResponseId("session-a", "resp_stale", 5_000, 1);
+
+		expect(store.getPreferredAccountIndex("session-a", 5_500)).toBe(2);
+		expect(store.getLastResponseId("session-a", 5_500)).toBe("resp_second");
+	});
 });


### PR DESCRIPTION
## Problem

Overlapping requests that share a prompt-cache session can finish out of order.

Before this change, older responses were allowed to overwrite newer session-affinity state, which meant stale `previous_response_id` values and stale preferred-account affinity could win after a newer request had already completed.

## Fix

Version session-affinity writes per request and reject stale writes.

This ensures the newest in-flight request for a session keeps control of both:
- the stored `previous_response_id`
- the preferred account affinity

## Changes

- `lib/session-affinity.ts`
  - add per-entry `writeVersion`
  - add `rememberWithVersion(...)`
  - ignore stale `rememberWithVersion(...)` and `updateLastResponseId(...)` calls
- `index.ts`
  - assign a monotonic per-request session-affinity write version
  - use the versioned session-affinity writes in the response-id callback
- `test/session-affinity.test.ts`
  - add regression coverage for stale overlapping response-id writes being ignored
- `test/index.test.ts`
  - update overlapping same-session stream regression to assert the newest request wins

## Validation

```text
npx vitest run test/session-affinity.test.ts test/index.test.ts
Test Files  2 passed (2)
Tests      131 passed (131)

npx vitest run
Test Files  222 passed (222)
Tests      3314 passed (3314)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this PR fixes stale prompt-cache session overwrites by adding a per-request monotonic `writeVersion` to session-affinity entries and rejecting writes whose version is older than the stored one. the core streaming mechanism is sound and the new regression test validates the primary overlapping-stream scenario.

- **correct**: `rememberWithVersion` and `updateLastResponseId` both guard on `entry.writeVersion > writeVersion`, preventing out-of-order responses from clobbering newer state
- **correct**: `sessionAffinityWriteVersion` at module scope keeps the counter monotonic across plugin config reloads — a reset to `0` would break stale-write prevention
- **correct**: the `test/index.test.ts` overlapping-stream test fires callbacks out-of-order and asserts the newest account and `previous_response_id` win
- **concurrency issue**: `remember()` passes `Date.now()` (~1.7e12) as `writeVersion`, while `onResponseId` uses integer versions (1, 2, 3 …). for non-streaming requests where `responseContinuationEnabled=true` and `onResponseId` never fires, the fallback `remember()` on the success path writes a timestamp-scale version and permanently blocks all subsequent integer-versioned `rememberWithVersion` calls for that session
- **missing coverage**: no vitest test exercises the timestamp-vs-integer version contamination path; the new test at line 147 only covers integer-vs-integer comparisons

<h3>Confidence Score: 3/5</h3>

safe to merge for the streaming path; non-streaming requests with response continuation enabled can permanently freeze session affinity after one response-ID-less response

the primary overlapping-stream bug is correctly fixed and well-tested. however, the mixed integer/timestamp version space is an existing concurrency issue not fully addressed by this PR — one non-streaming response per affected session can permanently poison its versioning, and there is no test covering this path.

lib/session-affinity.ts and the fallback remember() call sites in index.ts (success path around line 2397) need attention for the version-space contamination fix

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/session-affinity.ts | adds writeVersion field and rememberWithVersion/updateLastResponseId versioning — correct for integer-vs-integer comparisons but the numeric field is shared with timestamp-based writes from remember(), creating a mixed version space that can permanently freeze affinity updates |
| index.ts | assigns monotonic sessionAffinityVersion and threads it through onResponseId correctly; fallback remember() calls on success path still use Date.now() as version rather than the per-request integer, creating the contamination path; module-scope declaration is intentional but undocumented |
| test/session-affinity.test.ts | new regression test covers integer-vs-integer stale rejection correctly; missing coverage for timestamp-version contamination from fallback remember() path |
| test/index.test.ts | overlapping same-session stream test updated to fire callbacks out of order and assert newest account+response-id wins — scenario and assertions are correct |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R1 as Request 1 (v=1)
    participant R2 as Request 2 (v=2)
    participant SA as SessionAffinityStore
    participant R3 as Request 3 (v=3)

    R1->>SA: rememberWithVersion(key, acc0, t1, v=1)
    R2->>SA: rememberWithVersion(key, acc1, t2, v=2)
    Note over SA: writeVersion = 2
    SA-->>R2: onResponseId(resp_second) → updateLastResponseId(v=2) ✓
    SA-->>R1: onResponseId(resp_first) → updateLastResponseId(v=1) ✗ stale, rejected
    Note over SA: stored: acc1, resp_second, writeVersion=2 ✅
    Note over R1: non-streaming fallback: remember(key, acc0)
    R1->>SA: rememberWithVersion(key, acc0, now, writeVersion=Date.now()≈1.7e12)
    Note over SA: writeVersion = 1_700_000_000_000 ⚠️
    R3->>SA: rememberWithVersion(key, acc1, t3, v=3)
    Note over SA: 1.7e12 > 3 → REJECTED ❌ affinity frozen
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/session-affinity.ts`, line 127-154 ([link](https://github.com/ndycode/codex-multi-auth/blob/0f3f807e6d81454b1fa865bd6007cd46ce56da23/lib/session-affinity.ts#L127-L154)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **version-space contamination: integer versions permanently lose to timestamp fallback writes**

   `writeVersion` is used as two incompatible things:
   - an integer counter (`sessionAffinityVersion = 1, 2, 3 …`) assigned in the `onResponseId` callback
   - a unix-millisecond timestamp (`Date.now() ≈ 1_700_000_000_000`) assigned by the `remember()` fallback, which calls `rememberWithVersion(key, idx, now, now)`

   the stale guard `entry.writeVersion > writeVersion` (lines 143-145 and 83-85) works correctly when both sides use the same version space — but once a timestamp-versioned entry is stored, every future integer-versioned write is rejected because `1.7e12 >> 3`.

   the contamination path exists today in `index.ts`:
   ```typescript
   if (!responseContinuationEnabled || (!isStreaming && !storedResponseIdForSuccess)) {
       sessionAffinityStore?.remember(sessionAffinityKey, ...);  // writeVersion = Date.now()
   }
   ```
   this fires for **non-streaming requests where `responseContinuationEnabled=true` but `onResponseId` never fires** (`storedResponseIdForSuccess` stays `false`). after that one call, all subsequent `rememberWithVersion(…, sessionAffinityVersion)` writes for that session are silently rejected, freezing the preferred account and response-id indefinitely.

   fix — thread the per-request integer version into the fallback success path in `index.ts`:
   ```typescript
   if (!responseContinuationEnabled || (!isStreaming && !storedResponseIdForSuccess)) {
       sessionAffinityStore?.rememberWithVersion(
           sessionAffinityKey,
           successAccountForResponse.index,
           Date.now(),
           sessionAffinityVersion,  // ← same integer version used in onResponseId
       );
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/session-affinity.ts
   Line: 127-154

   Comment:
   **version-space contamination: integer versions permanently lose to timestamp fallback writes**

   `writeVersion` is used as two incompatible things:
   - an integer counter (`sessionAffinityVersion = 1, 2, 3 …`) assigned in the `onResponseId` callback
   - a unix-millisecond timestamp (`Date.now() ≈ 1_700_000_000_000`) assigned by the `remember()` fallback, which calls `rememberWithVersion(key, idx, now, now)`

   the stale guard `entry.writeVersion > writeVersion` (lines 143-145 and 83-85) works correctly when both sides use the same version space — but once a timestamp-versioned entry is stored, every future integer-versioned write is rejected because `1.7e12 >> 3`.

   the contamination path exists today in `index.ts`:
   ```typescript
   if (!responseContinuationEnabled || (!isStreaming && !storedResponseIdForSuccess)) {
       sessionAffinityStore?.remember(sessionAffinityKey, ...);  // writeVersion = Date.now()
   }
   ```
   this fires for **non-streaming requests where `responseContinuationEnabled=true` but `onResponseId` never fires** (`storedResponseIdForSuccess` stays `false`). after that one call, all subsequent `rememberWithVersion(…, sessionAffinityVersion)` writes for that session are silently rejected, freezing the preferred account and response-id indefinitely.

   fix — thread the per-request integer version into the fallback success path in `index.ts`:
   ```typescript
   if (!responseContinuationEnabled || (!isStreaming && !storedResponseIdForSuccess)) {
       sessionAffinityStore?.rememberWithVersion(
           sessionAffinityKey,
           successAccountForResponse.index,
           Date.now(),
           sessionAffinityVersion,  // ← same integer version used in onResponseId
       );
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fsession-affinity.ts%0ALine%3A%20127-154%0A%0AComment%3A%0A**version-space%20contamination%3A%20integer%20versions%20permanently%20lose%20to%20timestamp%20fallback%20writes**%0A%0A%60writeVersion%60%20is%20used%20as%20two%20incompatible%20things%3A%0A-%20an%20integer%20counter%20%28%60sessionAffinityVersion%20%3D%201%2C%202%2C%203%20%E2%80%A6%60%29%20assigned%20in%20the%20%60onResponseId%60%20callback%0A-%20a%20unix-millisecond%20timestamp%20%28%60Date.now%28%29%20%E2%89%88%201_700_000_000_000%60%29%20assigned%20by%20the%20%60remember%28%29%60%20fallback%2C%20which%20calls%20%60rememberWithVersion%28key%2C%20idx%2C%20now%2C%20now%29%60%0A%0Athe%20stale%20guard%20%60entry.writeVersion%20%3E%20writeVersion%60%20%28lines%20143-145%20and%2083-85%29%20works%20correctly%20when%20both%20sides%20use%20the%20same%20version%20space%20%E2%80%94%20but%20once%20a%20timestamp-versioned%20entry%20is%20stored%2C%20every%20future%20integer-versioned%20write%20is%20rejected%20because%20%601.7e12%20%3E%3E%203%60.%0A%0Athe%20contamination%20path%20exists%20today%20in%20%60index.ts%60%3A%0A%60%60%60typescript%0Aif%20%28!responseContinuationEnabled%20%7C%7C%20%28!isStreaming%20%26%26%20!storedResponseIdForSuccess%29%29%20%7B%0A%20%20%20%20sessionAffinityStore%3F.remember%28sessionAffinityKey%2C%20...%29%3B%20%20%2F%2F%20writeVersion%20%3D%20Date.now%28%29%0A%7D%0A%60%60%60%0Athis%20fires%20for%20**non-streaming%20requests%20where%20%60responseContinuationEnabled%3Dtrue%60%20but%20%60onResponseId%60%20never%20fires**%20%28%60storedResponseIdForSuccess%60%20stays%20%60false%60%29.%20after%20that%20one%20call%2C%20all%20subsequent%20%60rememberWithVersion%28%E2%80%A6%2C%20sessionAffinityVersion%29%60%20writes%20for%20that%20session%20are%20silently%20rejected%2C%20freezing%20the%20preferred%20account%20and%20response-id%20indefinitely.%0A%0Afix%20%E2%80%94%20thread%20the%20per-request%20integer%20version%20into%20the%20fallback%20success%20path%20in%20%60index.ts%60%3A%0A%60%60%60typescript%0Aif%20%28!responseContinuationEnabled%20%7C%7C%20%28!isStreaming%20%26%26%20!storedResponseIdForSuccess%29%29%20%7B%0A%20%20%20%20sessionAffinityStore%3F.rememberWithVersion%28%0A%20%20%20%20%20%20%20%20sessionAffinityKey%2C%0A%20%20%20%20%20%20%20%20successAccountForResponse.index%2C%0A%20%20%20%20%20%20%20%20Date.now%28%29%2C%0A%20%20%20%20%20%20%20%20sessionAffinityVersion%2C%20%20%2F%2F%20%E2%86%90%20same%20integer%20version%20used%20in%20onResponseId%0A%20%20%20%20%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fsession-affinity.ts%3A127-154%0A**version-space%20contamination%3A%20integer%20versions%20permanently%20lose%20to%20timestamp%20fallback%20writes**%0A%0A%60writeVersion%60%20is%20used%20as%20two%20incompatible%20things%3A%0A-%20an%20integer%20counter%20%28%60sessionAffinityVersion%20%3D%201%2C%202%2C%203%20%E2%80%A6%60%29%20assigned%20in%20the%20%60onResponseId%60%20callback%0A-%20a%20unix-millisecond%20timestamp%20%28%60Date.now%28%29%20%E2%89%88%201_700_000_000_000%60%29%20assigned%20by%20the%20%60remember%28%29%60%20fallback%2C%20which%20calls%20%60rememberWithVersion%28key%2C%20idx%2C%20now%2C%20now%29%60%0A%0Athe%20stale%20guard%20%60entry.writeVersion%20%3E%20writeVersion%60%20%28lines%20143-145%20and%2083-85%29%20works%20correctly%20when%20both%20sides%20use%20the%20same%20version%20space%20%E2%80%94%20but%20once%20a%20timestamp-versioned%20entry%20is%20stored%2C%20every%20future%20integer-versioned%20write%20is%20rejected%20because%20%601.7e12%20%3E%3E%203%60.%0A%0Athe%20contamination%20path%20exists%20today%20in%20%60index.ts%60%3A%0A%60%60%60typescript%0Aif%20%28!responseContinuationEnabled%20%7C%7C%20%28!isStreaming%20%26%26%20!storedResponseIdForSuccess%29%29%20%7B%0A%20%20%20%20sessionAffinityStore%3F.remember%28sessionAffinityKey%2C%20...%29%3B%20%20%2F%2F%20writeVersion%20%3D%20Date.now%28%29%0A%7D%0A%60%60%60%0Athis%20fires%20for%20**non-streaming%20requests%20where%20%60responseContinuationEnabled%3Dtrue%60%20but%20%60onResponseId%60%20never%20fires**%20%28%60storedResponseIdForSuccess%60%20stays%20%60false%60%29.%20after%20that%20one%20call%2C%20all%20subsequent%20%60rememberWithVersion%28%E2%80%A6%2C%20sessionAffinityVersion%29%60%20writes%20for%20that%20session%20are%20silently%20rejected%2C%20freezing%20the%20preferred%20account%20and%20response-id%20indefinitely.%0A%0Afix%20%E2%80%94%20thread%20the%20per-request%20integer%20version%20into%20the%20fallback%20success%20path%20in%20%60index.ts%60%3A%0A%60%60%60typescript%0Aif%20%28!responseContinuationEnabled%20%7C%7C%20%28!isStreaming%20%26%26%20!storedResponseIdForSuccess%29%29%20%7B%0A%20%20%20%20sessionAffinityStore%3F.rememberWithVersion%28%0A%20%20%20%20%20%20%20%20sessionAffinityKey%2C%0A%20%20%20%20%20%20%20%20successAccountForResponse.index%2C%0A%20%20%20%20%20%20%20%20Date.now%28%29%2C%0A%20%20%20%20%20%20%20%20sessionAffinityVersion%2C%20%20%2F%2F%20%E2%86%90%20same%20integer%20version%20used%20in%20onResponseId%0A%20%20%20%20%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aindex.ts%3A317-319%0A**%60sessionAffinityWriteVersion%60%20declared%20outside%20the%20plugin%20closure%20%E2%80%94%20document%20the%20intent**%0A%0Alines%20317-319%20have%20zero%20indentation%20while%20every%20other%20per-invocation%20%60let%60%20immediately%20above%20and%20below%20%28310-316%2C%20320%29%20is%20indented%20one%20tab%20inside%20%60OpenAIOAuthPlugin%60.%20%60sessionAffinityWriteVersion%60%20therefore%20lives%20at%20module%20scope%2C%20consistent%20with%20the%20pre-existing%20%60sessionAffinityStore%60.%0A%0Abeing%20at%20module%20scope%20is%20actually%20_correct_%20here%20%E2%80%94%20a%20reset%20to%20%600%60%20on%20each%20plugin%20reload%20would%20cause%20stale%20writes%20from%20pre-reload%20requests%20to%20overwrite%20post-reload%20ones.%20but%20the%20mismatched%20indentation%20makes%20the%20intent%20opaque%20and%20risks%20a%20future%20author%20accidentally%20pulling%20it%20inside%20the%20closure.%20consider%20adding%20a%20short%20comment%3A%0A%60%60%60suggestion%0A%2F%2F%20module-scope%3A%20shared%20across%20plugin%20reloads%20so%20the%20counter%20is%20strictly%0A%2F%2F%20monotonic%20for%20the%20lifetime%20of%20the%20process%20%E2%80%94%20do%20not%20move%20inside%20the%20closure.%0Alet%20sessionAffinityWriteVersion%20%3D%200%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fsession-affinity.test.ts%3A147-159%0A**missing%20vitest%20coverage%3A%20timestamp-version%20contamination%20from%20%60remember%28%29%60%20fallback**%0A%0Athe%20new%20regression%20test%20correctly%20covers%20integer-vs-integer%20stale%20rejection.%20there%20is%20no%20test%20for%20the%20mixed%20version-space%20scenario%20where%20%60remember%28%29%60%20%28timestamp%20version%29%20fires%20for%20a%20session%20that%20already%20has%20or%20will%20receive%20integer-versioned%20writes.%0A%0Asuggested%20additional%20case%3A%0A%60%60%60typescript%0Ait%28'remember%28%29%20timestamp%20version%20does%20not%20block%20subsequent%20rememberWithVersion%28%29%20integer%20writes'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20const%20store%20%3D%20new%20SessionAffinityStore%28%7B%20ttlMs%3A%2010_000%2C%20maxEntries%3A%204%20%7D%29%3B%0A%20%20%20%20%2F%2F%20integer-versioned%20write%20from%20onResponseId%0A%20%20%20%20store.rememberWithVersion%28'session-a'%2C%201%2C%201_000%2C%201%29%3B%0A%20%20%20%20store.updateLastResponseId%28'session-a'%2C%20'resp_first'%2C%202_000%2C%201%29%3B%0A%20%20%20%20%2F%2F%20simulate%20fallback%20remember%28%29%20%E2%80%94%20note%3A%20in%20prod%20writeVersion%20%3D%20Date.now%28%29%20%E2%89%88%201.7e12%0A%20%20%20%20%2F%2F%20use%20a%20large%20value%20to%20reproduce%20the%20contamination%0A%20%20%20%20store.rememberWithVersion%28'session-a'%2C%201%2C%203_000%2C%201_700_000_000_000%29%3B%0A%20%20%20%20%2F%2F%20next%20integer-versioned%20write%20must%20NOT%20be%20rejected%0A%20%20%20%20store.rememberWithVersion%28'session-a'%2C%202%2C%204_000%2C%202%29%3B%0A%20%20%20%20store.updateLastResponseId%28'session-a'%2C%20'resp_second'%2C%205_000%2C%202%29%3B%0A%20%20%20%20expect%28store.getPreferredAccountIndex%28'session-a'%2C%205_500%29%29.toBe%282%29%3B%0A%20%20%20%20expect%28store.getLastResponseId%28'session-a'%2C%205_500%29%29.toBe%28'resp_second'%29%3B%0A%7D%29%3B%0A%60%60%60%0Athis%20test%20will%20fail%20with%20the%20current%20implementation%2C%20confirming%20the%20contamination%20bug.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/session-affinity.ts
Line: 127-154

Comment:
**version-space contamination: integer versions permanently lose to timestamp fallback writes**

`writeVersion` is used as two incompatible things:
- an integer counter (`sessionAffinityVersion = 1, 2, 3 …`) assigned in the `onResponseId` callback
- a unix-millisecond timestamp (`Date.now() ≈ 1_700_000_000_000`) assigned by the `remember()` fallback, which calls `rememberWithVersion(key, idx, now, now)`

the stale guard `entry.writeVersion > writeVersion` (lines 143-145 and 83-85) works correctly when both sides use the same version space — but once a timestamp-versioned entry is stored, every future integer-versioned write is rejected because `1.7e12 >> 3`.

the contamination path exists today in `index.ts`:
```typescript
if (!responseContinuationEnabled || (!isStreaming && !storedResponseIdForSuccess)) {
    sessionAffinityStore?.remember(sessionAffinityKey, ...);  // writeVersion = Date.now()
}
```
this fires for **non-streaming requests where `responseContinuationEnabled=true` but `onResponseId` never fires** (`storedResponseIdForSuccess` stays `false`). after that one call, all subsequent `rememberWithVersion(…, sessionAffinityVersion)` writes for that session are silently rejected, freezing the preferred account and response-id indefinitely.

fix — thread the per-request integer version into the fallback success path in `index.ts`:
```typescript
if (!responseContinuationEnabled || (!isStreaming && !storedResponseIdForSuccess)) {
    sessionAffinityStore?.rememberWithVersion(
        sessionAffinityKey,
        successAccountForResponse.index,
        Date.now(),
        sessionAffinityVersion,  // ← same integer version used in onResponseId
    );
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: index.ts
Line: 317-319

Comment:
**`sessionAffinityWriteVersion` declared outside the plugin closure — document the intent**

lines 317-319 have zero indentation while every other per-invocation `let` immediately above and below (310-316, 320) is indented one tab inside `OpenAIOAuthPlugin`. `sessionAffinityWriteVersion` therefore lives at module scope, consistent with the pre-existing `sessionAffinityStore`.

being at module scope is actually _correct_ here — a reset to `0` on each plugin reload would cause stale writes from pre-reload requests to overwrite post-reload ones. but the mismatched indentation makes the intent opaque and risks a future author accidentally pulling it inside the closure. consider adding a short comment:
```suggestion
// module-scope: shared across plugin reloads so the counter is strictly
// monotonic for the lifetime of the process — do not move inside the closure.
let sessionAffinityWriteVersion = 0;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/session-affinity.test.ts
Line: 147-159

Comment:
**missing vitest coverage: timestamp-version contamination from `remember()` fallback**

the new regression test correctly covers integer-vs-integer stale rejection. there is no test for the mixed version-space scenario where `remember()` (timestamp version) fires for a session that already has or will receive integer-versioned writes.

suggested additional case:
```typescript
it('remember() timestamp version does not block subsequent rememberWithVersion() integer writes', () => {
    const store = new SessionAffinityStore({ ttlMs: 10_000, maxEntries: 4 });
    // integer-versioned write from onResponseId
    store.rememberWithVersion('session-a', 1, 1_000, 1);
    store.updateLastResponseId('session-a', 'resp_first', 2_000, 1);
    // simulate fallback remember() — note: in prod writeVersion = Date.now() ≈ 1.7e12
    // use a large value to reproduce the contamination
    store.rememberWithVersion('session-a', 1, 3_000, 1_700_000_000_000);
    // next integer-versioned write must NOT be rejected
    store.rememberWithVersion('session-a', 2, 4_000, 2);
    store.updateLastResponseId('session-a', 'resp_second', 5_000, 2);
    expect(store.getPreferredAccountIndex('session-a', 5_500)).toBe(2);
    expect(store.getLastResponseId('session-a', 5_500)).toBe('resp_second');
});
```
this test will fail with the current implementation, confirming the contamination bug.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent stale prompt cache session ..."](https://github.com/ndycode/codex-multi-auth/commit/0f3f807e6d81454b1fa865bd6007cd46ce56da23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27421931)</sub>

<!-- /greptile_comment -->