### PR TITLE
fix: add jitter to rate-limit backoff

### DIFF
--- a/lib/request/rate-limit-backoff.ts
+++ b/lib/request/rate-limit-backoff.ts
@@ -17,6 +17,7 @@ export interface RateLimitBackoffResult {
 const RATE_LIMIT_DEDUP_WINDOW_MS = 2000;
 const RATE_LIMIT_STATE_RESET_MS = 120_000;
 const MAX_BACKOFF_MS = 60_000;
+const RATE_LIMIT_BACKOFF_JITTER_FACTOR = 0.2;
 
 export const RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS = 5000;
 
@@ -24,6 +25,7 @@ interface RateLimitState {
 	consecutive429: number;
 	lastAt: number;
 	quotaKey: string;
+	lastDelayMs: number;
 }
 
 const rateLimitStateByAccountQuota = new Map<string, RateLimitState>();
@@ -31,6 +33,11 @@ const rateLimitStateByAccountQuota = new Map<string, RateLimitState>();
 function normalizeDelayMs(value: number | null | undefined, fallback: number): number {
 	const candidate = typeof value === "number" && Number.isFinite(value) ? value : fallback;
 	return Math.max(0, Math.floor(candidate));
+}
+
+function addBackoffJitter(baseMs: number): number {
+	const jitter = baseMs * RATE_LIMIT_BACKOFF_JITTER_FACTOR * (Math.random() * 2 - 1);
+	return Math.max(0, Math.floor(baseMs + jitter));
 }
 
 function pruneStaleRateLimitState(): void {
@@ -58,13 +65,9 @@ export function getRateLimitBackoff(
 	const baseDelay = normalizeDelayMs(serverRetryAfterMs, 1000);
 
 	if (previous && now - previous.lastAt < RATE_LIMIT_DEDUP_WINDOW_MS) {
-		const backoffDelay = Math.min(
-			baseDelay * Math.pow(2, previous.consecutive429 - 1),
-			MAX_BACKOFF_MS,
-		);
 		return {
 			attempt: previous.consecutive429,
-			delayMs: Math.max(baseDelay, backoffDelay),
+			delayMs: previous.lastDelayMs,
 			isDuplicate: true,
 		};
 	}
@@ -74,16 +77,18 @@ export function getRateLimitBackoff(
 			? previous.consecutive429 + 1
 			: 1;
 
+	const backoffDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), MAX_BACKOFF_MS);
+	const jitteredDelay = Math.min(addBackoffJitter(backoffDelay), MAX_BACKOFF_MS);
+	const delayMs = Math.max(baseDelay, jitteredDelay);
 	rateLimitStateByAccountQuota.set(stateKey, {
 		consecutive429: attempt,
 		lastAt: now,
 		quotaKey,
+		lastDelayMs: delayMs,
 	});
-
-	const backoffDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), MAX_BACKOFF_MS);
 	return {
 		attempt,
-		delayMs: Math.max(baseDelay, backoffDelay),
+		delayMs,
 		isDuplicate: false,
 	};
 }

--- a/test/rate-limit-backoff.test.ts
+++ b/test/rate-limit-backoff.test.ts
@@ -12,10 +12,12 @@ describe("Rate limit backoff", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(0));
 		clearRateLimitBackoffState();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
 	});
 
 	afterEach(() => {
 		clearRateLimitBackoffState();
+		vi.restoreAllMocks();
 		vi.useRealTimers();
 	});
 
@@ -36,6 +38,24 @@ describe("Rate limit backoff", () => {
 		const second = getRateLimitBackoff(0, "codex", 1000);
 		expect(second.attempt).toBe(2);
 		expect(second.delayMs).toBe(2000);
+		expect(second.isDuplicate).toBe(false);
+	});
+
+	it("applies jitter to new backoff windows but keeps duplicate retries stable", () => {
+		vi.mocked(Math.random).mockReturnValueOnce(1);
+		const first = getRateLimitBackoff(4, "jitter-test", 1000);
+		expect(first.delayMs).toBe(1200);
+
+		vi.setSystemTime(new Date(1000));
+		vi.mocked(Math.random).mockReturnValueOnce(0);
+		const duplicate = getRateLimitBackoff(4, "jitter-test", 1000);
+		expect(duplicate.delayMs).toBe(1200);
+		expect(duplicate.isDuplicate).toBe(true);
+
+		vi.setSystemTime(new Date(2500));
+		vi.mocked(Math.random).mockReturnValueOnce(0);
+		const second = getRateLimitBackoff(4, "jitter-test", 1000);
+		expect(second.delayMs).toBe(1600);
 		expect(second.isDuplicate).toBe(false);
 	});
 


### PR DESCRIPTION
## Problem

The runtime 429 backoff was purely exponential.

That means multiple clients or parallel workers can retry in lockstep after the same upstream rate limit window, creating avoidable bursts.

## Fix

Add bounded jitter when a new rate-limit backoff window is created.

Duplicate 429s inside the dedup window continue to reuse the same stored delay so a single retry window stays stable instead of being re-randomized on every duplicate response.

## Changes

- `lib/request/rate-limit-backoff.ts`
  - add bounded jitter for new backoff windows
  - store the most recent jittered delay in state
  - return the stored delay for duplicate 429s inside the dedup window
- `test/rate-limit-backoff.test.ts`
  - make the suite deterministic by mocking `Math.random()` to the neutral midpoint
  - add regression coverage for jittered first attempts and stable duplicate delays

## Validation

```text
npx vitest run test/rate-limit-backoff.test.ts
Test Files  1 passed (1)
Tests      25 passed (25)

npx vitest run
Test Files  222 passed (222)
Tests      3314 passed (3314)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds bounded ±20% jitter to the exponential rate-limit backoff in `lib/request/rate-limit-backoff.ts` and stores the jittered delay on state so duplicate 429s within the dedup window return the same stable value instead of recomputing.

**key changes:**
- `addBackoffJitter(baseMs)` applies ±20% of `baseMs` using `Math.random() * 2 - 1`
- `RateLimitState` gains `lastDelayMs` to cache the jittered delay
- duplicate returns now read `previous.lastDelayMs` instead of recalculating
- `Math.random()` is globally mocked to `0.5` in tests for determinism; a new regression test covers jittered-first and stable-duplicate paths

**issues found:**
- negative jitter is silently suppressed for attempt=1: `backoffDelay === baseDelay` on the first 429, so `Math.max(baseDelay, jitteredDelay)` clamps any downward jitter to zero. the effective spread for attempt=1 is `[baseDelay, baseDelay*1.2]`, not the symmetric ±20% the constant implies
- missing vitest branch: no test exercises attempt=1 with `Math.random()=0` to confirm the floor behaviour is intentional
- `mockReturnValueOnce(1)` tests an unreachable `Math.random()` value (`[0,1)` never includes 1); maximum achievable is ~0.9999
- no test exercises non-neutral jitter through `getRateLimitBackoffWithReason`, leaving the compounded effect of jitter + `calculateBackoffMs` untested

<h3>Confidence Score: 3/5</h3>

safe to merge with low risk — logic change is narrow, 25 tests pass, but asymmetric attempt=1 jitter partially defeats the stated anti-thundering-herd goal and missing branches leave the floor behaviour undocumented

core backoff logic is correct, the dedup path is stable, and no concurrency issues are introduced (getRateLimitBackoff is synchronous, module-level Map is fine under Node.js single-thread model). score is 3 rather than 4 because the one-sided jitter on attempt=1 (the most common 429 case) quietly reduces spreading effectiveness, the missing vitest branches conflict with the project's 80%+ coverage requirement, and the test uses Math.random()=1 which is an unreachable value in production

lib/request/rate-limit-backoff.ts line 82 (Math.max floor asymmetry for attempt=1) and test/rate-limit-backoff.test.ts (missing attempt=1 negative-jitter branch and non-neutral jitter through getRateLimitBackoffWithReason)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/rate-limit-backoff.ts | adds bounded ±20% jitter to new backoff windows and stores last delay for stable duplicate returns; jitter is asymmetrically suppressed for attempt=1 due to Math.max(baseDelay, jitteredDelay) floor — only upward jitter applies on first 429 |
| test/rate-limit-backoff.test.ts | adds global Math.random mock (0.5 neutral) and a new jitter regression case, but misses attempt=1 with negative jitter, uses an unreachable Math.random()=1 value, and lacks non-neutral jitter coverage through getRateLimitBackoffWithReason |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getRateLimitBackoff called] --> B[pruneStaleRateLimitState]
    B --> C{previous state\nexists?}
    C -->|yes| D{now - lastAt\n< DEDUP_WINDOW 2s?}
    D -->|yes - isDuplicate| E[return previous.lastDelayMs\nisDuplicate: true]
    D -->|no| F{now - lastAt\n< RESET_MS 120s?}
    F -->|yes| G[attempt = consecutive429 + 1]
    F -->|no| H[attempt = 1]
    C -->|no| H
    G --> I[backoffDelay = min baseDelay × 2^attempt-1, MAX_60s]
    H --> I
    I --> J[addBackoffJitter\nbaseMs ± 20% via Math.random]
    J --> K[jitteredDelay = min jittered, MAX_60s]
    K --> L{jitteredDelay\n< baseDelay?}
    L -->|yes — suppressed on attempt=1| M[delayMs = baseDelay]
    L -->|no| N[delayMs = jitteredDelay]
    M --> O[store lastDelayMs in state]
    N --> O
    O --> P[return delayMs\nisDuplicate: false]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Frequest%2Frate-limit-backoff.ts%3A80-82%0A**negative%20jitter%20silently%20discarded%20on%20attempt%3D1**%0A%0Afor%20attempt%3D1%2C%20%60backoffDelay%20%3D%3D%3D%20baseDelay%60.%20if%20%60Math.random%28%29%60%20returns%20a%20value%20below%20%600.5%60%2C%20%60jitteredDelay%20%3C%20baseDelay%60%2C%20and%20the%20%60Math.max%60%20floor%20restores%20it%20to%20%60baseDelay%60%20%E2%80%94%20so%20downward%20jitter%20has%20no%20effect%20on%20the%20first%20429.%20the%20effective%20spread%20is%20%60%5BbaseDelay%2C%20baseDelay%C3%971.2%5D%60%20%28one-sided%20upward%29%2C%20not%20the%20symmetric%20%60%C2%B120%25%60%20the%20constant%20implies.%0A%0Athis%20is%20the%20most%20common%20429%20case%2C%20so%20the%20anti-thundering-herd%20goal%20stated%20in%20the%20PR%20description%20is%20only%20half-realised%20for%20first%20retries.%20attempt%3D2%2B%20are%20unaffected%20because%20%60backoffDelay%20%3E%3E%20baseDelay%60%20and%20symmetric%20jitter%20applies.%0A%0Aif%20the%20%60Math.max%60%20floor%20is%20intentional%20%28to%20honour%20the%20server-sent%20%60Retry-After%60%20as%20a%20hard%20minimum%29%2C%20add%20a%20comment%3A%0A%0A%60%60%60suggestion%0A%09const%20backoffDelay%20%3D%20Math.min%28baseDelay%20*%20Math.pow%282%2C%20attempt%20-%201%29%2C%20MAX_BACKOFF_MS%29%3B%0A%09const%20jitteredDelay%20%3D%20Math.min%28addBackoffJitter%28backoffDelay%29%2C%20MAX_BACKOFF_MS%29%3B%0A%09%2F%2F%20Math.max%20honours%20server%20Retry-After%20as%20a%20hard%20floor%3B%20on%20attempt%3D1%20this%20makes%20jitter%20one-sided%20%28upward%20only%29%0A%09const%20delayMs%20%3D%20Math.max%28baseDelay%2C%20jitteredDelay%29%3B%0A%60%60%60%0A%0Aor%20remove%20the%20floor%20to%20get%20symmetric%20spread%3A%0A%0A%60%60%60typescript%0Aconst%20delayMs%20%3D%20Math.max%280%2C%20jitteredDelay%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Frate-limit-backoff.test.ts%3A44-60%0A**missing%20vitest%20branch%3A%20attempt%3D1%20with%20maximum%20negative%20jitter**%0A%0Athe%20new%20test%20only%20mocks%20%60Math.random%28%29%60%20to%20%601%60%20for%20attempt%3D1%20%28maximum%20positive%20jitter%20%E2%86%92%20%601200ms%60%29.%20two%20gaps%3A%0A%0A1.%20%60mockReturnValueOnce%281%29%60%20is%20unreachable%20in%20production%20%E2%80%94%20%60Math.random%28%29%60%20returns%20%60%5B0%2C%201%29%60%2C%20so%201%20is%20never%20produced.%20the%20assertion%20%601200%60%20is%20therefore%20a%20value%20that%20can%20never%20actually%20occur.%20use%20%600.999%60%20or%20similar%20to%20stay%20within%20the%20real%20range.%0A%0A2.%20there%20is%20no%20case%20for%20attempt%3D1%20with%20%60Math.random%28%29%3D0%60%20%28maximum%20negative%20jitter%29.%20this%20is%20the%20branch%20where%20%60jitteredDelay%20%3D%20800%20%3C%20baseDelay%20%3D%201000%60%20and%20the%20%60Math.max%60%20floor%20activates.%20the%20project%20requires%2080%25%2B%20branch%20coverage%20%E2%80%94%20add%20a%20test%20to%20document%20whether%20this%20floor%20is%20intentional%3A%0A%0A%60%60%60typescript%0Ait%28%22clamps%20negative%20jitter%20to%20baseDelay%20on%20attempt%3D1%22%2C%20%28%29%20%3D%3E%20%7B%0A%09vi.mocked%28Math.random%29.mockReturnValueOnce%280%29%3B%0A%09const%20result%20%3D%20getRateLimitBackoff%285%2C%20%22floor-test%22%2C%201000%29%3B%0A%09%2F%2F%20jitteredDelay%20%3D%20800%2C%20but%20Math.max%281000%2C%20800%29%20%3D%201000%0A%09expect%28result.delayMs%29.toBe%281000%29%3B%0A%09expect%28result.attempt%29.toBe%281%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Frate-limit-backoff.test.ts%3A150-188%0A**no%20vitest%20coverage%20for%20jitter%20%C3%97%20%60getRateLimitBackoffWithReason%60**%0A%0Aall%20tests%20in%20this%20block%20run%20with%20%60Math.random%28%29%60%20globally%20mocked%20to%20%600.5%60%20%28neutral%20jitter%20%3D%200%29.%20%60getRateLimitBackoffWithReason%60%20wraps%20%60getRateLimitBackoff%60%20and%20then%20calls%20%60calculateBackoffMs%28result.delayMs%2C%20result.attempt%2C%20reason%29%60%2C%20which%20multiplies%20the%20already-jittered%20delay%20by%20%602%5E%28attempt-1%29%20%C3%97%20multiplier%60.%20with%20neutral%20jitter%20the%20compounded%20output%20is%20always%20deterministic%2C%20but%20in%20production%20a%20non-zero%20jitter%20flows%20through%20the%20multiplier.%0A%0Aadd%20at%20least%20one%20test%20with%20a%20non-neutral%20mock%20to%20pin%20the%20expected%20output%20and%20document%20intent%3A%0A%0A%60%60%60typescript%0Ait%28%22jitter%20propagates%20through%20calculateBackoffMs%22%2C%20%28%29%20%3D%3E%20%7B%0A%09vi.mocked%28Math.random%29.mockReturnValueOnce%281%29%3B%20%2F%2F%20%2B20%25%20jitter%0A%09const%20result%20%3D%20getRateLimitBackoffWithReason%286%2C%20%22jitter-reason%22%2C%201000%2C%20%22tokens%22%29%3B%0A%09%2F%2F%20getRateLimitBackoff%3A%20delayMs%20%3D%20max%281000%2C%201200%29%20%3D%201200%0A%09%2F%2F%20calculateBackoffMs%281200%2C%201%2C%20%22tokens%22%29%20%3D%20floor%281200%20*%201%20*%201.5%29%20%3D%201800%0A%09expect%28result.delayMs%29.toBe%281800%29%3B%0A%09expect%28result.reason%29.toBe%28%22tokens%22%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/request/rate-limit-backoff.ts
Line: 80-82

Comment:
**negative jitter silently discarded on attempt=1**

for attempt=1, `backoffDelay === baseDelay`. if `Math.random()` returns a value below `0.5`, `jitteredDelay < baseDelay`, and the `Math.max` floor restores it to `baseDelay` — so downward jitter has no effect on the first 429. the effective spread is `[baseDelay, baseDelay×1.2]` (one-sided upward), not the symmetric `±20%` the constant implies.

this is the most common 429 case, so the anti-thundering-herd goal stated in the PR description is only half-realised for first retries. attempt=2+ are unaffected because `backoffDelay >> baseDelay` and symmetric jitter applies.

if the `Math.max` floor is intentional (to honour the server-sent `Retry-After` as a hard minimum), add a comment:

```suggestion
	const backoffDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), MAX_BACKOFF_MS);
	const jitteredDelay = Math.min(addBackoffJitter(backoffDelay), MAX_BACKOFF_MS);
	// Math.max honours server Retry-After as a hard floor; on attempt=1 this makes jitter one-sided (upward only)
	const delayMs = Math.max(baseDelay, jitteredDelay);
```

or remove the floor to get symmetric spread:

```typescript
const delayMs = Math.max(0, jitteredDelay);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/rate-limit-backoff.test.ts
Line: 44-60

Comment:
**missing vitest branch: attempt=1 with maximum negative jitter**

the new test only mocks `Math.random()` to `1` for attempt=1 (maximum positive jitter → `1200ms`). two gaps:

1. `mockReturnValueOnce(1)` is unreachable in production — `Math.random()` returns `[0, 1)`, so 1 is never produced. the assertion `1200` is therefore a value that can never actually occur. use `0.999` or similar to stay within the real range.

2. there is no case for attempt=1 with `Math.random()=0` (maximum negative jitter). this is the branch where `jitteredDelay = 800 < baseDelay = 1000` and the `Math.max` floor activates. the project requires 80%+ branch coverage — add a test to document whether this floor is intentional:

```typescript
it("clamps negative jitter to baseDelay on attempt=1", () => {
	vi.mocked(Math.random).mockReturnValueOnce(0);
	const result = getRateLimitBackoff(5, "floor-test", 1000);
	// jitteredDelay = 800, but Math.max(1000, 800) = 1000
	expect(result.delayMs).toBe(1000);
	expect(result.attempt).toBe(1);
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/rate-limit-backoff.test.ts
Line: 150-188

Comment:
**no vitest coverage for jitter × `getRateLimitBackoffWithReason`**

all tests in this block run with `Math.random()` globally mocked to `0.5` (neutral jitter = 0). `getRateLimitBackoffWithReason` wraps `getRateLimitBackoff` and then calls `calculateBackoffMs(result.delayMs, result.attempt, reason)`, which multiplies the already-jittered delay by `2^(attempt-1) × multiplier`. with neutral jitter the compounded output is always deterministic, but in production a non-zero jitter flows through the multiplier.

add at least one test with a non-neutral mock to pin the expected output and document intent:

```typescript
it("jitter propagates through calculateBackoffMs", () => {
	vi.mocked(Math.random).mockReturnValueOnce(1); // +20% jitter
	const result = getRateLimitBackoffWithReason(6, "jitter-reason", 1000, "tokens");
	// getRateLimitBackoff: delayMs = max(1000, 1200) = 1200
	// calculateBackoffMs(1200, 1, "tokens") = floor(1200 * 1 * 1.5) = 1800
	expect(result.delayMs).toBe(1800);
	expect(result.reason).toBe("tokens");
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add jitter to rate-limit backoff"](https://github.com/ndycode/codex-multi-auth/commit/69698153ba97ef39b5b5712c82609694fcbfaeab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27422430)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->