### PR TITLE
feat: add live probe budgets and warnings

### DIFF
--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -35,6 +35,9 @@ interface ReportCliOptions {
 	json: boolean;
 	explain: boolean;
 	model: string;
+	maxAccounts?: number;
+	maxProbes?: number;
+	cachedOnly: boolean;
 	outPath?: string;
 }
 
@@ -99,6 +102,9 @@ function printReportUsage(logInfo: (message: string) => void): void {
 			"  --json, -j         Print machine-readable JSON output",
 			"  --explain          Print per-account reasoning in text mode",
 			"  --model, -m        Probe model for live mode (default: gpt-5-codex)",
+			"  --max-accounts N   Limit how many enabled accounts live mode can consider",
+			"  --max-probes N     Limit how many live quota probes can run",
+			"  --cached-only      Skip refreshes and only use already-usable access tokens",
 			"  --out              Write JSON report to a file path",
 		].join("\n"),
 	);
@@ -110,6 +116,7 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 		json: false,
 		explain: false,
 		model: "gpt-5-codex",
+		cachedOnly: false,
 	};
 
 	for (let i = 0; i < args.length; i += 1) {
@@ -127,6 +134,10 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 			options.explain = true;
 			continue;
 		}
+		if (arg === "--cached-only") {
+			options.cachedOnly = true;
+			continue;
+		}
 		if (arg === "--model" || arg === "-m") {
 			const value = args[i + 1];
 			if (!value) return { ok: false, message: "Missing value for --model" };
@@ -138,6 +149,44 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 			const value = arg.slice("--model=".length).trim();
 			if (!value) return { ok: false, message: "Missing value for --model" };
 			options.model = value;
+			continue;
+		}
+		if (arg === "--max-accounts") {
+			const value = args[i + 1];
+			if (!value) return { ok: false, message: "Missing value for --max-accounts" };
+			const parsed = Number.parseInt(value, 10);
+			if (!Number.isFinite(parsed) || parsed < 1) {
+				return { ok: false, message: "--max-accounts must be a positive integer" };
+			}
+			options.maxAccounts = parsed;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--max-accounts=")) {
+			const parsed = Number.parseInt(arg.slice("--max-accounts=".length), 10);
+			if (!Number.isFinite(parsed) || parsed < 1) {
+				return { ok: false, message: "--max-accounts must be a positive integer" };
+			}
+			options.maxAccounts = parsed;
+			continue;
+		}
+		if (arg === "--max-probes") {
+			const value = args[i + 1];
+			if (!value) return { ok: false, message: "Missing value for --max-probes" };
+			const parsed = Number.parseInt(value, 10);
+			if (!Number.isFinite(parsed) || parsed < 1) {
+				return { ok: false, message: "--max-probes must be a positive integer" };
+			}
+			options.maxProbes = parsed;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--max-probes=")) {
+			const parsed = Number.parseInt(arg.slice("--max-probes=".length), 10);
+			if (!Number.isFinite(parsed) || parsed < 1) {
+				return { ok: false, message: "--max-probes must be a positive integer" };
+			}
+			options.maxProbes = parsed;
 			continue;
 		}
 		if (arg === "--out") {
@@ -360,16 +409,34 @@ export async function runReportCommand(
 	const refreshFailures = new Map<number, TokenFailure>();
 	const liveQuotaByIndex = new Map<number, CodexQuotaSnapshot>();
 	const probeErrors: string[] = [];
+	let consideredLiveAccounts = 0;
+	let executedLiveProbes = 0;
 
 	if (storage && options.live) {
 		for (let i = 0; i < storage.accounts.length; i += 1) {
+			if (
+				typeof options.maxAccounts === "number" &&
+				consideredLiveAccounts >= options.maxAccounts
+			) {
+				probeErrors.push(
+					`live probe account budget reached (${options.maxAccounts})`,
+				);
+				break;
+			}
 			const account = storage.accounts[i];
 			if (!account || account.enabled === false) continue;
+			consideredLiveAccounts += 1;
 
 			let probeAccessToken = account.accessToken;
 			let probeAccountId =
 				account.accountId ?? extractAccountId(account.accessToken);
 			if (!deps.hasUsableAccessToken(account, now)) {
+				if (options.cachedOnly) {
+					probeErrors.push(
+						`${formatAccountLabel(account, i)}: skipped refresh because --cached-only is enabled`,
+					);
+					continue;
+				}
 				const refreshResult = await deps.queuedRefresh(account.refreshToken);
 				if (refreshResult.type !== "success") {
 					refreshFailures.set(i, {
@@ -444,8 +511,16 @@ export async function runReportCommand(
 				);
 				continue;
 			}
+			if (
+				typeof options.maxProbes === "number" &&
+				executedLiveProbes >= options.maxProbes
+			) {
+				probeErrors.push(`live probe request budget reached (${options.maxProbes})`);
+				break;
+			}
 
 			try {
+				executedLiveProbes += 1;
 				const liveQuota = await deps.fetchCodexQuotaSnapshot({
 					accountId: probeAccountId,
 					accessToken: probeAccessToken,
@@ -506,6 +581,13 @@ export async function runReportCommand(
 			capabilities: modelInspection.capabilities,
 		},
 		liveProbe: options.live,
+		liveProbeBudget: {
+			cachedOnly: options.cachedOnly,
+			maxAccounts: options.maxAccounts ?? null,
+			maxProbes: options.maxProbes ?? null,
+			consideredAccounts: consideredLiveAccounts,
+			executedProbes: executedLiveProbes,
+		},
 		accounts: {
 			total: accountCount,
 			enabled: enabledCount,
@@ -543,6 +625,22 @@ export async function runReportCommand(
 	logInfo(`Report generated at ${report.generatedAt}`);
 	logInfo(`Storage: ${report.storagePath}`);
 	logInfo(`Model: ${formatModelInspection(modelInspection)}`);
+	if (options.live) {
+		const budgetParts = [
+			`considered ${consideredLiveAccounts} account(s)`,
+			`executed ${executedLiveProbes} probe(s)`,
+		];
+		if (typeof options.maxAccounts === "number") {
+			budgetParts.push(`max-accounts ${options.maxAccounts}`);
+		}
+		if (typeof options.maxProbes === "number") {
+			budgetParts.push(`max-probes ${options.maxProbes}`);
+		}
+		if (options.cachedOnly) {
+			budgetParts.push("cached-only");
+		}
+		logInfo(`Live probe budget: ${budgetParts.join(", ")}`);
+	}
 	logInfo(
 		`Accounts: ${report.accounts.total} total (${report.accounts.enabled} enabled, ${report.accounts.disabled} disabled, ${report.accounts.coolingDown} cooling, ${report.accounts.rateLimited} rate-limited)`,
 	);

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -81,6 +81,17 @@ describe("runReportCommand", () => {
 		expect(deps.logError).toHaveBeenCalledWith("Unknown option: --bogus");
 	});
 
+	it("rejects invalid live probe budget values", async () => {
+		const deps = createDeps();
+
+		const result = await runReportCommand(["--max-probes", "0"], deps);
+
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith(
+			"--max-probes must be a positive integer",
+		);
+	});
+
 	it("writes json report output when requested", async () => {
 		const deps = createDeps();
 
@@ -96,6 +107,61 @@ describe("runReportCommand", () => {
 		);
 		expect(deps.logInfo).toHaveBeenCalledWith(
 			expect.stringContaining('"forecast"'),
+		);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			expect.stringContaining('"liveProbeBudget"'),
+		);
+	});
+
+	it("respects live probe account and probe budgets", async () => {
+		const deps = createDeps({
+			loadAccounts: vi.fn(async () =>
+				createStorage([
+					{ email: "one@example.com", refreshToken: "r1", accessToken: "a1", accountId: "acct-1", expiresAt: 5_000, addedAt: 1, lastUsed: 1, enabled: true },
+					{ email: "two@example.com", refreshToken: "r2", accessToken: "a2", accountId: "acct-2", expiresAt: 5_000, addedAt: 2, lastUsed: 2, enabled: true },
+					{ email: "three@example.com", refreshToken: "r3", accessToken: "a3", accountId: "acct-3", expiresAt: 5_000, addedAt: 3, lastUsed: 3, enabled: true },
+				]),
+			),
+			hasUsableAccessToken: vi.fn(() => true),
+		});
+
+		const result = await runReportCommand(
+			["--live", "--json", "--max-accounts", "2", "--max-probes", "1"],
+			deps,
+		);
+
+		expect(result).toBe(0);
+		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(1);
+		const jsonOutput = JSON.parse(
+			(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? "{}",
+		) as { liveProbeBudget: { consideredAccounts: number; executedProbes: number }; forecast: { probeErrors: string[] } };
+		expect(jsonOutput.liveProbeBudget).toEqual(
+			expect.objectContaining({ consideredAccounts: 2, executedProbes: 1 }),
+		);
+		expect(jsonOutput.forecast.probeErrors).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("live probe request budget reached (1)"),
+			]),
+		);
+	});
+
+	it("skips refreshes in cached-only live mode", async () => {
+		const deps = createDeps({
+			hasUsableAccessToken: vi.fn(() => false),
+		});
+
+		const result = await runReportCommand(["--live", "--json", "--cached-only"], deps);
+
+		expect(result).toBe(0);
+		expect(deps.queuedRefresh).not.toHaveBeenCalled();
+		expect(deps.fetchCodexQuotaSnapshot).not.toHaveBeenCalled();
+		const jsonOutput = JSON.parse(
+			(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? "{}",
+		) as { forecast: { probeErrors: string[] } };
+		expect(jsonOutput.forecast.probeErrors).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("skipped refresh because --cached-only is enabled"),
+			]),
 		);
 	});
 


### PR DESCRIPTION
## Summary
- add `--max-accounts`, `--max-probes`, and `--cached-only` controls to `codex auth report --live`
- surface live probe budgets and actual considered/executed counts in both human-readable and JSON output
- add focused report-command coverage for invalid budget values, enforced limits, and cached-only behavior

## Validation
- node_modules/.bin/vitest.cmd run test/codex-manager-report-command.test.ts
- node_modules/.bin/tsc.cmd --noEmit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `--max-accounts`, `--max-probes`, and `--cached-only` flags to `codex auth report --live`, surfacing budget counters in both human-readable and JSON output with focused vitest coverage for budget enforcement, invalid-value rejection, and cached-only behaviour. the implementation is clean and the new tests are well-scoped; one ordering detail means token refresh can fire for an account that immediately hits the probe budget on the very next check.

<h3>Confidence Score: 5/5</h3>

safe to merge; all findings are P2 style/efficiency suggestions with no correctness or data-integrity impact

the budget logic produces correct output, the new tests cover the critical paths, and the one ordering concern (refresh before probe budget check) is a minor efficiency issue that does not affect report accuracy or cause data loss

lib/codex-manager/commands/report.ts — review the maxProbes check placement relative to queuedRefresh to avoid unnecessary refreshes on windows

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/report.ts | adds --max-accounts/--max-probes/--cached-only parsing and enforcement; probe budget check fires after queuedRefresh, creating an orphaned refresh+persist when maxProbes is set |
| test/codex-manager-report-command.test.ts | adds budget-enforcement, cached-only, and liveProbeBudget field tests; missing coverage for --max-accounts invalid value and the = inline parsing form |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as CLI args
    participant Parser as parseReportArgs
    participant Loop as Account Loop
    participant Refresh as queuedRefresh
    participant Probe as fetchCodexQuotaSnapshot

    CLI->>Parser: --live --max-accounts N --max-probes M --cached-only
    Parser-->>Loop: options{maxAccounts, maxProbes, cachedOnly}

    loop for each account in storage
        Loop->>Loop: check maxAccounts budget (break if hit)
        Loop->>Loop: skip disabled accounts
        Loop->>Loop: consideredLiveAccounts += 1
        alt token not usable AND NOT cachedOnly
            Loop->>Refresh: queuedRefresh(refreshToken)
            Note right of Refresh: network call + temp file write (windows risk)
            Refresh-->>Loop: TokenResult
            Loop->>Loop: persist refreshed token to disk
        else cachedOnly AND token not usable
            Loop->>Loop: push skip error, continue
        end
        Loop->>Loop: check missing accountId (continue if missing)
        Loop->>Loop: check maxProbes budget (break if hit)
        Note over Loop: ⚠ refresh already ran for this account
        Loop->>Probe: fetchCodexQuotaSnapshot(accountId, accessToken, model)
        Probe-->>Loop: CodexQuotaSnapshot
        Loop->>Loop: executedLiveProbes += 1
    end

    Loop-->>CLI: report{liveProbeBudget{consideredAccounts, executedProbes}}
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fcodex-manager%2Fcommands%2Freport.ts%3A433-523%0A**Refresh%20fires%20before%20%60--max-probes%60%20budget%20check**%0A%0Awhen%20%60--max-probes%3DN%60%20and%20accounts%20need%20refreshing%2C%20account%20N%2B1%20executes%20%60queuedRefresh%60%20%28network%20call%20%2B%20temp-file%20write%20on%20windows%29%20before%20the%20probe-budget%20guard%20fires%20and%20breaks%20the%20loop.%20on%20windows%2C%20an%20antivirus-held%20temp%20handle%20can%20trigger%20EPERM%20on%20the%20next%20write%20%E2%80%94%20per%20project%20convention%2C%20unnecessary%20temp%20files%20are%20a%20real%20risk.%0A%0Amoving%20the%20%60maxProbes%60%20check%20above%20the%20%60hasUsableAccessToken%60%20block%20prevents%20the%20orphaned%20refresh%3A%0A%0A%60%60%60typescript%0A%2F%2F%20check%20probe%20budget%20before%20attempting%20any%20refresh%0Aif%20%28%0A%09typeof%20options.maxProbes%20%3D%3D%3D%20%22number%22%20%26%26%0A%09executedLiveProbes%20%3E%3D%20options.maxProbes%0A%29%20%7B%0A%09probeErrors.push%28%60live%20probe%20request%20budget%20reached%20%28%24%7Boptions.maxProbes%7D%29%60%29%3B%0A%09break%3B%0A%7D%0A%0Alet%20probeAccessToken%20%3D%20account.accessToken%3B%0Alet%20probeAccountId%20%3D%20account.accountId%20%3F%3F%20extractAccountId%28account.accessToken%29%3B%0Aif%20%28!deps.hasUsableAccessToken%28account%2C%20now%29%29%20%7B%0A%09%2F%2F%20...%20refresh%20logic%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fcodex-manager-report-command.test.ts%3A84-93%0A**Missing%20coverage%20for%20%60--max-accounts%60%20invalid%20value**%0A%0Aonly%20%60--max-probes%200%60%20is%20tested%20for%20budget%20rejection%3B%20%60--max-accounts%200%60%20%28and%20the%20%60%3D%60-inline%20form%20%60--max-accounts%3D0%60%29%20have%20no%20parallel%20test.%20the%20two%20parsing%20paths%20are%20symmetrical%20%E2%80%94%20add%20a%20companion%20case%20to%20hit%20that%20validation%20branch%20and%20confirm%20it%20surfaces%20the%20right%20error%20message.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fcodex-manager%2Fcommands%2Freport.ts%3A583-590%0A**%60liveProbeBudget%60%20emitted%20unconditionally%20in%20non-live%20reports**%0A%0Athe%20field%20is%20always%20serialized%20even%20when%20%60options.live%60%20is%20%60false%60%2C%20so%20every%20non-live%20JSON%20report%20carries%20%60%7B%20cachedOnly%3A%20false%2C%20maxAccounts%3A%20null%2C%20maxProbes%3A%20null%2C%20consideredAccounts%3A%200%2C%20executedProbes%3A%200%20%7D%60.%20gating%20it%20avoids%20schema%20noise%20for%20consumers%20that%20never%20use%20live%20mode%3A%0A%0A%60%60%60suggestion%0A%09%09liveProbeBudget%3A%20options.live%0A%09%09%09%3F%20%7B%0A%09%09%09%09%09cachedOnly%3A%20options.cachedOnly%2C%0A%09%09%09%09%09maxAccounts%3A%20options.maxAccounts%20%3F%3F%20null%2C%0A%09%09%09%09%09maxProbes%3A%20options.maxProbes%20%3F%3F%20null%2C%0A%09%09%09%09%09consideredAccounts%3A%20consideredLiveAccounts%2C%0A%09%09%09%09%09executedProbes%3A%20executedLiveProbes%2C%0A%09%09%09%20%20%7D%0A%09%09%09%3A%20undefined%2C%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager/commands/report.ts
Line: 433-523

Comment:
**Refresh fires before `--max-probes` budget check**

when `--max-probes=N` and accounts need refreshing, account N+1 executes `queuedRefresh` (network call + temp-file write on windows) before the probe-budget guard fires and breaks the loop. on windows, an antivirus-held temp handle can trigger EPERM on the next write — per project convention, unnecessary temp files are a real risk.

moving the `maxProbes` check above the `hasUsableAccessToken` block prevents the orphaned refresh:

```typescript
// check probe budget before attempting any refresh
if (
	typeof options.maxProbes === "number" &&
	executedLiveProbes >= options.maxProbes
) {
	probeErrors.push(`live probe request budget reached (${options.maxProbes})`);
	break;
}

let probeAccessToken = account.accessToken;
let probeAccountId = account.accountId ?? extractAccountId(account.accessToken);
if (!deps.hasUsableAccessToken(account, now)) {
	// ... refresh logic
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-report-command.test.ts
Line: 84-93

Comment:
**Missing coverage for `--max-accounts` invalid value**

only `--max-probes 0` is tested for budget rejection; `--max-accounts 0` (and the `=`-inline form `--max-accounts=0`) have no parallel test. the two parsing paths are symmetrical — add a companion case to hit that validation branch and confirm it surfaces the right error message.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager/commands/report.ts
Line: 583-590

Comment:
**`liveProbeBudget` emitted unconditionally in non-live reports**

the field is always serialized even when `options.live` is `false`, so every non-live JSON report carries `{ cachedOnly: false, maxAccounts: null, maxProbes: null, consideredAccounts: 0, executedProbes: 0 }`. gating it avoids schema noise for consumers that never use live mode:

```suggestion
		liveProbeBudget: options.live
			? {
					cachedOnly: options.cachedOnly,
					maxAccounts: options.maxAccounts ?? null,
					maxProbes: options.maxProbes ?? null,
					consideredAccounts: consideredLiveAccounts,
					executedProbes: executedLiveProbes,
			  }
			: undefined,
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add live probe budgets and warning..."](https://github.com/ndycode/codex-multi-auth/commit/26cbb41fec310ef6ef78affaffbe5e2b1e6d47cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27423033)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->