### PR TITLE
security(deps): bump hono to 4.12.14 and vite override to ^7.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			"dependencies": {
 				"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 				"@openauthjs/openauth": "^0.4.3",
-				"hono": "4.12.10",
+				"hono": "4.12.14",
 				"undici": "^6.24.1",
 				"zod": "^4.3.6"
 			},
@@ -2376,9 +2376,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.10",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-			"integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+			"version": "4.12.14",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+			"integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -3430,9 +3430,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -154,17 +154,17 @@
 	"dependencies": {
 		"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 		"@openauthjs/openauth": "^0.4.3",
-		"hono": "4.12.10",
+		"hono": "4.12.14",
 		"undici": "^6.24.1",
 		"zod": "^4.3.6"
 	},
 	"overrides": {
-		"hono": "4.12.10",
+		"hono": "4.12.14",
 		"flatted": "3.4.2",
 		"minimatch": "10.2.4",
 		"picomatch": "4.0.4",
 		"rollup": "4.59.0",
-		"vite": "^7.3.1",
+		"vite": "^7.3.2",
 		"micromatch": {
 			"picomatch": "2.3.2"
 		},


### PR DESCRIPTION
## Summary

Fixes the 9 open Dependabot alerts on `package-lock.json`:

- `hono` 4.12.10 → 4.12.14 — closes alerts #16, #18, #20, #22, #24, #26
  - toSSG path traversal, serveStatic repeated-slash bypass, setCookie validation, IPv4-mapped IPv6 `ipRestriction`, `getCookie` non-breaking space bypass, `hono/jsx` SSR HTML injection
- `vite` override `^7.3.1` → `^7.3.2` (transitive, dev-only via vitest) — closes alerts #12, #13, #14
  - dev-server WebSocket arbitrary file read, optimized deps `.map` path traversal, `server.fs.deny` query bypass

## Changes

- `package.json`: bump `dependencies.hono`, `overrides.hono`, `overrides.vite`.
- `package-lock.json`: regenerated via `npm install --package-lock-only --ignore-scripts` (minimal diff, only the two packages).

## Validation

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 225 files, 3418/3418 tests pass
- No source or test changes required; both bumps are patch/minor within existing SemVer ranges.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

patches 9 dependabot alerts by pinning `hono` to `4.12.14` (6 CVEs: path traversal, cookie bypass, `ipRestriction` IPv4-mapped IPv6, JSX SSR injection) and raising the `vite` override to `^7.3.2` (3 dev-only CVEs). changes are minimal and correctly land in both `dependencies` and `overrides` for `hono`.

- `MIN_HONO_FLOOR` in `test/lockfile-version-floor.test.ts` is still `"4.12.2"` — the regression guard passes for any version in `4.12.2–4.12.13`, all of which carry the patched CVEs. it should be updated to `"4.12.14"`.
- no vitest floor coverage exists for the `vite` override, so a future regression below `7.3.2` would go undetected.

<h3>Confidence Score: 4/5</h3>

safe to merge after updating MIN_HONO_FLOOR in the floor test; vite gap is P2 but the core security bump is correct

one P1 finding: MIN_HONO_FLOOR is stale and would allow regressions to any CVE-affected version in 4.12.2–4.12.13 without failing the guard test; the fix is a one-liner. the vite floor gap is P2 and doesn't block merge.

test/lockfile-version-floor.test.ts — MIN_HONO_FLOOR needs updating to 4.12.14

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| package.json | bumps hono dependency and override to 4.12.14, vite override to ^7.3.2; both the dependency pin and override are consistent |
| package-lock.json | lock file regenerated cleanly; hono resolves to 4.12.14 and vite to 7.3.2 with valid integrity hashes |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot alerts #12-#26] --> B{Package}
    B -->|prod dep| C[hono 4.12.10]
    B -->|dev transitive| D[vite <7.3.2]
    C --> E[hono 4.12.14 CVE fixes: path traversal, cookie bypass, ipRestriction, JSX SSR injection]
    D --> F[vite 7.3.2 CVE fixes: WebSocket file read, .map traversal, fs.deny bypass]
    E --> G[package.json dependencies + overrides updated]
    F --> H[package.json overrides.vite updated]
    G --> I[package-lock.json regenerated]
    H --> I
    I --> J{Regression guard}
    J -->|MIN_HONO_FLOOR=4.12.2| K[stale — allows 4.12.2–4.12.13]
    J -->|vite floor| L[no test exists]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/lockfile-version-floor.test.ts`, line 6 ([link](https://github.com/ndycode/codex-multi-auth/blob/61d5f15522469649fedccfc4889d16aacdf98f90/test/lockfile-version-floor.test.ts#L6)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale hono security floor**

   `MIN_HONO_FLOOR` is still `"4.12.2"` — the floor test will pass for any version in the range `4.12.2–4.12.13`, all of which carry the CVEs this PR is patching (path traversal, cookie bypass, IPv6 `ipRestriction`, JSX SSR injection). a future accidental downgrade to e.g. `4.12.5` would not be caught.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/lockfile-version-floor.test.ts
   Line: 6

   Comment:
   **Stale hono security floor**

   `MIN_HONO_FLOOR` is still `"4.12.2"` — the floor test will pass for any version in the range `4.12.2–4.12.13`, all of which carry the CVEs this PR is patching (path traversal, cookie bypass, IPv6 `ipRestriction`, JSX SSR injection). a future accidental downgrade to e.g. `4.12.5` would not be caught.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22security%2Fdeps-hono-vite-2026-04%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22security%2Fdeps-hono-vite-2026-04%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Flockfile-version-floor.test.ts%0ALine%3A%206%0A%0AComment%3A%0A**Stale%20hono%20security%20floor**%0A%0A%60MIN_HONO_FLOOR%60%20is%20still%20%60%224.12.2%22%60%20%E2%80%94%20the%20floor%20test%20will%20pass%20for%20any%20version%20in%20the%20range%20%604.12.2%E2%80%934.12.13%60%2C%20all%20of%20which%20carry%20the%20CVEs%20this%20PR%20is%20patching%20%28path%20traversal%2C%20cookie%20bypass%2C%20IPv6%20%60ipRestriction%60%2C%20JSX%20SSR%20injection%29.%20a%20future%20accidental%20downgrade%20to%20e.g.%20%604.12.5%60%20would%20not%20be%20caught.%0A%0A%60%60%60suggestion%0Aconst%20MIN_HONO_FLOOR%20%3D%20%224.12.14%22%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22security%2Fdeps-hono-vite-2026-04%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22security%2Fdeps-hono-vite-2026-04%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Flockfile-version-floor.test.ts%3A6%0A**Stale%20hono%20security%20floor**%0A%0A%60MIN_HONO_FLOOR%60%20is%20still%20%60%224.12.2%22%60%20%E2%80%94%20the%20floor%20test%20will%20pass%20for%20any%20version%20in%20the%20range%20%604.12.2%E2%80%934.12.13%60%2C%20all%20of%20which%20carry%20the%20CVEs%20this%20PR%20is%20patching%20%28path%20traversal%2C%20cookie%20bypass%2C%20IPv6%20%60ipRestriction%60%2C%20JSX%20SSR%20injection%29.%20a%20future%20accidental%20downgrade%20to%20e.g.%20%604.12.5%60%20would%20not%20be%20caught.%0A%0A%60%60%60suggestion%0Aconst%20MIN_HONO_FLOOR%20%3D%20%224.12.14%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackage.json%3A167%0A**No%20vitest%20floor%20guard%20for%20vite%20override**%0A%0Athere's%20a%20floor%20test%20for%20%60hono%60%20and%20%60rollup%60%2C%20but%20none%20for%20%60overrides.vite%60.%20the%20three%20vite%20CVEs%20%28WebSocket%20arbitrary%20file%20read%2C%20%60.map%60%20path%20traversal%2C%20%60server.fs.deny%60%20query%20bypass%29%20are%20dev-only%2C%20but%20a%20future%20regression%20of%20the%20vite%20override%20below%20%607.3.2%60%20would%20go%20undetected.%20worth%20adding%20a%20%60MIN_VITE_FLOOR%60%20assertion%20in%20%60test%2Flockfile-version-floor.test.ts%60%20alongside%20the%20existing%20checks.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/lockfile-version-floor.test.ts
Line: 6

Comment:
**Stale hono security floor**

`MIN_HONO_FLOOR` is still `"4.12.2"` — the floor test will pass for any version in the range `4.12.2–4.12.13`, all of which carry the CVEs this PR is patching (path traversal, cookie bypass, IPv6 `ipRestriction`, JSX SSR injection). a future accidental downgrade to e.g. `4.12.5` would not be caught.

```suggestion
const MIN_HONO_FLOOR = "4.12.14";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: package.json
Line: 167

Comment:
**No vitest floor guard for vite override**

there's a floor test for `hono` and `rollup`, but none for `overrides.vite`. the three vite CVEs (WebSocket arbitrary file read, `.map` path traversal, `server.fs.deny` query bypass) are dev-only, but a future regression of the vite override below `7.3.2` would go undetected. worth adding a `MIN_VITE_FLOOR` assertion in `test/lockfile-version-floor.test.ts` alongside the existing checks.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["security(deps): bump hono to 4.12.14 and..."](https://github.com/ndycode/codex-multi-auth/commit/61d5f15522469649fedccfc4889d16aacdf98f90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28710579)</sub>

<!-- /greptile_comment -->