### PR TITLE
fix: serialize concurrent runtime cache writes

### DIFF
--- a/lib/auto-update-checker.ts
+++ b/lib/auto-update-checker.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "./logger.js";
 import { getCodexCacheDir } from "./runtime-paths.js";
@@ -28,6 +28,7 @@ interface ParsedSemver {
 }
 
 const RETRYABLE_WRITE_ERRORS = new Set(["EBUSY", "EPERM"]);
+let updateCacheWriteQueue: Promise<void> = Promise.resolve();
 
 function sleepSync(ms: number): void {
   const delay = Math.max(0, Math.floor(ms));
@@ -56,30 +57,53 @@ function loadCache(): UpdateCheckCache | null {
   }
 }
 
-function saveCache(cache: UpdateCheckCache): void {
-  try {
-    if (!existsSync(CACHE_DIR)) {
-      mkdirSync(CACHE_DIR, { recursive: true });
-    }
-    const serialized = JSON.stringify(cache, null, 2);
-    let lastError: Error | null = null;
-    for (let attempt = 0; attempt < 4; attempt++) {
-      try {
-        writeFileSync(CACHE_FILE, serialized, "utf8");
-        return;
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code ?? "";
-        lastError = error as Error;
-        if (!RETRYABLE_WRITE_ERRORS.has(code) || attempt >= 3) {
-          throw error;
-        }
-        sleepSync(15 * (2 ** attempt));
-      }
-    }
-    if (lastError) throw lastError;
-  } catch (error) {
-    log.warn("Failed to save update cache", { error: (error as Error).message });
-  }
+async function saveCache(cache: UpdateCheckCache): Promise<void> {
+	const writeTask = (): void => {
+		let tempPath: string | null = null;
+		let wroteTemp = false;
+		try {
+			if (!existsSync(CACHE_DIR)) {
+				mkdirSync(CACHE_DIR, { recursive: true });
+			}
+			const serialized = JSON.stringify(cache, null, 2);
+			tempPath = `${CACHE_FILE}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+			let lastError: Error | null = null;
+			for (let attempt = 0; attempt < 4; attempt++) {
+				try {
+					writeFileSync(tempPath, serialized, "utf8");
+					renameSync(tempPath, CACHE_FILE);
+					wroteTemp = false;
+					return;
+				} catch (error) {
+					const code = (error as NodeJS.ErrnoException).code ?? "";
+					lastError = error as Error;
+					wroteTemp = true;
+					if (!RETRYABLE_WRITE_ERRORS.has(code) || attempt >= 3) {
+						throw error;
+					}
+					sleepSync(15 * (2 ** attempt));
+				}
+			}
+			if (lastError) throw lastError;
+		} catch (error) {
+			log.warn("Failed to save update cache", { error: (error as Error).message });
+		} finally {
+			if (wroteTemp && tempPath) {
+				try {
+					unlinkSync(tempPath);
+				} catch {
+					// Best effort temp cleanup.
+				}
+			}
+		}
+	};
+
+	const queued = updateCacheWriteQueue.catch(() => undefined).then(writeTask);
+	updateCacheWriteQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	await queued;
 }
 
 function parseSemver(version: string): ParsedSemver {
@@ -211,11 +235,11 @@ export async function checkForUpdates(force = false): Promise<UpdateCheckResult>
 
   const latestVersion = await fetchLatestVersion();
 
-  saveCache({
-    lastCheck: now,
-    latestVersion,
-    currentVersion,
-  });
+	await saveCache({
+		lastCheck: now,
+		latestVersion,
+		currentVersion,
+	});
 
   const hasUpdate = latestVersion ? compareVersions(currentVersion, latestVersion) > 0 : false;
 

--- a/lib/quota-cache.ts
+++ b/lib/quota-cache.ts
@@ -33,6 +33,7 @@ interface QuotaCacheFile {
 const QUOTA_CACHE_PATH = join(getCodexMultiAuthDir(), "quota-cache.json");
 const QUOTA_CACHE_LABEL = basename(QUOTA_CACHE_PATH);
 const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+let quotaCacheWriteQueue: Promise<void> = Promise.resolve();
 
 function isRetryableFsError(error: unknown): boolean {
 	const code = (error as NodeJS.ErrnoException | undefined)?.code;
@@ -223,39 +224,48 @@ export async function saveQuotaCache(data: QuotaCacheData): Promise<void> {
 		byEmail: data.byEmail,
 	};
 
-	try {
-		await fs.mkdir(getCodexMultiAuthDir(), { recursive: true });
-		const tempPath = `${QUOTA_CACHE_PATH}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
-		await fs.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, {
-			encoding: "utf8",
-			mode: 0o600,
-		});
-		let renamed = false;
+	const writeTask = async (): Promise<void> => {
 		try {
-			for (let attempt = 0; attempt < 5; attempt += 1) {
-				try {
-					await fs.rename(tempPath, QUOTA_CACHE_PATH);
-					renamed = true;
-					break;
-				} catch (error) {
-					if (!isRetryableFsError(error) || attempt >= 4) throw error;
-					await sleep(10 * 2 ** attempt);
+			await fs.mkdir(getCodexMultiAuthDir(), { recursive: true });
+			const tempPath = `${QUOTA_CACHE_PATH}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+			await fs.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, {
+				encoding: "utf8",
+				mode: 0o600,
+			});
+			let renamed = false;
+			try {
+				for (let attempt = 0; attempt < 5; attempt += 1) {
+					try {
+						await fs.rename(tempPath, QUOTA_CACHE_PATH);
+						renamed = true;
+						break;
+					} catch (error) {
+						if (!isRetryableFsError(error) || attempt >= 4) throw error;
+						await sleep(10 * 2 ** attempt);
+					}
+				}
+			} finally {
+				if (!renamed) {
+					try {
+						await fs.unlink(tempPath);
+					} catch {
+						// Best effort temp cleanup.
+					}
 				}
 			}
-		} finally {
-			if (!renamed) {
-				try {
-					await fs.unlink(tempPath);
-				} catch {
-					// Best effort temp cleanup.
-				}
-			}
+		} catch (error) {
+			logWarn(
+				`Failed to save quota cache to ${QUOTA_CACHE_LABEL}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
 		}
-	} catch (error) {
-		logWarn(
-			`Failed to save quota cache to ${QUOTA_CACHE_LABEL}: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
-	}
+	};
+
+	const queued = quotaCacheWriteQueue.catch(() => undefined).then(writeTask);
+	quotaCacheWriteQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	await queued;
 }

--- a/test/auto-update-checker.test.ts
+++ b/test/auto-update-checker.test.ts
@@ -5,6 +5,8 @@ vi.mock("node:fs", () => ({
 	writeFileSync: vi.fn(),
 	existsSync: vi.fn(),
 	mkdirSync: vi.fn(),
+	renameSync: vi.fn(),
+	unlinkSync: vi.fn(),
 }));
 
 describe("auto-update-checker", () => {
@@ -358,11 +360,13 @@ describe("auto-update-checker", () => {
 			await checkForUpdates(true);
 
 			expect(fs.writeFileSync).toHaveBeenCalled();
+			expect(fs.renameSync).toHaveBeenCalled();
 			const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
 			const savedData = JSON.parse(writeCall[1] as string) as {
 				latestVersion: string;
 			};
 			expect(savedData.latestVersion).toBe("5.0.0");
+			expect(String(writeCall[0])).toContain("update-check-cache.json.");
 		});
 
 		it("creates cache directory if missing", async () => {
@@ -383,8 +387,8 @@ describe("auto-update-checker", () => {
 			"retries cache writes when filesystem is transiently locked (%s)",
 			async (code) => {
 			let attempts = 0;
-			vi.mocked(fs.writeFileSync).mockClear();
-			vi.mocked(fs.writeFileSync).mockImplementation(() => {
+			vi.mocked(fs.renameSync).mockClear();
+			vi.mocked(fs.renameSync).mockImplementation(() => {
 				attempts += 1;
 				if (attempts < 3) {
 					const error = new Error("busy") as NodeJS.ErrnoException;
@@ -400,9 +404,35 @@ describe("auto-update-checker", () => {
 
 			await checkForUpdates(true);
 
-			expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+			expect(fs.renameSync).toHaveBeenCalledTimes(3);
 			},
 		);
+
+		it("serializes concurrent cache writes through temp-file renames", async () => {
+			vi.mocked(fs.writeFileSync).mockClear();
+			vi.mocked(fs.renameSync).mockClear();
+			vi.mocked(globalThis.fetch)
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({ version: "5.0.0" }),
+				} as Response)
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({ version: "5.0.1" }),
+				} as Response);
+
+			await Promise.all([checkForUpdates(true), checkForUpdates(true)]);
+
+			expect(fs.renameSync).toHaveBeenCalledTimes(2);
+			const writeTargets = vi
+				.mocked(fs.writeFileSync)
+				.mock.calls.map((call) => String(call[0]));
+			expect(
+				writeTargets.every((target) =>
+					target.includes("update-check-cache.json."),
+				),
+			).toBe(true);
+		});
 
 		it("includes updateCommand in result", async () => {
 			vi.mocked(globalThis.fetch).mockResolvedValue({


### PR DESCRIPTION
## Problem

Multiple runtime cache writers could overlap within the same process.

- `quota-cache` already used temp-file renames, but concurrent saves still raced logically.
- `auto-update-checker` wrote directly to the final cache file, so concurrent writes had a higher corruption risk.

## Fix

Serialize in-process cache writes and make update-check cache writes atomic.

## Changes

- `lib/quota-cache.ts`
  - added an in-process write queue for `saveQuotaCache()`
  - retained temp-file + rename behavior, but now writes are serialized per process
- `lib/auto-update-checker.ts`
  - made cache saves queued and atomic via temp-file rename
  - kept retry behavior for transient `EBUSY` / `EPERM` failures
  - added best-effort temp cleanup on failed writes
- `test/auto-update-checker.test.ts`
  - updated expectations for temp-file + rename persistence
  - added concurrency coverage for concurrent cache writes

## Validation

```text
npx vitest run test/quota-cache.test.ts test/auto-update-checker.test.ts
Test Files  2 passed (2)
Tests      47 passed (47)

npx vitest run
Test Files  222 passed (222)
Tests      3314 passed (3314)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

serializes in-process cache writes for both `quota-cache` and `auto-update-checker` using a module-level promise queue with temp-file + rename for atomicity. the `quota-cache` refactor is clean. `auto-update-checker` has two minor gaps: `clearUpdateCache` bypasses the new queue (a queued rename can silently undo a clear), and the new code uses tabs while the rest of the file uses spaces.

<h3>Confidence Score: 4/5</h3>

safe to merge after addressing the clearUpdateCache queue bypass and fixing mixed indentation

the core serialization logic is correct and well-tested; the P2 gap in clearUpdateCache is a real behavioral issue (a stale rename can silently undo a clear) but unlikely to be triggered in normal use — still worth fixing before merge per the PR's explicit serialization goal

lib/auto-update-checker.ts — clearUpdateCache queue bypass and mixed tabs/spaces indentation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/auto-update-checker.ts | makes saveCache async with temp-file rename and write queue; clearUpdateCache still bypasses the queue and mixed tabs/spaces indentation introduced |
| lib/quota-cache.ts | cleanly wraps writeTask in a module-level write queue; payload captured correctly per closure; async retries preserved |
| test/auto-update-checker.test.ts | mocks updated for renameSync/unlinkSync; new concurrency test verifies two sequential renames through separate temp paths |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2
    participant Q as writeQueue
    participant FS as Filesystem

    C1->>Q: saveCache() → enqueue writeTask1
    C2->>Q: saveCache() → enqueue writeTask2
    Q->>FS: writeFileSync(tempPath1)
    Q->>FS: renameSync(tempPath1 → CACHE_FILE)
    Q->>FS: writeFileSync(tempPath2)
    Q->>FS: renameSync(tempPath2 → CACHE_FILE)
    note over FS: writes serialized,\neach atomic via rename

    note over C1,FS: clearUpdateCache() bypasses Q
    C1->>FS: writeFileSync(CACHE_FILE, '{}')
    Q-->>FS: renameSync(tempPath → CACHE_FILE) races ↑
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/auto-update-checker.ts`, line 276-284 ([link](https://github.com/ndycode/codex-multi-auth/blob/77637f4f1645b46fa0aec31c2ec0584de262d1db/lib/auto-update-checker.ts#L276-L284)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`clearUpdateCache` bypasses the write queue**

   `clearUpdateCache` writes directly to `CACHE_FILE` without going through `updateCacheWriteQueue`. if a queued `saveCache` task has already written its temp file but hasn't yet called `renameSync`, `clearUpdateCache` writes `{}` to the final path — then the pending `renameSync` immediately overwrites it with stale data, silently undoing the clear. routing through the queue would fix this:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/auto-update-checker.ts
   Line: 276-284

   Comment:
   **`clearUpdateCache` bypasses the write queue**

   `clearUpdateCache` writes directly to `CACHE_FILE` without going through `updateCacheWriteQueue`. if a queued `saveCache` task has already written its temp file but hasn't yet called `renameSync`, `clearUpdateCache` writes `{}` to the final path — then the pending `renameSync` immediately overwrites it with stale data, silently undoing the clear. routing through the queue would fix this:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fauto-update-checker.ts%0ALine%3A%20276-284%0A%0AComment%3A%0A**%60clearUpdateCache%60%20bypasses%20the%20write%20queue**%0A%0A%60clearUpdateCache%60%20writes%20directly%20to%20%60CACHE_FILE%60%20without%20going%20through%20%60updateCacheWriteQueue%60.%20if%20a%20queued%20%60saveCache%60%20task%20has%20already%20written%20its%20temp%20file%20but%20hasn't%20yet%20called%20%60renameSync%60%2C%20%60clearUpdateCache%60%20writes%20%60%7B%7D%60%20to%20the%20final%20path%20%E2%80%94%20then%20the%20pending%20%60renameSync%60%20immediately%20overwrites%20it%20with%20stale%20data%2C%20silently%20undoing%20the%20clear.%20routing%20through%20the%20queue%20would%20fix%20this%3A%0A%0A%60%60%60suggestion%0Aexport%20function%20clearUpdateCache%28%29%3A%20void%20%7B%0A%20%20const%20current%20%3D%20updateCacheWriteQueue.catch%28%28%29%20%3D%3E%20undefined%29%3B%0A%20%20updateCacheWriteQueue%20%3D%20current.then%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20if%20%28existsSync%28CACHE_FILE%29%29%20%7B%0A%20%20%20%20%20%20%20%20writeFileSync%28CACHE_FILE%2C%20%22%7B%7D%22%2C%20%22utf8%22%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%2F%2F%20Ignore%20errors%0A%20%20%20%20%7D%0A%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fauto-update-checker.ts%3A276-284%0A**%60clearUpdateCache%60%20bypasses%20the%20write%20queue**%0A%0A%60clearUpdateCache%60%20writes%20directly%20to%20%60CACHE_FILE%60%20without%20going%20through%20%60updateCacheWriteQueue%60.%20if%20a%20queued%20%60saveCache%60%20task%20has%20already%20written%20its%20temp%20file%20but%20hasn't%20yet%20called%20%60renameSync%60%2C%20%60clearUpdateCache%60%20writes%20%60%7B%7D%60%20to%20the%20final%20path%20%E2%80%94%20then%20the%20pending%20%60renameSync%60%20immediately%20overwrites%20it%20with%20stale%20data%2C%20silently%20undoing%20the%20clear.%20routing%20through%20the%20queue%20would%20fix%20this%3A%0A%0A%60%60%60suggestion%0Aexport%20function%20clearUpdateCache%28%29%3A%20void%20%7B%0A%20%20const%20current%20%3D%20updateCacheWriteQueue.catch%28%28%29%20%3D%3E%20undefined%29%3B%0A%20%20updateCacheWriteQueue%20%3D%20current.then%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20if%20%28existsSync%28CACHE_FILE%29%29%20%7B%0A%20%20%20%20%20%20%20%20writeFileSync%28CACHE_FILE%2C%20%22%7B%7D%22%2C%20%22utf8%22%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%2F%2F%20Ignore%20errors%0A%20%20%20%20%7D%0A%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fauto-update-checker.ts%3A60-107%0A**mixed%20indentation%20%28tabs%20vs%20spaces%29**%0A%0Athe%20new%20%60saveCache%60%20body%20and%20the%20%60await%20saveCache%28...%29%60%20block%20at%20lines%20238%E2%80%93242%20use%20tabs%2C%20while%20the%20rest%20of%20the%20file%20uses%202-space%20indentation.%20this%20breaks%20the%20file's%20consistent%20style%20and%20will%20show%20up%20as%20noisy%20diffs%20in%20editors%20configured%20for%20spaces.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fauto-update-checker.ts%3A84%0A**%60sleepSync%60%20blocks%20the%20event%20loop%20on%20windows**%0A%0A%60sleepSync%60%20uses%20%60Atomics.wait%60%20on%20the%20main%20thread%20%E2%80%94%20on%20windows%20where%20%60EBUSY%60%2F%60EPERM%60%20is%20common%2C%20retries%20can%20block%20for%20up%20to%20%6015%20%2B%2030%20%2B%2060%20%3D%20105%20ms%60%20per%20queued%20save.%20all%20subsequent%20queued%20saves%20stall%20during%20that%20window.%20%60quota-cache.ts%60%20already%20uses%20async%20%60sleep%28%29%60%20for%20its%20retries%3B%20aligning%20%60writeTask%60%20to%20be%20fully%20async%20would%20remove%20this%20risk%20and%20match%20the%20pattern%20used%20next%20door.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/auto-update-checker.ts
Line: 276-284

Comment:
**`clearUpdateCache` bypasses the write queue**

`clearUpdateCache` writes directly to `CACHE_FILE` without going through `updateCacheWriteQueue`. if a queued `saveCache` task has already written its temp file but hasn't yet called `renameSync`, `clearUpdateCache` writes `{}` to the final path — then the pending `renameSync` immediately overwrites it with stale data, silently undoing the clear. routing through the queue would fix this:

```suggestion
export function clearUpdateCache(): void {
  const current = updateCacheWriteQueue.catch(() => undefined);
  updateCacheWriteQueue = current.then(() => {
    try {
      if (existsSync(CACHE_FILE)) {
        writeFileSync(CACHE_FILE, "{}", "utf8");
      }
    } catch {
      // Ignore errors
    }
  });
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/auto-update-checker.ts
Line: 60-107

Comment:
**mixed indentation (tabs vs spaces)**

the new `saveCache` body and the `await saveCache(...)` block at lines 238–242 use tabs, while the rest of the file uses 2-space indentation. this breaks the file's consistent style and will show up as noisy diffs in editors configured for spaces.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/auto-update-checker.ts
Line: 84

Comment:
**`sleepSync` blocks the event loop on windows**

`sleepSync` uses `Atomics.wait` on the main thread — on windows where `EBUSY`/`EPERM` is common, retries can block for up to `15 + 30 + 60 = 105 ms` per queued save. all subsequent queued saves stall during that window. `quota-cache.ts` already uses async `sleep()` for its retries; aligning `writeTask` to be fully async would remove this risk and match the pattern used next door.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: serialize concurrent runtime cache ..."](https://github.com/ndycode/codex-multi-auth/commit/77637f4f1645b46fa0aec31c2ec0584de262d1db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27422224)</sub>

<!-- /greptile_comment -->