### PR TITLE
feat: expose account selection reasons

### DIFF
--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -167,6 +167,8 @@ function serializeForecastResults(
 	index: number;
 	label: string;
 	isCurrent: boolean;
+	selected: boolean;
+	primaryReason?: string;
 	availability: ForecastAccountResult["availability"];
 	riskScore: number;
 	riskLevel: ForecastAccountResult["riskLevel"];
@@ -187,6 +189,8 @@ function serializeForecastResults(
 			index: result.index,
 			label: result.label,
 			isCurrent: result.isCurrent,
+			selected: false,
+			primaryReason: result.reasons[0],
 			availability: result.availability,
 			riskScore: result.riskScore,
 			riskLevel: result.riskLevel,
@@ -516,7 +520,13 @@ export async function runReportCommand(
 		activeIndex: accountCount > 0 ? activeIndex + 1 : null,
 		forecast: {
 			summary: forecastSummary,
-			recommendation,
+			recommendation: {
+				...recommendation,
+				selectedReason:
+					recommendation.recommendedIndex !== null
+						? forecastResults[recommendation.recommendedIndex]?.reasons[0] ?? recommendation.reason
+						: recommendation.reason,
+			},
 			probeErrors,
 			accounts: serializeForecastResults(
 				forecastResults,
@@ -525,6 +535,13 @@ export async function runReportCommand(
 			),
 		},
 	};
+	if (report.forecast.recommendation.recommendedIndex !== null) {
+		const selectedIndex = report.forecast.recommendation.recommendedIndex;
+		const selected = report.forecast.accounts[selectedIndex];
+		if (selected) {
+			selected.selected = true;
+		}
+	}
 
 	const cwd = deps.getCwd?.() ?? process.cwd();
 	if (options.outPath) {

--- a/lib/codex-manager/commands/status.ts
+++ b/lib/codex-manager/commands/status.ts
@@ -3,6 +3,10 @@ import {
 	formatCooldown,
 	formatWaitTime,
 } from "../../accounts.js";
+import {
+	evaluateForecastAccounts,
+	recommendForecastAccount,
+} from "../../forecast.js";
 import type { ModelFamily } from "../../prompts/codex.js";
 import type { AccountStorageV3 } from "../../storage.js";
 
@@ -40,8 +44,22 @@ export async function runStatusCommand(
 
 	const now = deps.getNow?.() ?? Date.now();
 	const activeIndex = deps.resolveActiveIndex(storage, "codex");
+	const forecastResults = evaluateForecastAccounts(
+		storage.accounts.map((account, index) => ({
+			index,
+			account,
+			isCurrent: index === activeIndex,
+			now,
+		})),
+	);
+	const recommendation = recommendForecastAccount(forecastResults);
 	logInfo(`Accounts (${storage.accounts.length})`);
 	logInfo(`Storage: ${path}`);
+	if (recommendation.recommendedIndex !== null) {
+		logInfo(
+			`Selection reason: account ${recommendation.recommendedIndex + 1} (${recommendation.reason})`,
+		);
+	}
 	logInfo("");
 
 	for (let i = 0; i < storage.accounts.length; i += 1) {
@@ -61,6 +79,10 @@ export async function runStatusCommand(
 				? `used ${formatWaitTime(now - account.lastUsed)} ago`
 				: "never used";
 		logInfo(`${i + 1}. ${label}${markerLabel} ${lastUsed}`);
+		const primaryReason = forecastResults[i]?.reasons[0];
+		if (primaryReason) {
+			logInfo(`   reason: ${primaryReason}`);
+		}
 	}
 
 	return 0;

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -191,6 +191,9 @@ describe("runReportCommand", () => {
 			"token expired",
 		);
 		expect(jsonOutput.forecast.accounts[3]?.liveQuota?.planType).toBe("pro");
+		expect(jsonOutput.forecast.recommendation.selectedReason).toEqual(
+		expect.any(String),
+		);
 	});
 
 	it("reuses usable access tokens for live probes without forcing refresh", async () => {

--- a/test/codex-manager-status-command.test.ts
+++ b/test/codex-manager-status-command.test.ts
@@ -69,9 +69,15 @@ describe("runStatusCommand", () => {
 		expect(deps.logInfo).toHaveBeenCalledWith("Accounts (2)");
 		expect(deps.logInfo).toHaveBeenCalledWith("Storage: /tmp/codex.json");
 		expect(deps.logInfo).toHaveBeenCalledWith(
+			expect.stringContaining("Selection reason: account 1"),
+		);
+		expect(deps.logInfo).toHaveBeenCalledWith(
 			expect.stringContaining(
 				"1. Account 1 (one@example.com) [current, rate-limited]",
 			),
+		);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			expect.stringContaining("reason:"),
 		);
 		expect(deps.logInfo).toHaveBeenCalledWith(
 			expect.stringContaining(


### PR DESCRIPTION
## Summary
- expose the current recommendation reason directly in `codex auth status` instead of forcing operators to infer selection behavior
- add `selected` and `primaryReason` visibility to report forecast accounts plus a selected-reason field on the recommendation
- extend focused status/report coverage so account selection behavior is visible in both text and JSON surfaces

## Validation
- node_modules/.bin/vitest.cmd run test/codex-manager-status-command.test.ts test/codex-manager-report-command.test.ts
- node_modules/.bin/tsc.cmd --noEmit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

exposes `selectedReason` on `forecast.recommendation` and a `selected` flag on the recommended account entry in the report command, and adds per-account `reason:` lines plus a `Selection reason:` header to the status command. all status-command changes are offline (no live-probe inputs passed to `evaluateForecastAccounts`).

- test coverage for the new `selected`/`primaryReason` fields on report accounts is absent; only `selectedReason` is checked with `expect.any(String)`, which won't catch regressions
- the `recommendation.recommendedIndex === null` guard in `status.ts` (all accounts hard-failed/disabled) is untested

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are p2 test-quality issues, no runtime defects

production logic is correct: index math in report.ts is 1:1 with forecastResults, the selected mutation happens before serialization, and the selectedReason fallback chain (reasons[0] ?? recommendation.reason) is safe. test gaps are real but do not affect production behavior, so confidence stays at 5.

test/codex-manager-report-command.test.ts — incomplete type cast and weak assertions for the new selectedReason and selected fields

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/report.ts | adds selectedReason to recommendation and selected flag on accounts; index math is 1:1 with forecastResults and mutation of selected happens before serialization — logic is correct |
| lib/codex-manager/commands/status.ts | adds offline forecast evaluation to surface per-account reasons and a selection header; clean and minimal, no live-probe inputs needed for the status view |
| test/codex-manager-report-command.test.ts | new selectedReason assertion uses expect.any(String) — too weak to catch regressions; selected flag and primaryReason on accounts are never verified; type cast omits recommendation field |
| test/codex-manager-status-command.test.ts | adds Selection reason and per-account reason assertions; missing coverage for null-recommendation path and zero-reason accounts |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant StatusCmd as runStatusCommand
    participant ReportCmd as runReportCommand
    participant Forecast as forecast.ts

    CLI->>StatusCmd: runStatusCommand(deps)
    StatusCmd->>Forecast: evaluateForecastAccounts(accounts)
    Forecast-->>StatusCmd: forecastResults[]
    StatusCmd->>Forecast: recommendForecastAccount(results)
    Forecast-->>StatusCmd: { recommendedIndex, reason }
    StatusCmd->>CLI: logInfo(Selection reason: account N (reason))
    loop each account
        StatusCmd->>CLI: logInfo(N. label [markers] lastUsed)
        StatusCmd->>CLI: logInfo(   reason: primaryReason) if reasons exist
    end

    CLI->>ReportCmd: runReportCommand(args, deps)
    ReportCmd->>Forecast: evaluateForecastAccounts(accounts)
    Forecast-->>ReportCmd: forecastResults[]
    ReportCmd->>Forecast: recommendForecastAccount(results)
    Forecast-->>ReportCmd: { recommendedIndex, reason }
    ReportCmd->>ReportCmd: build report with recommendation.selectedReason
    ReportCmd->>ReportCmd: set accounts[recommendedIndex].selected = true
    ReportCmd->>CLI: logInfo(JSON.stringify(report))
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fcodex-manager-report-command.test.ts%3A176-196%0A**incomplete%20type%20cast%20hides%20%60recommendation%60%20field**%0A%0Athe%20%60as%20%7B%20forecast%3A%20%7B%20...%20%7D%20%7D%60%20cast%20at%20line%20176%20omits%20%60recommendation%60%20from%20the%20declared%20shape%2C%20so%20%60jsonOutput.forecast.recommendation.selectedReason%60%20at%20line%20194%20is%20an%20untyped%20access%20%E2%80%94%20if%20the%20field%20is%20renamed%20or%20removed%2C%20TypeScript%20won't%20catch%20the%20broken%20reference%20%28test%20files%20are%20excluded%20from%20%60tsconfig.json%60%29.%20additionally%2C%20%60expect.any%28String%29%60%20only%20proves%20a%20non-null%20string%20exists%20and%20won't%20catch%20a%20wrong%20reason%20string%20or%20the%20empty-fallback%20path.%20the%20%60selected%3A%20true%60%20flag%20added%20to%20the%20recommended%20account%20is%20never%20asserted%20anywhere.%0A%0A%60%60%60suggestion%0A%29%20as%20%7B%0A%09forecast%3A%20%7B%0A%09%09probeErrors%3A%20string%5B%5D%3B%0A%09%09accounts%3A%20Array%3C%7B%20refreshFailure%3F%3A%20%7B%20message%3F%3A%20string%20%7D%3B%20liveQuota%3F%3A%20%7B%20planType%3F%3A%20string%20%7D%3B%20selected%3F%3A%20boolean%20%7D%3E%3B%0A%09%09recommendation%3A%20%7B%20selectedReason%3A%20string%3B%20recommendedIndex%3A%20number%20%7C%20null%20%7D%3B%0A%09%7D%3B%0A%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fcodex-manager-status-command.test.ts%3A79-81%0A**missing%20coverage%20for%20zero-reason%20accounts%20and%20null-recommendation%20path**%0A%0Athe%20only%20exercised%20scenario%20has%20both%20accounts%20rate-limited%2C%20so%20%60reasons%5B0%5D%60%20is%20always%20populated.%20there's%20no%20test%20for%20an%20account%20with%20an%20empty%20%60reasons%60%20array%20%28where%20the%20%60reason%3A%60%20line%20at%20%60status.ts%3A83%E2%80%9385%60%20is%20silently%20skipped%29%2C%20and%20no%20test%20for%20the%20%60recommendation.recommendedIndex%20%3D%3D%3D%20null%60%20branch%20at%20%60status.ts%3A58%60%20%28all%20accounts%20hard-failed%2Fdisabled%29%2C%20where%20the%20%60Selection%20reason%3A%60%20header%20is%20suppressed%20entirely.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/codex-manager-report-command.test.ts
Line: 176-196

Comment:
**incomplete type cast hides `recommendation` field**

the `as { forecast: { ... } }` cast at line 176 omits `recommendation` from the declared shape, so `jsonOutput.forecast.recommendation.selectedReason` at line 194 is an untyped access — if the field is renamed or removed, TypeScript won't catch the broken reference (test files are excluded from `tsconfig.json`). additionally, `expect.any(String)` only proves a non-null string exists and won't catch a wrong reason string or the empty-fallback path. the `selected: true` flag added to the recommended account is never asserted anywhere.

```suggestion
) as {
	forecast: {
		probeErrors: string[];
		accounts: Array<{ refreshFailure?: { message?: string }; liveQuota?: { planType?: string }; selected?: boolean }>;
		recommendation: { selectedReason: string; recommendedIndex: number | null };
	};
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-status-command.test.ts
Line: 79-81

Comment:
**missing coverage for zero-reason accounts and null-recommendation path**

the only exercised scenario has both accounts rate-limited, so `reasons[0]` is always populated. there's no test for an account with an empty `reasons` array (where the `reason:` line at `status.ts:83–85` is silently skipped), and no test for the `recommendation.recommendedIndex === null` branch at `status.ts:58` (all accounts hard-failed/disabled), where the `Selection reason:` header is suppressed entirely.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: expose account selection reasons"](https://github.com/ndycode/codex-multi-auth/commit/ea5f9022a4d8083f269ae099ccc6538cf5fe1fef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27423036)</sub>

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->