### PR TITLE
fix: surface persisted rate limits in quota views

### DIFF
--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -80,6 +80,7 @@ import {
 } from "./request/helpers/model-map.js";
 import {
 	formatRateLimitEntry as formatAccountRateLimitEntry,
+	getRateLimitResetTimeForFamily,
 	resolveActiveIndex,
 } from "./runtime/account-status.js";
 import {
@@ -644,6 +645,41 @@ function getQuotaCacheEntryForAccount(
 	return null;
 }
 
+function getPersistedQuotaViewForAccount(
+	cache: QuotaCacheData | null,
+	account: Pick<AccountMetadataV3, "accountId" | "email" | "rateLimitResetTimes">,
+	accounts: readonly Pick<AccountMetadataV3, "accountId" | "email">[],
+	now: number,
+	emailFallbackState = buildQuotaEmailFallbackState(accounts),
+): QuotaCacheEntry | null {
+	const cachedEntry = cache
+		? getQuotaCacheEntryForAccount(cache, account, accounts, emailFallbackState)
+		: null;
+	const persistedResetAt = getRateLimitResetTimeForFamily(account, now, "codex");
+	if (typeof persistedResetAt !== "number") {
+		return cachedEntry;
+	}
+	const cachedPrimaryResetAt = cachedEntry?.primary.resetAtMs ?? 0;
+	const cachedSecondaryResetAt = cachedEntry?.secondary.resetAtMs ?? 0;
+	if (
+		cachedEntry?.status === 429 &&
+		Math.max(cachedPrimaryResetAt, cachedSecondaryResetAt) >= persistedResetAt
+	) {
+		return cachedEntry;
+	}
+	return {
+		updatedAt: cachedEntry?.updatedAt ?? now,
+		status: 429,
+		model: cachedEntry?.model ?? "gpt-5-codex",
+		planType: cachedEntry?.planType,
+		primary: {
+			...cachedEntry?.primary,
+			resetAtMs: Math.max(cachedPrimaryResetAt, persistedResetAt),
+		},
+		secondary: cachedEntry?.secondary ?? {},
+	};
+}
+
 function updateQuotaCacheForAccount(
 	cache: QuotaCacheData,
 	account: Pick<AccountMetadataV3, "accountId" | "email">,
@@ -1061,14 +1097,13 @@ function toExistingAccountInfo(
 	const layoutMode = resolveMenuLayoutMode(displaySettings);
 	const emailFallbackState = buildQuotaEmailFallbackState(storage.accounts);
 	const baseAccounts = storage.accounts.map((account, index) => {
-		const entry = quotaCache
-			? getQuotaCacheEntryForAccount(
-					quotaCache,
-					account,
-					storage.accounts,
-					emailFallbackState,
-				)
-			: null;
+		const entry = getPersistedQuotaViewForAccount(
+			quotaCache,
+			account,
+			storage.accounts,
+			now,
+			emailFallbackState,
+		);
 		return {
 			index,
 			sourceIndex: index,

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -7152,6 +7152,50 @@ describe("codex manager cli commands", () => {
 		expect(firstCallAccounts[1]?.quotaSummary).toBe("5h 90%");
 	});
 
+	it("surfaces persisted account rate limits when quota cache is empty", async () => {
+		const now = Date.now();
+		loadAccountsMock.mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "rate-limited@example.com",
+					accountId: "acc_rate_limited",
+					refreshToken: "refresh-rate-limited",
+					accessToken: "access-rate-limited",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+					rateLimitResetTimes: {
+						codex: now + 60_000,
+					},
+				},
+			],
+		});
+		loadDashboardDisplaySettingsMock.mockResolvedValue(
+			createReadyFirstMenuSettings({ menuAutoFetchLimits: false }),
+		);
+		loadQuotaCacheMock.mockResolvedValue({ byAccountId: {}, byEmail: {} });
+		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+
+		expect(exitCode).toBe(0);
+		const firstCallAccounts = promptLoginModeMock.mock.calls[0]?.[0] as Array<{
+			email?: string;
+			quotaRateLimited?: boolean;
+			quota5hResetAtMs?: number;
+			quotaSummary?: string;
+		}>;
+		expect(firstCallAccounts[0]?.email).toBe("rate-limited@example.com");
+		expect(firstCallAccounts[0]?.quotaRateLimited).toBe(true);
+		expect(firstCallAccounts[0]?.quota5hResetAtMs).toBe(now + 60_000);
+		expect(firstCallAccounts[0]?.quotaSummary).toBe("rate-limited");
+	});
+
 	it("treats accounts with no quota windows as the lowest ready-first floor", async () => {
 		const now = Date.now();
 		loadAccountsMock.mockResolvedValue({


### PR DESCRIPTION
## Problem

Persisted account rate-limit state and persisted quota-cache views were tracked separately.

That meant the CLI menu could lose rate-limit context between live probes: account storage still knew an account was rate-limited, but the quota view could look empty when the quota cache had no entry.

## Fix

Merge persisted account-side rate-limit resets into the display-side quota view.

This keeps the fix narrowly scoped to CLI/menu consumers and avoids changing runtime fetch behavior.

## Changes

- `lib/codex-manager.ts`
  - added a display-side helper that synthesizes a 429-style quota entry from persisted `rateLimitResetTimes`
  - uses that merged view in `toExistingAccountInfo(...)`
- `test/codex-manager-cli.test.ts`
  - added a regression showing a persisted account rate limit is surfaced even when quota cache is empty

## Validation

```text
npx vitest run test/codex-manager-cli.test.ts
Test Files  1 passed (1)
Tests      177 passed (177)

npx vitest run
Test Files  222 passed (222)
Tests      3314 passed (3314)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR surfaces persisted `rateLimitResetTimes` in the CLI menu quota view by introducing `getPersistedQuotaViewForAccount`, a pure display-side helper that merges account-storage rate-limit state into the quota cache entry passed to `promptLoginMode`. the change is correctly scoped to `toExistingAccountInfo` and does not touch the runtime fetch path.

- new helper `getPersistedQuotaViewForAccount` synthesizes a 429-style `QuotaCacheEntry` when the quota cache is empty or when the persisted reset time is more restrictive than the cached entry
- `toExistingAccountInfo` now calls the helper instead of `getQuotaCacheEntryForAccount` directly — no callers outside the CLI menu are affected
- regression test covers the primary bug (quota cache empty, persisted rate limit active), correctly verifying `quotaRateLimited: true`, `quota5hResetAtMs`, and `quotaSummary`
- the helper unconditionally prefers persisted state over a fresh live 200 probe when the reset time is still in the future — no freshness guard on the cached entry, which could produce false-positive rate-limited display if `rateLimitResetTimes` is not cleared on recovery
- existing sort-order test colocates a cache-200 entry with `rateLimitResetTimes` but lacks an explicit `quotaRateLimited` assertion for that account
- no vitest coverage for the "stale cached 429 gets a later `resetAtMs` from persisted state" branch (`Math.max` path on line 677)

<h3>Confidence Score: 3/5</h3>

safe to merge with minor display-side false-positive risk if rateLimitResetTimes is not cleared on live recovery

logic is sound for the primary use case and all 3314 tests pass; the unchecked override of a fresh 200 probe by persisted state is a latent display risk that depends on correct rateLimitResetTimes lifecycle management; two untested edge-case branches reduce confidence

lib/codex-manager.ts lines 664-668 (override condition has no freshness guard for cached 200); test/codex-manager-cli.test.ts (missing quotaRateLimited assertion for cache-200-overridden case, and no test for stale-429-bumped-up branch)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager.ts | adds getPersistedQuotaViewForAccount helper that synthesizes 429 from persisted rateLimitResetTimes; live 200 probe can be silently overridden if rateLimitResetTimes is not cleared on recovery |
| test/codex-manager-cli.test.ts | adds regression for quota-cache-empty + persisted rate limit; missing assertions for cache-200-overridden and stale-429-bumped-up paths |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getPersistedQuotaViewForAccount] --> B[getQuotaCacheEntryForAccount]
    B --> C{persistedResetAt\na number?}
    C -->|no| D[return cachedEntry\nmay be null]
    C -->|yes| E{cachedEntry.status\n=== 429 AND\ncache resetAt ≥\npersistedResetAt?}
    E -->|yes| F[return cachedEntry\ncache already more restrictive]
    E -->|no — includes fresh 200| G[synthesize entry\nstatus: 429\nmodel: cached ?? gpt-5-codex\nprimary.resetAtMs: max of cached and persisted\nsecondary: cached ?? empty]
    G --> H[toExistingAccountInfo\nquotaRateLimited: true]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fcodex-manager.ts%3A664-668%0A**live%20200%20probe%20silently%20overridden%20by%20persisted%20rate%20limit**%0A%0Awhen%20%60cachedEntry.status%20%3D%3D%3D%20200%60%20%28a%20recent%20live%20probe%20confirmed%20the%20account%20healthy%29%20but%20%60persistedResetAt%60%20is%20still%20in%20the%20future%2C%20the%20function%20unconditionally%20synthesizes%20a%20429%20entry%2C%20discarding%20the%20probe%20result.%20the%20early-return%20only%20fires%20when%20the%20cache%20itself%20already%20carries%20%60status%20%3D%3D%3D%20429%60%20%E2%80%94%20there%20is%20no%20freshness%20guard%20for%20a%20cached%20200.%0A%0Aif%20the%20runtime%20always%20clears%20%60rateLimitResetTimes%60%20the%20moment%20a%20429%20resolves%20this%20is%20harmless%2C%20but%20if%20that%20clear%20is%20ever%20missed%20%28e.g.%2C%20a%20probe%20races%20with%20a%20429%20reset%29%2C%20the%20menu%20permanently%20shows%20the%20account%20as%20rate-limited%20even%20though%20the%20live%20probe%20confirmed%20recovery.%20consider%20honoring%20a%20fresh%20cached%20200%3A%0A%0A%60%60%60suggestion%0A%09if%20%28%0A%09%09cachedEntry%20!%3D%3D%20null%20%26%26%0A%09%09%28cachedEntry.status%20%3D%3D%3D%20200%20%7C%7C%0A%09%09%09%28cachedEntry.status%20%3D%3D%3D%20429%20%26%26%0A%09%09%09%09Math.max%28cachedPrimaryResetAt%2C%20cachedSecondaryResetAt%29%20%3E%3D%20persistedResetAt%29%29%0A%09%29%20%7B%0A%09%09return%20cachedEntry%3B%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fcodex-manager-cli.test.ts%3A6957-6973%0A**missing%20%60quotaRateLimited%60%20assertion%20for%20the%20cache-200-overridden-by-persisted%20path**%0A%0Athis%20test%20is%20the%20only%20existing%20scenario%20where%20a%20cache%20entry%20with%20%60status%3A%20200%60%20coexists%20with%20a%20persisted%20%60rateLimitResetTimes%60.%20the%20new%20%60getPersistedQuotaViewForAccount%60%20helper%20now%20synthesizes%20a%20429%20for%20%60rate-limited%40example.com%60%20%28sourceIndex%204%2C%20display%20index%203%29%2C%20but%20the%20test%20only%20validates%20sort%20order%20%E2%80%94%20it%20never%20asserts%20%60quotaRateLimited%3A%20true%60%20for%20that%20account.%20locking%20in%20the%20assertion%20would%20catch%20a%20regression%20if%20the%20override%20condition%20were%20weakened%3A%0A%0A%60%60%60suggestion%0A%09%09expect%28firstCallAccounts%5B2%5D%3F.quotaRateLimited%29.toBe%28true%29%3B%0A%09%09expect%28firstCallAccounts%5B3%5D%3F.quotaRateLimited%29.toBe%28true%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fcodex-manager-cli.test.ts%3A7155-7197%0A**missing%20vitest%20coverage%3A%20stale%20cached%20429%20reset%20time%20bumped%20up%20by%20persisted%20state**%0A%0Athe%20new%20regression%20test%20covers%20quota-cache-empty%20%E2%86%92%20persisted%20rate%20limit%20surfaces.%20there%20is%20no%20test%20for%20the%20complementary%20branch%3A%20cache%20already%20has%20%60status%3A%20429%60%20with%20%60primary.resetAtMs%3A%20now%20%2B%205_000%60%20but%20persisted%20%60rateLimitResetTimes.codex%20%3D%20now%20%2B%2060_000%60.%20in%20that%20path%20%60getPersistedQuotaViewForAccount%60%20should%20produce%20a%20synthesized%20entry%20with%20%60primary.resetAtMs%20%3D%20now%20%2B%2060_000%60%20%28the%20%60Math.max%60%20on%20line%20677%20in%20%60lib%2Fcodex-manager.ts%60%29.%20without%20this%20test%2C%20a%20refactor%20of%20that%20comparison%20goes%20undetected.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager.ts
Line: 664-668

Comment:
**live 200 probe silently overridden by persisted rate limit**

when `cachedEntry.status === 200` (a recent live probe confirmed the account healthy) but `persistedResetAt` is still in the future, the function unconditionally synthesizes a 429 entry, discarding the probe result. the early-return only fires when the cache itself already carries `status === 429` — there is no freshness guard for a cached 200.

if the runtime always clears `rateLimitResetTimes` the moment a 429 resolves this is harmless, but if that clear is ever missed (e.g., a probe races with a 429 reset), the menu permanently shows the account as rate-limited even though the live probe confirmed recovery. consider honoring a fresh cached 200:

```suggestion
	if (
		cachedEntry !== null &&
		(cachedEntry.status === 200 ||
			(cachedEntry.status === 429 &&
				Math.max(cachedPrimaryResetAt, cachedSecondaryResetAt) >= persistedResetAt))
	) {
		return cachedEntry;
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-cli.test.ts
Line: 6957-6973

Comment:
**missing `quotaRateLimited` assertion for the cache-200-overridden-by-persisted path**

this test is the only existing scenario where a cache entry with `status: 200` coexists with a persisted `rateLimitResetTimes`. the new `getPersistedQuotaViewForAccount` helper now synthesizes a 429 for `rate-limited@example.com` (sourceIndex 4, display index 3), but the test only validates sort order — it never asserts `quotaRateLimited: true` for that account. locking in the assertion would catch a regression if the override condition were weakened:

```suggestion
		expect(firstCallAccounts[2]?.quotaRateLimited).toBe(true);
		expect(firstCallAccounts[3]?.quotaRateLimited).toBe(true);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-cli.test.ts
Line: 7155-7197

Comment:
**missing vitest coverage: stale cached 429 reset time bumped up by persisted state**

the new regression test covers quota-cache-empty → persisted rate limit surfaces. there is no test for the complementary branch: cache already has `status: 429` with `primary.resetAtMs: now + 5_000` but persisted `rateLimitResetTimes.codex = now + 60_000`. in that path `getPersistedQuotaViewForAccount` should produce a synthesized entry with `primary.resetAtMs = now + 60_000` (the `Math.max` on line 677 in `lib/codex-manager.ts`). without this test, a refactor of that comparison goes undetected.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: surface persisted rate limits in qu..."](https://github.com/ndycode/codex-multi-auth/commit/3c18e2b5d0dd1a0f8f8d412a8f6f767068178df1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27425587)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->