### PR TITLE
refactor: share forecast and report command helpers

### DIFF
--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -4,16 +4,18 @@ import {
 	buildForecastExplanation,
 	type ForecastAccountResult,
 } from "../../forecast.js";
+import {
+	applyRefreshedAccountPatch,
+	persistRefreshedAccountPatch,
+	serializeForecastResults,
+	type AccountIdentityMatch,
+	type RefreshedAccountPatch,
+} from "../forecast-report-shared.js";
 import type { QuotaCacheData } from "../../quota-cache.js";
 import type { CodexQuotaSnapshot } from "../../quota-probe.js";
 import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
-import {
-	findMatchingAccountIndex,
-	type AccountMetadataV3,
-	type AccountStorageV3,
-} from "../../storage.js";
+import { type AccountMetadataV3, type AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
-import { sleep } from "../../utils.js";
 
 interface ForecastCliOptions {
 	live: boolean;
@@ -31,8 +33,6 @@ type QuotaEmailFallbackState = ReadonlyMap<
 	string,
 	{ matchingCount: number; distinctAccountIds: Set<string> }
 >;
-
-const RETRYABLE_STORAGE_WRITE_CODES = new Set(["EBUSY", "EPERM"]);
 
 export interface ForecastCommandDeps {
 	setStoragePath: (path: string | null) => void;
@@ -112,82 +112,6 @@ export interface ForecastCommandDeps {
 	getNow?: () => number;
 }
 
-function isRetryableStorageWriteError(error: unknown): boolean {
-	const code = (error as NodeJS.ErrnoException | undefined)?.code;
-	return typeof code === "string" && RETRYABLE_STORAGE_WRITE_CODES.has(code);
-}
-
-async function saveAccountsWithRetry(
-	storage: AccountStorageV3,
-	saveAccounts: ForecastCommandDeps["saveAccounts"],
-): Promise<void> {
-	for (let attempt = 0; ; attempt += 1) {
-		try {
-			await saveAccounts(storage);
-			return;
-		} catch (error) {
-			if (!isRetryableStorageWriteError(error) || attempt >= 3) {
-				throw error;
-			}
-			await sleep(10 * 2 ** attempt);
-		}
-	}
-}
-
-type AccountIdentityMatch = Pick<
-	AccountMetadataV3,
-	"accountId" | "email" | "refreshToken"
->;
-type RefreshedAccountPatch = Pick<
-	AccountMetadataV3,
-	"refreshToken" | "accessToken" | "expiresAt"
-> & {
-	email?: AccountMetadataV3["email"];
-	accountId?: AccountMetadataV3["accountId"];
-	accountIdSource?: AccountMetadataV3["accountIdSource"];
-};
-
-function applyRefreshedAccountPatch(
-	account: AccountMetadataV3,
-	patch: RefreshedAccountPatch,
-): void {
-	account.refreshToken = patch.refreshToken;
-	account.accessToken = patch.accessToken;
-	account.expiresAt = patch.expiresAt;
-	if (patch.email) account.email = patch.email;
-	if (patch.accountId) {
-		account.accountId = patch.accountId;
-		account.accountIdSource = patch.accountIdSource;
-	}
-}
-
-async function persistRefreshedAccountPatch(
-	storage: AccountStorageV3,
-	accountMatch: AccountIdentityMatch,
-	patch: RefreshedAccountPatch,
-	loadAccounts: ForecastCommandDeps["loadAccounts"],
-	saveAccounts: ForecastCommandDeps["saveAccounts"],
-): Promise<void> {
-	const latestStorage = (await loadAccounts()) ?? storage;
-	const nextStorage = structuredClone(latestStorage);
-	const targetIndex =
-		findMatchingAccountIndex(nextStorage.accounts, accountMatch, {
-			allowUniqueAccountIdFallbackWithoutEmail: true,
-		}) ??
-		findMatchingAccountIndex(nextStorage.accounts, patch, {
-			allowUniqueAccountIdFallbackWithoutEmail: true,
-		});
-	if (targetIndex === undefined) {
-		throw new Error("Unable to resolve refreshed account for persistence");
-	}
-	const targetAccount = nextStorage.accounts[targetIndex];
-	if (!targetAccount) {
-		throw new Error("Unable to resolve refreshed account for persistence");
-	}
-	applyRefreshedAccountPatch(targetAccount, patch);
-	await saveAccountsWithRetry(nextStorage, saveAccounts);
-}
-
 function joinStyledSegments(
 	parts: string[],
 	styleText: (text: string, tone: PromptTone) => string,
@@ -253,54 +177,6 @@ function parseForecastArgs(
 	}
 
 	return { ok: true, options };
-}
-
-function serializeForecastResults(
-	results: ForecastAccountResult[],
-	liveQuotaByIndex: Map<number, CodexQuotaSnapshot>,
-	refreshFailures: Map<number, TokenFailure>,
-	formatQuotaSnapshotLine: (snapshot: CodexQuotaSnapshot) => string,
-): Array<{
-	index: number;
-	label: string;
-	isCurrent: boolean;
-	availability: ForecastAccountResult["availability"];
-	riskScore: number;
-	riskLevel: ForecastAccountResult["riskLevel"];
-	waitMs: number;
-	reasons: string[];
-	liveQuota?: {
-		status: number;
-		planType?: string;
-		activeLimit?: number;
-		model: string;
-		summary: string;
-	};
-	refreshFailure?: TokenFailure;
-}> {
-	return results.map((result) => {
-		const liveQuota = liveQuotaByIndex.get(result.index);
-		return {
-			index: result.index,
-			label: result.label,
-			isCurrent: result.isCurrent,
-			availability: result.availability,
-			riskScore: result.riskScore,
-			riskLevel: result.riskLevel,
-			waitMs: result.waitMs,
-			reasons: result.reasons,
-			liveQuota: liveQuota
-				? {
-						status: liveQuota.status,
-						planType: liveQuota.planType,
-						activeLimit: liveQuota.activeLimit,
-						model: liveQuota.model,
-						summary: formatQuotaSnapshotLine(liveQuota),
-					}
-				: undefined,
-			refreshFailure: refreshFailures.get(result.index),
-		};
-	});
 }
 
 export async function runForecastCommand(

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -8,10 +8,14 @@ import {
 } from "../../accounts.js";
 import {
 	evaluateForecastAccounts,
-	type ForecastAccountResult,
 	recommendForecastAccount,
 	summarizeForecast,
 } from "../../forecast.js";
+import {
+	applyRefreshedAccountPatch,
+	persistRefreshedAccountPatch,
+	serializeForecastResults,
+} from "../forecast-report-shared.js";
 import {
 	type CodexQuotaSnapshot,
 	formatQuotaSnapshotLine,
@@ -22,11 +26,7 @@ import {
 	getModelProfile,
 	resolveNormalizedModel,
 } from "../../request/helpers/model-map.js";
-import {
-	findMatchingAccountIndex,
-	type AccountMetadataV3,
-	type AccountStorageV3,
-} from "../../storage.js";
+import { type AccountMetadataV3, type AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 import { sleep } from "../../utils.js";
 
@@ -159,53 +159,6 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 	return { ok: true, options };
 }
 
-function serializeForecastResults(
-	results: ForecastAccountResult[],
-	liveQuotaByIndex: Map<number, CodexQuotaSnapshot>,
-	refreshFailures: Map<number, TokenFailure>,
-): Array<{
-	index: number;
-	label: string;
-	isCurrent: boolean;
-	availability: ForecastAccountResult["availability"];
-	riskScore: number;
-	riskLevel: ForecastAccountResult["riskLevel"];
-	waitMs: number;
-	reasons: string[];
-	liveQuota?: {
-		status: number;
-		planType?: string;
-		activeLimit?: number;
-		model: string;
-		summary: string;
-	};
-	refreshFailure?: TokenFailure;
-}> {
-	return results.map((result) => {
-		const liveQuota = liveQuotaByIndex.get(result.index);
-		return {
-			index: result.index,
-			label: result.label,
-			isCurrent: result.isCurrent,
-			availability: result.availability,
-			riskScore: result.riskScore,
-			riskLevel: result.riskLevel,
-			waitMs: result.waitMs,
-			reasons: result.reasons,
-			liveQuota: liveQuota
-				? {
-						status: liveQuota.status,
-						planType: liveQuota.planType,
-						activeLimit: liveQuota.activeLimit,
-						model: liveQuota.model,
-						summary: formatQuotaSnapshotLine(liveQuota),
-					}
-				: undefined,
-			refreshFailure: refreshFailures.get(result.index),
-		};
-	});
-}
-
 function inspectRequestedModel(requestedModel: string): ModelInspection {
 	const normalized = resolveNormalizedModel(requestedModel);
 	const profile = getModelProfile(normalized);
@@ -257,77 +210,6 @@ async function defaultWriteFile(path: string, contents: string): Promise<void> {
 			}
 		}
 	}
-}
-
-async function saveAccountsWithRetry(
-	storage: AccountStorageV3,
-	saveAccounts: ReportCommandDeps["saveAccounts"],
-): Promise<void> {
-	for (let attempt = 0; ; attempt += 1) {
-		try {
-			await saveAccounts(storage);
-			return;
-		} catch (error) {
-			if (!isRetryableWriteError(error) || attempt >= 3) {
-				throw error;
-			}
-			await sleep(10 * 2 ** attempt);
-		}
-	}
-}
-
-type AccountIdentityMatch = Pick<
-	AccountMetadataV3,
-	"accountId" | "email" | "refreshToken"
->;
-type RefreshedAccountPatch = Pick<
-	AccountMetadataV3,
-	"refreshToken" | "accessToken" | "expiresAt"
-> & {
-	email?: AccountMetadataV3["email"];
-	accountId?: AccountMetadataV3["accountId"];
-	accountIdSource?: AccountMetadataV3["accountIdSource"];
-};
-
-function applyRefreshedAccountPatch(
-	account: AccountMetadataV3,
-	patch: RefreshedAccountPatch,
-): void {
-	account.refreshToken = patch.refreshToken;
-	account.accessToken = patch.accessToken;
-	account.expiresAt = patch.expiresAt;
-	if (patch.email) account.email = patch.email;
-	if (patch.accountId) {
-		account.accountId = patch.accountId;
-		account.accountIdSource = patch.accountIdSource;
-	}
-}
-
-async function persistRefreshedAccountPatch(
-	storage: AccountStorageV3,
-	accountMatch: AccountIdentityMatch,
-	patch: RefreshedAccountPatch,
-	loadAccounts: ReportCommandDeps["loadAccounts"],
-	saveAccounts: ReportCommandDeps["saveAccounts"],
-): Promise<void> {
-	const latestStorage = (await loadAccounts()) ?? storage;
-	const nextStorage = structuredClone(latestStorage);
-	const targetIndex =
-		findMatchingAccountIndex(nextStorage.accounts, accountMatch, {
-			allowUniqueAccountIdFallbackWithoutEmail: true,
-		}) ??
-		findMatchingAccountIndex(nextStorage.accounts, patch, {
-			allowUniqueAccountIdFallbackWithoutEmail: true,
-		});
-	if (targetIndex === undefined) {
-		throw new Error("Unable to resolve refreshed account for persistence");
-	}
-	const targetAccount = nextStorage.accounts[targetIndex];
-	if (!targetAccount) {
-		throw new Error("Unable to resolve refreshed account for persistence");
-	}
-	applyRefreshedAccountPatch(targetAccount, patch);
-	await saveAccountsWithRetry(nextStorage, saveAccounts);
 }
 
 export async function runReportCommand(
@@ -522,6 +404,7 @@ export async function runReportCommand(
 				forecastResults,
 				liveQuotaByIndex,
 				refreshFailures,
+				formatQuotaSnapshotLine,
 			),
 		},
 	};

--- a/lib/codex-manager/forecast-report-shared.ts
+++ b/lib/codex-manager/forecast-report-shared.ts
@@ -1,0 +1,136 @@
+import type { ForecastAccountResult } from "../forecast.js";
+import type { CodexQuotaSnapshot } from "../quota-probe.js";
+import {
+	findMatchingAccountIndex,
+	type AccountMetadataV3,
+	type AccountStorageV3,
+} from "../storage.js";
+import type { TokenFailure } from "../types.js";
+import { sleep } from "../utils.js";
+
+const RETRYABLE_STORAGE_WRITE_CODES = new Set(["EBUSY", "EPERM"]);
+
+export type AccountIdentityMatch = Pick<
+	AccountMetadataV3,
+	"accountId" | "email" | "refreshToken"
+>;
+
+export type RefreshedAccountPatch = Pick<
+	AccountMetadataV3,
+	"refreshToken" | "accessToken" | "expiresAt"
+> & {
+	email?: AccountMetadataV3["email"];
+	accountId?: AccountMetadataV3["accountId"];
+	accountIdSource?: AccountMetadataV3["accountIdSource"];
+};
+
+export function isRetryableStorageWriteError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_STORAGE_WRITE_CODES.has(code);
+}
+
+export async function saveAccountsWithRetry(
+	storage: AccountStorageV3,
+	saveAccounts: (storage: AccountStorageV3) => Promise<void>,
+): Promise<void> {
+	for (let attempt = 0; ; attempt += 1) {
+		try {
+			await saveAccounts(storage);
+			return;
+		} catch (error) {
+			if (!isRetryableStorageWriteError(error) || attempt >= 3) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+}
+
+export function applyRefreshedAccountPatch(
+	account: AccountMetadataV3,
+	patch: RefreshedAccountPatch,
+): void {
+	account.refreshToken = patch.refreshToken;
+	account.accessToken = patch.accessToken;
+	account.expiresAt = patch.expiresAt;
+	if (patch.email) account.email = patch.email;
+	if (patch.accountId) {
+		account.accountId = patch.accountId;
+		account.accountIdSource = patch.accountIdSource;
+	}
+}
+
+export async function persistRefreshedAccountPatch(
+	storage: AccountStorageV3,
+	accountMatch: AccountIdentityMatch,
+	patch: RefreshedAccountPatch,
+	loadAccounts: () => Promise<AccountStorageV3 | null>,
+	saveAccounts: (storage: AccountStorageV3) => Promise<void>,
+): Promise<void> {
+	const latestStorage = (await loadAccounts()) ?? storage;
+	const nextStorage = structuredClone(latestStorage);
+	const targetIndex =
+		findMatchingAccountIndex(nextStorage.accounts, accountMatch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		}) ??
+		findMatchingAccountIndex(nextStorage.accounts, patch, {
+			allowUniqueAccountIdFallbackWithoutEmail: true,
+		});
+	if (targetIndex === undefined) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	const targetAccount = nextStorage.accounts[targetIndex];
+	if (!targetAccount) {
+		throw new Error("Unable to resolve refreshed account for persistence");
+	}
+	applyRefreshedAccountPatch(targetAccount, patch);
+	await saveAccountsWithRetry(nextStorage, saveAccounts);
+}
+
+export function serializeForecastResults(
+	results: ForecastAccountResult[],
+	liveQuotaByIndex: Map<number, CodexQuotaSnapshot>,
+	refreshFailures: Map<number, TokenFailure>,
+	formatQuotaSnapshotLine: (snapshot: CodexQuotaSnapshot) => string,
+): Array<{
+	index: number;
+	label: string;
+	isCurrent: boolean;
+	availability: ForecastAccountResult["availability"];
+	riskScore: number;
+	riskLevel: ForecastAccountResult["riskLevel"];
+	waitMs: number;
+	reasons: string[];
+	liveQuota?: {
+		status: number;
+		planType?: string;
+		activeLimit?: number;
+		model: string;
+		summary: string;
+	};
+	refreshFailure?: TokenFailure;
+}> {
+	return results.map((result) => {
+		const liveQuota = liveQuotaByIndex.get(result.index);
+		return {
+			index: result.index,
+			label: result.label,
+			isCurrent: result.isCurrent,
+			availability: result.availability,
+			riskScore: result.riskScore,
+			riskLevel: result.riskLevel,
+			waitMs: result.waitMs,
+			reasons: result.reasons,
+			liveQuota: liveQuota
+				? {
+						status: liveQuota.status,
+						planType: liveQuota.planType,
+						activeLimit: liveQuota.activeLimit,
+						model: liveQuota.model,
+						summary: formatQuotaSnapshotLine(liveQuota),
+				  }
+				: undefined,
+			refreshFailure: refreshFailures.get(result.index),
+		};
+	});
+}


### PR DESCRIPTION
## Problem

The `forecast` and `report` commands duplicated the same refreshed-account persistence flow and forecast-result serialization logic.

That increases maintenance cost and makes future fixes easy to miss in one path.

## Fix

Extract the shared logic into a single helper module and keep both commands delegating to the same implementation.

## Changes

- added `lib/codex-manager/forecast-report-shared.ts`
  - shared refreshed-account patch persistence
  - shared forecast-result serialization
- updated `lib/codex-manager/commands/forecast.ts`
- updated `lib/codex-manager/commands/report.ts`

## Validation

```text
npx vitest run test/codex-manager-forecast-command.test.ts test/codex-manager-report-command.test.ts
Test Files  2 passed (2)
Tests      16 passed (16)

npx vitest run
Test Files  222 passed (222)
Tests      3313 passed (3313)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR extracts the duplicated token-persistence and forecast-serialization logic from `forecast.ts` and `report.ts` into a new `lib/codex-manager/forecast-report-shared.ts` module. the extraction is structurally correct and a good maintenance improvement — but `report.ts` is missing the `type AccountIdentityMatch` and `type RefreshedAccountPatch` imports required for its explicit type annotations, which will break `npm run typecheck`. the new shared module also lacks dedicated unit tests.

- **`report.ts` missing type imports** — `RefreshedAccountPatch` and `AccountIdentityMatch` are annotated at lines 277/289 but not imported; `forecast.ts` imports them correctly and `report.ts` was overlooked — this is a guaranteed `tsc` failure
- **no unit tests for `forecast-report-shared.ts`** — the `EBUSY`/`EPERM` retry contract and patch-application logic are critical windows-filesystem safety invariants per `AGENTS.md`; they need an isolated test file
- **duplicate write-retry constants in `report.ts`** — `RETRYABLE_WRITE_CODES` / `isRetryableWriteError` mirror the shared module's pattern; the two concerns are separate but could drift
- **non-atomic read-modify-write in `persistRefreshedAccountPatch`** — no lock between the `loadAccounts` reload and `saveAccountsWithRetry`; concurrent `forecast --live` + `report --live` runs can race and drop a token patch, especially on windows where `EBUSY` retries extend the write window

<h3>Confidence Score: 2/5</h3>

not safe to merge — report.ts has missing type imports that will fail tsc

the logic extraction is correct but the omission of RefreshedAccountPatch and AccountIdentityMatch type imports in report.ts is a guaranteed typecheck failure; tests pass because vitest uses esbuild which strips types without checking them. additionally no unit tests exist for the new shared module and the non-atomic write in persistRefreshedAccountPatch is now the shared path for both commands without a concurrency guard.

lib/codex-manager/commands/report.ts (missing type imports — blocks tsc), lib/codex-manager/forecast-report-shared.ts (no unit tests, non-atomic write)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/forecast-report-shared.ts | new shared module; extraction is clean and logic is correct, but missing type exports cause a tsc failure in report.ts, no dedicated unit tests exist, and persistRefreshedAccountPatch has a non-atomic read-modify-write under concurrent command runs |
| lib/codex-manager/commands/report.ts | missing type imports for RefreshedAccountPatch and AccountIdentityMatch at lines 277/289 — will fail tsc; also retains duplicate write-retry constants vs. the shared module |
| lib/codex-manager/commands/forecast.ts | correctly delegates to shared helpers with complete type imports including AccountIdentityMatch and RefreshedAccountPatch; no issues found |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FC as forecast.ts
    participant RC as report.ts
    participant SH as forecast-report-shared.ts
    participant ST as Storage

    Note over FC,RC: both commands run --live; per-account loop (serial within each command)

    FC->>ST: loadAccounts() [initial]
    RC->>ST: loadAccounts() [initial]

    FC->>FC: hasUsableAccessToken? → false
    FC->>FC: queuedRefresh(refreshToken)
    FC->>SH: applyRefreshedAccountPatch(account, patch) [in-memory only]
    FC->>SH: persistRefreshedAccountPatch(storage, accountMatch, patch, deps)
    SH->>ST: loadAccounts() [reload latest to avoid clobbering concurrent writes]
    SH->>SH: structuredClone(latestStorage)
    SH->>SH: findMatchingAccountIndex × 2 (identity then patch fallback)
    SH->>SH: applyRefreshedAccountPatch(targetAccount, patch)
    SH->>ST: saveAccountsWithRetry [EBUSY/EPERM retry up to 3x, exponential backoff]
    SH-->>FC: return
    FC->>ST: fetchCodexQuotaSnapshot(probeAccessToken, probeAccountId)

    RC->>RC: hasUsableAccessToken? → false
    RC->>RC: queuedRefresh(refreshToken)
    RC->>SH: applyRefreshedAccountPatch(account, patch) [in-memory only]
    RC->>SH: persistRefreshedAccountPatch(storage, accountMatch, patch, deps)
    SH->>ST: loadAccounts() [reload latest]
    SH->>SH: structuredClone(latestStorage)
    SH->>SH: findMatchingAccountIndex × 2
    SH->>SH: applyRefreshedAccountPatch(targetAccount, patch)
    SH->>ST: saveAccountsWithRetry [EBUSY/EPERM retry up to 3x]
    SH-->>RC: return
    RC->>ST: fetchCodexQuotaSnapshot(probeAccessToken, probeAccountId)

    FC->>SH: serializeForecastResults(results, liveQuotaByIndex, refreshFailures, formatFn)
    RC->>SH: serializeForecastResults(results, liveQuotaByIndex, refreshFailures, formatFn)
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Fcodex-manager%2Fcommands%2Freport.ts%3A15-18%0A**Missing%20type%20imports%20for%20%60RefreshedAccountPatch%60%20and%20%60AccountIdentityMatch%60**%0A%0A%60report.ts%60%20uses%20both%20types%20as%20explicit%20annotations%20%28%60const%20refreshPatch%3A%20RefreshedAccountPatch%60%20at%20line%20277%20and%20%60const%20accountMatch%3A%20AccountIdentityMatch%60%20at%20line%20289%29%20but%20neither%20is%20in%20the%20import%20block.%20%60forecast.ts%60%20imports%20them%20correctly%20with%20%60type%20AccountIdentityMatch%60%20and%20%60type%20RefreshedAccountPatch%60%20%E2%80%94%20this%20was%20missed%20during%20the%20extraction.%20%60npm%20run%20typecheck%60%20will%20fail%20with%20%22Cannot%20find%20name%22%20errors.%0A%0A%60%60%60suggestion%0Aimport%20%7B%0A%09applyRefreshedAccountPatch%2C%0A%09persistRefreshedAccountPatch%2C%0A%09serializeForecastResults%2C%0A%09type%20AccountIdentityMatch%2C%0A%09type%20RefreshedAccountPatch%2C%0A%7D%20from%20%22..%2Fforecast-report-shared.js%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fcodex-manager%2Fcommands%2Freport.ts%3A53-89%0A**Duplicate%20write-retry%20constants%20and%20helper%20not%20unified%20with%20shared%20module**%0A%0A%60RETRYABLE_WRITE_CODES%60%20and%20%60isRetryableWriteError%60%20here%20implement%20the%20exact%20same%20two-code%20set%20%28%60EBUSY%60%2F%60EPERM%60%29%20and%20the%20same%20guard%20pattern%20as%20%60isRetryableStorageWriteError%60%20in%20%60forecast-report-shared.ts%60.%20these%20guard%20a%20different%20concern%20%28output-file%20writes%20in%20%60defaultWriteFile%60%20vs.%20storage%20writes%29%2C%20but%20since%20both%20target%20the%20same%20windows%20antivirus%20lock%20codes%2C%20splitting%20them%20risks%20the%20sets%20drifting.%20consider%20importing%20%60isRetryableStorageWriteError%60%20from%20the%20shared%20module%20and%20reusing%20it%20here%2C%20or%20rename%20the%20local%20constant%20%28%60RETRYABLE_OUTPUT_WRITE_CODES%60%29%20to%20make%20the%20intentional%20split%20obvious%20to%20future%20maintainers.%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Fcodex-manager%2Fforecast-report-shared.ts%3A32-47%0A**No%20dedicated%20unit%20tests%20for%20%60forecast-report-shared.ts%60**%0A%0Athe%20extracted%20helpers%20are%20exercised%20only%20indirectly%20through%20the%20command%20integration%20tests.%20per%20the%20windows%20filesystem%20safety%20rules%20in%20%60AGENTS.md%60%2C%20the%20%60EBUSY%60%2F%60EPERM%60%20retry%20contract%20is%20a%20critical%20invariant.%20a%20%60test%2Fcodex-manager-forecast-report-shared.test.ts%60%20should%20cover%3A%0A-%20%60isRetryableStorageWriteError%60%20with%20%60EBUSY%60%2C%20%60EPERM%60%2C%20and%20an%20unrelated%20error%20code%0A-%20%60saveAccountsWithRetry%60%20stops%20after%203%20retries%20and%20re-throws%20non-retryable%20errors%20immediately%0A-%20%60applyRefreshedAccountPatch%60%20mutates%20%60refreshToken%60%2F%60accessToken%60%2F%60expiresAt%60%20unconditionally%2C%20and%20only%20touches%20%60email%60%2F%60accountId%60%2F%60accountIdSource%60%20when%20the%20patch%20fields%20are%20truthy%0A-%20%60persistRefreshedAccountPatch%60%20happy%20path%20%28load%20%E2%86%92%20clone%20%E2%86%92%20find%20%E2%86%92%20apply%20%E2%86%92%20save%29%20and%20the%20%22account%20not%20found%22%20throw%20path%0A%0A%23%23%23%20Issue%204%20of%204%0Alib%2Fcodex-manager%2Fforecast-report-shared.ts%3A63-88%0A**Non-atomic%20read-modify-write%20%E2%80%94%20concurrent%20command%20runs%20can%20silently%20drop%20a%20token%20patch**%0A%0A%60persistRefreshedAccountPatch%60%20calls%20%60loadAccounts%28%29%60%20%28line%2070%29%2C%20clones%20the%20result%2C%20finds%20the%20target%20account%2C%20applies%20the%20patch%2C%20then%20calls%20%60saveAccountsWithRetry%60.%20there%20is%20no%20lock%20between%20the%20reload%20and%20the%20save.%20if%20%60forecast%20--live%60%20and%20%60report%20--live%60%20run%20simultaneously%2C%20the%20second%20caller's%20%60saveAccountsWithRetry%60%20will%20write%20a%20clone%20that%20does%20not%20contain%20the%20first%20caller's%20token%20update%2C%20silently%20dropping%20a%20refreshed%20%60refreshToken%60%2F%60accessToken%60%20%E2%80%94%20a%20token%20safety%20risk%20on%20windows%20where%20%60EBUSY%60%20retries%20mean%20the%20total%20write%20window%20is%20hundreds%20of%20milliseconds.%0A%0Athis%20was%20a%20pre-existing%20per-command%20risk%3B%20consolidating%20both%20commands%20into%20the%20same%20shared%20path%20without%20adding%20a%20concurrency%20guard%20makes%20the%20concurrent%20exposure%20larger.%20consider%20a%20per-storage-path%20write-queue%20similar%20to%20the%20queue%20already%20used%20in%20%60unified-settings.ts%60%2C%20or%20at%20minimum%20document%20the%20known%20race%20in%20a%20comment.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager/commands/report.ts
Line: 15-18

Comment:
**Missing type imports for `RefreshedAccountPatch` and `AccountIdentityMatch`**

`report.ts` uses both types as explicit annotations (`const refreshPatch: RefreshedAccountPatch` at line 277 and `const accountMatch: AccountIdentityMatch` at line 289) but neither is in the import block. `forecast.ts` imports them correctly with `type AccountIdentityMatch` and `type RefreshedAccountPatch` — this was missed during the extraction. `npm run typecheck` will fail with "Cannot find name" errors.

```suggestion
import {
	applyRefreshedAccountPatch,
	persistRefreshedAccountPatch,
	serializeForecastResults,
	type AccountIdentityMatch,
	type RefreshedAccountPatch,
} from "../forecast-report-shared.js";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager/commands/report.ts
Line: 53-89

Comment:
**Duplicate write-retry constants and helper not unified with shared module**

`RETRYABLE_WRITE_CODES` and `isRetryableWriteError` here implement the exact same two-code set (`EBUSY`/`EPERM`) and the same guard pattern as `isRetryableStorageWriteError` in `forecast-report-shared.ts`. these guard a different concern (output-file writes in `defaultWriteFile` vs. storage writes), but since both target the same windows antivirus lock codes, splitting them risks the sets drifting. consider importing `isRetryableStorageWriteError` from the shared module and reusing it here, or rename the local constant (`RETRYABLE_OUTPUT_WRITE_CODES`) to make the intentional split obvious to future maintainers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager/forecast-report-shared.ts
Line: 32-47

Comment:
**No dedicated unit tests for `forecast-report-shared.ts`**

the extracted helpers are exercised only indirectly through the command integration tests. per the windows filesystem safety rules in `AGENTS.md`, the `EBUSY`/`EPERM` retry contract is a critical invariant. a `test/codex-manager-forecast-report-shared.test.ts` should cover:
- `isRetryableStorageWriteError` with `EBUSY`, `EPERM`, and an unrelated error code
- `saveAccountsWithRetry` stops after 3 retries and re-throws non-retryable errors immediately
- `applyRefreshedAccountPatch` mutates `refreshToken`/`accessToken`/`expiresAt` unconditionally, and only touches `email`/`accountId`/`accountIdSource` when the patch fields are truthy
- `persistRefreshedAccountPatch` happy path (load → clone → find → apply → save) and the "account not found" throw path

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager/forecast-report-shared.ts
Line: 63-88

Comment:
**Non-atomic read-modify-write — concurrent command runs can silently drop a token patch**

`persistRefreshedAccountPatch` calls `loadAccounts()` (line 70), clones the result, finds the target account, applies the patch, then calls `saveAccountsWithRetry`. there is no lock between the reload and the save. if `forecast --live` and `report --live` run simultaneously, the second caller's `saveAccountsWithRetry` will write a clone that does not contain the first caller's token update, silently dropping a refreshed `refreshToken`/`accessToken` — a token safety risk on windows where `EBUSY` retries mean the total write window is hundreds of milliseconds.

this was a pre-existing per-command risk; consolidating both commands into the same shared path without adding a concurrency guard makes the concurrent exposure larger. consider a per-storage-path write-queue similar to the queue already used in `unified-settings.ts`, or at minimum document the known race in a comment.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: share forecast and report comm..."](https://github.com/ndycode/codex-multi-auth/commit/c559cea67964a1bda66e0f732414408e6e512c12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27424873)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->