### PR TITLE
keep GitHub language stats focused on TypeScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Keep repository language stats focused on authored TypeScript sources.
+*.ts linguist-detectable
+*.js -linguist-detectable
+*.mjs -linguist-detectable
+*.sh -linguist-detectable
+*.html -linguist-detectable

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -617,11 +617,17 @@ function compareSemverDescending(left: string, right: string): number {
 		).toBe(true);
 
 		const content = read(gitattributes);
-		expect(content).toContain("*.ts linguist-detectable");
-		expect(content).toContain("*.js -linguist-detectable");
-		expect(content).toContain("*.mjs -linguist-detectable");
-		expect(content).toContain("*.sh -linguist-detectable");
-		expect(content).toContain("*.html -linguist-detectable");
+		const normalized = content
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0 && !line.startsWith("#"));
+		expect(normalized).toEqual([
+			"*.ts linguist-detectable",
+			"*.js -linguist-detectable",
+			"*.mjs -linguist-detectable",
+			"*.sh -linguist-detectable",
+			"*.html -linguist-detectable",
+		]);
 	});
 
 	it("publishes maintainer runbooks for refactor-era changes", () => {

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -609,6 +609,21 @@ function compareSemverDescending(left: string, right: string): number {
 		expect(conduct).toContain("security.md");
 	});
 
+	it("locks linguist overrides for a TypeScript-only repository language bar", () => {
+		const gitattributes = ".gitattributes";
+		expect(
+			existsSync(join(projectRoot, gitattributes)),
+			`${gitattributes} should exist`,
+		).toBe(true);
+
+		const content = read(gitattributes);
+		expect(content).toContain("*.ts linguist-detectable");
+		expect(content).toContain("*.js -linguist-detectable");
+		expect(content).toContain("*.mjs -linguist-detectable");
+		expect(content).toContain("*.sh -linguist-detectable");
+		expect(content).toContain("*.html -linguist-detectable");
+	});
+
 	it("publishes maintainer runbooks for refactor-era changes", () => {
 		const docsPortal = read("docs/README.md");
 		const testingGuide = read("docs/development/TESTING.md");


### PR DESCRIPTION
## Summary

- keep GitHub Linguist stats focused on authored TypeScript instead of auxiliary script formats

## What Changed

- added `.gitattributes` rules that keep `*.ts` detectable while marking `*.js`, `*.mjs`, `*.sh`, and `*.html` as non-detectable for repo language stats
- added a `test/documentation.test.ts` assertion so the Linguist override contract stays explicit in repo governance coverage

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low; metadata-only Linguist override plus governance coverage
- Rollback plan: revert `d7ff9c7`

## Additional Notes

- `gh api repos/ndycode/codex-multi-auth/languages` currently reports `TypeScript`, `JavaScript`, `HTML`, and `Shell`; this change is intended to stop the non-TypeScript helper files from counting toward the repo language bar after merge
- full `npm test` is still red on inherited `test/proactive-refresh.test.ts` timeouts (`does not log when all accounts return no_refresh_token`, `refreshes multiple accounts in parallel`, `handles mixed success and failure results`); the same three failures reproduce on a clean detached `origin/main` worktree

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `.gitattributes` linguist overrides to exclude `.js`, `.mjs`, `.sh`, and `.html` files from github language stats, and locks the contract in `test/documentation.test.ts` with an exact-match governance assertion.

the implementation is clean and the test handles windows `\
\
` line endings correctly via `split(/\
?\
/)`.

<h3>Confidence Score: 5/5</h3>

safe to merge — metadata-only change with a single P2 observation about vendor .d.ts over-inclusion that doesn't affect correctness

both changed files are clean: the `.gitattributes` achieves the stated goal and the governance test is correctly implemented with proper windows line-ending handling. the only finding is a P2 style note about vendor `.d.ts` files being force-included, which doesn't break anything.

`.gitattributes` — the `*.ts linguist-detectable` glob catches vendor declaration files; worth a follow-up if accurate attribution matters

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .gitattributes | new file that sets linguist-detectable overrides; `*.ts linguist-detectable` will also force-include `vendor/*.d.ts` declaration files which linguist would normally exclude as vendor code |
| test/documentation.test.ts | adds governance test that reads and normalizes `.gitattributes`, asserting exact ordered content; handles windows line endings; correctly uses the existing `read()` helper scoped to `projectRoot` |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Linguist scans repo] --> B{File extension?}
    B -->|*.ts| C[linguist-detectable = true\nall .ts files counted\nincl. vendor/*.d.ts + test/*.ts]
    B -->|*.js / *.mjs| D[-linguist-detectable\nexcluded from stats]
    B -->|*.sh| E[-linguist-detectable\nexcluded from stats]
    B -->|*.html| F[-linguist-detectable\nexcluded from stats]
    C --> G[Language bar: TypeScript only]
    D --> G
    E --> G
    F --> G
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.gitattributes%3A2%0A**%60*.ts%20linguist-detectable%60%20will%20include%20vendored%20declaration%20files**%0A%0Athe%20pattern%20catches%20every%20%60.ts%60%20file%20in%20the%20repo%2C%20including%20the%20three%20vendored%20declaration%20files%20under%20%60vendor%2Fcodex-ai-plugin%2Fdist%2F%60%20and%20%60vendor%2Fcodex-ai-sdk%2Fdist%2F%60.%20linguist%20would%20normally%20exclude%20%60vendor%2F%60%20paths%20from%20language%20stats%3B%20the%20explicit%20%60linguist-detectable%60%20override%20re-admits%20them.%20they%20still%20count%20as%20TypeScript%20so%20the%20bar%20stays%20correct%2C%20but%20it%20contradicts%20the%20header%20comment%20%22authored%20TypeScript%20sources.%22%20if%20you%20want%20vendored%20declarations%20excluded%2C%20add%3A%0A%0A%60%60%60%0Avendor%2F**%2F*.ts%20linguist-vendored%0A%60%60%60%0A%0Abelow%20the%20%60*.ts%60%20rule%20%E2%80%94%20later%20rules%20take%20precedence%20and%20will%20re-exclude%20those%20paths.%0A%0A&repo=ndycode%2Fcodex-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .gitattributes
Line: 2

Comment:
**`*.ts linguist-detectable` will include vendored declaration files**

the pattern catches every `.ts` file in the repo, including the three vendored declaration files under `vendor/codex-ai-plugin/dist/` and `vendor/codex-ai-sdk/dist/`. linguist would normally exclude `vendor/` paths from language stats; the explicit `linguist-detectable` override re-admits them. they still count as TypeScript so the bar stays correct, but it contradicts the header comment "authored TypeScript sources." if you want vendored declarations excluded, add:

```
vendor/**/*.ts linguist-vendored
```

below the `*.ts` rule — later rules take precedence and will re-exclude those paths.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Tighten the linguist override regression..."](https://github.com/ndycode/codex-multi-auth/commit/6c0eec164cbd4f935391ee955bb619253ee7f246) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28011112)</sub>

<!-- /greptile_comment -->