### PR TITLE
fix: recreate live account sync on config changes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -309,8 +309,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 	let startupPrewarmTriggered = false;
 	let lastCodexCliActiveSyncIndex: number | null = null;
 	let perProjectStorageWarningShown = false;
-	let liveAccountSync: LiveAccountSync | null = null;
-	let liveAccountSyncPath: string | null = null;
+let liveAccountSync: LiveAccountSync | null = null;
+let liveAccountSyncPath: string | null = null;
+let liveAccountSyncConfigKey: string | null = null;
 	let refreshGuardian: RefreshGuardian | null = null;
 	let refreshGuardianConfigKey: string | null = null;
 	let refreshGuardianCleanupRegistered = false;
@@ -481,7 +482,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			authFallback,
 			currentSync: liveAccountSync,
 			currentPath: liveAccountSyncPath,
+			currentConfigKey: liveAccountSyncConfigKey,
 			getLiveAccountSync,
+			getLiveAccountSyncDebounceMs,
+			getLiveAccountSyncPollMs,
 			getStoragePath,
 			createSync: (oauthFallback) =>
 				new LiveAccountSync(
@@ -502,6 +506,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 		});
 		liveAccountSync = next.liveAccountSync;
 		liveAccountSyncPath = next.liveAccountSyncPath;
+		liveAccountSyncConfigKey = next.liveAccountSyncConfigKey;
 	};
 	const ensureRefreshGuardian = (
 		pluginConfig: ReturnType<typeof loadPluginConfig>,

--- a/lib/runtime/live-sync-entry.ts
+++ b/lib/runtime/live-sync-entry.ts
@@ -12,10 +12,17 @@ export async function ensureLiveAccountSyncEntry<
 	authFallback?: OAuthAuthDetails;
 	currentSync: TSync | null;
 	currentPath: string | null;
+	currentConfigKey?: string | null;
 	getLiveAccountSync: (
 		config: ReturnType<typeof import("../config.js").loadPluginConfig>,
 	) => boolean;
 	getStoragePath: () => string;
+	getLiveAccountSyncDebounceMs: (
+		config: ReturnType<typeof import("../config.js").loadPluginConfig>,
+	) => number;
+	getLiveAccountSyncPollMs: (
+		config: ReturnType<typeof import("../config.js").loadPluginConfig>,
+	) => number;
 	createSync: (authFallback?: OAuthAuthDetails) => TSync;
 	registerCleanup: (cleanup: () => void) => void;
 	logWarn: (message: string) => void;
@@ -25,6 +32,8 @@ export async function ensureLiveAccountSyncEntry<
 		targetPath: string;
 		currentSync: TSync | null;
 		currentPath: string | null;
+		currentConfigKey?: string | null;
+		configKey?: string | null;
 		authFallback?: OAuthAuthDetails;
 		createSync: (authFallback?: OAuthAuthDetails) => TSync;
 		registerCleanup: (cleanup: () => void) => void;
@@ -33,16 +42,22 @@ export async function ensureLiveAccountSyncEntry<
 	}) => Promise<{
 		liveAccountSync: TSync | null;
 		liveAccountSyncPath: string | null;
+		liveAccountSyncConfigKey: string | null;
 	}>;
 }): Promise<{
 	liveAccountSync: TSync | null;
 	liveAccountSyncPath: string | null;
+	liveAccountSyncConfigKey: string | null;
 }> {
+	const debounceMs = params.getLiveAccountSyncDebounceMs(params.pluginConfig);
+	const pollIntervalMs = params.getLiveAccountSyncPollMs(params.pluginConfig);
 	return params.ensureLiveAccountSyncState({
 		enabled: params.getLiveAccountSync(params.pluginConfig),
 		targetPath: params.getStoragePath(),
 		currentSync: params.currentSync,
 		currentPath: params.currentPath,
+		currentConfigKey: params.currentConfigKey,
+		configKey: `${debounceMs}:${pollIntervalMs}`,
 		authFallback: params.authFallback,
 		createSync: params.createSync,
 		registerCleanup: params.registerCleanup,

--- a/lib/runtime/live-sync.ts
+++ b/lib/runtime/live-sync.ts
@@ -15,6 +15,7 @@ export async function ensureRuntimeLiveAccountSync<
 	getStoragePath: () => string;
 	currentSync: TSync | null;
 	currentPath: string | null;
+	currentConfigKey?: string | null;
 	currentCleanupRegistered: boolean;
 	getCurrentSync: () => TSync | null;
 	createSync: (
@@ -29,6 +30,7 @@ export async function ensureRuntimeLiveAccountSync<
 	commitState: (state: {
 		sync: TSync | null;
 		path: string | null;
+		configKey: string | null;
 		cleanupRegistered: boolean;
 	}) => void;
 	registerCleanup: (cleanup: () => void) => void;
@@ -37,18 +39,24 @@ export async function ensureRuntimeLiveAccountSync<
 }): Promise<{
 	sync: TSync | null;
 	path: string | null;
+	configKey: string | null;
 	cleanupRegistered: boolean;
 }> {
+	const debounceMs = deps.getLiveAccountSyncDebounceMs(deps.pluginConfig);
+	const pollIntervalMs = deps.getLiveAccountSyncPollMs(deps.pluginConfig);
+	const nextConfigKey = `${debounceMs}:${pollIntervalMs}`;
 	if (!deps.getLiveAccountSync(deps.pluginConfig)) {
 		deps.currentSync?.stop();
 		deps.commitState({
 			sync: null,
 			path: null,
+			configKey: null,
 			cleanupRegistered: deps.currentCleanupRegistered,
 		});
 		return {
 			sync: null,
 			path: null,
+			configKey: null,
 			cleanupRegistered: deps.currentCleanupRegistered,
 		};
 	}
@@ -57,10 +65,18 @@ export async function ensureRuntimeLiveAccountSync<
 	let sync = deps.currentSync;
 	let cleanupRegistered = deps.currentCleanupRegistered;
 	let nextPath = deps.currentPath;
+	let configKey = deps.currentConfigKey ?? null;
+	if (sync && configKey !== null && configKey !== nextConfigKey) {
+		sync.stop();
+		sync = null;
+		nextPath = null;
+		configKey = null;
+	}
 	const commitState = (): void => {
 		deps.commitState({
 			sync,
 			path: nextPath,
+			configKey,
 			cleanupRegistered,
 		});
 	};
@@ -70,10 +86,11 @@ export async function ensureRuntimeLiveAccountSync<
 				await deps.reloadAccountManagerFromDisk(deps.authFallback);
 			},
 			{
-				debounceMs: deps.getLiveAccountSyncDebounceMs(deps.pluginConfig),
-				pollIntervalMs: deps.getLiveAccountSyncPollMs(deps.pluginConfig),
+				debounceMs,
+				pollIntervalMs,
 			},
 		);
+		configKey = nextConfigKey;
 		commitState();
 		if (!cleanupRegistered) {
 			deps.registerCleanup(() => {
@@ -106,5 +123,5 @@ export async function ensureRuntimeLiveAccountSync<
 		}
 	}
 
-	return { sync, path: nextPath, cleanupRegistered };
+	return { sync, path: nextPath, configKey, cleanupRegistered };
 }

--- a/lib/runtime/runtime-services.ts
+++ b/lib/runtime/runtime-services.ts
@@ -20,6 +20,8 @@ export async function ensureLiveAccountSyncState<
 	targetPath: string;
 	currentSync: TSync | null;
 	currentPath: string | null;
+	currentConfigKey?: string | null;
+	configKey?: string | null;
 	authFallback?: OAuthAuthDetails;
 	createSync: (authFallback?: OAuthAuthDetails) => TSync;
 	registerCleanup: (cleanup: () => void) => void;
@@ -28,21 +30,42 @@ export async function ensureLiveAccountSyncState<
 }): Promise<{
 	liveAccountSync: TSync | null;
 	liveAccountSyncPath: string | null;
+	liveAccountSyncConfigKey: string | null;
 }> {
 	let liveAccountSync = params.currentSync;
 	let liveAccountSyncPath = params.currentPath;
+	let liveAccountSyncConfigKey = params.currentConfigKey ?? null;
 
 	if (!params.enabled) {
 		if (liveAccountSync) {
 			liveAccountSync.stop();
 			liveAccountSync = null;
 			liveAccountSyncPath = null;
+			liveAccountSyncConfigKey = null;
 		}
-		return { liveAccountSync, liveAccountSyncPath };
+		return {
+			liveAccountSync,
+			liveAccountSyncPath,
+			liveAccountSyncConfigKey,
+		};
+	}
+
+	const nextConfigKey = params.configKey ?? null;
+	if (
+		liveAccountSync &&
+		nextConfigKey !== null &&
+		liveAccountSyncConfigKey !== null &&
+		liveAccountSyncConfigKey !== nextConfigKey
+	) {
+		liveAccountSync.stop();
+		liveAccountSync = null;
+		liveAccountSyncPath = null;
+		liveAccountSyncConfigKey = null;
 	}
 
 	if (!liveAccountSync) {
 		liveAccountSync = params.createSync(params.authFallback);
+		liveAccountSyncConfigKey = nextConfigKey;
 		params.registerCleanup(() => {
 			liveAccountSync?.stop();
 		});
@@ -71,7 +94,7 @@ export async function ensureLiveAccountSyncState<
 		}
 	}
 
-	return { liveAccountSync, liveAccountSyncPath };
+	return { liveAccountSync, liveAccountSyncPath, liveAccountSyncConfigKey };
 }
 
 export function ensureRefreshGuardianState<

--- a/test/live-sync-entry.test.ts
+++ b/test/live-sync-entry.test.ts
@@ -17,7 +17,10 @@ describe("live sync entry", () => {
 			} as never,
 			currentSync: null,
 			currentPath: null,
+			currentConfigKey: null,
 			getLiveAccountSync: () => true,
+			getLiveAccountSyncDebounceMs: () => 25,
+			getLiveAccountSyncPollMs: () => 250,
 			getStoragePath: () => "/tmp/accounts.json",
 			createSync: vi.fn(() => ({ stop: vi.fn(), syncToPath: vi.fn() })),
 			registerCleanup: vi.fn(),
@@ -30,6 +33,7 @@ describe("live sync entry", () => {
 			expect.objectContaining({
 				enabled: true,
 				targetPath: "/tmp/accounts.json",
+				configKey: "25:250",
 				pluginName: "plugin",
 			}),
 		);

--- a/test/runtime-live-sync.test.ts
+++ b/test/runtime-live-sync.test.ts
@@ -21,6 +21,7 @@ describe("runtime live sync", () => {
 		let committedState = {
 			sync: overrides.currentSync ?? null,
 			path: overrides.currentPath ?? null,
+			configKey: null as string | null,
 			cleanupRegistered: overrides.currentCleanupRegistered ?? false,
 		};
 		let cleanupCallback: (() => void) | null = null;
@@ -92,12 +93,14 @@ describe("runtime live sync", () => {
 		await expect(ensureRuntimeLiveAccountSync(deps)).resolves.toEqual({
 			sync: null,
 			path: null,
+			configKey: null,
 			cleanupRegistered: true,
 		});
 		expect(currentSync.stop).toHaveBeenCalledTimes(1);
 		expect(deps.commitState).toHaveBeenCalledWith({
 			sync: null,
 			path: null,
+			configKey: null,
 			cleanupRegistered: true,
 		});
 	});
@@ -111,6 +114,7 @@ describe("runtime live sync", () => {
 		expect(createSync).toHaveBeenCalledTimes(1);
 		expect(registerCleanup).toHaveBeenCalledTimes(1);
 		expect(first.path).toBe("C:\\repo\\accounts.json");
+		expect(first.configKey).toBe("25:250");
 		expect(first.cleanupRegistered).toBe(true);
 		expect(first.sync?.syncToPath).toHaveBeenCalledWith(
 			"C:\\repo\\accounts.json",
@@ -120,6 +124,7 @@ describe("runtime live sync", () => {
 			...deps,
 			currentSync: first.sync,
 			currentPath: first.path,
+			currentConfigKey: first.configKey,
 			currentCleanupRegistered: first.cleanupRegistered,
 		});
 
@@ -151,6 +156,7 @@ describe("runtime live sync", () => {
 		await expect(pending).resolves.toMatchObject({
 			sync: currentSync,
 			path: "C:\\repo\\new.json",
+			configKey: null,
 			cleanupRegistered: true,
 		});
 		expect(currentSync.syncToPath).toHaveBeenCalledTimes(3);
@@ -176,6 +182,7 @@ describe("runtime live sync", () => {
 		await expect(pending).resolves.toMatchObject({
 			sync: currentSync,
 			path: "C:\\repo\\old.json",
+			configKey: null,
 			cleanupRegistered: true,
 		});
 		expect(currentSync.syncToPath).toHaveBeenCalledTimes(3);
@@ -213,6 +220,7 @@ describe("runtime live sync", () => {
 		const committed = getCommittedState();
 		expect(committed.sync).toBe(createdSync);
 		expect(committed.path).toBeNull();
+		expect(committed.configKey).toBe("25:250");
 		expect(committed.cleanupRegistered).toBe(true);
 
 		const cleanup = getCleanupCallback();
@@ -238,12 +246,14 @@ describe("runtime live sync", () => {
 
 		const committed = getCommittedState();
 		expect(committed.sync).toBe(createdSync);
+		expect(committed.configKey).toBe("25:250");
 		expect(committed.cleanupRegistered).toBe(true);
 
 		const second = ensureRuntimeLiveAccountSync({
 			...deps,
 			currentSync: committed.sync,
 			currentPath: committed.path,
+			currentConfigKey: committed.configKey,
 			currentCleanupRegistered: committed.cleanupRegistered,
 		});
 		await vi.runAllTicks();
@@ -253,11 +263,13 @@ describe("runtime live sync", () => {
 		await expect(pending).resolves.toMatchObject({
 			sync: createdSync,
 			path: "C:\\repo\\accounts.json",
+			configKey: "25:250",
 			cleanupRegistered: true,
 		});
 		await expect(second).resolves.toMatchObject({
 			sync: createdSync,
 			path: "C:\\repo\\accounts.json",
+			configKey: "25:250",
 			cleanupRegistered: true,
 		});
 	});
@@ -273,6 +285,7 @@ describe("runtime live sync", () => {
 			...deps,
 			currentSync: first.sync,
 			currentPath: first.path,
+			currentConfigKey: first.configKey,
 			currentCleanupRegistered: first.cleanupRegistered,
 			getLiveAccountSync: vi.fn().mockReturnValue(false),
 		});
@@ -282,6 +295,7 @@ describe("runtime live sync", () => {
 			...deps,
 			currentSync: disabled.sync,
 			currentPath: disabled.path,
+			currentConfigKey: disabled.configKey,
 			currentCleanupRegistered: disabled.cleanupRegistered,
 		});
 		setLiveSync(reenabled.sync);
@@ -292,5 +306,37 @@ describe("runtime live sync", () => {
 		cleanup?.();
 		expect((reenabled.sync as { stop: ReturnType<typeof vi.fn> }).stop).toHaveBeenCalledTimes(1);
 		expect((first.sync as { stop: ReturnType<typeof vi.fn> }).stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("recreates live sync when debounce/poll settings change", async () => {
+		const firstSync = {
+			stop: vi.fn(),
+			syncToPath: vi.fn().mockResolvedValue(undefined),
+		};
+		const secondSync = {
+			stop: vi.fn(),
+			syncToPath: vi.fn().mockResolvedValue(undefined),
+		};
+		const { deps, createSync } = createDeps({
+			currentSync: firstSync,
+			currentPath: "C:\\repo\\accounts.json",
+			currentCleanupRegistered: true,
+		});
+		createSync.mockReturnValue(secondSync);
+		deps.getLiveAccountSyncDebounceMs = vi.fn().mockReturnValue(50);
+		deps.getLiveAccountSyncPollMs = vi.fn().mockReturnValue(500);
+
+		const result = await ensureRuntimeLiveAccountSync({
+			...deps,
+			currentSync: firstSync,
+			currentPath: "C:\\repo\\accounts.json",
+			currentConfigKey: "25:250",
+		});
+
+		expect(firstSync.stop).toHaveBeenCalledTimes(1);
+		expect(createSync).toHaveBeenCalledTimes(1);
+		expect(result.sync).toBe(secondSync);
+		expect(result.configKey).toBe("50:500");
+		expect(secondSync.syncToPath).toHaveBeenCalledWith("C:\\repo\\accounts.json");
 	});
 });

--- a/test/runtime-services.test.ts
+++ b/test/runtime-services.test.ts
@@ -13,6 +13,7 @@ describe("runtime services helpers", () => {
 			targetPath: "/tmp/a",
 			currentSync: { stop, syncToPath: vi.fn() },
 			currentPath: "/tmp/old",
+			currentConfigKey: "old",
 			createSync: vi.fn(),
 			registerCleanup: vi.fn(),
 			logWarn: vi.fn(),
@@ -23,6 +24,7 @@ describe("runtime services helpers", () => {
 		expect(result).toEqual({
 			liveAccountSync: null,
 			liveAccountSyncPath: null,
+			liveAccountSyncConfigKey: null,
 		});
 	});
 
@@ -34,6 +36,7 @@ describe("runtime services helpers", () => {
 			targetPath: "/tmp/a",
 			currentSync: null,
 			currentPath: null,
+			configKey: "25:250",
 			createSync: vi.fn(() => created),
 			registerCleanup: vi.fn(),
 			logWarn: vi.fn(),
@@ -43,6 +46,7 @@ describe("runtime services helpers", () => {
 		expect(syncToPath).toHaveBeenCalledWith("/tmp/a");
 		expect(result.liveAccountSync).toBe(created);
 		expect(result.liveAccountSyncPath).toBe("/tmp/a");
+		expect(result.liveAccountSyncConfigKey).toBe("25:250");
 	});
 
 	it("warns and keeps the previous path when busy retries are exhausted", async () => {
@@ -59,9 +63,10 @@ describe("runtime services helpers", () => {
 			const resultPromise = ensureLiveAccountSyncState({
 				enabled: true,
 				targetPath: "/tmp/new",
-				currentSync,
-				currentPath: "/tmp/old",
-				createSync: vi.fn(),
+			currentSync,
+			currentPath: "/tmp/old",
+			currentConfigKey: "old",
+			createSync: vi.fn(),
 				registerCleanup: vi.fn(),
 				logWarn,
 				pluginName: "plugin",
@@ -77,10 +82,36 @@ describe("runtime services helpers", () => {
 			expect(result).toEqual({
 				liveAccountSync: currentSync,
 				liveAccountSyncPath: "/tmp/old",
+				liveAccountSyncConfigKey: "old",
 			});
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("recreates live sync when config key changes", async () => {
+		const oldSync = { stop: vi.fn(), syncToPath: vi.fn() };
+		const newSync = { stop: vi.fn(), syncToPath: vi.fn().mockResolvedValue(undefined) };
+		const createSync = vi.fn(() => newSync);
+
+		const result = await ensureLiveAccountSyncState({
+			enabled: true,
+			targetPath: "/tmp/a",
+			currentSync: oldSync,
+			currentPath: "/tmp/a",
+			currentConfigKey: "25:250",
+			configKey: "50:500",
+			createSync,
+			registerCleanup: vi.fn(),
+			logWarn: vi.fn(),
+			pluginName: "plugin",
+		});
+
+		expect(oldSync.stop).toHaveBeenCalledTimes(1);
+		expect(createSync).toHaveBeenCalledTimes(1);
+		expect(newSync.syncToPath).toHaveBeenCalledWith("/tmp/a");
+		expect(result.liveAccountSync).toBe(newSync);
+		expect(result.liveAccountSyncConfigKey).toBe("50:500");
 	});
 
 	it("recreates refresh guardian when config changes and clears when disabled", () => {


### PR DESCRIPTION
## Problem

Live account sync kept reusing the same controller once created, even when its effective debounce/poll configuration changed.

That leaves stale runtime state in place and continues watching with outdated timing parameters.

## Fix

Track a live-sync config key and recreate the controller when its effective configuration changes.

This mirrors the existing refresh-guardian pattern and keeps runtime watcher state aligned with the current config.

## Changes

- `lib/runtime/live-sync.ts`
  - added config-key tracking to the runtime live-sync helper
  - recreates the controller when the config key changes
- `lib/runtime/runtime-services.ts`
  - extended the lower-level helper to preserve and return a live-sync config key
- `lib/runtime/live-sync-entry.ts`
  - forwards debounce/poll-derived config key data into the helper
- `index.ts`
  - stores `liveAccountSyncConfigKey` alongside the sync instance/path
- tests updated in:
  - `test/runtime-live-sync.test.ts`
  - `test/runtime-services.test.ts`
  - `test/live-sync-entry.test.ts`

## Validation

```text
npx vitest run test/live-sync-entry.test.ts test/runtime-services.test.ts test/runtime-live-sync.test.ts test/live-account-sync.test.ts test/live-account-sync-edge.test.ts
Test Files  5 passed (5)
Tests      26 passed (26)

npx vitest run
Test Files  222 passed (222)
Tests      3315 passed (3315)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr adds config-key tracking to the live account sync system so the watcher is torn down and recreated whenever debounce/poll settings change, mirroring the existing refresh-guardian pattern. changes are clean and the overall approach is sound.

- `lib/runtime/live-sync.ts`: new generic helper adds `currentConfigKey`/`configKey` params, compares keys on entry, stops stale sync, and tracks `cleanupRegistered` to avoid duplicate handlers
- `lib/runtime/runtime-services.ts`: new `ensureLiveAccountSyncState` delegates to the same pattern but **does not track `cleanupRegistered`** — `registerCleanup` is called on every sync creation, including recreations triggered by config changes
- `lib/runtime/live-sync-entry.ts`: cleanly computes `configKey` from debounce+poll and forwards `currentConfigKey` down; return value now includes `liveAccountSyncConfigKey`
- `index.ts`: adds the module-level `liveAccountSyncConfigKey` state variable and threads it through `ensureLiveAccountSyncEntry` correctly
- tests cover the new recreation path and ebusy retries, but `live-sync-entry.test.ts` doesn't assert on the new `liveAccountSyncConfigKey` return value and the mock omits it

<h3>Confidence Score: 3/5</h3>

mergeable with caution — the cleanup accumulation in runtime-services.ts is a real correctness divergence from the established pattern

the core logic in live-sync.ts and the wiring in index.ts/live-sync-entry.ts are correct and well-tested. the missing cleanupRegistered guard in runtime-services.ts is a meaningful gap that will silently accumulate handlers across config changes and is inconsistent with the sibling implementation. the missing test coverage in live-sync-entry.test.ts means the new config-key threading is unverified at that layer. neither issue is blocking at normal usage volumes, but both are worth fixing before merge.

lib/runtime/runtime-services.ts (missing cleanupRegistered guard) and test/live-sync-entry.test.ts (missing mock field and assertion)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/runtime/runtime-services.ts | adds ensureLiveAccountSyncState with config-key recreation logic, but missing cleanupRegistered guard — diverges from live-sync.ts pattern and accumulates cleanup handlers across recreations |
| lib/runtime/live-sync.ts | well-structured generic helper; correctly tracks currentConfigKey, stops stale sync on key change, guards cleanupRegistered to prevent handler accumulation |
| lib/runtime/live-sync-entry.ts | cleanly computes configKey from debounce/poll, forwards currentConfigKey and new configKey into state helper, returns liveAccountSyncConfigKey to caller |
| index.ts | adds liveAccountSyncConfigKey module-level state and threads it through ensureLiveAccountSyncEntry correctly |
| test/runtime-live-sync.test.ts | comprehensive: covers creation, config-key recreation, cleanup dedup, EBUSY/EPERM retries, concurrency (commit-before-await), toggle cycle |
| test/runtime-services.test.ts | covers key scenarios but missing assertion on registerCleanup call count during config-key recreation |
| test/live-sync-entry.test.ts | single test; mock omits liveAccountSyncConfigKey from return and no assertion on it — zero coverage of the new config-key threading behaviour |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant I as index.ts
    participant E as live-sync-entry.ts
    participant S as runtime-services.ts
    participant Sync as LiveAccountSync

    note over I,Sync: initial call — configKey=25:250
    I->>E: ensureLiveAccountSyncEntry(currentConfigKey=null)
    E->>E: compute configKey="25:250"
    E->>S: ensureLiveAccountSyncState(currentConfigKey=null, configKey="25:250")
    S->>Sync: createSync() → sync1
    S->>S: registerCleanup(sync1.stop) ✓
    S->>Sync: sync1.syncToPath(targetPath)
    S-->>E: {liveAccountSync: sync1, configKey: "25:250"}
    E-->>I: {liveAccountSync: sync1, liveAccountSyncConfigKey: "25:250"}
    I->>I: liveAccountSyncConfigKey = "25:250"

    note over I,Sync: config change — debounce/poll updated
    I->>E: ensureLiveAccountSyncEntry(currentConfigKey="25:250")
    E->>E: compute configKey="50:500"
    E->>S: ensureLiveAccountSyncState(currentConfigKey="25:250", configKey="50:500")
    S->>Sync: sync1.stop() [key mismatch]
    S->>Sync: createSync() → sync2
    S->>S: registerCleanup(sync2.stop) ⚠ no guard — extra handler registered
    S->>Sync: sync2.syncToPath(targetPath)
    S-->>E: {liveAccountSync: sync2, configKey: "50:500"}
    E-->>I: {liveAccountSync: sync2, liveAccountSyncConfigKey: "50:500"}
    I->>I: liveAccountSyncConfigKey = "50:500"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/runtime/runtime-services.ts`, line 66-72 ([link](https://github.com/ndycode/codex-multi-auth/blob/9e35ef5a8cb7a479f57faf4400071df5309ca5a9/lib/runtime/runtime-services.ts#L66-L72)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **cleanup accumulates on every sync recreation**

   no `cleanupRegistered` guard here. every time the config key changes and a new sync is created, another closure is pushed into the cleanup registry. the sibling `live-sync.ts` (lines 95-101) was written with an explicit `cleanupRegistered` flag + `getCurrentSync()` indirection precisely to prevent this.

   each extra closure captures its own local `liveAccountSync` binding, so it won't double-stop the *current* sync — but it will call `.stop()` on the already-stopped previous sync, which is only safe if `stop()` is idempotent. more importantly, after N config changes the registry holds N cleanup handlers. on windows, antivirus-induced re-entrant fs locks during a flurry of config reloads could trigger multiple concurrent stop/recreate cycles, each registering another handler.

   mirror the pattern from `live-sync.ts`:

   ```typescript
   if (!liveAccountSync) {
       liveAccountSync = params.createSync(params.authFallback);
       liveAccountSyncConfigKey = nextConfigKey;
       if (!params.currentCleanupRegistered) {
           params.registerCleanup(() => {
               liveAccountSync?.stop();
           });
       }
   }
   ```

   or accept/return a `cleanupRegistered` boolean in the params/return type so callers can track and pass it back on the next invocation — exactly how `live-sync.ts` handles it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/runtime/runtime-services.ts
   Line: 66-72

   Comment:
   **cleanup accumulates on every sync recreation**

   no `cleanupRegistered` guard here. every time the config key changes and a new sync is created, another closure is pushed into the cleanup registry. the sibling `live-sync.ts` (lines 95-101) was written with an explicit `cleanupRegistered` flag + `getCurrentSync()` indirection precisely to prevent this.

   each extra closure captures its own local `liveAccountSync` binding, so it won't double-stop the *current* sync — but it will call `.stop()` on the already-stopped previous sync, which is only safe if `stop()` is idempotent. more importantly, after N config changes the registry holds N cleanup handlers. on windows, antivirus-induced re-entrant fs locks during a flurry of config reloads could trigger multiple concurrent stop/recreate cycles, each registering another handler.

   mirror the pattern from `live-sync.ts`:

   ```typescript
   if (!liveAccountSync) {
       liveAccountSync = params.createSync(params.authFallback);
       liveAccountSyncConfigKey = nextConfigKey;
       if (!params.currentCleanupRegistered) {
           params.registerCleanup(() => {
               liveAccountSync?.stop();
           });
       }
   }
   ```

   or accept/return a `cleanupRegistered` boolean in the params/return type so callers can track and pass it back on the next invocation — exactly how `live-sync.ts` handles it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fruntime%2Fruntime-services.ts%0ALine%3A%2066-72%0A%0AComment%3A%0A**cleanup%20accumulates%20on%20every%20sync%20recreation**%0A%0Ano%20%60cleanupRegistered%60%20guard%20here.%20every%20time%20the%20config%20key%20changes%20and%20a%20new%20sync%20is%20created%2C%20another%20closure%20is%20pushed%20into%20the%20cleanup%20registry.%20the%20sibling%20%60live-sync.ts%60%20%28lines%2095-101%29%20was%20written%20with%20an%20explicit%20%60cleanupRegistered%60%20flag%20%2B%20%60getCurrentSync%28%29%60%20indirection%20precisely%20to%20prevent%20this.%0A%0Aeach%20extra%20closure%20captures%20its%20own%20local%20%60liveAccountSync%60%20binding%2C%20so%20it%20won't%20double-stop%20the%20*current*%20sync%20%E2%80%94%20but%20it%20will%20call%20%60.stop%28%29%60%20on%20the%20already-stopped%20previous%20sync%2C%20which%20is%20only%20safe%20if%20%60stop%28%29%60%20is%20idempotent.%20more%20importantly%2C%20after%20N%20config%20changes%20the%20registry%20holds%20N%20cleanup%20handlers.%20on%20windows%2C%20antivirus-induced%20re-entrant%20fs%20locks%20during%20a%20flurry%20of%20config%20reloads%20could%20trigger%20multiple%20concurrent%20stop%2Frecreate%20cycles%2C%20each%20registering%20another%20handler.%0A%0Amirror%20the%20pattern%20from%20%60live-sync.ts%60%3A%0A%0A%60%60%60typescript%0Aif%20%28!liveAccountSync%29%20%7B%0A%20%20%20%20liveAccountSync%20%3D%20params.createSync%28params.authFallback%29%3B%0A%20%20%20%20liveAccountSyncConfigKey%20%3D%20nextConfigKey%3B%0A%20%20%20%20if%20%28!params.currentCleanupRegistered%29%20%7B%0A%20%20%20%20%20%20%20%20params.registerCleanup%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20liveAccountSync%3F.stop%28%29%3B%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0Aor%20accept%2Freturn%20a%20%60cleanupRegistered%60%20boolean%20in%20the%20params%2Freturn%20type%20so%20callers%20can%20track%20and%20pass%20it%20back%20on%20the%20next%20invocation%20%E2%80%94%20exactly%20how%20%60live-sync.ts%60%20handles%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fruntime%2Fruntime-services.ts%3A66-72%0A**cleanup%20accumulates%20on%20every%20sync%20recreation**%0A%0Ano%20%60cleanupRegistered%60%20guard%20here.%20every%20time%20the%20config%20key%20changes%20and%20a%20new%20sync%20is%20created%2C%20another%20closure%20is%20pushed%20into%20the%20cleanup%20registry.%20the%20sibling%20%60live-sync.ts%60%20%28lines%2095-101%29%20was%20written%20with%20an%20explicit%20%60cleanupRegistered%60%20flag%20%2B%20%60getCurrentSync%28%29%60%20indirection%20precisely%20to%20prevent%20this.%0A%0Aeach%20extra%20closure%20captures%20its%20own%20local%20%60liveAccountSync%60%20binding%2C%20so%20it%20won't%20double-stop%20the%20*current*%20sync%20%E2%80%94%20but%20it%20will%20call%20%60.stop%28%29%60%20on%20the%20already-stopped%20previous%20sync%2C%20which%20is%20only%20safe%20if%20%60stop%28%29%60%20is%20idempotent.%20more%20importantly%2C%20after%20N%20config%20changes%20the%20registry%20holds%20N%20cleanup%20handlers.%20on%20windows%2C%20antivirus-induced%20re-entrant%20fs%20locks%20during%20a%20flurry%20of%20config%20reloads%20could%20trigger%20multiple%20concurrent%20stop%2Frecreate%20cycles%2C%20each%20registering%20another%20handler.%0A%0Amirror%20the%20pattern%20from%20%60live-sync.ts%60%3A%0A%0A%60%60%60typescript%0Aif%20%28!liveAccountSync%29%20%7B%0A%20%20%20%20liveAccountSync%20%3D%20params.createSync%28params.authFallback%29%3B%0A%20%20%20%20liveAccountSyncConfigKey%20%3D%20nextConfigKey%3B%0A%20%20%20%20if%20%28!params.currentCleanupRegistered%29%20%7B%0A%20%20%20%20%20%20%20%20params.registerCleanup%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20liveAccountSync%3F.stop%28%29%3B%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0Aor%20accept%2Freturn%20a%20%60cleanupRegistered%60%20boolean%20in%20the%20params%2Freturn%20type%20so%20callers%20can%20track%20and%20pass%20it%20back%20on%20the%20next%20invocation%20%E2%80%94%20exactly%20how%20%60live-sync.ts%60%20handles%20it.%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Flive-sync-entry.test.ts%3A6-40%0A**mock%20omits%20%60liveAccountSyncConfigKey%60%2C%20no%20assertion%20on%20it**%0A%0Athe%20%60ensureLiveAccountSyncState%60%20mock%20returns%3A%0A%0A%60%60%60typescript%0Avi.fn%28async%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20liveAccountSync%3A%20%7B%20stop%3A%20vi.fn%28%29%2C%20syncToPath%3A%20vi.fn%28%29%20%7D%2C%0A%20%20%20%20liveAccountSyncPath%3A%20%22%2Ftmp%2Faccounts.json%22%2C%0A%20%20%20%20%2F%2F%20liveAccountSyncConfigKey%20missing%0A%7D%29%29%0A%60%60%60%0A%0Athe%20only%20assertion%20at%20line%2040%20checks%20%60liveAccountSyncPath%60.%20%60result.liveAccountSyncConfigKey%60%20will%20be%20%60undefined%60%20in%20this%20test%2C%20and%20the%20test%20has%20no%20assertion%20on%20it%20at%20all%20%E2%80%94%20so%20there%20is%20zero%20signal%20that%20the%20config%20key%20is%20forwarded%20from%20%60ensureLiveAccountSyncEntry%60%20through%20to%20the%20caller.%20this%20is%20the%20core%20observable%20behaviour%20added%20by%20this%20pr%20for%20the%20entry-point%20layer.%0A%0Aadd%20%60liveAccountSyncConfigKey%3A%20%2225%3A250%22%60%20to%20the%20mock%20return%20and%20assert%3A%0A%0A%60%60%60suggestion%0A%09%09const%20ensureLiveAccountSyncState%20%3D%20vi.fn%28async%20%28%29%20%3D%3E%20%28%7B%0A%09%09%09liveAccountSync%3A%20%7B%20stop%3A%20vi.fn%28%29%2C%20syncToPath%3A%20vi.fn%28%29%20%7D%2C%0A%09%09%09liveAccountSyncPath%3A%20%22%2Ftmp%2Faccounts.json%22%2C%0A%09%09%09liveAccountSyncConfigKey%3A%20%2225%3A250%22%2C%0A%09%09%7D%29%29%3B%0A%60%60%60%0A%0Athen%20add%20after%20line%2040%3A%0A%60%60%60typescript%0Aexpect%28result.liveAccountSyncConfigKey%29.toBe%28%2225%3A250%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fruntime-services.test.ts%3A92-115%0A**missing%20coverage%3A%20%60registerCleanup%60%20call%20count%20on%20recreation**%0A%0Athe%20%22recreates%20live%20sync%20when%20config%20key%20changes%22%20test%20correctly%20checks%20that%20the%20old%20sync%20is%20stopped%20and%20a%20new%20one%20is%20created%2C%20but%20it%20doesn't%20assert%20how%20many%20times%20%60registerCleanup%60%20is%20called.%20given%20the%20missing%20guard%20in%20%60runtime-services.ts%60%2C%20this%20test%20would%20pass%20even%20if%20cleanup%20handlers%20accumulate%20%E2%80%94%20and%20it%20would%20continue%20to%20pass%20after%20a%20fix.%20adding%20%60expect%28registerCleanup%29.toHaveBeenCalledTimes%281%29%60%20would%20lock%20in%20the%20expected%20behaviour%20and%20catch%20regressions.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/runtime/runtime-services.ts
Line: 66-72

Comment:
**cleanup accumulates on every sync recreation**

no `cleanupRegistered` guard here. every time the config key changes and a new sync is created, another closure is pushed into the cleanup registry. the sibling `live-sync.ts` (lines 95-101) was written with an explicit `cleanupRegistered` flag + `getCurrentSync()` indirection precisely to prevent this.

each extra closure captures its own local `liveAccountSync` binding, so it won't double-stop the *current* sync — but it will call `.stop()` on the already-stopped previous sync, which is only safe if `stop()` is idempotent. more importantly, after N config changes the registry holds N cleanup handlers. on windows, antivirus-induced re-entrant fs locks during a flurry of config reloads could trigger multiple concurrent stop/recreate cycles, each registering another handler.

mirror the pattern from `live-sync.ts`:

```typescript
if (!liveAccountSync) {
    liveAccountSync = params.createSync(params.authFallback);
    liveAccountSyncConfigKey = nextConfigKey;
    if (!params.currentCleanupRegistered) {
        params.registerCleanup(() => {
            liveAccountSync?.stop();
        });
    }
}
```

or accept/return a `cleanupRegistered` boolean in the params/return type so callers can track and pass it back on the next invocation — exactly how `live-sync.ts` handles it.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/live-sync-entry.test.ts
Line: 6-40

Comment:
**mock omits `liveAccountSyncConfigKey`, no assertion on it**

the `ensureLiveAccountSyncState` mock returns:

```typescript
vi.fn(async () => ({
    liveAccountSync: { stop: vi.fn(), syncToPath: vi.fn() },
    liveAccountSyncPath: "/tmp/accounts.json",
    // liveAccountSyncConfigKey missing
}))
```

the only assertion at line 40 checks `liveAccountSyncPath`. `result.liveAccountSyncConfigKey` will be `undefined` in this test, and the test has no assertion on it at all — so there is zero signal that the config key is forwarded from `ensureLiveAccountSyncEntry` through to the caller. this is the core observable behaviour added by this pr for the entry-point layer.

add `liveAccountSyncConfigKey: "25:250"` to the mock return and assert:

```suggestion
		const ensureLiveAccountSyncState = vi.fn(async () => ({
			liveAccountSync: { stop: vi.fn(), syncToPath: vi.fn() },
			liveAccountSyncPath: "/tmp/accounts.json",
			liveAccountSyncConfigKey: "25:250",
		}));
```

then add after line 40:
```typescript
expect(result.liveAccountSyncConfigKey).toBe("25:250");
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/runtime-services.test.ts
Line: 92-115

Comment:
**missing coverage: `registerCleanup` call count on recreation**

the "recreates live sync when config key changes" test correctly checks that the old sync is stopped and a new one is created, but it doesn't assert how many times `registerCleanup` is called. given the missing guard in `runtime-services.ts`, this test would pass even if cleanup handlers accumulate — and it would continue to pass after a fix. adding `expect(registerCleanup).toHaveBeenCalledTimes(1)` would lock in the expected behaviour and catch regressions.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: recreate live account sync on confi..."](https://github.com/ndycode/codex-multi-auth/commit/9e35ef5a8cb7a479f57faf4400071df5309ca5a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27423695)</sub>

<!-- /greptile_comment -->