### PR TITLE
feat: version runtime observability snapshots

### DIFF
--- a/lib/runtime/runtime-observability.ts
+++ b/lib/runtime/runtime-observability.ts
@@ -4,6 +4,7 @@ import { getCodexMultiAuthDir } from "../runtime-paths.js";
 import type { RuntimeMetrics } from "./metrics.js";
 
 export interface RuntimeObservabilitySnapshot {
+	version: number;
 	updatedAt: number;
 	currentRequestId: string | null;
 	responsesRequests: number;
@@ -16,6 +17,7 @@ export interface RuntimeObservabilitySnapshot {
 
 const SNAPSHOT_FILE_NAME = "runtime-observability.json";
 const PERSIST_RUNTIME_SNAPSHOT = process.env.VITEST !== "true";
+const RUNTIME_OBSERVABILITY_SNAPSHOT_VERSION = 1;
 
 let snapshotState: RuntimeObservabilitySnapshot | null = null;
 let pendingWrite: Promise<void> | null = null;
@@ -26,6 +28,7 @@ function getSnapshotPath(): string {
 
 function createDefaultSnapshot(): RuntimeObservabilitySnapshot {
 	return {
+		version: RUNTIME_OBSERVABILITY_SNAPSHOT_VERSION,
 		updatedAt: 0,
 		currentRequestId: null,
 		responsesRequests: 0,
@@ -114,8 +117,26 @@ export async function loadPersistedRuntimeObservabilitySnapshot(): Promise<Runti
 	}
 	try {
 		const raw = await fs.readFile(path, "utf-8");
-		const parsed = JSON.parse(raw) as RuntimeObservabilitySnapshot;
-		return parsed;
+		const parsed = JSON.parse(raw) as Partial<RuntimeObservabilitySnapshot> | null;
+		if (!parsed || typeof parsed !== "object") {
+			return null;
+		}
+		if (
+			typeof parsed.version === "number" &&
+			parsed.version !== RUNTIME_OBSERVABILITY_SNAPSHOT_VERSION
+		) {
+			return null;
+		}
+		const base = createDefaultSnapshot();
+		return {
+			...base,
+			...parsed,
+			version: RUNTIME_OBSERVABILITY_SNAPSHOT_VERSION,
+			runtimeMetrics: {
+				...base.runtimeMetrics,
+				...(parsed.runtimeMetrics ?? {}),
+			},
+		};
 	} catch {
 		return null;
 	}

--- a/test/runtime-observability.test.ts
+++ b/test/runtime-observability.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const readFileMock = vi.fn();
+vi.mock("node:fs", () => ({
+	existsSync: vi.fn(() => true),
+	promises: {
+		readFile: readFileMock,
+		writeFile: vi.fn(async () => undefined),
+		rename: vi.fn(async () => undefined),
+		unlink: vi.fn(async () => undefined),
+		mkdir: vi.fn(async () => undefined),
+	},
+}));
+
+vi.mock("../lib/runtime-paths.js", () => ({
+	getCodexMultiAuthDir: () => "/mock/.codex/multi-auth",
+}));
+
+describe("runtime observability snapshot versioning", () => {
+	afterEach(() => {
+		readFileMock.mockReset();
+	});
+
+	it("normalizes legacy unversioned snapshots", async () => {
+		readFileMock.mockResolvedValueOnce(
+			JSON.stringify({
+				updatedAt: 1,
+				responsesRequests: 2,
+				runtimeMetrics: { totalRequests: 3 },
+			}),
+		);
+
+		const { loadPersistedRuntimeObservabilitySnapshot } = await import(
+			"../lib/runtime/runtime-observability.js"
+		);
+		const snapshot = await loadPersistedRuntimeObservabilitySnapshot();
+
+		expect(snapshot?.version).toBe(1);
+		expect(snapshot?.responsesRequests).toBe(2);
+		expect(snapshot?.runtimeMetrics.totalRequests).toBe(3);
+		expect(snapshot?.runtimeMetrics.failedRequests).toBe(0);
+	});
+
+	it("drops unknown future snapshot versions safely", async () => {
+		readFileMock.mockResolvedValueOnce(JSON.stringify({ version: 99 }));
+
+		const { loadPersistedRuntimeObservabilitySnapshot } = await import(
+			"../lib/runtime/runtime-observability.js"
+		);
+		const snapshot = await loadPersistedRuntimeObservabilitySnapshot();
+
+		expect(snapshot).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- add a version field to persisted runtime observability snapshots and normalize legacy unversioned snapshots onto the current schema
- safely ignore unknown future snapshot versions instead of trying to load incompatible runtime telemetry files
- add focused runtime observability tests for both backward-compatible normalization and unknown-version rejection

## Validation
- node_modules/.bin/vitest.cmd run test/runtime-observability.test.ts test/runtime-metrics.test.ts
- node_modules/.bin/tsc.cmd --noEmit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr adds a `version` field to persisted runtime observability snapshots and implements two migration behaviors: legacy unversioned snapshots are normalized onto the current schema via a safe spread-merge, and unknown future versions are silently rejected. the approach is consistent with how `storage/migrations.ts` handles v1/v2→v3 upgrades elsewhere in the codebase.

key concerns:
- **windows rename safety**: `writeSnapshot` calls `fs.rename` without EBUSY/EPERM retry logic, violating the project's explicit anti-pattern. the failure is then silently swallowed by the `pendingWrite` chain's `.catch(() => undefined)`, making the data loss invisible on windows.
- **test module isolation**: both tests call `await import(...)` without `vi.resetModules()` in a `beforeEach`, sharing the module-level `snapshotState` singleton across tests — currently harmless but fragile as the suite grows.
- **missing branch coverage**: the `existsSync=false`, JSON-parse-error, and non-object guard branches in `loadPersistedRuntimeObservabilitySnapshot` are untested; the 80% threshold may be at risk.

<h3>Confidence Score: 3/5</h3>

safe to merge on linux/mac; windows rename path silently loses snapshot data without retry logic

core versioning logic is correct and well-scoped; the windows filesystem safety gap is a real concern per project conventions but non-blocking for non-windows environments; missing test isolation is fragile but not currently failing

lib/runtime/runtime-observability.ts (writeSnapshot rename retry), test/runtime-observability.test.ts (vi.resetModules + branch coverage)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/runtime/runtime-observability.ts | adds versioning + legacy normalization to snapshot persistence; windows rename lacks EBUSY/EPERM retry and write failures are silently swallowed in the pendingWrite chain |
| test/runtime-observability.test.ts | two focused snapshot-versioning tests; missing vi.resetModules() before dynamic imports and missing branch coverage for file-not-found, JSON-error, and non-object-guard paths |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant mutate as mutateRuntimeObservabilitySnapshot
    participant chain as pendingWrite chain
    participant write as writeSnapshot
    participant fs as node:fs

    Caller->>mutate: mutator fn
    mutate->>mutate: apply mutator, stamp updatedAt
    mutate->>chain: .then(writeSnapshot(clone))
    chain->>write: writeSnapshot(snapshot)
    write->>fs: mkdir(dir, recursive)
    write->>fs: writeFile(tempPath)
    write->>fs: rename(tempPath → path)
    note over fs: ⚠ no EBUSY/EPERM retry on Windows
    fs-->>write: ok / EBUSY throws
    write-->>chain: rejects
    note over chain: next .catch(() => undefined) silently drops error

    Caller->>+write: loadPersistedRuntimeObservabilitySnapshot()
    write->>fs: existsSync(path)
    alt file missing
        write-->>Caller: null
    else file present
        write->>fs: readFile(path)
        write->>write: parse + check version
        alt version undefined — legacy
            write-->>Caller: spread-merged snapshot (version=1)
        else version === 1 — current
            write-->>Caller: spread-merged snapshot
        else version > 1 — unknown future
            write-->>Caller: null
        end
    end
    deactivate write
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/runtime/runtime-observability.ts`, line 79-81 ([link](https://github.com/ndycode/codex-multi-auth/blob/c7bf640a4d128dffcea9894230d3934573dc56e2/lib/runtime/runtime-observability.ts#L79-L81)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **missing EBUSY/EPERM retry on windows rename**

   `fs.rename` on windows can fail with `EBUSY` or `EPERM` when antivirus has the destination file open. per `AGENTS.md`, bare filesystem writes without retry logic are an explicit anti-pattern (`"do not use bare fs.rm without retry logic — Windows antivirus locks"`). the failure propagates into `writeSnapshot` which throws, the `moved` flag stays false, the temp file is cleaned up — but the `pendingWrite` chain's next `.catch(() => undefined)` silently swallows the rejection. windows users will lose snapshot data with zero diagnostic signal.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/runtime/runtime-observability.ts
   Line: 79-81

   Comment:
   **missing EBUSY/EPERM retry on windows rename**

   `fs.rename` on windows can fail with `EBUSY` or `EPERM` when antivirus has the destination file open. per `AGENTS.md`, bare filesystem writes without retry logic are an explicit anti-pattern (`"do not use bare fs.rm without retry logic — Windows antivirus locks"`). the failure propagates into `writeSnapshot` which throws, the `moved` flag stays false, the temp file is cleaned up — but the `pendingWrite` chain's next `.catch(() => undefined)` silently swallows the rejection. windows users will lose snapshot data with zero diagnostic signal.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fruntime%2Fruntime-observability.ts%0ALine%3A%2079-81%0A%0AComment%3A%0A**missing%20EBUSY%2FEPERM%20retry%20on%20windows%20rename**%0A%0A%60fs.rename%60%20on%20windows%20can%20fail%20with%20%60EBUSY%60%20or%20%60EPERM%60%20when%20antivirus%20has%20the%20destination%20file%20open.%20per%20%60AGENTS.md%60%2C%20bare%20filesystem%20writes%20without%20retry%20logic%20are%20an%20explicit%20anti-pattern%20%28%60%22do%20not%20use%20bare%20fs.rm%20without%20retry%20logic%20%E2%80%94%20Windows%20antivirus%20locks%22%60%29.%20the%20failure%20propagates%20into%20%60writeSnapshot%60%20which%20throws%2C%20the%20%60moved%60%20flag%20stays%20false%2C%20the%20temp%20file%20is%20cleaned%20up%20%E2%80%94%20but%20the%20%60pendingWrite%60%20chain's%20next%20%60.catch%28%28%29%20%3D%3E%20undefined%29%60%20silently%20swallows%20the%20rejection.%20windows%20users%20will%20lose%20snapshot%20data%20with%20zero%20diagnostic%20signal.%0A%0A%60%60%60suggestion%0A%09%09await%20fs.writeFile%28tempPath%2C%20JSON.stringify%28snapshot%2C%20null%2C%202%29%2C%20%22utf-8%22%29%3B%0A%09%09for%20%28let%20attempt%20%3D%200%3B%20attempt%20%3C%204%3B%20attempt%2B%2B%29%20%7B%0A%09%09%09try%20%7B%0A%09%09%09%09await%20fs.rename%28tempPath%2C%20path%29%3B%0A%09%09%09%09moved%20%3D%20true%3B%0A%09%09%09%09break%3B%0A%09%09%09%7D%20catch%20%28err%29%20%7B%0A%09%09%09%09const%20code%20%3D%20%28err%20as%20NodeJS.ErrnoException%29.code%3B%0A%09%09%09%09if%20%28%28code%20%3D%3D%3D%20%22EBUSY%22%20%7C%7C%20code%20%3D%3D%3D%20%22EPERM%22%20%7C%7C%20code%20%3D%3D%3D%20%22ENOTEMPTY%22%29%20%26%26%20attempt%20%3C%203%29%20%7B%0A%09%09%09%09%09await%20new%20Promise%28%28r%29%20%3D%3E%20setTimeout%28r%2C%2050%20*%202%20**%20attempt%29%29%3B%0A%09%09%09%09%09continue%3B%0A%09%09%09%09%7D%0A%09%09%09%09throw%20err%3B%0A%09%09%09%7D%0A%09%09%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fruntime%2Fruntime-observability.ts%3A79-81%0A**missing%20EBUSY%2FEPERM%20retry%20on%20windows%20rename**%0A%0A%60fs.rename%60%20on%20windows%20can%20fail%20with%20%60EBUSY%60%20or%20%60EPERM%60%20when%20antivirus%20has%20the%20destination%20file%20open.%20per%20%60AGENTS.md%60%2C%20bare%20filesystem%20writes%20without%20retry%20logic%20are%20an%20explicit%20anti-pattern%20%28%60%22do%20not%20use%20bare%20fs.rm%20without%20retry%20logic%20%E2%80%94%20Windows%20antivirus%20locks%22%60%29.%20the%20failure%20propagates%20into%20%60writeSnapshot%60%20which%20throws%2C%20the%20%60moved%60%20flag%20stays%20false%2C%20the%20temp%20file%20is%20cleaned%20up%20%E2%80%94%20but%20the%20%60pendingWrite%60%20chain's%20next%20%60.catch%28%28%29%20%3D%3E%20undefined%29%60%20silently%20swallows%20the%20rejection.%20windows%20users%20will%20lose%20snapshot%20data%20with%20zero%20diagnostic%20signal.%0A%0A%60%60%60suggestion%0A%09%09await%20fs.writeFile%28tempPath%2C%20JSON.stringify%28snapshot%2C%20null%2C%202%29%2C%20%22utf-8%22%29%3B%0A%09%09for%20%28let%20attempt%20%3D%200%3B%20attempt%20%3C%204%3B%20attempt%2B%2B%29%20%7B%0A%09%09%09try%20%7B%0A%09%09%09%09await%20fs.rename%28tempPath%2C%20path%29%3B%0A%09%09%09%09moved%20%3D%20true%3B%0A%09%09%09%09break%3B%0A%09%09%09%7D%20catch%20%28err%29%20%7B%0A%09%09%09%09const%20code%20%3D%20%28err%20as%20NodeJS.ErrnoException%29.code%3B%0A%09%09%09%09if%20%28%28code%20%3D%3D%3D%20%22EBUSY%22%20%7C%7C%20code%20%3D%3D%3D%20%22EPERM%22%20%7C%7C%20code%20%3D%3D%3D%20%22ENOTEMPTY%22%29%20%26%26%20attempt%20%3C%203%29%20%7B%0A%09%09%09%09%09await%20new%20Promise%28%28r%29%20%3D%3E%20setTimeout%28r%2C%2050%20*%202%20**%20attempt%29%29%3B%0A%09%09%09%09%09continue%3B%0A%09%09%09%09%7D%0A%09%09%09%09throw%20err%3B%0A%09%09%09%7D%0A%09%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fruntime-observability.test.ts%3A19-22%0A**module%20cache%20shared%20across%20tests%20%E2%80%94%20missing%20%60vi.resetModules%28%29%60**%0A%0Aboth%20tests%20use%20dynamic%20%60await%20import%28...%29%60%20inside%20their%20%60it%28%29%60%20bodies%20but%20there%20is%20no%20%60vi.resetModules%28%29%60%20call%20between%20them.%20in%20vitest's%20ESM%20mode%20the%20second%20test%20reuses%20the%20already-cached%20module%20instance%2C%20including%20the%20module-level%20%60snapshotState%60%20and%20%60pendingWrite%60%20singletons.%20the%20current%20tests%20pass%20only%20because%20they%20both%20call%20%60loadPersistedRuntimeObservabilitySnapshot%60%2C%20which%20is%20stateless%20with%20respect%20to%20those%20singletons.%20any%20future%20test%20that%20calls%20%60mutateRuntimeObservabilitySnapshot%60%20will%20see%20leftover%20state%20and%20produce%20intermittent%20failures%20depending%20on%20test%20order.%0A%0Aadd%20a%20%60beforeEach%60%20reset%3A%0A%0A%60%60%60suggestion%0Adescribe%28%22runtime%20observability%20snapshot%20versioning%22%2C%20%28%29%20%3D%3E%20%7B%0A%09beforeEach%28%28%29%20%3D%3E%20%7B%0A%09%09vi.resetModules%28%29%3B%0A%09%7D%29%3B%0A%0A%09afterEach%28%28%29%20%3D%3E%20%7B%0A%09%09readFileMock.mockReset%28%29%3B%0A%09%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fruntime-observability.test.ts%3A3-13%0A**missing%20vitest%20coverage%3A%20several%20branches%20in%20%60loadPersistedRuntimeObservabilitySnapshot%60%20untested**%0A%0A%60existsSync%60%20is%20globally%20mocked%20to%20return%20%60true%60%20for%20every%20test%2C%20so%20the%20early%20%60return%20null%60%20%28file%20does%20not%20exist%2C%20line%20115%20of%20%60runtime-observability.ts%60%29%20is%20never%20exercised.%20likewise%2C%20the%20%60!parsed%20%7C%7C%20typeof%20parsed%20!%3D%3D%20'object'%60%20guard%20and%20the%20JSON%20parse-error%20catch%20block%20are%20untested.%20given%20the%2080%25%20branch-coverage%20threshold%2C%20these%20gaps%20may%20trip%20the%20coverage%20gate.%0A%0Aadd%20at%20minimum%3A%0A%60%60%60ts%0Ait%28%22returns%20null%20when%20snapshot%20file%20does%20not%20exist%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20const%20%7B%20existsSync%20%7D%20%3D%20await%20import%28%22node%3Afs%22%29%3B%0A%20%20vi.mocked%28existsSync%29.mockReturnValueOnce%28false%29%3B%0A%20%20const%20%7B%20loadPersistedRuntimeObservabilitySnapshot%20%7D%20%3D%20await%20import%28%0A%20%20%20%20%22..%2Flib%2Fruntime%2Fruntime-observability.js%22%0A%20%20%29%3B%0A%20%20expect%28await%20loadPersistedRuntimeObservabilitySnapshot%28%29%29.toBeNull%28%29%3B%0A%7D%29%3B%0A%0Ait%28%22returns%20null%20on%20malformed%20JSON%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20readFileMock.mockResolvedValueOnce%28%22not-json%22%29%3B%0A%20%20const%20%7B%20loadPersistedRuntimeObservabilitySnapshot%20%7D%20%3D%20await%20import%28%0A%20%20%20%20%22..%2Flib%2Fruntime%2Fruntime-observability.js%22%0A%20%20%29%3B%0A%20%20expect%28await%20loadPersistedRuntimeObservabilitySnapshot%28%29%29.toBeNull%28%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/runtime/runtime-observability.ts
Line: 79-81

Comment:
**missing EBUSY/EPERM retry on windows rename**

`fs.rename` on windows can fail with `EBUSY` or `EPERM` when antivirus has the destination file open. per `AGENTS.md`, bare filesystem writes without retry logic are an explicit anti-pattern (`"do not use bare fs.rm without retry logic — Windows antivirus locks"`). the failure propagates into `writeSnapshot` which throws, the `moved` flag stays false, the temp file is cleaned up — but the `pendingWrite` chain's next `.catch(() => undefined)` silently swallows the rejection. windows users will lose snapshot data with zero diagnostic signal.

```suggestion
		await fs.writeFile(tempPath, JSON.stringify(snapshot, null, 2), "utf-8");
		for (let attempt = 0; attempt < 4; attempt++) {
			try {
				await fs.rename(tempPath, path);
				moved = true;
				break;
			} catch (err) {
				const code = (err as NodeJS.ErrnoException).code;
				if ((code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY") && attempt < 3) {
					await new Promise((r) => setTimeout(r, 50 * 2 ** attempt));
					continue;
				}
				throw err;
			}
		}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/runtime-observability.test.ts
Line: 19-22

Comment:
**module cache shared across tests — missing `vi.resetModules()`**

both tests use dynamic `await import(...)` inside their `it()` bodies but there is no `vi.resetModules()` call between them. in vitest's ESM mode the second test reuses the already-cached module instance, including the module-level `snapshotState` and `pendingWrite` singletons. the current tests pass only because they both call `loadPersistedRuntimeObservabilitySnapshot`, which is stateless with respect to those singletons. any future test that calls `mutateRuntimeObservabilitySnapshot` will see leftover state and produce intermittent failures depending on test order.

add a `beforeEach` reset:

```suggestion
describe("runtime observability snapshot versioning", () => {
	beforeEach(() => {
		vi.resetModules();
	});

	afterEach(() => {
		readFileMock.mockReset();
	});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/runtime-observability.test.ts
Line: 3-13

Comment:
**missing vitest coverage: several branches in `loadPersistedRuntimeObservabilitySnapshot` untested**

`existsSync` is globally mocked to return `true` for every test, so the early `return null` (file does not exist, line 115 of `runtime-observability.ts`) is never exercised. likewise, the `!parsed || typeof parsed !== 'object'` guard and the JSON parse-error catch block are untested. given the 80% branch-coverage threshold, these gaps may trip the coverage gate.

add at minimum:
```ts
it("returns null when snapshot file does not exist", async () => {
  const { existsSync } = await import("node:fs");
  vi.mocked(existsSync).mockReturnValueOnce(false);
  const { loadPersistedRuntimeObservabilitySnapshot } = await import(
    "../lib/runtime/runtime-observability.js"
  );
  expect(await loadPersistedRuntimeObservabilitySnapshot()).toBeNull();
});

it("returns null on malformed JSON", async () => {
  readFileMock.mockResolvedValueOnce("not-json");
  const { loadPersistedRuntimeObservabilitySnapshot } = await import(
    "../lib/runtime/runtime-observability.js"
  );
  expect(await loadPersistedRuntimeObservabilitySnapshot()).toBeNull();
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: version runtime observability snap..."](https://github.com/ndycode/codex-multi-auth/commit/c7bf640a4d128dffcea9894230d3934573dc56e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27423038)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->