### PR TITLE
refactor: remove unsafe overload casts in parallel probe

### DIFF
--- a/lib/parallel-probe.ts
+++ b/lib/parallel-probe.ts
@@ -38,6 +38,34 @@ export interface GetTopCandidatesParams {
 	maxCandidates: number;
 }
 
+function isAccountManager(value: unknown): value is AccountManager {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"getAccountsSnapshot" in value &&
+		typeof value.getAccountsSnapshot === "function"
+	);
+}
+
+function isGetTopCandidatesParams(value: unknown): value is GetTopCandidatesParams {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"accountManager" in value &&
+		isAccountManager(value.accountManager) &&
+		"modelFamily" in value &&
+		typeof value.modelFamily === "string" &&
+		"model" in value &&
+		(typeof value.model === "string" || value.model === null) &&
+		"maxCandidates" in value &&
+		typeof value.maxCandidates === "number"
+	);
+}
+
+function toProbeError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
 /**
  * Get top N candidates ranked by hybrid score WITHOUT mutating AccountManager state.
  * Uses getAccountsSnapshot() and ranks by health + tokens + freshness.
@@ -64,13 +92,19 @@ export function getTopCandidates(
 	let resolvedMaxCandidates: number | undefined;
 
 	if (useNamedParams) {
-		const namedParams = accountManagerOrParams as GetTopCandidatesParams;
+		if (!isGetTopCandidatesParams(accountManagerOrParams)) {
+			throw new TypeError("getTopCandidates requires accountManager");
+		}
+		const namedParams = accountManagerOrParams;
 		resolvedAccountManager = namedParams.accountManager;
 		resolvedModelFamily = namedParams.modelFamily;
 		resolvedModel = namedParams.model;
 		resolvedMaxCandidates = namedParams.maxCandidates;
 	} else {
-		resolvedAccountManager = accountManagerOrParams as AccountManager;
+		if (!isAccountManager(accountManagerOrParams)) {
+			throw new TypeError("getTopCandidates requires accountManager");
+		}
+		resolvedAccountManager = accountManagerOrParams;
 		resolvedModelFamily = modelFamily;
 		resolvedModel = model;
 		resolvedMaxCandidates = maxCandidates;
@@ -158,7 +192,7 @@ export async function probeAccountsInParallel<T>(
 			const response = await probeFn(account, controller.signal);
 			return { type: "success", account, response };
 		} catch (error) {
-			return { type: "failure", account, error: error as Error };
+			return { type: "failure", account, error: toProbeError(error) };
 		}
 	}
 

--- a/test/parallel-probe.test.ts
+++ b/test/parallel-probe.test.ts
@@ -77,6 +77,19 @@ describe("parallel-probe", () => {
 			expect(result?.error?.message).toBe("network error");
 		});
 
+		it("normalizes non-Error probe failures for single candidates", async () => {
+			const account = createMockAccount(0);
+			const candidates = createProbeCandidates([account]);
+
+			const result = await probeAccountsInParallel(candidates, async () => {
+				throw "string failure";
+			});
+
+			expect(result?.type).toBe("failure");
+			expect(result?.error).toBeInstanceOf(Error);
+			expect(result?.error?.message).toBe("string failure");
+		});
+
 		it("returns first success in parallel probing", async () => {
 			const accounts = [createMockAccount(0), createMockAccount(1), createMockAccount(2)];
 			const candidates = createProbeCandidates(accounts);
@@ -174,6 +187,23 @@ describe("parallel-probe", () => {
 	});
 
 	describe("getTopCandidates", () => {
+		it("accepts named params without overload casts", () => {
+			const accounts = [createMockAccount(0), createMockAccount(1)];
+			const mockManager = {
+				getAccountsSnapshot: vi.fn().mockReturnValue(accounts),
+			};
+
+			const candidates = getTopCandidates({
+				accountManager: mockManager as AccountManager,
+				modelFamily: "codex",
+				model: null,
+				maxCandidates: 1,
+			});
+
+			expect(candidates).toHaveLength(1);
+			expect(mockManager.getAccountsSnapshot).toHaveBeenCalledTimes(1);
+		});
+
 		it("returns empty array when no accounts available", () => {
 			const mockManager = {
 				getAccountsSnapshot: vi.fn().mockReturnValue([]),


### PR DESCRIPTION
## Problem

`parallel-probe` relied on unsafe forced casts to distinguish its overload inputs and to normalize probe failures.

That keeps behavior working, but it weakens the type guarantees around a hot path that is already small enough to model explicitly.

## Fix

Replace the forced casts with explicit type guards and a small error-normalization helper.

## Changes

- `lib/parallel-probe.ts`
  - added `isAccountManager(...)`
  - added `isGetTopCandidatesParams(...)`
  - added `toProbeError(...)`
  - removed unsafe overload casts in `getTopCandidates(...)`
  - normalized single-candidate probe failures without `as Error`
- `test/parallel-probe.test.ts`
  - added coverage for named-params overload usage
  - added coverage for non-`Error` probe failures being normalized

## Validation

```text
npx vitest run test/parallel-probe.test.ts
Test Files  1 passed (1)
Tests      23 passed (23)

npx vitest run
Test Files  222 passed (222)
Tests      3315 passed (3315)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR replaces unsafe forced casts (`as GetTopCandidatesParams`, `as AccountManager`, `as Error`) in `lib/parallel-probe.ts` with explicit runtime type guards (`isAccountManager`, `isGetTopCandidatesParams`) and an error-normalization helper (`toProbeError`). two new test cases cover non-`Error` throw normalization in single-candidate probing and the named-params overload path. no windows filesystem or token safety concerns are introduced; no concurrency issues are added — the parallel probe path is structurally unchanged.

- the type-narrowing change is correct and the new tests pass
- `isGetTopCandidatesParams` failure emits `\"requires accountManager\"` even when `modelFamily` or `maxCandidates` is the bad field — misleading for callers
- the new `isAccountManager` guard in the positional-args `else` branch has no vitest test (named-params path is covered; positional path is not)
- the pre-existing defense-in-depth guard at lines 113-118 is now dead code after the refactor

<h3>Confidence Score: 4/5</h3>

safe to merge with minor fixes recommended — the core type-narrowing logic is correct and tests pass

the refactor is sound and improves type safety; the two gaps (misleading error message in the named-params failure path, missing positional-args TypeError test) are low-risk but worth addressing before merge. no concurrency, token safety, or windows filesystem concerns introduced.

lib/parallel-probe.ts lines 95-97 (error message) and 104-106 (missing test coverage)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/parallel-probe.ts | adds isAccountManager/isGetTopCandidatesParams guards and toProbeError; misleading error message in the named-params failure path and a now-dead guard at lines 113-118 |
| test/parallel-probe.test.ts | adds non-Error normalization test and named-params overload test; missing coverage for positional-args TypeError branch introduced in this PR |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant getTopCandidates
    participant isGetTopCandidatesParams
    participant isAccountManager
    participant AccountManager

    Caller->>getTopCandidates: named params call
    getTopCandidates->>isGetTopCandidatesParams: validate params object
    isGetTopCandidatesParams->>isAccountManager: validate accountManager field
    isAccountManager-->>isGetTopCandidatesParams: bool
    isGetTopCandidatesParams-->>getTopCandidates: bool
    alt invalid params (misleading error message)
        getTopCandidates-->>Caller: TypeError("requires accountManager")
    else valid
        getTopCandidates->>AccountManager: getAccountsSnapshot()
        AccountManager-->>getTopCandidates: ManagedAccount[]
        getTopCandidates-->>Caller: top-N ManagedAccount[]
    end

    Caller->>getTopCandidates: positional args call
    getTopCandidates->>isAccountManager: validate first arg
    isAccountManager-->>getTopCandidates: bool
    alt invalid (no test coverage for this path)
        getTopCandidates-->>Caller: TypeError("requires accountManager")
    else valid
        getTopCandidates->>AccountManager: getAccountsSnapshot()
        AccountManager-->>getTopCandidates: ManagedAccount[]
        getTopCandidates-->>Caller: top-N ManagedAccount[]
    end
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fparallel-probe.ts%3A95-97%0A**misleading%20error%20message%20when%20non-accountManager%20field%20is%20invalid**%0A%0A%60isGetTopCandidatesParams%60%20validates%20four%20fields%20%E2%80%94%20%60accountManager%60%2C%20%60modelFamily%60%2C%20%60model%60%2C%20and%20%60maxCandidates%60%20%E2%80%94%20but%20the%20thrown%20message%20always%20says%20%60%22getTopCandidates%20requires%20accountManager%22%60.%20a%20caller%20that%20passes%20%60%7B%20accountManager%3A%20validMgr%2C%20modelFamily%3A%20123%2C%20model%3A%20null%2C%20maxCandidates%3A%202%20%7D%60%20hits%20this%20throw%20because%20%60modelFamily%60%20is%20not%20a%20string%2C%20but%20the%20error%20blames%20%60accountManager%60.%20this%20is%20a%20new%20throw%20path%20introduced%20by%20this%20PR%2C%20and%20the%20message%20is%20wrong%20in%20those%20cases.%0A%0A%60%60%60suggestion%0A%09%09if%20%28!isGetTopCandidatesParams%28accountManagerOrParams%29%29%20%7B%0A%09%09%09throw%20new%20TypeError%28%22getTopCandidates%3A%20invalid%20named%20params%20%28check%20accountManager%2C%20modelFamily%2C%20model%2C%20maxCandidates%29%22%29%3B%0A%09%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fparallel-probe.ts%3A104-106%0A**missing%20vitest%20coverage%20for%20positional-args%20TypeError%20branch**%0A%0Athis%20new%20throw%20path%20has%20no%20test.%20the%20named-params%20equivalent%20is%20covered%20by%20%60%22throws%20clear%20TypeError%20when%20accountManager%20is%20missing%20required%20shape%22%60%20%28test%20line%20~450%29%2C%20but%20nothing%20exercises%20passing%20a%20non-%60AccountManager%60%20object%20via%20positional%20args.%20per%20the%20repo's%2080%25%20coverage%20threshold%20and%20the%20convention%20to%20call%20out%20missing%20vitest%20coverage%20explicitly%3A%0A%0A%60%60%60ts%0Ait%28%22throws%20TypeError%20when%20positional%20accountManager%20is%20missing%20required%20shape%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20expect%28%28%29%20%3D%3E%0A%20%20%20%20getTopCandidates%28%7B%7D%20as%20unknown%20as%20AccountManager%2C%20%22codex%22%2C%20null%2C%202%29%0A%20%20%29.toThrowError%28%22getTopCandidates%20requires%20accountManager%22%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fparallel-probe.ts%3A113-118%0A**dead%20code%20%E2%80%94%20guard%20is%20unreachable%20after%20the%20type-guard%20refactor**%0A%0Aboth%20branches%20above%20either%20throw%20%28if%20the%20type%20guard%20fails%29%20or%20set%20%60resolvedAccountManager%60%20to%20a%20value%20that%20already%20satisfies%20%60isAccountManager%60.%20the%20%60!resolvedAccountManager%60%20and%20%60getAccountsSnapshot%20!%3D%3D%20%22function%22%60%20conditions%20can%20never%20be%20true%20when%20execution%20reaches%20this%20point.%20the%20guard%20predates%20this%20PR%2C%20but%20the%20refactor%20makes%20it%20dead%20%E2%80%94%20worth%20removing%20to%20avoid%20misleading%20future%20readers%20into%20thinking%20this%20path%20can%20fire.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/parallel-probe.ts
Line: 95-97

Comment:
**misleading error message when non-accountManager field is invalid**

`isGetTopCandidatesParams` validates four fields — `accountManager`, `modelFamily`, `model`, and `maxCandidates` — but the thrown message always says `"getTopCandidates requires accountManager"`. a caller that passes `{ accountManager: validMgr, modelFamily: 123, model: null, maxCandidates: 2 }` hits this throw because `modelFamily` is not a string, but the error blames `accountManager`. this is a new throw path introduced by this PR, and the message is wrong in those cases.

```suggestion
		if (!isGetTopCandidatesParams(accountManagerOrParams)) {
			throw new TypeError("getTopCandidates: invalid named params (check accountManager, modelFamily, model, maxCandidates)");
		}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/parallel-probe.ts
Line: 104-106

Comment:
**missing vitest coverage for positional-args TypeError branch**

this new throw path has no test. the named-params equivalent is covered by `"throws clear TypeError when accountManager is missing required shape"` (test line ~450), but nothing exercises passing a non-`AccountManager` object via positional args. per the repo's 80% coverage threshold and the convention to call out missing vitest coverage explicitly:

```ts
it("throws TypeError when positional accountManager is missing required shape", () => {
  expect(() =>
    getTopCandidates({} as unknown as AccountManager, "codex", null, 2)
  ).toThrowError("getTopCandidates requires accountManager");
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/parallel-probe.ts
Line: 113-118

Comment:
**dead code — guard is unreachable after the type-guard refactor**

both branches above either throw (if the type guard fails) or set `resolvedAccountManager` to a value that already satisfies `isAccountManager`. the `!resolvedAccountManager` and `getAccountsSnapshot !== "function"` conditions can never be true when execution reaches this point. the guard predates this PR, but the refactor makes it dead — worth removing to avoid misleading future readers into thinking this path can fire.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove unsafe overload casts i..."](https://github.com/ndycode/codex-multi-auth/commit/361d3caf2c449b281ee32f2519db34c2b7f2ab1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27425048)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->