### PR TITLE
support native Codex CLI installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/codex-multi-auth.svg)](https://www.npmjs.com/package/codex-multi-auth)
 [![npm downloads](https://img.shields.io/npm/dw/codex-multi-auth.svg)](https://www.npmjs.com/package/codex-multi-auth)
 
-Codex CLI-first multi-account OAuth manager for the official `@openai/codex` CLI.
+Codex CLI-first multi-account OAuth manager for the official Codex CLI, including the `@openai/codex` npm launcher and native `codex` installs.
 
 <img width="1270" height="729" alt="2026-02-28 12_54_58-prompt txt ‎- Notepads" src="https://github.com/user-attachments/assets/0cecb77e-a6d3-432a-ba48-3577db0c7093" />
 
@@ -72,6 +72,8 @@ codex-multi-auth --version
 codex auth status
 ```
 
+Any official install path is fine as long as `codex` is on `PATH`: `npm i -g @openai/codex`, `brew install --cask codex`, or an official release binary.
+
 </details>
 
 <details>
@@ -102,6 +104,13 @@ Install and sign in:
 
 ```bash
 npm i -g @openai/codex
+npm i -g codex-multi-auth
+codex auth login
+```
+
+If you already installed the official native CLI via Homebrew or a release binary, you only need:
+
+```bash
 npm i -g codex-multi-auth
 codex auth login
 ```
@@ -274,7 +283,7 @@ codex auth login
 <details>
 <summary><b>Common symptoms</b></summary>
 
-- `codex auth` unrecognized: run `where codex`, then follow `docs/troubleshooting.md` for routing fallback commands
+- `codex auth` unrecognized: run `where codex` or `which codex`, then follow `docs/troubleshooting.md` for routing fallback commands
 - Switch succeeds but wrong account appears active: run `codex auth switch <index>`, then restart session
 - Requests fail fast with a pool cooldown message: wait for the cooldown window or inspect `codex auth status`
 - Requests fail fast after repeated upstream 5xx errors: inspect `codex auth report --json` for runtime traffic and cooldown details

--- a/scripts/codex-bin-resolver.js
+++ b/scripts/codex-bin-resolver.js
@@ -1,9 +1,21 @@
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { basename, delimiter, dirname, extname, join } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+
+function isJavaScriptEntryPath(candidate) {
+	const extension = extname(candidate).toLowerCase();
+	return extension === ".js" || extension === ".mjs" || extension === ".cjs";
+}
+
+function createResolvedCodexBin(path) {
+	return {
+		path,
+		launchWithNode: isJavaScriptEntryPath(path),
+	};
+}
 
 function defaultResolvePackageBin(moduleUrl) {
 	try {
@@ -26,6 +38,80 @@ function resolveWindowsCmdPath(env) {
 	return "cmd.exe";
 }
 
+function splitPathEntries(pathValue) {
+	if (typeof pathValue !== "string" || pathValue.trim().length === 0) {
+		return [];
+	}
+	return pathValue
+		.split(delimiter)
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+}
+
+function resolvePathExecutableName(platform) {
+	return platform === "win32" ? "codex.exe" : "codex";
+}
+
+function resolveCodexExecutableFromPath(pathEntries, platform, existsSyncImpl) {
+	const executableName = resolvePathExecutableName(platform);
+	for (const entry of pathEntries) {
+		const candidate = join(entry, executableName);
+		if (existsSyncImpl(candidate)) {
+			return candidate;
+		}
+	}
+	return null;
+}
+
+function normalizeWhereOutput(stdout) {
+	return stdout
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+}
+
+function resolveCodexExecutableFromSystemPath(env, platform, spawnSyncImpl, existsSyncImpl) {
+	const pathEntries = splitPathEntries(env.PATH ?? env.Path ?? "");
+	const fromEnvPath = resolveCodexExecutableFromPath(pathEntries, platform, existsSyncImpl);
+	if (fromEnvPath) {
+		return fromEnvPath;
+	}
+
+	try {
+		const lookupResult =
+			platform === "win32"
+				? spawnSyncImpl(resolveWindowsCmdPath(env), ["/d", "/s", "/c", "where codex"], {
+						encoding: "utf8",
+						env,
+						stdio: ["ignore", "pipe", "ignore"],
+						timeout: 5000,
+						windowsHide: true,
+					})
+				: spawnSyncImpl("which", ["codex"], {
+						encoding: "utf8",
+						env,
+						stdio: ["ignore", "pipe", "ignore"],
+						timeout: 5000,
+					});
+		if (lookupResult.status !== 0) {
+			return null;
+		}
+		for (const candidate of normalizeWhereOutput(lookupResult.stdout)) {
+			if (!existsSyncImpl(candidate)) {
+				continue;
+			}
+			const fileName = basename(candidate).toLowerCase();
+			if (fileName === "codex" || fileName === "codex.exe") {
+				return candidate;
+			}
+		}
+	} catch {
+		// Ignore and fall through.
+	}
+
+	return null;
+}
+
 export function resolveRealCodexBin(options = {}) {
 	const {
 		env = process.env,
@@ -39,13 +125,13 @@ export function resolveRealCodexBin(options = {}) {
 
 	const override = (env.CODEX_MULTI_AUTH_REAL_CODEX_BIN ?? "").trim();
 	if (override.length > 0) {
-		if (existsSyncImpl(override)) return override;
+		if (existsSyncImpl(override)) return createResolvedCodexBin(override);
 		return null;
 	}
 
 	const resolved = resolvePackageBin(moduleUrl);
 	if (typeof resolved === "string" && resolved.length > 0 && existsSyncImpl(resolved)) {
-		return resolved;
+		return createResolvedCodexBin(resolved);
 	}
 
 	const searchRoots = [];
@@ -65,7 +151,7 @@ export function resolveRealCodexBin(options = {}) {
 
 	for (const root of searchRoots) {
 		const candidate = join(root, "@openai", "codex", "bin", "codex.js");
-		if (existsSyncImpl(candidate)) return candidate;
+		if (existsSyncImpl(candidate)) return createResolvedCodexBin(candidate);
 	}
 
 	try {
@@ -88,11 +174,21 @@ export function resolveRealCodexBin(options = {}) {
 			const globalRoot = rootResult.stdout.trim();
 			if (globalRoot.length > 0) {
 				const globalBin = join(globalRoot, "@openai", "codex", "bin", "codex.js");
-				if (existsSyncImpl(globalBin)) return globalBin;
+				if (existsSyncImpl(globalBin)) return createResolvedCodexBin(globalBin);
 			}
 		}
 	} catch {
 		// Ignore and fall through to null.
+	}
+
+	const nativeCodexBin = resolveCodexExecutableFromSystemPath(
+		env,
+		platform,
+		spawnSyncImpl,
+		existsSyncImpl,
+	);
+	if (nativeCodexBin) {
+		return createResolvedCodexBin(nativeCodexBin);
 	}
 
 	return null;

--- a/scripts/codex-bin-resolver.js
+++ b/scripts/codex-bin-resolver.js
@@ -50,7 +50,7 @@ function resolveWindowsCmdPath(env) {
 	return "cmd.exe";
 }
 
-function splitPathEntries(pathValue) {
+export function splitPathEntries(pathValue) {
 	if (typeof pathValue !== "string" || pathValue.trim().length === 0) {
 		return [];
 	}
@@ -64,6 +64,13 @@ function resolvePathExecutableName(platform) {
 	return platform === "win32" ? "codex.exe" : "codex";
 }
 
+function resolveCandidateExecutableNames(platform) {
+	if (platform !== "win32") {
+		return [resolvePathExecutableName(platform)];
+	}
+	return ["codex.exe", "codex"];
+}
+
 function resolveCodexExecutableFromPath(
 	pathEntries,
 	platform,
@@ -71,19 +78,18 @@ function resolveCodexExecutableFromPath(
 	selfScriptPath,
 	realpathSyncImpl,
 ) {
-	const executableName = resolvePathExecutableName(platform);
 	for (const entry of pathEntries) {
-		const candidate = join(entry, executableName);
-		if (!existsSyncImpl(candidate)) {
-			continue;
-		}
-		if (
-			selfScriptPath &&
-			normalizeResolvedPath(candidate, realpathSyncImpl) === selfScriptPath
-		) {
-			continue;
-		}
-		if (existsSyncImpl(candidate)) {
+		for (const executableName of resolveCandidateExecutableNames(platform)) {
+			const candidate = join(entry, executableName);
+			if (!existsSyncImpl(candidate)) {
+				continue;
+			}
+			if (
+				selfScriptPath &&
+				normalizeResolvedPath(candidate, realpathSyncImpl) === selfScriptPath
+			) {
+				continue;
+			}
 			return candidate;
 		}
 	}

--- a/scripts/codex-bin-resolver.js
+++ b/scripts/codex-bin-resolver.js
@@ -29,6 +29,8 @@ function resolveWrapperScriptPath(moduleUrl, realpathSyncImpl) {
 	return normalizeResolvedPath(fileURLToPath(moduleUrl), realpathSyncImpl);
 }
 
+const DEFAULT_WRAPPER_MODULE_URL = new URL("./codex.js", import.meta.url).href;
+
 function defaultResolvePackageBin(moduleUrl) {
 	try {
 		const require = createRequire(moduleUrl);
@@ -169,7 +171,7 @@ export function resolveRealCodexBin(options = {}) {
 		env = process.env,
 		argv = process.argv,
 		platform = process.platform,
-		moduleUrl = import.meta.url,
+		moduleUrl = DEFAULT_WRAPPER_MODULE_URL,
 		existsSyncImpl = existsSync,
 		realpathSyncImpl = realpathSync,
 		spawnSyncImpl = spawnSync,

--- a/scripts/codex-bin-resolver.js
+++ b/scripts/codex-bin-resolver.js
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
 import { basename, delimiter, dirname, extname, join } from "node:path";
 import process from "node:process";
@@ -15,6 +15,18 @@ function createResolvedCodexBin(path) {
 		path,
 		launchWithNode: isJavaScriptEntryPath(path),
 	};
+}
+
+function normalizeResolvedPath(candidatePath, realpathSyncImpl) {
+	try {
+		return realpathSyncImpl(candidatePath);
+	} catch {
+		return candidatePath;
+	}
+}
+
+function resolveWrapperScriptPath(moduleUrl, realpathSyncImpl) {
+	return normalizeResolvedPath(fileURLToPath(moduleUrl), realpathSyncImpl);
 }
 
 function defaultResolvePackageBin(moduleUrl) {
@@ -52,10 +64,25 @@ function resolvePathExecutableName(platform) {
 	return platform === "win32" ? "codex.exe" : "codex";
 }
 
-function resolveCodexExecutableFromPath(pathEntries, platform, existsSyncImpl) {
+function resolveCodexExecutableFromPath(
+	pathEntries,
+	platform,
+	existsSyncImpl,
+	selfScriptPath,
+	realpathSyncImpl,
+) {
 	const executableName = resolvePathExecutableName(platform);
 	for (const entry of pathEntries) {
 		const candidate = join(entry, executableName);
+		if (!existsSyncImpl(candidate)) {
+			continue;
+		}
+		if (
+			selfScriptPath &&
+			normalizeResolvedPath(candidate, realpathSyncImpl) === selfScriptPath
+		) {
+			continue;
+		}
 		if (existsSyncImpl(candidate)) {
 			return candidate;
 		}
@@ -70,9 +97,22 @@ function normalizeWhereOutput(stdout) {
 		.filter((line) => line.length > 0);
 }
 
-function resolveCodexExecutableFromSystemPath(env, platform, spawnSyncImpl, existsSyncImpl) {
+function resolveCodexExecutableFromSystemPath(
+	env,
+	platform,
+	spawnSyncImpl,
+	existsSyncImpl,
+	selfScriptPath,
+	realpathSyncImpl,
+) {
 	const pathEntries = splitPathEntries(env.PATH ?? env.Path ?? "");
-	const fromEnvPath = resolveCodexExecutableFromPath(pathEntries, platform, existsSyncImpl);
+	const fromEnvPath = resolveCodexExecutableFromPath(
+		pathEntries,
+		platform,
+		existsSyncImpl,
+		selfScriptPath,
+		realpathSyncImpl,
+	);
 	if (fromEnvPath) {
 		return fromEnvPath;
 	}
@@ -100,6 +140,12 @@ function resolveCodexExecutableFromSystemPath(env, platform, spawnSyncImpl, exis
 			if (!existsSyncImpl(candidate)) {
 				continue;
 			}
+			if (
+				selfScriptPath &&
+				normalizeResolvedPath(candidate, realpathSyncImpl) === selfScriptPath
+			) {
+				continue;
+			}
 			const fileName = basename(candidate).toLowerCase();
 			if (fileName === "codex" || fileName === "codex.exe") {
 				return candidate;
@@ -119,6 +165,7 @@ export function resolveRealCodexBin(options = {}) {
 		platform = process.platform,
 		moduleUrl = import.meta.url,
 		existsSyncImpl = existsSync,
+		realpathSyncImpl = realpathSync,
 		spawnSyncImpl = spawnSync,
 		resolvePackageBin = defaultResolvePackageBin,
 	} = options;
@@ -181,11 +228,15 @@ export function resolveRealCodexBin(options = {}) {
 		// Ignore and fall through to null.
 	}
 
+	const selfScriptPath = resolveWrapperScriptPath(moduleUrl, realpathSyncImpl);
+
 	const nativeCodexBin = resolveCodexExecutableFromSystemPath(
 		env,
 		platform,
 		spawnSyncImpl,
 		existsSyncImpl,
+		selfScriptPath,
+		realpathSyncImpl,
 	);
 	if (nativeCodexBin) {
 		return createResolvedCodexBin(nativeCodexBin);

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -18,7 +18,10 @@ import { homedir, tmpdir } from "node:os";
 import { basename, delimiter, dirname, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { resolveRealCodexBin as resolveRealCodexBinFromEnvironment } from "./codex-bin-resolver.js";
+import {
+	resolveRealCodexBin as resolveRealCodexBinFromEnvironment,
+	splitPathEntries,
+} from "./codex-bin-resolver.js";
 import { normalizeAuthAlias, shouldHandleMultiAuthAuth } from "./codex-routing.js";
 
 const RETRYABLE_SHADOW_HOME_CLEANUP_CODES = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
@@ -999,16 +1002,6 @@ function shouldInstallWindowsBatchShimGuard() {
 	if (process.platform !== "win32") return false;
 	const override = (process.env.CODEX_MULTI_AUTH_WINDOWS_BATCH_SHIM_GUARD ?? "0").trim();
 	return override !== "0";
-}
-
-function splitPathEntries(pathValue) {
-	if (typeof pathValue !== "string" || pathValue.trim().length === 0) {
-		return [];
-	}
-	return pathValue
-		.split(delimiter)
-		.map((entry) => entry.trim())
-		.filter((entry) => entry.length > 0);
 }
 
 function resolveWindowsShimDirectoryFromInvocation() {

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -124,11 +124,17 @@ async function autoSyncManagerActiveSelectionIfEnabled() {
 function resolveRealCodexBin() {
 	const override = (process.env.CODEX_MULTI_AUTH_REAL_CODEX_BIN ?? "").trim();
 	if (override.length > 0) {
-		if (existsSync(override)) return override;
-		console.error(
-			`CODEX_MULTI_AUTH_REAL_CODEX_BIN is set but missing: ${override}`,
-		);
-		return null;
+		if (!existsSync(override)) {
+			console.error(
+				`CODEX_MULTI_AUTH_REAL_CODEX_BIN is set but missing: ${override}`,
+			);
+			return null;
+		}
+		return resolveRealCodexBinFromEnvironment({
+			moduleUrl: import.meta.url,
+			env: process.env,
+			existsSyncImpl: existsSync,
+		});
 	}
 
 	return resolveRealCodexBinFromEnvironment({ moduleUrl: import.meta.url });
@@ -145,7 +151,9 @@ function forwardToRealCodex(codexBin, args, env = process.env, cleanup) {
 			resolve(exitCode);
 		};
 
-		const child = spawn(process.execPath, [codexBin, ...args], {
+		const command = codexBin.launchWithNode ? process.execPath : codexBin.path;
+		const commandArgs = codexBin.launchWithNode ? [codexBin.path, ...args] : args;
+		const child = spawn(command, commandArgs, {
 			stdio: "inherit",
 			env,
 		});
@@ -1138,7 +1146,13 @@ function ensureWindowsShellShim(filePath, desiredContent, options = {}) {
 		}
 		const looksLikeStockOpenAiShim =
 			currentContent.includes("node_modules\\@openai\\codex\\bin\\codex.js") ||
-			currentContent.includes("node_modules/@openai/codex/bin/codex.js");
+			currentContent.includes("node_modules/@openai/codex/bin/codex.js") ||
+			currentContent.includes("@openai\\codex-win32-") ||
+			currentContent.includes("@openai/codex-win32-") ||
+			currentContent.includes("vendor\\x86_64-pc-windows-msvc\\codex\\codex.exe") ||
+			currentContent.includes("vendor\\aarch64-pc-windows-msvc\\codex\\codex.exe") ||
+			currentContent.includes("vendor/x86_64-pc-windows-msvc/codex/codex.exe") ||
+			currentContent.includes("vendor/aarch64-pc-windows-msvc/codex/codex.exe");
 		if (looksLikeStockOpenAiShim) {
 			try {
 				writeFileSync(filePath, desiredContent, { encoding: "utf8", mode: 0o755 });
@@ -1318,9 +1332,9 @@ async function main() {
 	if (!realCodexBin) {
 		console.error(
 			[
-				"Could not locate the official Codex CLI binary (@openai/codex).",
-				"Install it globally: npm install -g @openai/codex",
-				"Or set CODEX_MULTI_AUTH_REAL_CODEX_BIN to a full bin/codex.js path.",
+				"Could not locate the official Codex CLI.",
+				"Install it with npm, Homebrew, or an official native release so `codex` is on PATH.",
+				"Or set CODEX_MULTI_AUTH_REAL_CODEX_BIN to the full path of either codex or @openai/codex/bin/codex.js.",
 			].join("\n"),
 		);
 		return 1;

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1288,6 +1288,82 @@ describe("codex bin wrapper", () => {
 		});
 	});
 
+	it("skips self-referential codex wrapper entries on PATH before native binaries", () => {
+		const wrapperScriptPath = join(
+			"C:\\test-root",
+			"npm",
+			"lib",
+			"node_modules",
+			"codex-multi-auth",
+			"scripts",
+			"codex.js",
+		);
+		const wrapperBinPath = join("C:\\test-root", "npm", "bin", "codex");
+		const nativeCodexPath = join("C:\\test-root", "native", "bin", "codex");
+		const resolved = resolveRealCodexBin({
+			env: {
+				PATH: [join("C:\\test-root", "npm", "bin"), join("C:\\test-root", "native", "bin")].join(delimiter),
+			},
+			argv: [process.execPath, wrapperScriptPath],
+			platform: "linux",
+			moduleUrl: pathToFileURL(join(repoRootDir, "scripts", "codex.js")).href,
+			resolvePackageBin: () => null,
+			spawnSyncImpl: () => createSpawnSyncSuccess(""),
+			existsSyncImpl: (candidate) =>
+				candidate === wrapperBinPath || candidate === nativeCodexPath,
+			realpathSyncImpl: (candidate) => {
+				if (candidate === join(repoRootDir, "scripts", "codex.js")) {
+					return wrapperScriptPath;
+				}
+				if (candidate === wrapperBinPath) {
+					return wrapperScriptPath;
+				}
+				return candidate;
+			},
+		});
+
+		expect(resolved).toEqual({
+			path: nativeCodexPath,
+			launchWithNode: false,
+		});
+	});
+
+	it("discovers native codex executables via which fallback when PATH scan misses", () => {
+		const nativeCodexPath = "/opt/homebrew/bin/codex";
+		const spawnCalls = [];
+		const resolved = resolveRealCodexBin({
+			env: {
+				PATH: "/usr/local/bin",
+			},
+			argv: [process.execPath, join(repoRootDir, "scripts", "codex.js")],
+			platform: "linux",
+			moduleUrl: pathToFileURL(join(repoRootDir, "scripts", "codex.js")).href,
+			resolvePackageBin: () => null,
+			spawnSyncImpl: (command, args, options) => {
+				spawnCalls.push({ command, args, options: options ?? {} });
+				if (command === "npm") {
+					return createSpawnSyncSuccess("");
+				}
+				return createSpawnSyncSuccess(`${nativeCodexPath}\n`);
+			},
+			existsSyncImpl: (candidate) => candidate === nativeCodexPath,
+		});
+
+		expect(resolved).toEqual({
+			path: nativeCodexPath,
+			launchWithNode: false,
+		});
+		expect(spawnCalls).toHaveLength(2);
+		expect(spawnCalls[0]).toMatchObject({
+			command: "npm",
+			args: ["root", "-g"],
+		});
+		expect(spawnCalls[1]).toMatchObject({
+			command: "which",
+			args: ["codex"],
+		});
+	});
+
 	it.skipIf(process.platform !== "win32")(
 		"does not install Windows shell guards unless explicitly enabled",
 		() => {
@@ -1438,6 +1514,51 @@ describe("codex bin wrapper", () => {
 			expect(readFileSync(join(shimDir, "codex.ps1"), "utf8")).toContain(
 				"node_modules/codex-multi-auth/scripts/codex.js",
 			);
+		},
+	);
+
+	it.skipIf(process.platform !== "win32")(
+		"installs Windows shell guards over each native Codex shim pattern",
+		() => {
+			const patterns = [
+				{
+					cmd: '@ECHO OFF\r\necho "%dp0%\\node_modules\\@openai\\codex-win32-x64\\vendor\\x86_64-pc-windows-msvc\\codex\\codex.exe"\r\n',
+					ps1: 'Write-Output "$basedir/node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/codex/codex.exe"',
+				},
+				{
+					cmd: '@ECHO OFF\r\necho "%dp0%\\node_modules\\@openai\\codex-win32-arm64\\vendor\\aarch64-pc-windows-msvc\\codex\\codex.exe"\r\n',
+					ps1: 'Write-Output "$basedir/node_modules/@openai/codex-win32-arm64/vendor/aarch64-pc-windows-msvc/codex/codex.exe"',
+				},
+			];
+
+			for (const [index, pattern] of patterns.entries()) {
+				const fixtureRoot = createWrapperFixture();
+				const fakeBin = createFakeCodexBin(fixtureRoot);
+				const shimDir = join(fixtureRoot, `native-shim-bin-${index}`);
+				mkdirSync(shimDir, { recursive: true });
+				writeFileSync(
+					join(shimDir, "codex-multi-auth.cmd"),
+					"@ECHO OFF\r\nREM fixture codex-multi-auth shim\r\n",
+					"utf8",
+				);
+				writeFileSync(join(shimDir, "codex.cmd"), pattern.cmd, "utf8");
+				writeFileSync(join(shimDir, "codex.ps1"), `${pattern.ps1}\r\n`, "utf8");
+
+				const result = runWrapper(fixtureRoot, ["--version"], {
+					CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+					CODEX_MULTI_AUTH_WINDOWS_BATCH_SHIM_GUARD: "1",
+					PATH: `${shimDir}${delimiter}${process.env.PATH ?? ""}`,
+					USERPROFILE: fixtureRoot,
+					HOME: fixtureRoot,
+				});
+				expect(result.status).toBe(0);
+				expect(readFileSync(join(shimDir, "codex.cmd"), "utf8")).toContain(
+					"node_modules\\codex-multi-auth\\scripts\\codex.js",
+				);
+				expect(readFileSync(join(shimDir, "codex.ps1"), "utf8")).toContain(
+					"node_modules/codex-multi-auth/scripts/codex.js",
+				);
+			}
 		},
 	);
 

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -481,12 +481,12 @@ describe("codex bin wrapper", () => {
 	it("auto-discovers native codex executables on PATH and forwards end-to-end", () => {
 		const fixtureRoot = createWrapperFixture();
 		const resolverPath = join(fixtureRoot, "scripts", "codex-bin-resolver.js");
+		const originalSource = readFileSync(resolverPath, "utf8");
+		const patchTarget = 'return require.resolve("@openai/codex/bin/codex.js");';
+		expect(originalSource).toContain(patchTarget);
 		writeFileSync(
 			resolverPath,
-			readFileSync(resolverPath, "utf8").replace(
-				'return require.resolve("@openai/codex/bin/codex.js");',
-				"return null;",
-			),
+			originalSource.replace(patchTarget, "return null;"),
 			"utf8",
 		);
 		const nativeFixture = createPathDiscoveredNativeCodexFixture(fixtureRoot);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1,5 +1,6 @@
 import { type SpawnSyncReturns, spawn, spawnSync } from "node:child_process";
 import {
+	chmodSync,
 	copyFileSync,
 	mkdirSync,
 	mkdtempSync,
@@ -167,6 +168,43 @@ function createCustomFakeCodexBin(rootDir: string, lines: string[]): string {
 	const fakeBin = join(rootDir, `fake-codex-${createdDirs.length}.js`);
 	writeFileSync(fakeBin, lines.join("\n"), "utf8");
 	return fakeBin;
+}
+
+function createFakeNativeCodexBin(rootDir: string): string {
+	if (process.platform === "win32") {
+		const fakeBin = join(rootDir, `fake-native-codex-${createdDirs.length}.ps1`);
+		writeFileSync(
+			fakeBin,
+			[
+				'Write-Output ("FORWARDED_NATIVE:" + ($args -join " "))',
+				"exit 0",
+			].join("\r\n"),
+			"utf8",
+		);
+		return fakeBin;
+	}
+
+	const fakeBin = join(rootDir, `fake-native-codex-${createdDirs.length}`);
+	writeFileSync(
+		fakeBin,
+		[
+			"#!/bin/sh",
+			'printf "FORWARDED_NATIVE:%s\\n" "$*"',
+			exitLine(),
+		].join("\n"),
+		"utf8",
+	);
+	chmodSync(fakeBin, 0o755);
+	return fakeBin;
+}
+
+function exitLine(): string {
+	return "exit 0";
+}
+
+function resolveWindowsPowerShellPath(): string {
+	const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT ?? "C:\\Windows";
+	return join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
 }
 
 function injectShadowCleanupBusyFailures(
@@ -376,6 +414,22 @@ describe("codex bin wrapper", () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("FORWARDED:--version");
+	});
+
+	it("forwards non-auth commands to native codex executables", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createFakeNativeCodexBin(fixtureRoot);
+		const nativeBin = process.platform === "win32" ? resolveWindowsPowerShellPath() : fakeBin;
+		const args =
+			process.platform === "win32"
+				? ["-NoProfile", "-File", fakeBin, "--version"]
+				: ["--version"];
+		const result = runWrapper(fixtureRoot, args, {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: nativeBin,
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("FORWARDED_NATIVE:--version");
 	});
 
 	it("injects file auth store forwarding for wrapped real cli invocations by default", () => {
@@ -1139,6 +1193,30 @@ describe("codex bin wrapper", () => {
 		},
 	);
 
+	it("prefers native codex executables on PATH when npm launcher is unavailable", () => {
+		const pathEntries = [join("C:", "custom", "bin")];
+		const nativeCodexPath =
+			process.platform === "win32"
+				? join(pathEntries[0], "codex.exe")
+				: join("/opt", "homebrew", "bin", "codex");
+		const resolved = resolveRealCodexBin({
+			env: {
+				PATH: process.platform === "win32" ? pathEntries.join(";") : "/opt/homebrew/bin:/usr/bin",
+			},
+			argv: [process.execPath, join(repoRootDir, "scripts", "codex.js")],
+			platform: process.platform,
+			moduleUrl: pathToFileURL(join(repoRootDir, "scripts", "codex.js")).href,
+			resolvePackageBin: () => null,
+			spawnSyncImpl: () => createSpawnSyncSuccess(`${nativeCodexPath}\n`),
+			existsSyncImpl: (candidate) => candidate === nativeCodexPath,
+		});
+
+		expect(resolved).toEqual({
+			path: nativeCodexPath,
+			launchWithNode: false,
+		});
+	});
+
 	it.skipIf(process.platform !== "win32")(
 		"does not install Windows shell guards unless explicitly enabled",
 		() => {
@@ -1396,9 +1474,9 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain(
 			`CODEX_MULTI_AUTH_REAL_CODEX_BIN is set but missing: ${missingOverride}`,
 		);
-		expect(output).toContain("Could not locate the official Codex CLI binary");
+		expect(output).toContain("Could not locate the official Codex CLI.");
 		expect(output).toContain(
-			"Install it globally: npm install -g @openai/codex",
+			"Install it with npm, Homebrew, or an official native release so `codex` is on PATH.",
 		);
 	});
 
@@ -1433,7 +1511,7 @@ describe("codex bin wrapper", () => {
 			},
 		});
 
-		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(resolvedBin).toEqual({ path: fakeGlobalBin, launchWithNode: true });
 		expect(spawnCalls).toHaveLength(1);
 		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
@@ -1482,7 +1560,7 @@ describe("codex bin wrapper", () => {
 			},
 		});
 
-		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(resolvedBin).toEqual({ path: fakeGlobalBin, launchWithNode: true });
 		expect(spawnCalls).toHaveLength(1);
 		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
@@ -1531,7 +1609,7 @@ describe("codex bin wrapper", () => {
 			},
 		});
 
-		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(resolvedBin).toEqual({ path: fakeGlobalBin, launchWithNode: true });
 		expect(spawnCalls).toHaveLength(1);
 		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
@@ -1574,7 +1652,7 @@ describe("codex bin wrapper", () => {
 			},
 		});
 
-		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(resolvedBin).toEqual({ path: fakeGlobalBin, launchWithNode: true });
 		expect(spawnCalls).toHaveLength(1);
 		expect(spawnCalls[0]?.command).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
@@ -1612,7 +1690,7 @@ describe("codex bin wrapper", () => {
 			},
 		});
 
-		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls).toHaveLength(2);
 		expect(spawnCalls[0]?.command).toBe("cmd.exe");
 		expect(spawnCalls[0]?.args).toEqual(["/d", "/s", "/c", "npm root -g"]);
 		expect(spawnCalls[0]?.options).toMatchObject({
@@ -1626,6 +1704,8 @@ describe("codex bin wrapper", () => {
 			timeout: 5000,
 			windowsHide: true,
 		});
+		expect(spawnCalls[1]?.command).toBe("cmd.exe");
+		expect(spawnCalls[1]?.args).toEqual(["/d", "/s", "/c", "where codex"]);
 	});
 
 	it("discovers the real codex bin via npm root fallback on POSIX", () => {
@@ -1658,7 +1738,7 @@ describe("codex bin wrapper", () => {
 			},
 		});
 
-		expect(resolvedBin).toBe(fakeGlobalBin);
+		expect(resolvedBin).toEqual({ path: fakeGlobalBin, launchWithNode: true });
 		expect(spawnCalls).toHaveLength(1);
 		expect(spawnCalls[0]?.command).toBe("npm");
 		expect(spawnCalls[0]?.args).toEqual(["root", "-g"]);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1306,6 +1306,29 @@ describe("codex bin wrapper", () => {
 		});
 	});
 
+	it("prefers Windows codex.exe over extensionless codex when both exist", () => {
+		const pathEntry = join("C:", "custom", "bin");
+		const nativeCodexExePath = join(pathEntry, "codex.exe");
+		const nativeCodexPath = join(pathEntry, "codex");
+		const resolved = resolveRealCodexBin({
+			env: {
+				PATH: pathEntry,
+			},
+			argv: [process.execPath, join(repoRootDir, "scripts", "codex.js")],
+			platform: "win32",
+			moduleUrl: pathToFileURL(join(repoRootDir, "scripts", "codex.js")).href,
+			resolvePackageBin: () => null,
+			spawnSyncImpl: () => createSpawnSyncSuccess("") as SpawnSyncReturns<string>,
+			existsSyncImpl: (candidate) =>
+				candidate === nativeCodexExePath || candidate === nativeCodexPath,
+		});
+
+		expect(resolved).toEqual({
+			path: nativeCodexExePath,
+			launchWithNode: false,
+		});
+	});
+
 	it("skips self-referential codex wrapper entries on PATH before native binaries", () => {
 		const wrapperScriptPath = join(
 			"C:\\test-root",

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1288,6 +1288,27 @@ describe("codex bin wrapper", () => {
 		});
 	});
 
+	it("accepts Windows native codex paths without an .exe suffix", () => {
+		const pathEntry = join("C:", "custom", "bin");
+		const nativeCodexPath = join(pathEntry, "codex");
+		const resolved = resolveRealCodexBin({
+			env: {
+				PATH: pathEntry,
+			},
+			argv: [process.execPath, join(repoRootDir, "scripts", "codex.js")],
+			platform: "win32",
+			moduleUrl: pathToFileURL(join(repoRootDir, "scripts", "codex.js")).href,
+			resolvePackageBin: () => null,
+			spawnSyncImpl: () => createSpawnSyncSuccess("") as SpawnSyncReturns<string>,
+			existsSyncImpl: (candidate) => candidate === nativeCodexPath,
+		});
+
+		expect(resolved).toEqual({
+			path: nativeCodexPath,
+			launchWithNode: false,
+		});
+	});
+
 	it("skips self-referential codex wrapper entries on PATH before native binaries", () => {
 		const wrapperScriptPath = join(
 			"C:\\test-root",

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -2,6 +2,7 @@ import { type SpawnSyncReturns, spawn, spawnSync } from "node:child_process";
 import {
 	chmodSync,
 	copyFileSync,
+	linkSync,
 	mkdirSync,
 	mkdtempSync,
 	readdirSync,
@@ -205,6 +206,54 @@ function exitLine(): string {
 function resolveWindowsPowerShellPath(): string {
 	const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT ?? "C:\\Windows";
 	return join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+function createPathDiscoveredNativeCodexFixture(rootDir: string): {
+	args: string[];
+	binDir: string;
+	expectedOutput: string;
+} {
+	const binDir = join(rootDir, `native-codex-bin-${createdDirs.length}`);
+	mkdirSync(binDir, { recursive: true });
+	if (process.platform === "win32") {
+		const scriptPath = join(binDir, "native-codex-marker.js");
+		writeFileSync(
+			scriptPath,
+			[
+				'console.log(`FORWARDED_NATIVE_PATH:${process.argv.slice(2).join(" ")}`);',
+				"process.exit(0);",
+			].join("\n"),
+			"utf8",
+		);
+		const nativeExePath = join(binDir, "codex.exe");
+		try {
+			linkSync(process.execPath, nativeExePath);
+		} catch {
+			copyFileSync(process.execPath, nativeExePath);
+		}
+		return {
+			binDir,
+			args: [scriptPath, "--version"],
+			expectedOutput: "FORWARDED_NATIVE_PATH:--version",
+		};
+	}
+
+	const nativeCodexPath = join(binDir, "codex");
+	writeFileSync(
+		nativeCodexPath,
+		[
+			"#!/bin/sh",
+			'printf "FORWARDED_NATIVE_PATH:%s\\n" "$*"',
+			"exit 0",
+		].join("\n"),
+		"utf8",
+	);
+	chmodSync(nativeCodexPath, 0o755);
+	return {
+		binDir,
+		args: ["--version"],
+		expectedOutput: "FORWARDED_NATIVE_PATH:--version",
+	};
 }
 
 function injectShadowCleanupBusyFailures(
@@ -430,6 +479,28 @@ describe("codex bin wrapper", () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("FORWARDED_NATIVE:--version");
+	});
+
+	it("auto-discovers native codex executables on PATH and forwards end-to-end", () => {
+		const fixtureRoot = createWrapperFixture();
+		const resolverPath = join(fixtureRoot, "scripts", "codex-bin-resolver.js");
+		writeFileSync(
+			resolverPath,
+			readFileSync(resolverPath, "utf8").replace(
+				'return require.resolve("@openai/codex/bin/codex.js");',
+				"return null;",
+			),
+			"utf8",
+		);
+		const nativeFixture = createPathDiscoveredNativeCodexFixture(fixtureRoot);
+		const result = runWrapper(fixtureRoot, nativeFixture.args, {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: undefined,
+			PATH: nativeFixture.binDir,
+			Path: nativeFixture.binDir,
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain(nativeFixture.expectedOutput);
 	});
 
 	it("injects file auth store forwarding for wrapped real cli invocations by default", () => {
@@ -1321,6 +1392,51 @@ describe("codex bin wrapper", () => {
 			);
 			expect(readFileSync(pwshProfilePath, "utf8")).toContain(
 				"CodexMultiAuthShim",
+			);
+		},
+	);
+
+	it.skipIf(process.platform !== "win32")(
+		"installs Windows shell guards over native Codex launcher shims",
+		() => {
+			const fixtureRoot = createWrapperFixture();
+			const fakeBin = createFakeCodexBin(fixtureRoot);
+			const shimDir = join(fixtureRoot, "native-shim-bin");
+			mkdirSync(shimDir, { recursive: true });
+			writeFileSync(
+				join(shimDir, "codex-multi-auth.cmd"),
+				"@ECHO OFF\r\nREM fixture codex-multi-auth shim\r\n",
+				"utf8",
+			);
+			writeFileSync(
+				join(shimDir, "codex.cmd"),
+				'@ECHO OFF\r\necho "%dp0%\\node_modules\\@openai\\codex-win32-x64\\vendor\\x86_64-pc-windows-msvc\\codex\\codex.exe"\r\n',
+				"utf8",
+			);
+			writeFileSync(
+				join(shimDir, "codex.ps1"),
+				'Write-Output "$basedir/node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/codex/codex.exe"' +
+					"\r\n",
+				"utf8",
+			);
+
+			const result = runWrapper(fixtureRoot, ["--version"], {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_MULTI_AUTH_WINDOWS_BATCH_SHIM_GUARD: "1",
+				PATH: `${shimDir}${delimiter}${process.env.PATH ?? ""}`,
+				USERPROFILE: fixtureRoot,
+				HOME: fixtureRoot,
+			});
+			expect(result.status).toBe(0);
+
+			expect(readFileSync(join(shimDir, "codex.bat"), "utf8")).toContain(
+				"codex-multi-auth windows shim guardian v1",
+			);
+			expect(readFileSync(join(shimDir, "codex.cmd"), "utf8")).toContain(
+				"node_modules\\codex-multi-auth\\scripts\\codex.js",
+			);
+			expect(readFileSync(join(shimDir, "codex.ps1"), "utf8")).toContain(
+				"node_modules/codex-multi-auth/scripts/codex.js",
 			);
 		},
 	);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -21,6 +21,7 @@ import { resolveRealCodexBin } from "../scripts/codex-bin-resolver.js";
 const createdDirs: string[] = [];
 const testFileDir = dirname(fileURLToPath(import.meta.url));
 const repoRootDir = join(testFileDir, "..");
+const EXIT_SUCCESS_LINE = "exit 0";
 
 function isRetriableFsError(error: unknown): boolean {
 	if (!error || typeof error !== "object" || !("code" in error)) {
@@ -191,16 +192,12 @@ function createFakeNativeCodexBin(rootDir: string): string {
 		[
 			"#!/bin/sh",
 			'printf "FORWARDED_NATIVE:%s\\n" "$*"',
-			exitLine(),
+			EXIT_SUCCESS_LINE,
 		].join("\n"),
 		"utf8",
 	);
 	chmodSync(fakeBin, 0o755);
 	return fakeBin;
-}
-
-function exitLine(): string {
-	return "exit 0";
 }
 
 function resolveWindowsPowerShellPath(): string {

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -910,9 +910,14 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "list"]);
 
 		expect(exitCode).toBe(0);
-		expect(logSpy).toHaveBeenCalledWith("No accounts configured.");
+		expect(logSpy).toHaveBeenCalledWith(
+			"No accounts configured. Storage was intentionally reset.",
+		);
 		expect(logSpy).toHaveBeenCalledWith(
 			"Storage: /mock/openai-codex-accounts.json",
+		);
+		expect(logSpy).toHaveBeenCalledWith(
+			"Storage health: intentional-reset",
 		);
 		expect(setStoragePathMock).toHaveBeenCalledWith(null);
 	});

--- a/test/proactive-refresh.test.ts
+++ b/test/proactive-refresh.test.ts
@@ -225,6 +225,19 @@ describe("proactive-refresh", () => {
 	});
 
 	describe("refreshExpiringAccounts", () => {
+		async function runRefreshExpiringAccounts(
+			accounts: ManagedAccount[],
+			bufferMs?: number,
+			onResult?: (
+				account: ManagedAccount,
+				result: Awaited<ReturnType<typeof proactiveRefreshAccount>>,
+			) => Promise<void> | void,
+		): Promise<Map<number, Awaited<ReturnType<typeof proactiveRefreshAccount>>>> {
+			const pending = refreshExpiringAccounts(accounts, bufferMs, onResult);
+			await vi.runAllTimersAsync();
+			return pending;
+		}
+
 		it("returns empty map when no accounts need refresh", async () => {
 			const accounts = [
 				createMockAccount({
@@ -239,7 +252,7 @@ describe("proactive-refresh", () => {
 				}),
 			];
 
-			const results = await refreshExpiringAccounts(accounts);
+			const results = await runRefreshExpiringAccounts(accounts);
 
 			expect(results.size).toBe(0);
 			expect(refreshQueue.queuedRefresh).not.toHaveBeenCalled();
@@ -261,7 +274,7 @@ describe("proactive-refresh", () => {
 				}),
 			];
 
-			const results = await refreshExpiringAccounts(accounts);
+			const results = await runRefreshExpiringAccounts(accounts);
 
 			expect(results.size).toBe(2);
 			expect(results.get(0)?.reason).toBe("no_refresh_token");
@@ -292,7 +305,7 @@ describe("proactive-refresh", () => {
 				expires: Date.now() + 3600000,
 			});
 
-			const results = await refreshExpiringAccounts(accounts);
+			const results = await runRefreshExpiringAccounts(accounts);
 
 			expect(results.size).toBe(1);
 			expect(results.has(0)).toBe(true);
@@ -330,7 +343,7 @@ describe("proactive-refresh", () => {
 				expires: Date.now() + 3600000,
 			});
 
-			const results = await refreshExpiringAccounts(accounts);
+			const results = await runRefreshExpiringAccounts(accounts);
 
 			expect(results.size).toBe(3);
 			expect(refreshQueue.queuedRefresh).toHaveBeenCalledTimes(3);
@@ -365,7 +378,7 @@ describe("proactive-refresh", () => {
 					message: "Invalid token",
 				});
 
-			const results = await refreshExpiringAccounts(accounts);
+			const results = await runRefreshExpiringAccounts(accounts);
 
 			expect(results.size).toBe(2);
 			expect(results.get(0)?.reason).toBe("success");
@@ -396,7 +409,7 @@ describe("proactive-refresh", () => {
 				expires: Date.now() + 3_600_000,
 			});
 
-			const results = await refreshExpiringAccounts(
+			const results = await runRefreshExpiringAccounts(
 				accounts,
 				DEFAULT_PROACTIVE_BUFFER_MS,
 				onResult,


### PR DESCRIPTION
Fixes #390

## Summary

- add native Codex executable discovery and forwarding alongside the existing `@openai/codex` npm launcher path

## What Changed

- taught `scripts/codex-bin-resolver.js` to return launcher metadata, keep resolving the npm `bin/codex.js` entrypoint, and fall back to native `codex` / `codex.exe` discovery on `PATH`
- updated `scripts/codex.js` to spawn JavaScript launchers with Node, spawn native executables directly, widen Windows shim takeover detection for native Codex launchers, and improve user-facing install guidance
- added wrapper coverage for native executable forwarding and native-path resolution, and updated the README to document npm, Homebrew, and release-binary installs

## Validation

- [ ] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm test -- test/documentation.test.ts`
- [ ] `npm run build`
- [x] `npm exec vitest run test/codex-bin-wrapper.test.ts`

## Docs and Governance Checklist

- [x] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: medium
- Rollback plan: revert `baadcb3` to restore npm-launcher-only forwarding and docs

## Additional Notes

- auth, quota, and request-routing behavior are intentionally unchanged in this PR; the scope stays at the wrapper/discovery layer

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR wires up native codex binary discovery (homebrew/release-binary) alongside the existing npm launcher path, with a self-referential path loop guard. the three issues flagged in prior review rounds are resolved: `DEFAULT_WRAPPER_MODULE_URL` now points to `codex.js` (not the resolver), the patch guard assertion is present in the test, and both PATH and `which`/`where` fallbacks skip any candidate whose real path matches the wrapper.

- the self-referential loop guard is correctly implemented, but **no test exercises the specific scenario where the wrapper symlink appears in `$PATH` before the native binary** — this is the entire reason the guard exists and the most important missing coverage
- `test/codex-manager-cli.test.ts` and `test/proactive-refresh.test.ts` include changes that look unrelated to native binary support (`codex-manager-cli` updates expected "intentional-reset" strings; `proactive-refresh` adds a `runRefreshExpiringAccounts` helper with `vi.runAllTimersAsync()`); clarifying whether these are bundled housekeeping or should be in a separate PR would help reviewers track scope

<h3>Confidence Score: 5/5</h3>

safe to merge — all prior P0/P1 concerns are resolved; remaining findings are P2 documentation and test coverage gaps

the three issues from previous review rounds are addressed: DEFAULT_WRAPPER_MODULE_URL correctly points to codex.js, the patch-guard assertion is in the test, and both PATH and which/where fallbacks apply the self-referential check. remaining findings are a missing loop-guard test scenario, a comment for the load-bearing constant, and unrelated test bundling — all P2

scripts/codex-bin-resolver.js (DEFAULT_WRAPPER_MODULE_URL comment), test/codex-bin-wrapper.test.ts (missing self-referential guard scenario)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/codex-bin-resolver.js | adds resolveRealCodexBin result wrapper, PATH/which native discovery, and self-referential loop guard via DEFAULT_WRAPPER_MODULE_URL; guard logic is correct but untested for the actual loop-prevention scenario |
| scripts/codex.js | spawns native binaries directly (skipping node) via codexBin.launchWithNode; widens windows shim takeover to cover native installer paths; outer resolveRealCodexBin adds a specific error message for missing override but otherwise delegates correctly to the resolver |
| test/codex-bin-wrapper.test.ts | adds native exe override forwarding and PATH-discovery end-to-end tests; patch guard assertion is present; missing coverage for self-referential symlink appearing in PATH |
| test/codex-manager-cli.test.ts | updates expected output strings for intentional-reset storage state; appears unrelated to native binary support |
| test/proactive-refresh.test.ts | extracts runRefreshExpiringAccounts helper with vi.runAllTimersAsync() to fix fake-timer test reliability; unrelated to native binary support |
| README.md | documents homebrew and release-binary installs, adds which codex to troubleshooting; looks correct |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fnative-codex-cli-support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fnative-codex-cli-support%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atest%2Fcodex-bin-wrapper.test.ts%3A481-501%0A**Missing%20test%20for%20the%20self-referential%20PATH%20guard**%0A%0Athis%20test%20exercises%20PATH%20discovery%20when%20only%20the%20native%20binary%20is%20in%20%60PATH%60%2C%20but%20never%20puts%20the%20wrapper%20symlink%20in%20%60PATH%60%20ahead%20of%20it.%20the%20guard%20in%20%60resolveCodexExecutableFromPath%60%20%28and%20the%20%60which%60%2F%60where%60%20fallback%29%20only%20fires%20when%20%60normalizeResolvedPath%28candidate%29%20%3D%3D%3D%20selfScriptPath%60.%20if%20that%20comparison%20regresses%20%E2%80%94%20wrong%20default%20URL%2C%20broken%20%60realpathSync%60%20path%2C%20etc.%20%E2%80%94%20an%20infinite%20fork%20loop%20reappears%20silently.%0A%0Aconsider%20adding%20a%20test%20along%20these%20lines%3A%0A%0A%60%60%60typescript%0Ait%28%22skips%20wrapper%20symlink%20on%20PATH%20and%20falls%20through%20to%20native%20codex%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20const%20fixtureRoot%20%3D%20createWrapperFixture%28%29%3B%0A%20%20const%20resolverPath%20%3D%20join%28fixtureRoot%2C%20%22scripts%22%2C%20%22codex-bin-resolver.js%22%29%3B%0A%20%20const%20src%20%3D%20readFileSync%28resolverPath%2C%20%22utf8%22%29%3B%0A%20%20const%20patchTarget%20%3D%20'return%20require.resolve%28%22%40openai%2Fcodex%2Fbin%2Fcodex.js%22%29%3B'%3B%0A%20%20expect%28src%29.toContain%28patchTarget%29%3B%0A%20%20writeFileSync%28resolverPath%2C%20src.replace%28patchTarget%2C%20%22return%20null%3B%22%29%2C%20%22utf8%22%29%3B%0A%0A%20%20const%20nativeFixture%20%3D%20createPathDiscoveredNativeCodexFixture%28fixtureRoot%29%3B%0A%0A%20%20const%20wrapperDir%20%3D%20join%28fixtureRoot%2C%20%22fake-wrapper-bin%22%29%3B%0A%20%20mkdirSync%28wrapperDir%2C%20%7B%20recursive%3A%20true%20%7D%29%3B%0A%20%20const%20wrapperLink%20%3D%20join%28wrapperDir%2C%20process.platform%20%3D%3D%3D%20%22win32%22%20%3F%20%22codex.exe%22%20%3A%20%22codex%22%29%3B%0A%20%20linkSync%28join%28fixtureRoot%2C%20%22scripts%22%2C%20%22codex.js%22%29%2C%20wrapperLink%29%3B%0A%0A%20%20const%20combined%20%3D%20%60%24%7BwrapperDir%7D%24%7Bdelimiter%7D%24%7BnativeFixture.binDir%7D%60%3B%0A%20%20const%20result%20%3D%20runWrapper%28fixtureRoot%2C%20nativeFixture.args%2C%20%7B%0A%20%20%20%20CODEX_MULTI_AUTH_REAL_CODEX_BIN%3A%20undefined%2C%0A%20%20%20%20PATH%3A%20combined%2C%0A%20%20%20%20Path%3A%20combined%2C%0A%20%20%7D%29%3B%0A%0A%20%20expect%28result.status%29.toBe%280%29%3B%0A%20%20expect%28result.stdout%29.toContain%28nativeFixture.expectedOutput%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fcodex-manager-cli.test.ts%3A910-924%0A**Out-of-scope%20test%20changes**%0A%0Athese%20expectation%20updates%20%28%22Storage%20was%20intentionally%20reset%22%20%2F%20%22Storage%20health%3A%20intentional-reset%22%29%20aren't%20mentioned%20in%20the%20PR%20description%20and%20don't%20appear%20related%20to%20native%20binary%20discovery.%20same%20applies%20to%20the%20%60proactive-refresh.test.ts%60%20helper%20extraction.%20are%20these%20bundled%20housekeeping%20fixes%2C%20or%20should%20they%20be%20a%20separate%20commit%20so%20reviewers%20can%20track%20what%20changed%20in%20the%20CLI%20output%20and%20why%3F%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fcodex-bin-resolver.js%3A32%0A**%60DEFAULT_WRAPPER_MODULE_URL%60%20invariant%20should%20be%20documented**%0A%0Athe%20self-referential%20loop%20guard%20depends%20on%20this%20constant%20resolving%20to%20%60codex.js%60%20%28the%20npm-wrapper%20entry%29%2C%20not%20%60codex-bin-resolver.js%60%20itself.%20the%20distinction%20is%20load-bearing%3A%20the%20npm%20bin%20symlink%20points%20to%20%60codex.js%60%2C%20and%20%60realpathSync%60%20on%20the%20symlink%20must%20match%20this%20path%20for%20the%20guard%20to%20fire.%20adding%20a%20brief%20inline%20comment%20makes%20the%20constraint%20visible%20to%20future%20refactors%3A%0A%0A%60%60%60suggestion%0A%2F%2F%20IMPORTANT%3A%20must%20point%20to%20the%20npm%20wrapper%20entry%20%28codex.js%29%2C%20not%20this%20file.%0A%2F%2F%20The%20self-referential%20PATH%20loop%20guard%20in%20resolveCodexExecutableFromSystemPath%0A%2F%2F%20compares%20realpathSync%28PATH-candidate%29%20against%20this%20resolved%20path%3B%20if%20this%0A%2F%2F%20constant%20were%20changed%20to%20codex-bin-resolver.js%20the%20guard%20would%20silently%0A%2F%2F%20stop%20matching%20the%20%22codex%22%20npm%20bin%20symlink%20and%20the%20infinite-fork%20loop%20would%0A%2F%2F%20return%20on%20POSIX%20installs.%0Aconst%20DEFAULT_WRAPPER_MODULE_URL%20%3D%20new%20URL%28%22.%2Fcodex.js%22%2C%20import.meta.url%29.href%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/codex-bin-wrapper.test.ts
Line: 481-501

Comment:
**Missing test for the self-referential PATH guard**

this test exercises PATH discovery when only the native binary is in `PATH`, but never puts the wrapper symlink in `PATH` ahead of it. the guard in `resolveCodexExecutableFromPath` (and the `which`/`where` fallback) only fires when `normalizeResolvedPath(candidate) === selfScriptPath`. if that comparison regresses — wrong default URL, broken `realpathSync` path, etc. — an infinite fork loop reappears silently.

consider adding a test along these lines:

```typescript
it("skips wrapper symlink on PATH and falls through to native codex", () => {
  const fixtureRoot = createWrapperFixture();
  const resolverPath = join(fixtureRoot, "scripts", "codex-bin-resolver.js");
  const src = readFileSync(resolverPath, "utf8");
  const patchTarget = 'return require.resolve("@openai/codex/bin/codex.js");';
  expect(src).toContain(patchTarget);
  writeFileSync(resolverPath, src.replace(patchTarget, "return null;"), "utf8");

  const nativeFixture = createPathDiscoveredNativeCodexFixture(fixtureRoot);

  const wrapperDir = join(fixtureRoot, "fake-wrapper-bin");
  mkdirSync(wrapperDir, { recursive: true });
  const wrapperLink = join(wrapperDir, process.platform === "win32" ? "codex.exe" : "codex");
  linkSync(join(fixtureRoot, "scripts", "codex.js"), wrapperLink);

  const combined = `${wrapperDir}${delimiter}${nativeFixture.binDir}`;
  const result = runWrapper(fixtureRoot, nativeFixture.args, {
    CODEX_MULTI_AUTH_REAL_CODEX_BIN: undefined,
    PATH: combined,
    Path: combined,
  });

  expect(result.status).toBe(0);
  expect(result.stdout).toContain(nativeFixture.expectedOutput);
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-cli.test.ts
Line: 910-924

Comment:
**Out-of-scope test changes**

these expectation updates ("Storage was intentionally reset" / "Storage health: intentional-reset") aren't mentioned in the PR description and don't appear related to native binary discovery. same applies to the `proactive-refresh.test.ts` helper extraction. are these bundled housekeeping fixes, or should they be a separate commit so reviewers can track what changed in the CLI output and why?

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/codex-bin-resolver.js
Line: 32

Comment:
**`DEFAULT_WRAPPER_MODULE_URL` invariant should be documented**

the self-referential loop guard depends on this constant resolving to `codex.js` (the npm-wrapper entry), not `codex-bin-resolver.js` itself. the distinction is load-bearing: the npm bin symlink points to `codex.js`, and `realpathSync` on the symlink must match this path for the guard to fire. adding a brief inline comment makes the constraint visible to future refactors:

```suggestion
// IMPORTANT: must point to the npm wrapper entry (codex.js), not this file.
// The self-referential PATH loop guard in resolveCodexExecutableFromSystemPath
// compares realpathSync(PATH-candidate) against this resolved path; if this
// constant were changed to codex-bin-resolver.js the guard would silently
// stop matching the "codex" npm bin symlink and the infinite-fork loop would
// return on POSIX installs.
const DEFAULT_WRAPPER_MODULE_URL = new URL("./codex.js", import.meta.url).href;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["cover windows codex precedence"](https://github.com/ndycode/codex-multi-auth/commit/776c59408eafe516c3d10f246cb075352731a166) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28602699)</sub>

<!-- /greptile_comment -->