### PR TITLE
fix: skip accounts with all workspaces disabled during rotation

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -535,6 +535,7 @@ export class AccountManager {
 		const account = this.getAccountByIndex(index);
 		if (!account) return false;
 		if (account.enabled === false) return false;
+		if (!this.hasEnabledWorkspaces(account)) return false;
 		clearExpiredRateLimits(account);
 		return (
 			!isRateLimitedForFamily(account, family, model) &&
@@ -606,6 +607,7 @@ export class AccountManager {
 			const account = this.accounts[idx];
 			if (!account) continue;
 			if (account.enabled === false) continue;
+			if (!this.hasEnabledWorkspaces(account)) continue;
 
 			clearExpiredRateLimits(account);
 			if (
@@ -636,6 +638,7 @@ export class AccountManager {
 			const account = this.accounts[idx];
 			if (!account) continue;
 			if (account.enabled === false) continue;
+			if (!this.hasEnabledWorkspaces(account)) continue;
 
 			clearExpiredRateLimits(account);
 			if (
@@ -666,6 +669,7 @@ export class AccountManager {
 			.map((account): AccountWithMetrics | null => {
 				if (!account) return null;
 				if (account.enabled === false) return null;
+				if (!this.hasEnabledWorkspaces(account)) return null;
 				clearExpiredRateLimits(account);
 				const isAvailable =
 					!isRateLimitedForFamily(account, family, model) &&

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -427,6 +427,55 @@ describe("AccountManager", () => {
     expect(manager.isAccountAvailableForFamily(3, "codex")).toBe(true);
   });
 
+  it("treats accounts with all tracked workspaces disabled as unavailable for selection", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      activeIndexByFamily: { codex: 0 },
+      accounts: [
+        {
+          refreshToken: "token-workspace-disabled",
+          addedAt: now,
+          lastUsed: now,
+          workspaces: [
+            { id: "workspace-1", name: "Workspace 1", enabled: false },
+            { id: "workspace-2", name: "Workspace 2", enabled: false },
+          ],
+          currentWorkspaceIndex: 0,
+        },
+        {
+          refreshToken: "token-ready",
+          addedAt: now,
+          lastUsed: now - 10_000,
+        },
+      ],
+    };
+
+    const manager = new AccountManager(undefined, stored as never);
+
+    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
+    expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe("token-ready");
+    expect(manager.getNextForFamily("codex")?.refreshToken).toBe("token-ready");
+    expect(manager.getCurrentOrNextForFamilyHybrid("codex")?.refreshToken).toBe("token-ready");
+  });
+
+  it("keeps workspace-less legacy accounts eligible for selection", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      activeIndexByFamily: { codex: 0 },
+      accounts: [{ refreshToken: "token-legacy", addedAt: now, lastUsed: now }],
+    };
+
+    const manager = new AccountManager(undefined, stored as never);
+
+    expect(manager.hasEnabledWorkspaces(manager.getAccountByIndex(0)!)).toBe(true);
+    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
+    expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe("token-legacy");
+  });
+
   it("returns false for invalid account index in availability checks", () => {
     const now = Date.now();
     const stored = {


### PR DESCRIPTION
## Problem

Accounts with tracked workspaces could remain eligible for family selection even after every workspace had been disabled.

That leaves a workspace-exhausted account in the rotation pool and can block fallback selection unnecessarily.

## Fix

Treat accounts whose tracked workspaces are all disabled as unavailable for selection.

Legacy workspace-less accounts remain eligible for backwards compatibility.

## Changes

- `lib/accounts.ts`
  - exclude accounts with no enabled tracked workspaces from:
    - `isAccountAvailableForFamily(...)`
    - `getCurrentOrNextForFamily(...)`
    - `getNextForFamily(...)`
    - `getCurrentOrNextForFamilyHybrid(...)`
- `test/accounts.test.ts`
  - added regression coverage for tracked all-disabled workspaces being skipped
  - added regression coverage for legacy workspace-less accounts remaining selectable

## Validation

```text
npx vitest run test/accounts.test.ts test/accounts-edge.test.ts test/accounts-load-from-disk.test.ts test/index-retry.test.ts
Test Files  4 passed (4)
Tests      161 passed (161)

npx vitest run
Test Files  222 passed (222)
Tests      3315 passed (3315)
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr correctly fixes workspace-exhausted accounts lingering in the rotation pool by adding a `hasEnabledWorkspaces()` guard to all four selection paths: `isAccountAvailableForFamily`, `getCurrentOrNextForFamily`, `getNextForFamily`, and `getCurrentOrNextForFamilyHybrid`. the `hasEnabledWorkspaces` helper uses `enabled !== false` (not `=== true`) so legacy accounts without a `workspaces` array stay eligible — a correct backwards-compat choice consistent with how `account.enabled` is normalized in the constructor. no concurrency risk (all guard checks are synchronous, no async gap between read and write of cursor state). no windows filesystem or token safety concerns introduced.

<h3>Confidence Score: 5/5</h3>

safe to merge — fix is minimal, targeted, and all 4 selection paths are consistently guarded

no p0/p1 findings. logic is correct, `enabled !== false` idiom properly treats undefined as enabled for backwards compat, legacy account path is explicitly covered by test. no concurrency or filesystem risk.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds hasEnabledWorkspaces() guard consistently to all 4 rotation/selection methods; helper correctly handles legacy workspace-less accounts and the all-disabled edge case |
| test/accounts.test.ts | adds regression tests covering all 4 guarded methods for all-disabled workspace exclusion and legacy workspace-less backwards compatibility |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[select account for family] --> B{account exists?}
    B -- no --> Z[return null / skip]
    B -- yes --> C{account.enabled !== false?}
    C -- no --> Z
    C -- yes --> D{hasEnabledWorkspaces?}
    D -- no workspaces array --> E[true: legacy account]
    D -- has workspaces --> F{any workspace.enabled !== false?}
    F -- yes --> E
    F -- all disabled --> Z
    E --> H[check rate-limit / cooldown / circuit-breaker]
    H -- blocked --> Z
    H -- clear --> I[return account]
```

<sub>Reviews (1): Last reviewed commit: ["fix: skip accounts with all workspaces d..."](https://github.com/ndycode/codex-multi-auth/commit/770a5654ba4c785d0f96c6dbdebe2c8ceae4361b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27425806)</sub>

<!-- /greptile_comment -->