### PR TITLE
fix: surface silent update-check parse failures

### DIFF
--- a/lib/auto-update-checker.ts
+++ b/lib/auto-update-checker.ts
@@ -41,7 +41,10 @@ function getCurrentVersion(): string {
     const packageJsonPath = join(import.meta.dirname ?? __dirname, "..", "package.json");
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { version: string };
     return packageJson.version;
-  } catch {
+  } catch (error) {
+    log.debug("Failed to read current package version", {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return "0.0.0";
   }
 }
@@ -51,7 +54,10 @@ function loadCache(): UpdateCheckCache | null {
     if (!existsSync(CACHE_FILE)) return null;
     const content = readFileSync(CACHE_FILE, "utf8");
     return JSON.parse(content) as UpdateCheckCache;
-  } catch {
+  } catch (error) {
+    log.debug("Failed to load update cache", {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }

--- a/test/auto-update-checker.test.ts
+++ b/test/auto-update-checker.test.ts
@@ -12,6 +12,11 @@ describe("auto-update-checker", () => {
 	let checkForUpdates: typeof import("../lib/auto-update-checker.js").checkForUpdates;
 	let checkAndNotify: typeof import("../lib/auto-update-checker.js").checkAndNotify;
 	let clearUpdateCache: typeof import("../lib/auto-update-checker.js").clearUpdateCache;
+	let logger: {
+		debug: ReturnType<typeof vi.fn>;
+		info: ReturnType<typeof vi.fn>;
+		warn: ReturnType<typeof vi.fn>;
+	};
 
 	const mockPackageJson = { version: "4.12.0" };
 
@@ -20,6 +25,14 @@ describe("auto-update-checker", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-01-30T12:00:00Z"));
 		mockPackageJson.version = "4.12.0";
+		logger = {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+		};
+		vi.doMock("../lib/logger.js", () => ({
+			createLogger: () => logger,
+		}));
 
 		fs = await import("node:fs");
 		vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
@@ -226,6 +239,27 @@ describe("auto-update-checker", () => {
 	});
 
 	describe("checkForUpdates", () => {
+		it("logs debug details when package metadata cannot be parsed", async () => {
+			vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+				if (String(path).includes("package.json")) {
+					return "{";
+				}
+				throw new Error("File not found");
+			});
+			vi.mocked(globalThis.fetch).mockResolvedValue({
+				ok: true,
+				json: async () => ({ version: "5.0.0" }),
+			} as Response);
+
+			const result = await checkForUpdates(true);
+
+			expect(result.currentVersion).toBe("0.0.0");
+			expect(logger.debug).toHaveBeenCalledWith(
+				"Failed to read current package version",
+				expect.objectContaining({ error: expect.any(String) }),
+			);
+		});
+
 		it("uses cache when check is recent", async () => {
 			const cacheData = {
 				lastCheck: Date.now() - 1000 * 60 * 60,
@@ -248,6 +282,31 @@ describe("auto-update-checker", () => {
 			expect(globalThis.fetch).not.toHaveBeenCalled();
 			expect(result.hasUpdate).toBe(true);
 			expect(result.latestVersion).toBe("5.0.0");
+		});
+
+		it("logs debug details when cached update JSON is unreadable", async () => {
+			vi.mocked(fs.existsSync).mockReturnValue(true);
+			vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+				if (String(path).includes("package.json")) {
+					return JSON.stringify(mockPackageJson);
+				}
+				if (String(path).includes("update-check-cache.json")) {
+					return "{";
+				}
+				throw new Error("File not found");
+			});
+			vi.mocked(globalThis.fetch).mockResolvedValue({
+				ok: true,
+				json: async () => ({ version: "5.0.0" }),
+			} as Response);
+
+			await checkForUpdates();
+
+			expect(logger.debug).toHaveBeenCalledWith(
+				"Failed to load update cache",
+				expect.objectContaining({ error: expect.any(String) }),
+			);
+			expect(globalThis.fetch).toHaveBeenCalled();
 		});
 
 		it("handles cached null latestVersion without update", async () => {


### PR DESCRIPTION
## Problem

The update checker silently swallowed invalid local package metadata and unreadable cached JSON.

The fallback behavior was safe, but those failures were invisible during diagnosis.

## Fix

Keep the same fallback behavior, but log those silent parse/read failures at debug level.

## Changes

- `lib/auto-update-checker.ts`
  - logs debug details when reading local `package.json` fails
  - logs debug details when loading cached update JSON fails
- `test/auto-update-checker.test.ts`
  - added coverage for package metadata parse failures being logged
  - added coverage for unreadable cache JSON being logged and bypassed

## Validation

```text
npx vitest run test/auto-update-checker.test.ts
Test Files  1 passed (1)
Tests      36 passed (36)

npx vitest run
Test Files  222 passed (222)
Tests      3315 passed (3315)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds `log.debug` calls in the two previously-silent `catch {}` blocks inside `getCurrentVersion()` and `loadCache()`, surfacing parse and read failures for diagnosis without changing the existing fallback behavior (`"0.0.0"` / `null`). tests are added for both paths using a `vi.doMock` logger stub that correctly intercepts the module-level `createLogger("update-checker")` call before the module is dynamically imported.

<h3>Confidence Score: 5/5</h3>

safe to merge — no behavior change, only adds debug observability to two existing catch blocks

minimal diff, fallback values are identical to before, both new catch paths are exercised by dedicated tests, and the pattern matches the existing log.debug call in fetchLatestVersion()

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/auto-update-checker.ts | adds debug-level logging in two previously-silent catch blocks for read/parse failures; fallback behavior unchanged |
| test/auto-update-checker.test.ts | adds logger mock via vi.doMock and two new tests covering the debug log paths in getCurrentVersion and loadCache |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as checkForUpdates()
    participant GV as getCurrentVersion()
    participant LC as loadCache()
    participant FS as node:fs
    participant LOG as log (debug)
    participant NPM as npm registry

    C->>GV: call
    GV->>FS: readFileSync(package.json)
    alt read/parse succeeds
        FS-->>GV: version string
        GV-->>C: "4.12.0"
    else read/parse fails (new)
        FS-->>GV: throws
        GV->>LOG: debug("Failed to read current package version", {error})
        GV-->>C: "0.0.0"
    end

    C->>LC: call
    LC->>FS: existsSync(cache)
    alt cache absent
        LC-->>C: null
    else cache present
        LC->>FS: readFileSync(cache)
        alt parse succeeds
            FS-->>LC: UpdateCheckCache
            LC-->>C: cache object
        else parse fails (new)
            FS-->>LC: throws
            LC->>LOG: debug("Failed to load update cache", {error})
            LC-->>C: null
        end
    end

    alt cache valid and not expired
        C-->>C: return cached result
    else cache missing/expired/forced
        C->>NPM: fetchLatestVersion()
        NPM-->>C: latestVersion
        C->>FS: saveCache(...)
        C-->>C: return fresh result
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix: surface silent update-check parse f..."](https://github.com/ndycode/codex-multi-auth/commit/a2203dbc0200a3eac474df654a13a886973d7506) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27425261)</sub>

<!-- /greptile_comment -->