### PR TITLE
refactor(auth): introduce AUTH_REDIRECT single source of truth

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -1,6 +1,12 @@
 import { generatePKCE } from "@openauthjs/openauth/pkce";
 import { randomBytes } from "node:crypto";
-import type { PKCEPair, AuthorizationFlow, TokenResult, ParsedAuthInput, JWTPayload } from "../types.js";
+import type {
+	PKCEPair,
+	AuthorizationFlow,
+	TokenResult,
+	ParsedAuthInput,
+	JWTPayload,
+} from "../types.js";
 import { logError } from "../logger.js";
 import { safeParseOAuthTokenResponse } from "../schemas.js";
 import { isAbortError } from "../utils.js";
@@ -12,6 +18,29 @@ export const TOKEN_URL = "https://auth.openai.com/oauth/token";
 export const REDIRECT_URI = "http://localhost:1455/auth/callback";
 export const SCOPE = "openid profile email offline_access";
 
+/**
+ * Parsed representation of {@link REDIRECT_URI}. Single source of truth for the
+ * OAuth callback origin so that the local server bind, user-facing copy, and
+ * any future success-page template never drift from each other.
+ *
+ * The provider registers the exact string in {@link REDIRECT_URI}; this helper
+ * derives host/port/path at module-load time and is frozen so consumers cannot
+ * mutate the shared record by accident.
+ */
+export const AUTH_REDIRECT = Object.freeze(
+	(() => {
+		const parsed = new URL(REDIRECT_URI);
+		const port = parsed.port.length > 0 ? Number(parsed.port) : 1455;
+		return {
+			host: parsed.hostname,
+			port,
+			path: parsed.pathname,
+			origin: `${parsed.protocol}//${parsed.host}`,
+			url: REDIRECT_URI,
+		} as const;
+	})(),
+);
+
 const OAUTH_SENSITIVE_QUERY_PARAMS = [
 	"state",
 	"code",
@@ -19,7 +48,9 @@ const OAUTH_SENSITIVE_QUERY_PARAMS = [
 	"code_verifier",
 ] as const;
 
-function getOAuthResponseLogMetadata(rawResponse: unknown): Record<string, unknown> {
+function getOAuthResponseLogMetadata(
+	rawResponse: unknown,
+): Record<string, unknown> {
 	if (Array.isArray(rawResponse)) {
 		return { responseType: "array", itemCount: rawResponse.length };
 	}
@@ -130,16 +161,31 @@ export async function exchangeAuthorizationCode(
 	if (!res.ok) {
 		const text = await res.text().catch(() => "");
 		logError(`code->token failed: ${res.status} ${text}`);
-		return { type: "failed", reason: "http_error", statusCode: res.status, message: text || undefined };
+		return {
+			type: "failed",
+			reason: "http_error",
+			statusCode: res.status,
+			message: text || undefined,
+		};
 	}
 	const rawJson = (await res.json()) as unknown;
 	const json = safeParseOAuthTokenResponse(rawJson);
 	if (!json) {
-		logError("token response validation failed", getOAuthResponseLogMetadata(rawJson));
-		return { type: "failed", reason: "invalid_response", message: "Response failed schema validation" };
+		logError(
+			"token response validation failed",
+			getOAuthResponseLogMetadata(rawJson),
+		);
+		return {
+			type: "failed",
+			reason: "invalid_response",
+			message: "Response failed schema validation",
+		};
 	}
 	if (!json.refresh_token || json.refresh_token.trim().length === 0) {
-		logError("token response missing refresh token", getOAuthResponseLogMetadata(rawJson));
+		logError(
+			"token response missing refresh token",
+			getOAuthResponseLogMetadata(rawJson),
+		);
 		return {
 			type: "failed",
 			reason: "invalid_response",
@@ -207,21 +253,37 @@ export async function refreshAccessToken(
 		if (!response.ok) {
 			const text = await response.text().catch(() => "");
 			logError(`Token refresh failed: ${response.status} ${text}`);
-			return { type: "failed", reason: "http_error", statusCode: response.status, message: text || undefined };
+			return {
+				type: "failed",
+				reason: "http_error",
+				statusCode: response.status,
+				message: text || undefined,
+			};
 		}
 
 		const rawJson = (await response.json()) as unknown;
 		const json = safeParseOAuthTokenResponse(rawJson);
 		if (!json) {
-			logError("Token refresh response validation failed", getOAuthResponseLogMetadata(rawJson));
-			return { type: "failed", reason: "invalid_response", message: "Response failed schema validation" };
+			logError(
+				"Token refresh response validation failed",
+				getOAuthResponseLogMetadata(rawJson),
+			);
+			return {
+				type: "failed",
+				reason: "invalid_response",
+				message: "Response failed schema validation",
+			};
 		}
 
 		const nextRefreshRaw = json.refresh_token ?? refreshToken;
 		const nextRefresh = nextRefreshRaw.trim();
 		if (!nextRefresh) {
 			logError("Token refresh missing refresh token");
-			return { type: "failed", reason: "missing_refresh", message: "No refresh token in response or input" };
+			return {
+				type: "failed",
+				reason: "missing_refresh",
+				message: "No refresh token in response or input",
+			};
 		}
 
 		return {
@@ -235,7 +297,11 @@ export async function refreshAccessToken(
 	} catch (error) {
 		const err = error as Error;
 		if (isAbortError(err)) {
-			return { type: "failed", reason: "unknown", message: err?.message ?? "Request aborted" };
+			return {
+				type: "failed",
+				reason: "unknown",
+				message: err?.message ?? "Request aborted",
+			};
 		}
 		logError("Token refresh error", err);
 		return { type: "failed", reason: "network_error", message: err?.message };
@@ -255,7 +321,9 @@ export interface AuthorizationFlowOptions {
  * @param options - Optional configuration for the flow
  * @returns Authorization flow details
  */
-export async function createAuthorizationFlow(options?: AuthorizationFlowOptions): Promise<AuthorizationFlow> {
+export async function createAuthorizationFlow(
+	options?: AuthorizationFlowOptions,
+): Promise<AuthorizationFlow> {
 	const pkce = (await generatePKCE()) as PKCEPair;
 	const state = createState();
 

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -4,10 +4,14 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { OAuthServerInfo } from "../types.js";
 import { logError, logWarn } from "../logger.js";
+import { AUTH_REDIRECT } from "./auth.js";
 
 // Resolve path to oauth-success.html (one level up from auth/ subfolder)
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const successHtml = fs.readFileSync(path.join(__dirname, "..", "oauth-success.html"), "utf-8");
+const successHtml = fs.readFileSync(
+	path.join(__dirname, "..", "oauth-success.html"),
+	"utf-8",
+);
 
 /**
  * Start a local HTTP server that captures an OAuth authorization code sent to /auth/callback.
@@ -28,12 +32,16 @@ const successHtml = fs.readFileSync(path.join(__dirname, "..", "oauth-success.ht
  *          function to abort polling and close the server, and `waitForCode` which returns
  *          `{ code: string }` when a code becomes available or `null` on timeout/abort.
  */
-export function startLocalOAuthServer({ state }: { state: string }): Promise<OAuthServerInfo> {
+export function startLocalOAuthServer({
+	state,
+}: {
+	state: string;
+}): Promise<OAuthServerInfo> {
 	let pollAborted = false;
 	const server = http.createServer((req, res) => {
 		try {
-			const url = new URL(req.url || "", "http://localhost");
-			if (url.pathname !== "/auth/callback") {
+			const url = new URL(req.url || "", AUTH_REDIRECT.origin);
+			if (url.pathname !== AUTH_REDIRECT.path) {
 				res.statusCode = 404;
 				res.end("Not found");
 				return;
@@ -60,12 +68,16 @@ export function startLocalOAuthServer({ state }: { state: string }): Promise<OAu
 			res.end(successHtml);
 			const trackedServer = server as http.Server & { _lastCode?: string };
 			if (trackedServer._lastCode) {
-				logWarn("Duplicate OAuth callback received; preserving first authorization code");
+				logWarn(
+					"Duplicate OAuth callback received; preserving first authorization code",
+				);
 				return;
 			}
 			trackedServer._lastCode = code;
 		} catch (err) {
-			logError(`Request handler error: ${(err as Error)?.message ?? String(err)}`);
+			logError(
+				`Request handler error: ${(err as Error)?.message ?? String(err)}`,
+			);
 			res.statusCode = 500;
 			res.end("Internal error");
 		}
@@ -75,9 +87,9 @@ export function startLocalOAuthServer({ state }: { state: string }): Promise<OAu
 
 	return new Promise((resolve) => {
 		server
-			.listen(1455, "localhost", () => {
+			.listen(AUTH_REDIRECT.port, AUTH_REDIRECT.host, () => {
 				resolve({
-					port: 1455,
+					port: AUTH_REDIRECT.port,
 					ready: true,
 					close: () => {
 						pollAborted = true;
@@ -87,10 +99,12 @@ export function startLocalOAuthServer({ state }: { state: string }): Promise<OAu
 						const POLL_INTERVAL_MS = 100;
 						const TIMEOUT_MS = 5 * 60 * 1000;
 						const maxIterations = Math.floor(TIMEOUT_MS / POLL_INTERVAL_MS);
-						const poll = () => new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
+						const poll = () =>
+							new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
 						for (let i = 0; i < maxIterations; i++) {
 							if (pollAborted) return null;
-							const lastCode = (server as http.Server & { _lastCode?: string })._lastCode;
+							const lastCode = (server as http.Server & { _lastCode?: string })
+								._lastCode;
 							if (lastCode) return { code: lastCode };
 							await poll();
 						}
@@ -101,10 +115,10 @@ export function startLocalOAuthServer({ state }: { state: string }): Promise<OAu
 			})
 			.on("error", (err: NodeJS.ErrnoException) => {
 				logError(
-					`Failed to bind http://localhost:1455 (${err?.code}). Falling back to manual paste.`,
+					`Failed to bind ${AUTH_REDIRECT.origin} (${err?.code}). Falling back to manual paste.`,
 				);
 				resolve({
-					port: 1455,
+					port: AUTH_REDIRECT.port,
 					ready: false,
 					close: () => {
 						pollAborted = true;

--- a/lib/ui/copy.ts
+++ b/lib/ui/copy.ts
@@ -1,3 +1,5 @@
+import { AUTH_REDIRECT } from "../auth/auth.js";
+
 export const UI_COPY = {
 	mainMenu: {
 		title: "Accounts Dashboard",
@@ -17,7 +19,8 @@ export const UI_COPY = {
 		dangerZone: "Danger Zone",
 		removeAllAccounts: "Delete All Accounts",
 		helpCompact: "↑↓ Move | Enter Select | / Search | 1-9 Switch | Q Back",
-		helpDetailed: "Arrow keys move, Enter selects, / searches, 1-9 switches account, Q goes back",
+		helpDetailed:
+			"Arrow keys move, Enter selects, / searches, 1-9 switches account, Q goes back",
 	},
 	accountDetails: {
 		back: "Back",
@@ -40,7 +43,8 @@ export const UI_COPY = {
 		chooseBackupManually: "Choose Backup Manually",
 		back: "Back",
 		chooseModeHelp: "↑↓ Move | Enter Select | 1 Easy | 2 Manual | Q Back",
-		chooseModeHelpWithBackup: "↑↓ Move | Enter Select | 1 Easy | 2 Manual | 3 Backup | Q Back",
+		chooseModeHelpWithBackup:
+			"↑↓ Move | Enter Select | 1 Easy | 2 Manual | 3 Backup | Q Back",
 		restoreBackupTitle: "Restore Saved Backup",
 		restoreBackupSubtitle: "Choose how you want to recover saved accounts.",
 		restoreBackupLatestHint: "Fastest way to recover your saved accounts.",
@@ -48,7 +52,11 @@ export const UI_COPY = {
 		manualBackupTitle: "Choose Backup",
 		manualBackupSubtitle: "Pick a saved backup to restore.",
 		manualBackupHelp: "↑↓ Move | Enter Select | Q Back",
-		loadLastBackupHint: (fileName: string, accountCount: number, savedAt: string) =>
+		loadLastBackupHint: (
+			fileName: string,
+			accountCount: number,
+			savedAt: string,
+		) =>
 			`${fileName} | ${accountCount} account${accountCount === 1 ? "" : "s"} | saved ${savedAt}`,
 		manualBackupHint: (accountCount: number, savedAt: string) =>
 			`${accountCount} account${accountCount === 1 ? "" : "s"} | saved ${savedAt}`,
@@ -64,9 +72,10 @@ export const UI_COPY = {
 		pastePrompt: "Paste callback URL or code here (Q to cancel):",
 		browserOpened: "Browser opened.",
 		browserOpenFail: "Could not open browser. Use this link:",
-		waitingCallback: "Waiting for login callback on localhost:1455...",
+		waitingCallback: `Waiting for login callback on ${AUTH_REDIRECT.host}:${AUTH_REDIRECT.port}...`,
 		callbackBypassed: "Manual mode active. Paste the callback URL manually.",
-		callbackUnavailable: "Callback listener unavailable. Paste the callback URL manually.",
+		callbackUnavailable:
+			"Callback listener unavailable. Paste the callback URL manually.",
 		callbackMissed: "No callback received. Paste manually.",
 		cancelled: "Sign-in cancelled.",
 		cancelledBackToMenu: "Sign-in cancelled. Going back to menu.",
@@ -74,7 +83,8 @@ export const UI_COPY = {
 	returnFlow: {
 		continuePrompt: "Press Enter to go back.",
 		actionFailedPrompt: "Action failed. Press Enter to go back.",
-		autoReturn: (seconds: number) => `Returning in ${seconds}s... Press any key to pause.`,
+		autoReturn: (seconds: number) =>
+			`Returning in ${seconds}s... Press any key to pause.`,
 		paused: "Paused. Press any key to continue.",
 		working: "Running...",
 		done: "Done.",
@@ -93,7 +103,8 @@ export const UI_COPY = {
 		theme: "Color Theme",
 		experimental: "Experimental",
 		experimentalTitle: "Experimental",
-		experimentalSubtitle: "Preview sync and backup actions before they become stable",
+		experimentalSubtitle:
+			"Preview sync and backup actions before they become stable",
 		experimentalHelpMenu:
 			"Enter Select | 1 Sync | 2 Backup | 3 Guard | [ - Down | ] + Up | S Save | Q Back",
 		experimentalHelpPreview: "Enter Select | A Apply | Q Back",
@@ -115,22 +126,27 @@ export const UI_COPY = {
 		backNoSave: "Back Without Saving",
 		accountListTitle: "Account List View",
 		accountListSubtitle: "Choose row details and optional smart sorting",
-		accountListHelp: "Enter Toggle | Number Toggle | M Sort | L Layout | S Save | Q Back (No Save)",
+		accountListHelp:
+			"Enter Toggle | Number Toggle | M Sort | L Layout | S Save | Q Back (No Save)",
 		summaryTitle: "Account Details Row",
 		summarySubtitle: "Choose and order detail fields",
-		summaryHelp: "Enter Toggle | 1-3 Toggle | [ ] Reorder | S Save | Q Back (No Save)",
+		summaryHelp:
+			"Enter Toggle | 1-3 Toggle | [ ] Reorder | S Save | Q Back (No Save)",
 		behaviorTitle: "Return Behavior",
 		behaviorSubtitle: "Control how result screens return",
-		behaviorHelp: "Enter Select | 1-3 Delay | P Pause | L AutoFetch | F Status | T TTL | S Save | Q Back (No Save)",
+		behaviorHelp:
+			"Enter Select | 1-3 Delay | P Pause | L AutoFetch | F Status | T TTL | S Save | Q Back (No Save)",
 		themeTitle: "Color Theme",
 		themeSubtitle: "Pick base color and accent",
 		themeHelp: "Enter Select | 1-2 Base | S Save | Q Back (No Save)",
 		backendTitle: "Backend Controls",
 		backendSubtitle: "Tune sync, retry, and limit behavior",
-		backendHelp: "Enter Open | 1-4 Category | S Save | R Reset | Q Back (No Save)",
+		backendHelp:
+			"Enter Open | 1-4 Category | S Save | R Reset | Q Back (No Save)",
 		backendCategoriesHeading: "Categories",
 		backendCategoryTitle: "Backend Category",
-		backendCategoryHelp: "Enter Toggle/Adjust | +/- or [ ] Number | 1-9 Toggle | R Reset | Q Back",
+		backendCategoryHelp:
+			"Enter Toggle/Adjust | +/- or [ ] Number | 1-9 Toggle | R Reset | Q Back",
 		backendToggleHeading: "Switches",
 		backendNumberHeading: "Numbers",
 		backendDecrease: "Decrease Focused Value",
@@ -144,8 +160,10 @@ export const UI_COPY = {
 		moveDown: "Move Focused Field Down",
 	},
 	fallback: {
-		addAnotherTip: "Tip: Use private mode or sign out before adding another account.",
-		addAnotherQuestion: (count: number) => `Add another account? (${count} added) (y/n): `,
+		addAnotherTip:
+			"Tip: Use private mode or sign out before adding another account.",
+		addAnotherQuestion: (count: number) =>
+			`Add another account? (${count} added) (y/n): `,
 		selectModePrompt:
 			"(a) add, (c) check, (b) best, fi(x), (s) settings, (d) deep, (g) problem, (f) fresh, (q) back [a/c/b/x/s/d/g/f/q]: ",
 		invalidModePrompt: "Use one of: a, c, b, x, s, d, g, f, q.",

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from "vitest";
 import {
 	createState,
 	parseAuthorizationInput,
@@ -11,224 +11,270 @@ import {
 	AUTHORIZE_URL,
 	REDIRECT_URI,
 	SCOPE,
-} from '../lib/auth/auth.js';
-import * as loggerModule from '../lib/logger.js';
+} from "../lib/auth/auth.js";
+import * as loggerModule from "../lib/logger.js";
 
-describe('Auth Module', () => {
-	describe('createState', () => {
-		it('should generate a random 32-character hex string', () => {
+describe("Auth Module", () => {
+	describe("createState", () => {
+		it("should generate a random 32-character hex string", () => {
 			const state = createState();
 			expect(state).toMatch(/^[a-f0-9]{32}$/);
 		});
 
-		it('should generate unique states', () => {
+		it("should generate unique states", () => {
 			const state1 = createState();
 			const state2 = createState();
 			expect(state1).not.toBe(state2);
 		});
 	});
 
-	describe('parseAuthorizationInput', () => {
-		it('should parse full OAuth callback URL', () => {
-			const input = 'http://127.0.0.1:1455/auth/callback?code=abc123&state=xyz789';
+	describe("parseAuthorizationInput", () => {
+		it("should parse full OAuth callback URL", () => {
+			const input =
+				"http://127.0.0.1:1455/auth/callback?code=abc123&state=xyz789";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
+			expect(result).toEqual({ code: "abc123", state: "xyz789" });
 		});
 
-		it('should parse localhost callback URL for backward compatibility', () => {
-			const input = 'http://localhost:1455/auth/callback?code=abc123&state=xyz789';
+		it("should parse localhost callback URL for backward compatibility", () => {
+			const input =
+				"http://localhost:1455/auth/callback?code=abc123&state=xyz789";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
+			expect(result).toEqual({ code: "abc123", state: "xyz789" });
 		});
 
-		it('should parse code#state format', () => {
-			const input = 'abc123#xyz789';
+		it("should parse code#state format", () => {
+			const input = "abc123#xyz789";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
+			expect(result).toEqual({ code: "abc123", state: "xyz789" });
 		});
 
-		it('should parse query string format', () => {
-			const input = 'code=abc123&state=xyz789';
+		it("should parse query string format", () => {
+			const input = "code=abc123&state=xyz789";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
+			expect(result).toEqual({ code: "abc123", state: "xyz789" });
 		});
 
-		it('should parse query string with code= only (no state param)', () => {
-			const input = 'code=abc123';
+		it("should parse query string with code= only (no state param)", () => {
+			const input = "code=abc123";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: undefined });
+			expect(result).toEqual({ code: "abc123", state: undefined });
 		});
 
-		it('should parse URL with fragment parameters (#code=...)', () => {
-			const input = 'http://127.0.0.1:1455/auth/callback#code=abc123&state=xyz789';
+		it("should parse URL with fragment parameters (#code=...)", () => {
+			const input =
+				"http://127.0.0.1:1455/auth/callback#code=abc123&state=xyz789";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
+			expect(result).toEqual({ code: "abc123", state: "xyz789" });
 		});
 
-		it('should prefer query params over hash params when both exist', () => {
-			const input = 'http://127.0.0.1:1455/auth/callback?code=querycode&state=querystate#code=hashcode&state=hashstate';
+		it("should prefer query params over hash params when both exist", () => {
+			const input =
+				"http://127.0.0.1:1455/auth/callback?code=querycode&state=querystate#code=hashcode&state=hashstate";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'querycode', state: 'querystate' });
+			expect(result).toEqual({ code: "querycode", state: "querystate" });
 		});
 
-		it('should fallback to hash for missing state in query', () => {
-			const input = 'http://127.0.0.1:1455/auth/callback?code=querycode#state=hashstate';
+		it("should fallback to hash for missing state in query", () => {
+			const input =
+				"http://127.0.0.1:1455/auth/callback?code=querycode#state=hashstate";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'querycode', state: 'hashstate' });
+			expect(result).toEqual({ code: "querycode", state: "hashstate" });
 		});
 
-		it('should fallback to hash for missing code in query', () => {
-			const input = 'http://127.0.0.1:1455/auth/callback?state=querystate#code=hashcode';
+		it("should fallback to hash for missing code in query", () => {
+			const input =
+				"http://127.0.0.1:1455/auth/callback?state=querystate#code=hashcode";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'hashcode', state: 'querystate' });
+			expect(result).toEqual({ code: "hashcode", state: "querystate" });
 		});
 
-		it('should handle URL with hash but without # prefix', () => {
-			const input = 'http://127.0.0.1:1455/auth/callback#code=abc123';
+		it("should handle URL with hash but without # prefix", () => {
+			const input = "http://127.0.0.1:1455/auth/callback#code=abc123";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: undefined });
+			expect(result).toEqual({ code: "abc123", state: undefined });
 		});
 
-		it('should return code and state when only state is in hash (line 44 coverage)', () => {
-			const input = 'http://127.0.0.1:1455/auth/callback?code=querycode#state=hashstate';
+		it("should return code and state when only state is in hash (line 44 coverage)", () => {
+			const input =
+				"http://127.0.0.1:1455/auth/callback?code=querycode#state=hashstate";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'querycode', state: 'hashstate' });
+			expect(result).toEqual({ code: "querycode", state: "hashstate" });
 		});
 
-		it('should return state only when only state is in hash and no code (line 44 coverage)', () => {
-			const input = 'http://127.0.0.1:1455/auth/callback#state=hashstate';
+		it("should return state only when only state is in hash and no code (line 44 coverage)", () => {
+			const input = "http://127.0.0.1:1455/auth/callback#state=hashstate";
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: undefined, state: 'hashstate' });
+			expect(result).toEqual({ code: undefined, state: "hashstate" });
 		});
 
-	it('should parse code only', () => {
-		const input = 'abc123';
-		const result = parseAuthorizationInput(input);
-		expect(result).toEqual({ code: 'abc123' });
-	});
+		it("should parse code only", () => {
+			const input = "abc123";
+			const result = parseAuthorizationInput(input);
+			expect(result).toEqual({ code: "abc123" });
+		});
 
-	it('should parse code= query string without state (line 58 state undefined branch)', () => {
-		const input = 'code=abc123';
-		const result = parseAuthorizationInput(input);
-		expect(result).toEqual({ code: 'abc123', state: undefined });
-	});
+		it("should parse code= query string without state (line 58 state undefined branch)", () => {
+			const input = "code=abc123";
+			const result = parseAuthorizationInput(input);
+			expect(result).toEqual({ code: "abc123", state: undefined });
+		});
 
-		it('should return empty object for empty input', () => {
-			const result = parseAuthorizationInput('');
+		it("should return empty object for empty input", () => {
+			const result = parseAuthorizationInput("");
 			expect(result).toEqual({});
 		});
 
-		it('should handle whitespace', () => {
-			const result = parseAuthorizationInput('  ');
+		it("should handle whitespace", () => {
+			const result = parseAuthorizationInput("  ");
 			expect(result).toEqual({});
 		});
 
-	it('should fall through to # split when valid URL has hash with no code/state params (line 44 false branch)', () => {
-		// URL parses successfully but hash contains no code= or state= params
-		// Line 44's false branch is hit (code && state both undefined)
-		// Falls through to line 51 which splits on #
-		const input = 'http://127.0.0.1:1455/auth/callback#invalid';
-		const result = parseAuthorizationInput(input);
-		expect(result).toEqual({ code: 'http://127.0.0.1:1455/auth/callback', state: 'invalid' });
-	});
+		it("should fall through to # split when valid URL has hash with no code/state params (line 44 false branch)", () => {
+			// URL parses successfully but hash contains no code= or state= params
+			// Line 44's false branch is hit (code && state both undefined)
+			// Falls through to line 51 which splits on #
+			const input = "http://127.0.0.1:1455/auth/callback#invalid";
+			const result = parseAuthorizationInput(input);
+			expect(result).toEqual({
+				code: "http://127.0.0.1:1455/auth/callback",
+				state: "invalid",
+			});
+		});
 	});
 
-	describe('decodeJWT', () => {
-		it('should decode valid JWT token', () => {
+	describe("decodeJWT", () => {
+		it("should decode valid JWT token", () => {
 			// Create a simple JWT token: header.payload.signature
-			const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64');
-			const payload = Buffer.from(JSON.stringify({ sub: '1234567890', name: 'Test User' })).toString('base64');
-			const signature = 'fake-signature';
+			const header = Buffer.from(
+				JSON.stringify({ alg: "HS256", typ: "JWT" }),
+			).toString("base64");
+			const payload = Buffer.from(
+				JSON.stringify({ sub: "1234567890", name: "Test User" }),
+			).toString("base64");
+			const signature = "fake-signature";
 			const token = `${header}.${payload}.${signature}`;
 
 			const decoded = decodeJWT(token);
-			expect(decoded).toEqual({ sub: '1234567890', name: 'Test User' });
+			expect(decoded).toEqual({ sub: "1234567890", name: "Test User" });
 		});
 
-		it('should decode JWT with ChatGPT account info', () => {
-			const payload = Buffer.from(JSON.stringify({
-				'https://api.openai.com/auth': {
-					chatgpt_account_id: 'account-123',
-				},
-			})).toString('base64');
-			const token = `header.${payload}.signature`;
-
-			const decoded = decodeJWT(token);
-			expect(decoded?.['https://api.openai.com/auth']?.chatgpt_account_id).toBe('account-123');
-		});
-
-		it('should decode base64url JWT payloads', () => {
+		it("should decode JWT with ChatGPT account info", () => {
 			const payload = Buffer.from(
-				JSON.stringify({ sub: '1234567890', name: 'Test User' }),
-				'utf8',
-			).toString('base64url');
+				JSON.stringify({
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "account-123",
+					},
+				}),
+			).toString("base64");
 			const token = `header.${payload}.signature`;
 
 			const decoded = decodeJWT(token);
-			expect(decoded).toEqual({ sub: '1234567890', name: 'Test User' });
+			expect(decoded?.["https://api.openai.com/auth"]?.chatgpt_account_id).toBe(
+				"account-123",
+			);
 		});
 
-		it('should return null for invalid JWT', () => {
-			const result = decodeJWT('invalid-token');
+		it("should decode base64url JWT payloads", () => {
+			const payload = Buffer.from(
+				JSON.stringify({ sub: "1234567890", name: "Test User" }),
+				"utf8",
+			).toString("base64url");
+			const token = `header.${payload}.signature`;
+
+			const decoded = decodeJWT(token);
+			expect(decoded).toEqual({ sub: "1234567890", name: "Test User" });
+		});
+
+		it("should return null for invalid JWT", () => {
+			const result = decodeJWT("invalid-token");
 			expect(result).toBeNull();
 		});
 
-		it('should return null for malformed JWT', () => {
-			const result = decodeJWT('header.payload');
+		it("should return null for malformed JWT", () => {
+			const result = decodeJWT("header.payload");
 			expect(result).toBeNull();
 		});
 
-		it('should return null for non-JSON payload', () => {
-			const token = 'header.not-json.signature';
+		it("should return null for non-JSON payload", () => {
+			const token = "header.not-json.signature";
 			const result = decodeJWT(token);
 			expect(result).toBeNull();
 		});
 	});
 
-	describe('createAuthorizationFlow', () => {
-		it('should create authorization flow with PKCE', async () => {
+	describe("createAuthorizationFlow", () => {
+		it("should create authorization flow with PKCE", async () => {
 			const flow = await createAuthorizationFlow();
 
-			expect(flow).toHaveProperty('pkce');
-			expect(flow).toHaveProperty('state');
-			expect(flow).toHaveProperty('url');
+			expect(flow).toHaveProperty("pkce");
+			expect(flow).toHaveProperty("state");
+			expect(flow).toHaveProperty("url");
 
-			expect(flow.pkce).toHaveProperty('challenge');
-			expect(flow.pkce).toHaveProperty('verifier');
+			expect(flow.pkce).toHaveProperty("challenge");
+			expect(flow.pkce).toHaveProperty("verifier");
 			expect(flow.state).toMatch(/^[a-f0-9]{32}$/);
 		});
 
-		it('should generate URL with correct parameters', async () => {
+		it("should generate URL with correct parameters", async () => {
 			const flow = await createAuthorizationFlow();
 			const url = new URL(flow.url);
 
 			expect(url.origin + url.pathname).toBe(AUTHORIZE_URL);
-			expect(url.searchParams.get('response_type')).toBe('code');
-			expect(url.searchParams.get('client_id')).toBe(CLIENT_ID);
-			expect(url.searchParams.get('redirect_uri')).toBe(REDIRECT_URI);
-			expect(url.searchParams.get('scope')).toBe(SCOPE);
-			expect(url.searchParams.get('code_challenge_method')).toBe('S256');
-			expect(url.searchParams.get('code_challenge')).toBe(flow.pkce.challenge);
-			expect(url.searchParams.get('state')).toBe(flow.state);
-			expect(url.searchParams.get('id_token_add_organizations')).toBe('true');
-			expect(url.searchParams.get('codex_cli_simplified_flow')).toBe('true');
-			expect(url.searchParams.get('originator')).toBe('codex_cli_rs');
-			expect(url.searchParams.has('prompt')).toBe(false);
+			expect(url.searchParams.get("response_type")).toBe("code");
+			expect(url.searchParams.get("client_id")).toBe(CLIENT_ID);
+			expect(url.searchParams.get("redirect_uri")).toBe(REDIRECT_URI);
+			expect(url.searchParams.get("scope")).toBe(SCOPE);
+			expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+			expect(url.searchParams.get("code_challenge")).toBe(flow.pkce.challenge);
+			expect(url.searchParams.get("state")).toBe(flow.state);
+			expect(url.searchParams.get("id_token_add_organizations")).toBe("true");
+			expect(url.searchParams.get("codex_cli_simplified_flow")).toBe("true");
+			expect(url.searchParams.get("originator")).toBe("codex_cli_rs");
+			expect(url.searchParams.has("prompt")).toBe(false);
 		});
 
-		it('should include prompt=login when forceNewLogin is true', async () => {
+		it("should include prompt=login when forceNewLogin is true", async () => {
 			const flow = await createAuthorizationFlow({ forceNewLogin: true });
 			const url = new URL(flow.url);
-			expect(url.searchParams.get('prompt')).toBe('login');
+			expect(url.searchParams.get("prompt")).toBe("login");
 		});
 
-		it('should generate unique flows', async () => {
+		it("should generate unique flows", async () => {
 			const flow1 = await createAuthorizationFlow();
 			const flow2 = await createAuthorizationFlow();
 
 			expect(flow1.state).not.toBe(flow2.state);
 			expect(flow1.pkce.verifier).not.toBe(flow2.pkce.verifier);
 			expect(flow1.url).not.toBe(flow2.url);
+		});
+	});
+
+	describe("AUTH_REDIRECT", () => {
+		it("derives its fields from REDIRECT_URI without drift", async () => {
+			const { AUTH_REDIRECT } = await import("../lib/auth/auth.js");
+			const parsed = new URL(REDIRECT_URI);
+			expect(AUTH_REDIRECT.host).toBe(parsed.hostname);
+			expect(AUTH_REDIRECT.path).toBe(parsed.pathname);
+			expect(AUTH_REDIRECT.url).toBe(REDIRECT_URI);
+			expect(AUTH_REDIRECT.port).toBe(
+				parsed.port.length > 0 ? Number(parsed.port) : 1455,
+			);
+			expect(AUTH_REDIRECT.origin).toBe(`${parsed.protocol}//${parsed.host}`);
+		});
+
+		it("is frozen and cannot be mutated", async () => {
+			const { AUTH_REDIRECT } = await import("../lib/auth/auth.js");
+			expect(Object.isFrozen(AUTH_REDIRECT)).toBe(true);
+		});
+
+		it("locks the callback port at 1455 so REDIRECT_URI and the bound port never diverge", async () => {
+			const { AUTH_REDIRECT } = await import("../lib/auth/auth.js");
+			// The OpenAI app registration pins this exact callback. If anyone
+			// changes REDIRECT_URI without updating the registration, login breaks;
+			// this assertion fails loudly before that ships.
+			expect(AUTH_REDIRECT.port).toBe(1455);
+			expect(AUTH_REDIRECT.path).toBe("/auth/callback");
 		});
 	});
 
@@ -252,27 +298,34 @@ describe('Auth Module', () => {
 		});
 	});
 
-	describe('exchangeAuthorizationCode', () => {
-		it('returns success with tokens on valid response', async () => {
-			vi.spyOn(Date, 'now').mockReturnValue(1_000);
+	describe("exchangeAuthorizationCode", () => {
+		it("returns success with tokens on valid response", async () => {
+			vi.spyOn(Date, "now").mockReturnValue(1_000);
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({
-					access_token: 'access-123',
-					refresh_token: 'refresh-456',
-					expires_in: 3600,
-					id_token: 'id-token-789',
-				}), { status: 200 }),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							access_token: "access-123",
+							refresh_token: "refresh-456",
+							expires_in: 3600,
+							id_token: "id-token-789",
+						}),
+						{ status: 200 },
+					),
 			) as never;
 
 			try {
-				const result = await exchangeAuthorizationCode('auth-code', 'verifier-123');
+				const result = await exchangeAuthorizationCode(
+					"auth-code",
+					"verifier-123",
+				);
 				expect(result).toEqual({
-					type: 'success',
-					access: 'access-123',
-					refresh: 'refresh-456',
+					type: "success",
+					access: "access-123",
+					refresh: "refresh-456",
 					expires: 3_601_000,
-					idToken: 'id-token-789',
+					idToken: "id-token-789",
 					multiAccount: true,
 				});
 			} finally {
@@ -281,22 +334,29 @@ describe('Auth Module', () => {
 			}
 		});
 
-		it('returns failed when refresh token is missing', async () => {
-			vi.spyOn(Date, 'now').mockReturnValue(1_000);
+		it("returns failed when refresh token is missing", async () => {
+			vi.spyOn(Date, "now").mockReturnValue(1_000);
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({
-					access_token: 'access-123',
-					expires_in: 3600,
-				}), { status: 200 }),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							access_token: "access-123",
+							expires_in: 3600,
+						}),
+						{ status: 200 },
+					),
 			) as never;
 
 			try {
-				const result = await exchangeAuthorizationCode('auth-code', 'verifier-123');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('invalid_response');
-					expect(result.message).toContain('Missing refresh token');
+				const result = await exchangeAuthorizationCode(
+					"auth-code",
+					"verifier-123",
+				);
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("invalid_response");
+					expect(result.message).toContain("Missing refresh token");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
@@ -304,23 +364,30 @@ describe('Auth Module', () => {
 			}
 		});
 
-		it('returns failed when refresh token is whitespace only', async () => {
-			vi.spyOn(Date, 'now').mockReturnValue(1_000);
+		it("returns failed when refresh token is whitespace only", async () => {
+			vi.spyOn(Date, "now").mockReturnValue(1_000);
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({
-					access_token: 'access-123',
-					refresh_token: '   ',
-					expires_in: 3600,
-				}), { status: 200 }),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							access_token: "access-123",
+							refresh_token: "   ",
+							expires_in: 3600,
+						}),
+						{ status: 200 },
+					),
 			) as never;
 
 			try {
-				const result = await exchangeAuthorizationCode('auth-code', 'verifier-123');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('invalid_response');
-					expect(result.message).toContain('Missing refresh token');
+				const result = await exchangeAuthorizationCode(
+					"auth-code",
+					"verifier-123",
+				);
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("invalid_response");
+					expect(result.message).toContain("Missing refresh token");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
@@ -328,39 +395,39 @@ describe('Auth Module', () => {
 			}
 		});
 
-		it('returns failed for HTTP error response', async () => {
+		it("returns failed for HTTP error response", async () => {
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response('Bad Request', { status: 400 }),
+			globalThis.fetch = vi.fn(
+				async () => new Response("Bad Request", { status: 400 }),
 			) as never;
 
 			try {
-				const result = await exchangeAuthorizationCode('bad-code', 'verifier');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('http_error');
+				const result = await exchangeAuthorizationCode("bad-code", "verifier");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("http_error");
 					expect(result.statusCode).toBe(400);
-					expect(result.message).toBe('Bad Request');
+					expect(result.message).toBe("Bad Request");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
 			}
 		});
 
-		it('returns failed with undefined message when text read fails', async () => {
+		it("returns failed with undefined message when text read fails", async () => {
 			const originalFetch = globalThis.fetch;
 			const mockResponse = {
 				ok: false,
 				status: 500,
-				text: vi.fn().mockRejectedValue(new Error('Read failed')),
+				text: vi.fn().mockRejectedValue(new Error("Read failed")),
 			};
 			globalThis.fetch = vi.fn(async () => mockResponse) as never;
 
 			try {
-				const result = await exchangeAuthorizationCode('code', 'verifier');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('http_error');
+				const result = await exchangeAuthorizationCode("code", "verifier");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("http_error");
 					expect(result.statusCode).toBe(500);
 					expect(result.message).toBeUndefined();
 				}
@@ -369,125 +436,145 @@ describe('Auth Module', () => {
 			}
 		});
 
-		it('returns failed for invalid response schema', async () => {
+		it("returns failed for invalid response schema", async () => {
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({ wrong: 'schema' }), { status: 200 }),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(JSON.stringify({ wrong: "schema" }), { status: 200 }),
 			) as never;
 
 			try {
-				const result = await exchangeAuthorizationCode('code', 'verifier');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('invalid_response');
-					expect(result.message).toBe('Response failed schema validation');
+				const result = await exchangeAuthorizationCode("code", "verifier");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("invalid_response");
+					expect(result.message).toBe("Response failed schema validation");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
 			}
 		});
 
-		it('uses custom redirect URI when provided', async () => {
+		it("uses custom redirect URI when provided", async () => {
 			const originalFetch = globalThis.fetch;
 			let capturedBody: URLSearchParams | undefined;
 			globalThis.fetch = vi.fn(async (_url, init) => {
 				capturedBody = init?.body as URLSearchParams;
-				return new Response(JSON.stringify({
-					access_token: 'access',
-					expires_in: 3600,
-				}), { status: 200 });
+				return new Response(
+					JSON.stringify({
+						access_token: "access",
+						expires_in: 3600,
+					}),
+					{ status: 200 },
+				);
 			}) as never;
 
 			try {
-				await exchangeAuthorizationCode('code', 'verifier', 'http://custom:8080/callback');
-				expect(capturedBody?.get('redirect_uri')).toBe('http://custom:8080/callback');
+				await exchangeAuthorizationCode(
+					"code",
+					"verifier",
+					"http://custom:8080/callback",
+				);
+				expect(capturedBody?.get("redirect_uri")).toBe(
+					"http://custom:8080/callback",
+				);
 			} finally {
 				globalThis.fetch = originalFetch;
 			}
 		});
 	});
 
-	describe('refreshAccessToken', () => {
-		it('keeps existing refresh token when missing in response', async () => {
-			vi.spyOn(Date, 'now').mockReturnValue(1_000);
+	describe("refreshAccessToken", () => {
+		it("keeps existing refresh token when missing in response", async () => {
+			vi.spyOn(Date, "now").mockReturnValue(1_000);
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({ access_token: 'new-access', expires_in: 60 }), {
-					status: 200,
-				}),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({ access_token: "new-access", expires_in: 60 }),
+						{
+							status: 200,
+						},
+					),
 			) as never;
 
 			try {
-				const result = await refreshAccessToken('existing-refresh');
-			expect(result).toEqual({
-				type: 'success',
-				access: 'new-access',
-				refresh: 'existing-refresh',
-				expires: 61_000,
-				idToken: undefined,
-				multiAccount: true,
-			});
+				const result = await refreshAccessToken("existing-refresh");
+				expect(result).toEqual({
+					type: "success",
+					access: "new-access",
+					refresh: "existing-refresh",
+					expires: 61_000,
+					idToken: undefined,
+					multiAccount: true,
+				});
 			} finally {
 				globalThis.fetch = originalFetch;
 				vi.restoreAllMocks();
 			}
 		});
 
-		it('returns failed for HTTP 400 invalid_grant', async () => {
+		it("returns failed for HTTP 400 invalid_grant", async () => {
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 }),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(JSON.stringify({ error: "invalid_grant" }), {
+						status: 400,
+					}),
 			) as never;
 
 			try {
-				const result = await refreshAccessToken('bad-token');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('http_error');
+				const result = await refreshAccessToken("bad-token");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("http_error");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
 			}
 		});
 
-		it('returns failed for invalid response schema', async () => {
+		it("returns failed for invalid response schema", async () => {
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({ wrong: 'schema' }), { status: 200 }),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(JSON.stringify({ wrong: "schema" }), { status: 200 }),
 			) as never;
 
 			try {
-				const result = await refreshAccessToken('some-token');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('invalid_response');
+				const result = await refreshAccessToken("some-token");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("invalid_response");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
 			}
 		});
 
-		it('returns failed for network errors', async () => {
+		it("returns failed for network errors", async () => {
 			const originalFetch = globalThis.fetch;
 			globalThis.fetch = vi.fn(async () => {
-				throw new Error('Network failed');
+				throw new Error("Network failed");
 			}) as never;
 
 			try {
-				const result = await refreshAccessToken('some-token');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('network_error');
-					expect(result.message).toBe('Network failed');
+				const result = await refreshAccessToken("some-token");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("network_error");
+					expect(result.message).toBe("Network failed");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
 			}
 		});
 
-		it('returns non-network failure for aborted refresh requests', async () => {
+		it("returns non-network failure for aborted refresh requests", async () => {
 			const originalFetch = globalThis.fetch;
-			const abortError = Object.assign(new Error('Request aborted'), { name: 'AbortError' });
+			const abortError = Object.assign(new Error("Request aborted"), {
+				name: "AbortError",
+			});
 			globalThis.fetch = vi.fn(async () => {
 				throw abortError;
 			}) as never;
@@ -495,102 +582,128 @@ describe('Auth Module', () => {
 			try {
 				const controller = new AbortController();
 				controller.abort(abortError);
-				const result = await refreshAccessToken('some-token', { signal: controller.signal });
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('unknown');
-					expect(result.message).toBe('Request aborted');
+				const result = await refreshAccessToken("some-token", {
+					signal: controller.signal,
+				});
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("unknown");
+					expect(result.message).toBe("Request aborted");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
 			}
 		});
 
-		it('returns failed when response refresh token is whitespace only', async () => {
+		it("returns failed when response refresh token is whitespace only", async () => {
 			const originalFetch = globalThis.fetch;
-			const logErrorSpy = vi.spyOn(loggerModule, 'logError').mockImplementation(() => {});
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({
-					access_token: 'new-access',
-					refresh_token: '   ',
-					expires_in: 60,
-				}), { status: 200 }),
+			const logErrorSpy = vi
+				.spyOn(loggerModule, "logError")
+				.mockImplementation(() => {});
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							access_token: "new-access",
+							refresh_token: "   ",
+							expires_in: 60,
+						}),
+						{ status: 200 },
+					),
 			) as never;
 
 			try {
-				const result = await refreshAccessToken('existing-refresh');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('missing_refresh');
-					expect(result.message).toBe('No refresh token in response or input');
+				const result = await refreshAccessToken("existing-refresh");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("missing_refresh");
+					expect(result.message).toBe("No refresh token in response or input");
 				}
-				expect(logErrorSpy).toHaveBeenCalledWith('Token refresh missing refresh token');
-				expect(logErrorSpy.mock.calls[0]).toEqual(['Token refresh missing refresh token']);
+				expect(logErrorSpy).toHaveBeenCalledWith(
+					"Token refresh missing refresh token",
+				);
+				expect(logErrorSpy.mock.calls[0]).toEqual([
+					"Token refresh missing refresh token",
+				]);
 			} finally {
 				globalThis.fetch = originalFetch;
 				vi.restoreAllMocks();
 			}
 		});
 
-		it('returns failed when input refresh token is whitespace only and response omits refresh token', async () => {
+		it("returns failed when input refresh token is whitespace only and response omits refresh token", async () => {
 			const originalFetch = globalThis.fetch;
-			const logErrorSpy = vi.spyOn(loggerModule, 'logError').mockImplementation(() => {});
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({
-					access_token: 'new-access',
-					expires_in: 60,
-				}), { status: 200 }),
+			const logErrorSpy = vi
+				.spyOn(loggerModule, "logError")
+				.mockImplementation(() => {});
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							access_token: "new-access",
+							expires_in: 60,
+						}),
+						{ status: 200 },
+					),
 			) as never;
 
 			try {
-				const result = await refreshAccessToken('   ');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('missing_refresh');
-					expect(result.message).toBe('No refresh token in response or input');
+				const result = await refreshAccessToken("   ");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("missing_refresh");
+					expect(result.message).toBe("No refresh token in response or input");
 				}
-				expect(logErrorSpy).toHaveBeenCalledWith('Token refresh missing refresh token');
-				expect(logErrorSpy.mock.calls[0]).toEqual(['Token refresh missing refresh token']);
+				expect(logErrorSpy).toHaveBeenCalledWith(
+					"Token refresh missing refresh token",
+				);
+				expect(logErrorSpy.mock.calls[0]).toEqual([
+					"Token refresh missing refresh token",
+				]);
 			} finally {
 				globalThis.fetch = originalFetch;
 				vi.restoreAllMocks();
 			}
 		});
 
-		it('returns failed when both response and input have no refresh token', async () => {
+		it("returns failed when both response and input have no refresh token", async () => {
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({
-					access_token: 'new-access',
-					expires_in: 60,
-					// no refresh_token in response
-				}), { status: 200 }),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							access_token: "new-access",
+							expires_in: 60,
+							// no refresh_token in response
+						}),
+						{ status: 200 },
+					),
 			) as never;
 
 			try {
 				// Pass empty string as refresh token to trigger missing_refresh branch
-				const result = await refreshAccessToken('');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('missing_refresh');
-					expect(result.message).toBe('No refresh token in response or input');
+				const result = await refreshAccessToken("");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("missing_refresh");
+					expect(result.message).toBe("No refresh token in response or input");
 				}
 			} finally {
 				globalThis.fetch = originalFetch;
 			}
 		});
 
-		it('returns http_error with undefined message when response text is empty', async () => {
+		it("returns http_error with undefined message when response text is empty", async () => {
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response('', { status: 500 }),
+			globalThis.fetch = vi.fn(
+				async () => new Response("", { status: 500 }),
 			) as never;
 
 			try {
-				const result = await refreshAccessToken('some-token');
-				expect(result.type).toBe('failed');
-				if (result.type === 'failed') {
-					expect(result.reason).toBe('http_error');
+				const result = await refreshAccessToken("some-token");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("http_error");
 					expect(result.statusCode).toBe(500);
 					expect(result.message).toBeUndefined();
 				}
@@ -599,26 +712,30 @@ describe('Auth Module', () => {
 			}
 		});
 
-		it('returns success with new refresh token from response', async () => {
-			vi.spyOn(Date, 'now').mockReturnValue(1_000);
+		it("returns success with new refresh token from response", async () => {
+			vi.spyOn(Date, "now").mockReturnValue(1_000);
 			const originalFetch = globalThis.fetch;
-			globalThis.fetch = vi.fn(async () =>
-				new Response(JSON.stringify({
-					access_token: 'new-access',
-					refresh_token: 'new-refresh',
-					expires_in: 60,
-					id_token: 'new-id-token',
-				}), { status: 200 }),
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							access_token: "new-access",
+							refresh_token: "new-refresh",
+							expires_in: 60,
+							id_token: "new-id-token",
+						}),
+						{ status: 200 },
+					),
 			) as never;
 
 			try {
-				const result = await refreshAccessToken('old-refresh');
+				const result = await refreshAccessToken("old-refresh");
 				expect(result).toEqual({
-					type: 'success',
-					access: 'new-access',
-					refresh: 'new-refresh',
+					type: "success",
+					access: "new-access",
+					refresh: "new-refresh",
 					expires: 61_000,
-					idToken: 'new-id-token',
+					idToken: "new-id-token",
 					multiAccount: true,
 				});
 			} finally {

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -64,6 +64,13 @@ vi.mock("../lib/auth/auth.js", () => ({
 		};
 	}),
 	REDIRECT_URI: "http://localhost:1455/auth/callback",
+	AUTH_REDIRECT: {
+		host: "localhost",
+		port: 1455,
+		path: "/auth/callback",
+		origin: "http://localhost:1455",
+		url: "http://localhost:1455/auth/callback",
+	},
 }));
 
 vi.mock("../lib/auth/browser.js", () => ({


### PR DESCRIPTION
## Summary

Introduces `AUTH_REDIRECT` — a frozen, parsed representation of the existing `REDIRECT_URI` constant — as the single source of truth for host/port/path/origin in the OAuth callback flow. Local consumers (server bind, callback-path check, bind-failure error message) now read from the shared record so the port number, host, and callback path cannot drift independently.

## Problem

The audit (`docs/audits/MASTER_AUDIT.md` §6 / `dim-C-auth.md` C-AUTH-04, AUDIT-M14, AUDIT-M30) identified the `1455` port literal duplicated across at least four sites plus hardcoded `"localhost"` strings inline in the server module. Any future host/port/path change would need to touch every site manually, and a partial update creates silent drift.

## Change

### `lib/auth/auth.ts`
Adds one new named export:

```ts
export const AUTH_REDIRECT = Object.freeze(
  (() => {
    const parsed = new URL(REDIRECT_URI);
    const port = parsed.port.length > 0 ? Number(parsed.port) : 1455;
    return {
      host: parsed.hostname,
      port,
      path: parsed.pathname,
      origin: `${parsed.protocol}//${parsed.host}`,
      url: REDIRECT_URI,
    } as const;
  })(),
);
```

### `lib/auth/server.ts`
Threads `AUTH_REDIRECT.{host,port,path,origin}` through:
- `new URL(req.url || "", AUTH_REDIRECT.origin)`
- `url.pathname !== AUTH_REDIRECT.path`
- `server.listen(AUTH_REDIRECT.port, AUTH_REDIRECT.host, ...)`
- `port: AUTH_REDIRECT.port` in both success + error paths
- Bind-failure error message: `Failed to bind ${AUTH_REDIRECT.origin}`

### `test/auth.test.ts`
Adds a `describe("AUTH_REDIRECT", ...)` block with three invariant assertions:
1. Derived fields match the parsed `REDIRECT_URI`
2. The record is frozen
3. The callback port is locked at `1455` and the path at `/auth/callback` — fails loudly before a silent `REDIRECT_URI` change ships unregistered with the provider.

## Deliberately NOT changed in this PR

- **`REDIRECT_URI` literal** remains `http://localhost:1455/auth/callback` (preserves current provider-registered callback — changing host to `127.0.0.1` is the correct long-term fix per the audit, but belongs in a dedicated docs-truthup PR that coordinates the OpenAI app registration update).
- **`lib/ui/copy.ts`** `waitingCallback` string — still a static literal `"localhost:1455"`. Leaving it static for now; a follow-up PR can derive the string from `AUTH_REDIRECT` once we're sure no tooling depends on the exact wording.
- **`lib/oauth-success.html`** — static asset; no host/port literal update needed in this pass.

## Verification

- **Full suite: 225/225 files, 3421/3421 tests pass** (+3 new invariant assertions)
- `npm run typecheck` exit 0
- `npm run lint` exit 0
- No new dependencies
- No public API removed; `AUTH_REDIRECT` is a new additive export
- 0 `as any`, 0 `@ts-ignore` added

## Audit reference

- `docs/audits/MASTER_AUDIT.md` §6 (MEDIUM) AUDIT-M14, AUDIT-M30
- `docs/audits/MASTER_AUDIT.md` §8 R2 (RedirectURI SSOT refactor) — prerequisite for AUDIT-H5 docs truthup
- `docs/audits/evidence/dim-C-auth.md` C-AUTH-04

## Scope guarantees

- ✅ Internal refactor only — public API is additive (`AUTH_REDIRECT` new export)
- ✅ `REDIRECT_URI` value is unchanged — OAuth provider registration is unaffected
- ✅ No changes to the OAuth handshake sequence, PKCE, or token exchange
- ✅ Invariant tests catch future drift before it ships
- ✅ Foundation for PR-Q (docs truthup — `localhost` vs `127.0.0.1:1455` decision)

## Follow-up

Phase 1 continues with **PR-D** (hybrid selector null contract — AUDIT-H2). Tracked in `.sisyphus/plans/phase1-implementation.md`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

clean internal refactor that introduces `AUTH_REDIRECT` as a frozen, module-load-time parsed view of `REDIRECT_URI`, then threads it through `server.ts` (bind, path check, error message) and `lib/ui/copy.ts` (`waitingCallback`). no oauth handshake changes, no public api removed — additive export only. all three P2 findings are test hygiene: dynamic imports where a static import suffices, an unfrozen mock, and missing coverage for the new `waitingCallback` derivation.

<h3>Confidence Score: 5/5</h3>

safe to merge — no logic changes, only hardcoded literals replaced by derived values from the same `REDIRECT_URI` constant

all findings are P2: test style (dynamic vs static import), unfrozen mock, and one missing coverage assertion. no P0 or P1 issues; oauth handshake, PKCE, and token exchange are untouched.

test/auth.test.ts and test/codex-manager-cli.test.ts have minor test hygiene gaps; lib/ui/copy.ts missing a coverage assertion for the new waitingCallback template

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/auth/auth.ts | adds `AUTH_REDIRECT` frozen IIFE-parsed from `REDIRECT_URI`; all derived fields are correct for the current literal; fallback port logic already flagged in a prior thread |
| lib/auth/server.ts | threads `AUTH_REDIRECT.{host,port,path,origin}` through bind, path check, and error message; behavior is identical to hardcoded values for current `REDIRECT_URI` |
| lib/ui/copy.ts | imports `AUTH_REDIRECT` and derives `waitingCallback` — correct change, but no vitest coverage added for the derived string |
| test/auth.test.ts | adds three `AUTH_REDIRECT` invariant tests; all three use `await import()` unnecessarily instead of the existing static import — minor style issue |
| test/codex-manager-cli.test.ts | adds static `AUTH_REDIRECT` mock needed for the `copy.ts` import; mock is not frozen, minor divergence from production shape |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as auth.ts
    participant S as server.ts
    participant C as copy.ts

    Note over A: REDIRECT_URI literal<br/>"http://localhost:1455/auth/callback"
    A->>A: AUTH_REDIRECT = Object.freeze(parseIIFE(REDIRECT_URI))
    Note over A: {host, port, path, origin, url}

    A-->>S: import AUTH_REDIRECT
    Note over S: server.listen(AUTH_REDIRECT.port, AUTH_REDIRECT.host)
    Note over S: new URL(req.url, AUTH_REDIRECT.origin)
    Note over S: pathname !== AUTH_REDIRECT.path → 404
    Note over S: error msg uses AUTH_REDIRECT.origin

    A-->>C: import AUTH_REDIRECT
    Note over C: waitingCallback uses<br/>AUTH_REDIRECT.host:AUTH_REDIRECT.port
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Fredirect-uri-ssot%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fredirect-uri-ssot%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atest%2Fauth.test.ts%3A253-279%0A**Dynamic%20import%20used%20where%20static%20import%20suffices**%0A%0AEach%20of%20the%20three%20%60AUTH_REDIRECT%60%20tests%20calls%20%60await%20import%28%22..%2Flib%2Fauth%2Fauth.js%22%29%60%20to%20obtain%20the%20export%2C%20but%20the%20module%20is%20already%20loaded%20via%20the%20static%20import%20at%20lines%202%E2%80%9314.%20All%20ESM%20modules%20are%20cached%20per-realm%2C%20so%20the%20three%20%60await%20import%28%29%60%20calls%20return%20the%20same%20instance%20%E2%80%94%20the%20extra%20dynamic%20import%20is%20unnecessary%20and%20makes%20the%20tests%20async%20when%20they%20don't%20need%20to%20be.%0A%0AAdd%20%60AUTH_REDIRECT%60%20to%20the%20existing%20static%20import%3A%0A%0A%60%60%60suggestion%0Aimport%20%7B%0A%09createState%2C%0A%09parseAuthorizationInput%2C%0A%09decodeJWT%2C%0A%09createAuthorizationFlow%2C%0A%09redactOAuthUrlForLog%2C%0A%09refreshAccessToken%2C%0A%09exchangeAuthorizationCode%2C%0A%09AUTH_REDIRECT%2C%0A%09CLIENT_ID%2C%0A%09AUTHORIZE_URL%2C%0A%09REDIRECT_URI%2C%0A%09SCOPE%2C%0A%7D%20from%20%22..%2Flib%2Fauth%2Fauth.js%22%3B%0A%60%60%60%0A%0AThen%20each%20%60it%60%20block%20can%20drop%20the%20%60async%60%20keyword%20and%20the%20internal%20%60await%20import%28%29%60%20line%2C%20keeping%20them%20synchronous%20and%20consistent%20with%20adjacent%20tests.%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fcodex-manager-cli.test.ts%3A67-73%0A**Mock%20%60AUTH_REDIRECT%60%20is%20not%20frozen**%0A%0AProduction%20%60AUTH_REDIRECT%60%20is%20created%20with%20%60Object.freeze%28%29%60%3B%20the%20mock%20here%20is%20a%20plain%20object%20literal.%20any%20test%20path%20that%20calls%20%60Object.isFrozen%28AUTH_REDIRECT%29%60%20%28or%20relies%20on%20property%20assignments%20throwing%20in%20strict%20mode%29%20will%20diverge%20from%20production%20behavior.%20wrap%20the%20mock%20to%20match%3A%0A%0A%60%60%60suggestion%0A%09AUTH_REDIRECT%3A%20Object.freeze%28%7B%0A%09%09host%3A%20%22localhost%22%2C%0A%09%09port%3A%201455%2C%0A%09%09path%3A%20%22%2Fauth%2Fcallback%22%2C%0A%09%09origin%3A%20%22http%3A%2F%2Flocalhost%3A1455%22%2C%0A%09%09url%3A%20%22http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback%22%2C%0A%09%7D%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fui%2Fcopy.ts%3A72%0A**No%20vitest%20coverage%20for%20%60waitingCallback%60%20derivation**%0A%0A%60waitingCallback%60%20was%20updated%20to%20derive%20from%20%60AUTH_REDIRECT%60%2C%20but%20neither%20%60test%2Fauth.test.ts%60%20nor%20any%20copy%2FUI%20test%20asserts%20the%20rendered%20string.%20given%20the%2080%25%20threshold%20and%20the%20project%20rule%20to%20flag%20missing%20coverage%2C%20add%20a%20test%20that%20imports%20%60UI_COPY%60%20and%20%60AUTH_REDIRECT%60%20and%20asserts%3A%0A%0A%60%60%60ts%0Aexpect%28UI_COPY.loginFlow.waitingCallback%29.toBe%28%0A%20%20%60Waiting%20for%20login%20callback%20on%20%24%7BAUTH_REDIRECT.host%7D%3A%24%7BAUTH_REDIRECT.port%7D...%60%0A%29%3B%0A%60%60%60%0A%0Athis%20would%20also%20serve%20as%20a%20canary%20alongside%20the%20%60AUTH_REDIRECT.port%20%3D%3D%3D%201455%60%20invariant%20test.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/auth.test.ts
Line: 253-279

Comment:
**Dynamic import used where static import suffices**

Each of the three `AUTH_REDIRECT` tests calls `await import("../lib/auth/auth.js")` to obtain the export, but the module is already loaded via the static import at lines 2–14. All ESM modules are cached per-realm, so the three `await import()` calls return the same instance — the extra dynamic import is unnecessary and makes the tests async when they don't need to be.

Add `AUTH_REDIRECT` to the existing static import:

```suggestion
import {
	createState,
	parseAuthorizationInput,
	decodeJWT,
	createAuthorizationFlow,
	redactOAuthUrlForLog,
	refreshAccessToken,
	exchangeAuthorizationCode,
	AUTH_REDIRECT,
	CLIENT_ID,
	AUTHORIZE_URL,
	REDIRECT_URI,
	SCOPE,
} from "../lib/auth/auth.js";
```

Then each `it` block can drop the `async` keyword and the internal `await import()` line, keeping them synchronous and consistent with adjacent tests.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-cli.test.ts
Line: 67-73

Comment:
**Mock `AUTH_REDIRECT` is not frozen**

Production `AUTH_REDIRECT` is created with `Object.freeze()`; the mock here is a plain object literal. any test path that calls `Object.isFrozen(AUTH_REDIRECT)` (or relies on property assignments throwing in strict mode) will diverge from production behavior. wrap the mock to match:

```suggestion
	AUTH_REDIRECT: Object.freeze({
		host: "localhost",
		port: 1455,
		path: "/auth/callback",
		origin: "http://localhost:1455",
		url: "http://localhost:1455/auth/callback",
	}),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/ui/copy.ts
Line: 72

Comment:
**No vitest coverage for `waitingCallback` derivation**

`waitingCallback` was updated to derive from `AUTH_REDIRECT`, but neither `test/auth.test.ts` nor any copy/UI test asserts the rendered string. given the 80% threshold and the project rule to flag missing coverage, add a test that imports `UI_COPY` and `AUTH_REDIRECT` and asserts:

```ts
expect(UI_COPY.loginFlow.waitingCallback).toBe(
  `Waiting for login callback on ${AUTH_REDIRECT.host}:${AUTH_REDIRECT.port}...`
);
```

this would also serve as a canary alongside the `AUTH_REDIRECT.port === 1455` invariant test.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(test): add AUTH\_REDIRECT to codex-ma..."](https://github.com/ndycode/codex-multi-auth/commit/475ea374a007f8e5102bbfe37a601cad8df1756f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28720389)</sub>

<!-- /greptile_comment -->