### PR TITLE
feat: surface explicit storage health state

### DIFF
--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -100,6 +100,7 @@ import {
 	clearAccounts,
 	findMatchingAccountIndex,
 	formatStorageErrorHint,
+	inspectStorageHealth,
 	getLastAccountsSaveTimestamp,
 	getNamedBackups,
 	getStoragePath,
@@ -3203,6 +3204,7 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 			setStoragePath,
 			getStoragePath,
 			loadAccounts,
+			inspectStorageHealth,
 			resolveActiveIndex,
 			formatRateLimitEntry,
 		});
@@ -3234,6 +3236,7 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 			setStoragePath,
 			getStoragePath,
 			loadAccounts,
+			inspectStorageHealth,
 			saveAccounts,
 			resolveActiveIndex,
 			hasUsableAccessToken,

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -26,6 +26,7 @@ import {
 	findMatchingAccountIndex,
 	type AccountMetadataV3,
 	type AccountStorageV3,
+	type StorageHealthSummary,
 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 import { sleep } from "../../utils.js";
@@ -73,6 +74,7 @@ export interface ReportCommandDeps {
 		now: number,
 		family: "codex",
 	) => string | null;
+	inspectStorageHealth?: () => Promise<StorageHealthSummary>;
 	normalizeFailureDetail: (
 		message: string | undefined,
 		reason: string | undefined,
@@ -354,6 +356,7 @@ export async function runReportCommand(
 	deps.setStoragePath(null);
 	const storagePath = deps.getStoragePath();
 	const storage = await deps.loadAccounts();
+	const storageHealth = await deps.inspectStorageHealth?.();
 	const now = deps.getNow?.() ?? Date.now();
 	const accountCount = storage?.accounts.length ?? 0;
 	const activeIndex = storage ? deps.resolveActiveIndex(storage, "codex") : 0;
@@ -497,6 +500,7 @@ export async function runReportCommand(
 		command: "report",
 		generatedAt: new Date(now).toISOString(),
 		storagePath,
+		storageHealth,
 		model: requestedModel,
 		modelSelection: {
 			requested: modelInspection.requested,
@@ -542,6 +546,9 @@ export async function runReportCommand(
 
 	logInfo(`Report generated at ${report.generatedAt}`);
 	logInfo(`Storage: ${report.storagePath}`);
+	if (report.storageHealth) {
+		logInfo(`Storage health: ${report.storageHealth.state}`);
+	}
 	logInfo(`Model: ${formatModelInspection(modelInspection)}`);
 	logInfo(
 		`Accounts: ${report.accounts.total} total (${report.accounts.enabled} enabled, ${report.accounts.disabled} disabled, ${report.accounts.coolingDown} cooling, ${report.accounts.rateLimited} rate-limited)`,

--- a/lib/codex-manager/commands/status.ts
+++ b/lib/codex-manager/commands/status.ts
@@ -4,7 +4,7 @@ import {
 	formatWaitTime,
 } from "../../accounts.js";
 import type { ModelFamily } from "../../prompts/codex.js";
-import type { AccountStorageV3 } from "../../storage.js";
+import type { AccountStorageV3, StorageHealthSummary } from "../../storage.js";
 
 type LoadedStorage = AccountStorageV3 | null;
 
@@ -21,6 +21,7 @@ export interface StatusCommandDeps {
 		now: number,
 		family: ModelFamily,
 	) => string | null;
+	inspectStorageHealth?: () => Promise<StorageHealthSummary>;
 	getNow?: () => number;
 	logInfo?: (message: string) => void;
 }
@@ -31,10 +32,22 @@ export async function runStatusCommand(
 	deps.setStoragePath(null);
 	const storage = await deps.loadAccounts();
 	const path = deps.getStoragePath();
+	const storageHealth = await deps.inspectStorageHealth?.();
 	const logInfo = deps.logInfo ?? console.log;
 	if (!storage || storage.accounts.length === 0) {
-		logInfo("No accounts configured.");
+		logInfo(
+			storageHealth?.state === "intentional-reset"
+				? "No accounts configured. Storage was intentionally reset."
+				: storageHealth?.state === "recoverable"
+					? "No accounts configured. Recovery artifacts are available."
+					: storageHealth?.state === "corrupt"
+						? "No accounts configured. Storage appears corrupted."
+						: "No accounts configured.",
+		);
 		logInfo(`Storage: ${path}`);
+		if (storageHealth) {
+			logInfo(`Storage health: ${storageHealth.state}`);
+		}
 		return 0;
 	}
 
@@ -42,6 +55,9 @@ export async function runStatusCommand(
 	const activeIndex = deps.resolveActiveIndex(storage, "codex");
 	logInfo(`Accounts (${storage.accounts.length})`);
 	logInfo(`Storage: ${path}`);
+	if (storageHealth) {
+		logInfo(`Storage health: ${storageHealth.state}`);
+	}
 	logInfo("");
 
 	for (let i = 0; i < storage.accounts.length; i += 1) {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -52,6 +52,10 @@ import { loadFlaggedAccountsEntry } from "./storage/flagged-load-entry.js";
 import { saveFlaggedAccountsEntry } from "./storage/flagged-save-entry.js";
 import { normalizeFlaggedStorage } from "./storage/flagged-storage.js";
 import {
+	createStorageHealthSummary,
+	type StorageHealthSummary,
+} from "./storage/health.js";
+import {
 	clearFlaggedAccountsOnDisk,
 	loadFlaggedAccountsState,
 	saveFlaggedAccountsUnlockedToDisk,
@@ -128,6 +132,7 @@ import {
 } from "./storage/transactions.js";
 
 export type {
+	StorageHealthSummary,
 	CooldownReason,
 	RateLimitStateV3,
 	AccountMetadataV1,
@@ -1262,6 +1267,105 @@ export async function getRestoreAssessment(): Promise<RestoreAssessment> {
 		backupMetadata,
 		hasResetMarker: existsSync(resetMarkerPath),
 	});
+}
+
+export async function inspectStorageHealth(): Promise<StorageHealthSummary> {
+	const path = getStoragePath();
+	const walPath = getAccountsWalPath(path);
+	const resetMarkerPath = getIntentionalResetMarkerPath(path);
+	if (existsSync(resetMarkerPath)) {
+		return createStorageHealthSummary({
+			state: "intentional-reset",
+			path,
+			walPath,
+			resetMarkerPath,
+			details: "intentional reset marker present",
+		});
+	}
+	if (!existsSync(path)) {
+		const walRecovered = await loadAccountsFromJournal(path);
+		if (walRecovered && walRecovered.accounts.length > 0) {
+			return createStorageHealthSummary({
+				state: "recoverable",
+				path,
+				walPath,
+				resetMarkerPath,
+				details: "primary storage missing but WAL recovery is available",
+				recoverySource: "wal",
+			});
+		}
+		return createStorageHealthSummary({
+			state: "empty",
+			path,
+			walPath,
+			resetMarkerPath,
+			details: "storage file is missing",
+		});
+	}
+	try {
+		const { normalized, schemaErrors } = await loadAccountsFromPath(path, {
+			normalizeAccountStorage,
+			isRecord,
+		});
+		if (normalized && normalized.accounts.length > 0) {
+			return createStorageHealthSummary({
+				state: "healthy",
+				path,
+				walPath,
+				resetMarkerPath,
+				schemaErrors,
+			});
+		}
+		if (normalized) {
+			return createStorageHealthSummary({
+				state: "empty",
+				path,
+				walPath,
+				resetMarkerPath,
+				schemaErrors,
+				details: "storage parsed but contains no accounts",
+			});
+		}
+		const walRecovered = await loadAccountsFromJournal(path);
+		if (walRecovered && walRecovered.accounts.length > 0) {
+			return createStorageHealthSummary({
+				state: "recoverable",
+				path,
+				walPath,
+				resetMarkerPath,
+				schemaErrors,
+				details: "primary storage is invalid but WAL recovery is available",
+				recoverySource: "wal",
+			});
+		}
+		return createStorageHealthSummary({
+			state: "corrupt",
+			path,
+			walPath,
+			resetMarkerPath,
+			schemaErrors,
+			details: "storage could not be normalized",
+		});
+	} catch (error) {
+		const walRecovered = await loadAccountsFromJournal(path);
+		if (walRecovered && walRecovered.accounts.length > 0) {
+			return createStorageHealthSummary({
+				state: "recoverable",
+				path,
+				walPath,
+				resetMarkerPath,
+				details: error instanceof Error ? error.message : String(error),
+				recoverySource: "wal",
+			});
+		}
+		return createStorageHealthSummary({
+			state: "corrupt",
+			path,
+			walPath,
+			resetMarkerPath,
+			details: error instanceof Error ? error.message : String(error),
+		});
+	}
 }
 
 async function loadAccountsFromJournal(

--- a/lib/storage/health.ts
+++ b/lib/storage/health.ts
@@ -1,0 +1,42 @@
+import { existsSync } from "node:fs";
+
+export type StorageHealthState =
+	| "healthy"
+	| "empty"
+	| "intentional-reset"
+	| "corrupt"
+	| "recoverable";
+
+export interface StorageHealthSummary {
+	state: StorageHealthState;
+	path: string;
+	resetMarkerPath: string;
+	walPath: string;
+	hasResetMarker: boolean;
+	hasWal: boolean;
+	details?: string;
+	schemaErrors?: string[];
+	recoverySource?: "wal";
+}
+
+export function createStorageHealthSummary(params: {
+	state: StorageHealthState;
+	path: string;
+	resetMarkerPath: string;
+	walPath: string;
+	details?: string;
+	schemaErrors?: string[];
+	recoverySource?: "wal";
+}): StorageHealthSummary {
+	return {
+		state: params.state,
+		path: params.path,
+		resetMarkerPath: params.resetMarkerPath,
+		walPath: params.walPath,
+		hasResetMarker: existsSync(params.resetMarkerPath),
+		hasWal: existsSync(params.walPath),
+		details: params.details,
+		schemaErrors: params.schemaErrors,
+		recoverySource: params.recoverySource,
+	};
+}

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -3,7 +3,7 @@ import {
 	type ReportCommandDeps,
 	runReportCommand,
 } from "../lib/codex-manager/commands/report.js";
-import type { AccountStorageV3 } from "../lib/storage.js";
+import type { AccountStorageV3, StorageHealthSummary } from "../lib/storage.js";
 
 function createStorage(
 	accounts: AccountStorageV3["accounts"] = [
@@ -50,6 +50,14 @@ function createDeps(
 			secondary: {},
 		})),
 		formatRateLimitEntry: vi.fn(() => null),
+		inspectStorageHealth: vi.fn(async (): Promise<StorageHealthSummary> => ({
+			state: "healthy",
+			path: "/mock/openai-codex-accounts.json",
+			resetMarkerPath: "/mock/openai-codex-accounts.json.intentional-reset",
+			walPath: "/mock/openai-codex-accounts.json.wal",
+			hasResetMarker: false,
+			hasWal: false,
+		})),
 		normalizeFailureDetail: vi.fn((message) => message ?? "unknown"),
 		logInfo: vi.fn(),
 		logError: vi.fn(),
@@ -96,6 +104,9 @@ describe("runReportCommand", () => {
 		);
 		expect(deps.logInfo).toHaveBeenCalledWith(
 			expect.stringContaining('"forecast"'),
+		);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			expect.stringContaining('"storageHealth"'),
 		);
 	});
 

--- a/test/codex-manager-status-command.test.ts
+++ b/test/codex-manager-status-command.test.ts
@@ -5,7 +5,7 @@ import {
 	runStatusCommand,
 	type StatusCommandDeps,
 } from "../lib/codex-manager/commands/status.js";
-import type { AccountStorageV3 } from "../lib/storage.js";
+import type { AccountStorageV3, StorageHealthSummary } from "../lib/storage.js";
 
 function createStorage(): AccountStorageV3 {
 	return {
@@ -39,6 +39,14 @@ function createStatusDeps(
 		loadAccounts: vi.fn(async () => createStorage()),
 		resolveActiveIndex: vi.fn(() => 0),
 		formatRateLimitEntry: vi.fn(() => null),
+		inspectStorageHealth: vi.fn(async (): Promise<StorageHealthSummary> => ({
+			state: "healthy",
+			path: "/tmp/codex.json",
+			resetMarkerPath: "/tmp/codex.json.intentional-reset",
+			walPath: "/tmp/codex.json.wal",
+			hasResetMarker: false,
+			hasWal: false,
+		})),
 		getNow: vi.fn(() => 2_000),
 		logInfo: vi.fn(),
 		...overrides,
@@ -55,6 +63,29 @@ describe("runStatusCommand", () => {
 		expect(deps.getStoragePath).toHaveBeenCalledTimes(1);
 		expect(deps.logInfo).toHaveBeenCalledWith("No accounts configured.");
 		expect(deps.logInfo).toHaveBeenCalledWith("Storage: /tmp/codex.json");
+		expect(deps.logInfo).toHaveBeenCalledWith("Storage health: healthy");
+	});
+
+	it("prints explicit corrupt storage state for empty result cases", async () => {
+		const deps = createStatusDeps({
+			loadAccounts: vi.fn(async () => null),
+			inspectStorageHealth: vi.fn(async () => ({
+				state: "corrupt",
+				path: "/tmp/codex.json",
+				resetMarkerPath: "/tmp/codex.json.intentional-reset",
+				walPath: "/tmp/codex.json.wal",
+				hasResetMarker: false,
+				hasWal: false,
+				details: "Unexpected token",
+			})),
+		});
+
+		await runStatusCommand(deps);
+
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			"No accounts configured. Storage appears corrupted.",
+		);
+		expect(deps.logInfo).toHaveBeenCalledWith("Storage health: corrupt");
 	});
 
 	it("prints account rows with current and disabled markers", async () => {


### PR DESCRIPTION
## Summary
- add a first-class storage health summary that distinguishes healthy, empty, intentional-reset, corrupt, and recoverable states
- surface that storage health state in `codex auth status` and `codex auth report` so empty and broken storage are no longer conflated
- add focused command coverage for explicit corrupt and empty-state reporting

## Validation
- node_modules/.bin/vitest.cmd run test/codex-manager-status-command.test.ts test/codex-manager-report-command.test.ts
- node_modules/.bin/tsc.cmd --noEmit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr introduces `StorageHealthSummary` with five states (`healthy`, `empty`, `intentional-reset`, `corrupt`, `recoverable`) and wires it through `codex auth status` and `codex auth report`, replacing the prior empty/broken conflation with explicit diagnostic messaging. the overall design is clean and the dependency-injection pattern keeps both commands fully testable.

- `lib/storage/health.ts` — new factory module defining the state enum, summary interface, and `createStorageHealthSummary`
- `lib/storage.ts` — adds `inspectStorageHealth()` with an exhaustive decision tree covering reset marker, missing file, wal recovery, parse failure, and schema errors
- `lib/codex-manager/commands/status.ts` and `report.ts` — surface health state in both text and json output via optional `inspectStorageHealth` dep; backward compat via optional chaining
- `lib/codex-manager.ts` — wires the real `inspectStorageHealth` into both command dispatches

three issues warrant attention before merging:

- **toctou risk**: `createStorageHealthSummary` re-probes `resetMarkerPath` and `walPath` via `existsSync` even though `inspectStorageHealth` already ran those checks to determine `state`. on windows, antivirus/indexer locks between the two rounds can leave `state` and `hasResetMarker`/`hasWal` contradictory — a logic inconsistency callers cannot resolve
- **concurrency gap**: `loadAccounts()` and `inspectStorageHealth?.()` are sequential reads with no shared lock; a concurrent writer on windows can make them disagree about the storage state
- **missing vitest coverage**: `intentional-reset` and `recoverable` branches in `runStatusCommand` are untested — two of four non-default health states are dark against the project's 80% branch threshold

<h3>Confidence Score: 3/5</h3>

safe to merge with low risk, but the toctou double-existsSync in health.ts and missing branch coverage for recoverable/intentional-reset states should be addressed before shipping

overall logic is correct and the feature is well-structured. score is 3 rather than 4 due to: (1) the toctou window in createStorageHealthSummary that is particularly risky on windows — the explicit filesystem-safety concern of this codebase; (2) the sequential-read consistency gap shared between status and report commands; (3) two uncovered health-state branches in status tests that leave the project's 80% threshold at risk

lib/storage/health.ts (toctou existsSync), lib/codex-manager/commands/status.ts (consistency window + missing coverage), test/codex-manager-status-command.test.ts (two dark branches)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage/health.ts | new factory module; re-probes both paths via existsSync at construction, creating a toctou window vs. the caller's own checks in inspectStorageHealth — particularly risky on windows |
| lib/storage.ts | adds inspectStorageHealth() with exhaustive state tree; each createStorageHealthSummary call re-fires existsSync for resetMarkerPath and walPath — redundant and racy on windows under concurrent filesystem activity |
| lib/codex-manager/commands/status.ts | surfaces storageHealth in status output; loadAccounts and inspectStorageHealth are sequential reads with no shared lock (windows consistency risk); intentional-reset and recoverable message branches have no vitest coverage |
| lib/codex-manager/commands/report.ts | same sequential-read pattern at lines 358-360; storageHealth embedded correctly in json and text output; optional dep ensures backward compat with callers that do not provide it |
| lib/codex-manager.ts | straightforward plumbing — wires inspectStorageHealth into runStatusCommand (line 3207) and runReportCommand (line 3239) with no logic changes |
| test/codex-manager-status-command.test.ts | covers healthy and corrupt states only; intentional-reset and recoverable branches are dark — two of four non-default health states have no assertions, risking the 80% branch threshold |
| test/codex-manager-report-command.test.ts | broad scenario coverage including json storageHealth assertion; no non-healthy health state override tested but the report text branch surface is small — low risk |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Status as runStatusCommand
    participant Load as loadAccounts()
    participant Inspect as inspectStorageHealth()
    participant Factory as createStorageHealthSummary()
    participant FS as existsSync (node:fs)

    Caller->>Status: runStatusCommand(deps)
    Status->>Load: await deps.loadAccounts()
    Load-->>Status: storage | null
    Note over Status,Load: probe #1 — reads storage file
    Status->>Inspect: await deps.inspectStorageHealth?.()
    Note over Status,Inspect: sequential, no shared lock — windows concurrency risk
    Inspect->>FS: existsSync(resetMarkerPath)
    FS-->>Inspect: boolean (probe #2)
    Inspect->>FS: existsSync(path)
    FS-->>Inspect: boolean (probe #3)
    Inspect->>Factory: createStorageHealthSummary({state, ...})
    Factory->>FS: existsSync(resetMarkerPath)
    FS-->>Factory: boolean (probe #4 — TOCTOU window)
    Factory->>FS: existsSync(walPath)
    FS-->>Factory: boolean (probe #5 — TOCTOU window)
    Factory-->>Inspect: StorageHealthSummary
    Inspect-->>Status: StorageHealthSummary
    Status-->>Caller: exit code
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fstorage%2Fhealth.ts%3A36-37%0A**toctou%3A%20double%20%60existsSync%60%20can%20contradict%20%60state%60**%0A%0A%60createStorageHealthSummary%60%20re-probes%20both%20paths%20via%20%60existsSync%60%20at%20construction%20time%2C%20but%20%60inspectStorageHealth%60%20in%20%60storage.ts%60%20already%20ran%20those%20same%20checks%20to%20decide%20%60state%60.%20on%20windows%2C%20an%20antivirus%20scan%20or%20concurrent%20writer%20between%20the%20two%20rounds%20can%20produce%20%60state%3A%20%22intentional-reset%22%60%20with%20%60hasResetMarker%3A%20false%60%20%E2%80%94%20contradictory%20data%20callers%20cannot%20reconcile.%20pass%20the%20already-computed%20booleans%20as%20explicit%20params%20instead%20of%20re-probing%20the%20filesystem%3A%0A%0A%60%60%60suggestion%0A%09%09hasResetMarker%3A%20params.hasResetMarker%20%3F%3F%20existsSync%28params.resetMarkerPath%29%2C%0A%09%09hasWal%3A%20params.hasWal%20%3F%3F%20existsSync%28params.walPath%29%2C%0A%60%60%60%0A%0Aor%20extend%20the%20params%20type%20to%20accept%20optional%20pre-computed%20%60hasResetMarker%60%20%2F%20%60hasWal%60%20booleans%20and%20have%20%60inspectStorageHealth%60%20pass%20them%20in%20%E2%80%94%20that%20way%20the%20factory%20never%20needs%20to%20touch%20the%20filesystem%20at%20all.%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fcodex-manager-status-command.test.ts%3A69-89%0A**missing%20vitest%20coverage%20for%20%60recoverable%60%20and%20%60intentional-reset%60%20branches**%0A%0A%60runStatusCommand%60%20has%20explicit%20message%20paths%20for%20both%20states%20%28status.ts%20lines%2039%E2%80%9342%29%20but%20neither%20is%20exercised.%20only%20%60healthy%60%20%28the%20default%20in%20%60createStatusDeps%60%29%20and%20%60corrupt%60%20are%20covered%20%E2%80%94%20two%20of%20four%20non-default%20health%20states%20are%20dark%2C%20putting%20branch%20coverage%20below%20the%20project's%2080%25%20threshold.%20add%20two%20small%20cases%3A%0A%0A%60%60%60ts%0Ait%28%22prints%20intentional-reset%20message%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20const%20deps%20%3D%20createStatusDeps%28%7B%0A%20%20%20%20loadAccounts%3A%20vi.fn%28async%20%28%29%20%3D%3E%20null%29%2C%0A%20%20%20%20inspectStorageHealth%3A%20vi.fn%28async%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20%20%20state%3A%20%22intentional-reset%22%2C%0A%20%20%20%20%20%20path%3A%20%22%2Ftmp%2Fcodex.json%22%2C%0A%20%20%20%20%20%20resetMarkerPath%3A%20%22%2Ftmp%2Fcodex.json.intentional-reset%22%2C%0A%20%20%20%20%20%20walPath%3A%20%22%2Ftmp%2Fcodex.json.wal%22%2C%0A%20%20%20%20%20%20hasResetMarker%3A%20true%2C%0A%20%20%20%20%20%20hasWal%3A%20false%2C%0A%20%20%20%20%7D%29%29%2C%0A%20%20%7D%29%3B%0A%20%20await%20runStatusCommand%28deps%29%3B%0A%20%20expect%28deps.logInfo%29.toHaveBeenCalledWith%28%0A%20%20%20%20%22No%20accounts%20configured.%20Storage%20was%20intentionally%20reset.%22%2C%0A%20%20%29%3B%0A%7D%29%3B%0A%0Ait%28%22prints%20recoverable%20message%20when%20wal%20is%20available%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20const%20deps%20%3D%20createStatusDeps%28%7B%0A%20%20%20%20loadAccounts%3A%20vi.fn%28async%20%28%29%20%3D%3E%20null%29%2C%0A%20%20%20%20inspectStorageHealth%3A%20vi.fn%28async%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20%20%20state%3A%20%22recoverable%22%2C%0A%20%20%20%20%20%20path%3A%20%22%2Ftmp%2Fcodex.json%22%2C%0A%20%20%20%20%20%20resetMarkerPath%3A%20%22%2Ftmp%2Fcodex.json.intentional-reset%22%2C%0A%20%20%20%20%20%20walPath%3A%20%22%2Ftmp%2Fcodex.json.wal%22%2C%0A%20%20%20%20%20%20hasResetMarker%3A%20false%2C%0A%20%20%20%20%20%20hasWal%3A%20true%2C%0A%20%20%20%20%7D%29%29%2C%0A%20%20%7D%29%3B%0A%20%20await%20runStatusCommand%28deps%29%3B%0A%20%20expect%28deps.logInfo%29.toHaveBeenCalledWith%28%0A%20%20%20%20%22No%20accounts%20configured.%20Recovery%20artifacts%20are%20available.%22%2C%0A%20%20%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fcodex-manager%2Fcommands%2Fstatus.ts%3A33-35%0A**sequential%20reads%20%E2%80%94%20consistency%20window%20on%20windows**%0A%0A%60loadAccounts%28%29%60%20and%20%60inspectStorageHealth%3F.%28%29%60%20probe%20the%20same%20storage%20path%20one%20after%20the%20other%20with%20no%20shared%20read%20or%20lock.%20on%20windows%2C%20a%20concurrent%20writer%20or%20antivirus-triggered%20file-rename%20between%20the%20two%20calls%20can%20leave%20%60storage%60%20and%20%60storageHealth%60%20disagreeing%20%28e.g.%20%60loadAccounts%60%20returns%20a%20healthy%20list%20while%20%60inspectStorageHealth%60%20subsequently%20observes%20a%20corrupt%20file%2C%20or%20the%20reverse%20after%20a%20background%20reset%29.%20the%20same%20pattern%20is%20present%20in%20%60report.ts%60%20at%20lines%20358%E2%80%93360.%20at%20minimum%2C%20document%20the%20semantics%20as%20a%20best-effort%20snapshot%20so%20future%20contributors%20are%20not%20surprised%20by%20the%20mismatch%3A%0A%0A%60%60%60suggestion%0A%09%09const%20storage%20%3D%20await%20deps.loadAccounts%28%29%3B%0A%09%09const%20path%20%3D%20deps.getStoragePath%28%29%3B%0A%09%09%2F%2F%20storageHealth%20is%20a%20best-effort%20snapshot%3B%20not%20atomically%20consistent%20with%20%60storage%60.%0A%09%09%2F%2F%20on%20windows%20a%20concurrent%20write%20between%20these%20two%20probes%20may%20cause%20divergence.%0A%09%09const%20storageHealth%20%3D%20await%20deps.inspectStorageHealth%3F.%28%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/storage/health.ts
Line: 36-37

Comment:
**toctou: double `existsSync` can contradict `state`**

`createStorageHealthSummary` re-probes both paths via `existsSync` at construction time, but `inspectStorageHealth` in `storage.ts` already ran those same checks to decide `state`. on windows, an antivirus scan or concurrent writer between the two rounds can produce `state: "intentional-reset"` with `hasResetMarker: false` — contradictory data callers cannot reconcile. pass the already-computed booleans as explicit params instead of re-probing the filesystem:

```suggestion
		hasResetMarker: params.hasResetMarker ?? existsSync(params.resetMarkerPath),
		hasWal: params.hasWal ?? existsSync(params.walPath),
```

or extend the params type to accept optional pre-computed `hasResetMarker` / `hasWal` booleans and have `inspectStorageHealth` pass them in — that way the factory never needs to touch the filesystem at all.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-status-command.test.ts
Line: 69-89

Comment:
**missing vitest coverage for `recoverable` and `intentional-reset` branches**

`runStatusCommand` has explicit message paths for both states (status.ts lines 39–42) but neither is exercised. only `healthy` (the default in `createStatusDeps`) and `corrupt` are covered — two of four non-default health states are dark, putting branch coverage below the project's 80% threshold. add two small cases:

```ts
it("prints intentional-reset message", async () => {
  const deps = createStatusDeps({
    loadAccounts: vi.fn(async () => null),
    inspectStorageHealth: vi.fn(async () => ({
      state: "intentional-reset",
      path: "/tmp/codex.json",
      resetMarkerPath: "/tmp/codex.json.intentional-reset",
      walPath: "/tmp/codex.json.wal",
      hasResetMarker: true,
      hasWal: false,
    })),
  });
  await runStatusCommand(deps);
  expect(deps.logInfo).toHaveBeenCalledWith(
    "No accounts configured. Storage was intentionally reset.",
  );
});

it("prints recoverable message when wal is available", async () => {
  const deps = createStatusDeps({
    loadAccounts: vi.fn(async () => null),
    inspectStorageHealth: vi.fn(async () => ({
      state: "recoverable",
      path: "/tmp/codex.json",
      resetMarkerPath: "/tmp/codex.json.intentional-reset",
      walPath: "/tmp/codex.json.wal",
      hasResetMarker: false,
      hasWal: true,
    })),
  });
  await runStatusCommand(deps);
  expect(deps.logInfo).toHaveBeenCalledWith(
    "No accounts configured. Recovery artifacts are available.",
  );
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager/commands/status.ts
Line: 33-35

Comment:
**sequential reads — consistency window on windows**

`loadAccounts()` and `inspectStorageHealth?.()` probe the same storage path one after the other with no shared read or lock. on windows, a concurrent writer or antivirus-triggered file-rename between the two calls can leave `storage` and `storageHealth` disagreeing (e.g. `loadAccounts` returns a healthy list while `inspectStorageHealth` subsequently observes a corrupt file, or the reverse after a background reset). the same pattern is present in `report.ts` at lines 358–360. at minimum, document the semantics as a best-effort snapshot so future contributors are not surprised by the mismatch:

```suggestion
		const storage = await deps.loadAccounts();
		const path = deps.getStoragePath();
		// storageHealth is a best-effort snapshot; not atomically consistent with `storage`.
		// on windows a concurrent write between these two probes may cause divergence.
		const storageHealth = await deps.inspectStorageHealth?.();
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: surface explicit storage health st..."](https://github.com/ndycode/codex-multi-auth/commit/c4e70739a29635ede7998fb35a25f6a8f8e62da8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27423035)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->