### PR TITLE
fix(routing): hybrid selector returns null when no accounts are available

### DIFF
--- a/lib/rotation.ts
+++ b/lib/rotation.ts
@@ -15,38 +15,41 @@ const log = createLogger("rotation");
 // ============================================================================
 
 export interface HealthScoreConfig {
-  /** Points added on successful request */
-  successDelta: number;
-  /** Points deducted on rate limit (negative) */
-  rateLimitDelta: number;
-  /** Points deducted on other failures (negative) */
-  failureDelta: number;
-  /** Maximum health score */
-  maxScore: number;
-  /** Minimum health score */
-  minScore: number;
-  /** Points recovered per hour of inactivity */
-  passiveRecoveryPerHour: number;
+	/** Points added on successful request */
+	successDelta: number;
+	/** Points deducted on rate limit (negative) */
+	rateLimitDelta: number;
+	/** Points deducted on other failures (negative) */
+	failureDelta: number;
+	/** Maximum health score */
+	maxScore: number;
+	/** Minimum health score */
+	minScore: number;
+	/** Points recovered per hour of inactivity */
+	passiveRecoveryPerHour: number;
 }
 
 export const DEFAULT_HEALTH_SCORE_CONFIG: HealthScoreConfig = {
-  successDelta: 1,
-  rateLimitDelta: -10,
-  failureDelta: -20,
-  maxScore: 100,
-  minScore: 0,
-  passiveRecoveryPerHour: 2,
+	successDelta: 1,
+	rateLimitDelta: -10,
+	failureDelta: -20,
+	maxScore: 100,
+	minScore: 0,
+	passiveRecoveryPerHour: 2,
 };
 
 interface HealthEntry {
-  score: number;
-  lastUpdated: number;
-  consecutiveFailures: number;
+	score: number;
+	lastUpdated: number;
+	consecutiveFailures: number;
 }
 
 type TrackerKey = number | string;
 
-function normalizeTrackerKey(accountKey: TrackerKey, quotaKey?: string): string {
+function normalizeTrackerKey(
+	accountKey: TrackerKey,
+	quotaKey?: string,
+): string {
 	const normalizedKey =
 		typeof accountKey === "number" ? `${accountKey}` : accountKey;
 	return JSON.stringify([normalizedKey, quotaKey ?? null]);
@@ -57,81 +60,96 @@ function normalizeTrackerKey(accountKey: TrackerKey, quotaKey?: string): string 
  * Accounts with higher health scores are preferred for selection.
  */
 export class HealthScoreTracker {
-  private entries: Map<string, HealthEntry> = new Map();
-  private config: HealthScoreConfig;
+	private entries: Map<string, HealthEntry> = new Map();
+	private config: HealthScoreConfig;
 
-  constructor(config: Partial<HealthScoreConfig> = {}) {
-    this.config = { ...DEFAULT_HEALTH_SCORE_CONFIG, ...config };
-  }
+	constructor(config: Partial<HealthScoreConfig> = {}) {
+		this.config = { ...DEFAULT_HEALTH_SCORE_CONFIG, ...config };
+	}
 
-  private getKey(accountKey: TrackerKey, quotaKey?: string): string {
-    return normalizeTrackerKey(accountKey, quotaKey);
-  }
+	private getKey(accountKey: TrackerKey, quotaKey?: string): string {
+		return normalizeTrackerKey(accountKey, quotaKey);
+	}
 
-  private applyPassiveRecovery(entry: HealthEntry): number {
-    const now = Date.now();
-    const hoursSinceUpdate = (now - entry.lastUpdated) / (1000 * 60 * 60);
-    const recovery = hoursSinceUpdate * this.config.passiveRecoveryPerHour;
-    return Math.min(entry.score + recovery, this.config.maxScore);
-  }
+	private applyPassiveRecovery(entry: HealthEntry): number {
+		const now = Date.now();
+		const hoursSinceUpdate = (now - entry.lastUpdated) / (1000 * 60 * 60);
+		const recovery = hoursSinceUpdate * this.config.passiveRecoveryPerHour;
+		return Math.min(entry.score + recovery, this.config.maxScore);
+	}
 
-  getScore(accountKey: TrackerKey, quotaKey?: string): number {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    if (!entry) return this.config.maxScore;
-    return this.applyPassiveRecovery(entry);
-  }
+	getScore(accountKey: TrackerKey, quotaKey?: string): number {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		if (!entry) return this.config.maxScore;
+		return this.applyPassiveRecovery(entry);
+	}
 
-  getConsecutiveFailures(accountKey: TrackerKey, quotaKey?: string): number {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    return entry?.consecutiveFailures ?? 0;
-  }
+	getConsecutiveFailures(accountKey: TrackerKey, quotaKey?: string): number {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		return entry?.consecutiveFailures ?? 0;
+	}
 
-  recordSuccess(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
-    const newScore = Math.min(baseScore + this.config.successDelta, this.config.maxScore);
-    this.entries.set(key, {
-      score: newScore,
-      lastUpdated: Date.now(),
-      consecutiveFailures: 0,
-    });
-  }
+	recordSuccess(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		const baseScore = entry
+			? this.applyPassiveRecovery(entry)
+			: this.config.maxScore;
+		const newScore = Math.min(
+			baseScore + this.config.successDelta,
+			this.config.maxScore,
+		);
+		this.entries.set(key, {
+			score: newScore,
+			lastUpdated: Date.now(),
+			consecutiveFailures: 0,
+		});
+	}
 
-  recordRateLimit(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
-    const newScore = Math.max(baseScore + this.config.rateLimitDelta, this.config.minScore);
-    this.entries.set(key, {
-      score: newScore,
-      lastUpdated: Date.now(),
-      consecutiveFailures: (entry?.consecutiveFailures ?? 0) + 1,
-    });
-  }
+	recordRateLimit(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		const baseScore = entry
+			? this.applyPassiveRecovery(entry)
+			: this.config.maxScore;
+		const newScore = Math.max(
+			baseScore + this.config.rateLimitDelta,
+			this.config.minScore,
+		);
+		this.entries.set(key, {
+			score: newScore,
+			lastUpdated: Date.now(),
+			consecutiveFailures: (entry?.consecutiveFailures ?? 0) + 1,
+		});
+	}
 
-  recordFailure(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
-    const newScore = Math.max(baseScore + this.config.failureDelta, this.config.minScore);
-    this.entries.set(key, {
-      score: newScore,
-      lastUpdated: Date.now(),
-      consecutiveFailures: (entry?.consecutiveFailures ?? 0) + 1,
-    });
-  }
+	recordFailure(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		const baseScore = entry
+			? this.applyPassiveRecovery(entry)
+			: this.config.maxScore;
+		const newScore = Math.max(
+			baseScore + this.config.failureDelta,
+			this.config.minScore,
+		);
+		this.entries.set(key, {
+			score: newScore,
+			lastUpdated: Date.now(),
+			consecutiveFailures: (entry?.consecutiveFailures ?? 0) + 1,
+		});
+	}
 
-  reset(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    this.entries.delete(key);
-  }
+	reset(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		this.entries.delete(key);
+	}
 
-  clear(): void {
-    this.entries.clear();
-  }
+	clear(): void {
+		this.entries.clear();
+	}
 }
 
 // ============================================================================
@@ -139,23 +157,23 @@ export class HealthScoreTracker {
 // ============================================================================
 
 export interface TokenBucketConfig {
-  /** Maximum tokens in bucket */
-  maxTokens: number;
-  /** Tokens regenerated per minute */
-  tokensPerMinute: number;
+	/** Maximum tokens in bucket */
+	maxTokens: number;
+	/** Tokens regenerated per minute */
+	tokensPerMinute: number;
 }
 
 export const DEFAULT_TOKEN_BUCKET_CONFIG: TokenBucketConfig = {
-  maxTokens: 50,
-  tokensPerMinute: 6,
+	maxTokens: 50,
+	tokensPerMinute: 6,
 };
 
 const TOKEN_REFUND_WINDOW_MS = 30_000;
 
 interface TokenBucketEntry {
-  tokens: number;
-  lastRefill: number;
-  consumptions: number[];
+	tokens: number;
+	lastRefill: number;
+	consumptions: number[];
 }
 
 /**
@@ -163,109 +181,117 @@ interface TokenBucketEntry {
  * Prevents sending requests to accounts that are likely to be rate-limited.
  */
 export class TokenBucketTracker {
-  private buckets: Map<string, TokenBucketEntry> = new Map();
-  private config: TokenBucketConfig;
+	private buckets: Map<string, TokenBucketEntry> = new Map();
+	private config: TokenBucketConfig;
 
-  constructor(config: Partial<TokenBucketConfig> = {}) {
-    this.config = { ...DEFAULT_TOKEN_BUCKET_CONFIG, ...config };
-  }
+	constructor(config: Partial<TokenBucketConfig> = {}) {
+		this.config = { ...DEFAULT_TOKEN_BUCKET_CONFIG, ...config };
+	}
 
-  private getKey(accountKey: TrackerKey, quotaKey?: string): string {
-    return normalizeTrackerKey(accountKey, quotaKey);
-  }
+	private getKey(accountKey: TrackerKey, quotaKey?: string): string {
+		return normalizeTrackerKey(accountKey, quotaKey);
+	}
 
-  private refillTokens(entry: TokenBucketEntry): number {
-    const now = Date.now();
-    const minutesSinceRefill = (now - entry.lastRefill) / (1000 * 60);
-    const tokensToAdd = minutesSinceRefill * this.config.tokensPerMinute;
-    return Math.min(entry.tokens + tokensToAdd, this.config.maxTokens);
-  }
+	private refillTokens(entry: TokenBucketEntry): number {
+		const now = Date.now();
+		const minutesSinceRefill = (now - entry.lastRefill) / (1000 * 60);
+		const tokensToAdd = minutesSinceRefill * this.config.tokensPerMinute;
+		return Math.min(entry.tokens + tokensToAdd, this.config.maxTokens);
+	}
 
-  getTokens(accountKey: TrackerKey, quotaKey?: string): number {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.buckets.get(key);
-    if (!entry) return this.config.maxTokens;
-    return this.refillTokens(entry);
-  }
+	getTokens(accountKey: TrackerKey, quotaKey?: string): number {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.buckets.get(key);
+		if (!entry) return this.config.maxTokens;
+		return this.refillTokens(entry);
+	}
 
-  /**
-   * Attempt to consume a token. Returns true if successful, false if bucket is empty.
-   */
-  tryConsume(accountKey: TrackerKey, quotaKey?: string): boolean {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.buckets.get(key);
-    const currentTokens = entry ? this.refillTokens(entry) : this.config.maxTokens;
+	/**
+	 * Attempt to consume a token. Returns true if successful, false if bucket is empty.
+	 */
+	tryConsume(accountKey: TrackerKey, quotaKey?: string): boolean {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.buckets.get(key);
+		const currentTokens = entry
+			? this.refillTokens(entry)
+			: this.config.maxTokens;
 
-    if (currentTokens < 1) {
-      return false;
-    }
+		if (currentTokens < 1) {
+			return false;
+		}
 
-    const now = Date.now();
-    const cutoff = now - TOKEN_REFUND_WINDOW_MS;
-    const consumptions = (entry?.consumptions ?? []).filter(
-      (timestamp) => timestamp >= cutoff
-    );
-    consumptions.push(now);
+		const now = Date.now();
+		const cutoff = now - TOKEN_REFUND_WINDOW_MS;
+		const consumptions = (entry?.consumptions ?? []).filter(
+			(timestamp) => timestamp >= cutoff,
+		);
+		consumptions.push(now);
 
-    this.buckets.set(key, {
-      tokens: currentTokens - 1,
-      lastRefill: now,
-      consumptions,
-    });
-    return true;
-  }
+		this.buckets.set(key, {
+			tokens: currentTokens - 1,
+			lastRefill: now,
+			consumptions,
+		});
+		return true;
+	}
 
-  /**
-   * Attempt to refund a token consumed within the refund window.
-   * Use this when a request fails due to network errors (not rate limits).
-   * @returns true if refund was successful, false if no valid consumption found
-   */
-  refundToken(accountKey: TrackerKey, quotaKey?: string): boolean {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.buckets.get(key);
-    if (!entry || entry.consumptions.length === 0) return false;
+	/**
+	 * Attempt to refund a token consumed within the refund window.
+	 * Use this when a request fails due to network errors (not rate limits).
+	 * @returns true if refund was successful, false if no valid consumption found
+	 */
+	refundToken(accountKey: TrackerKey, quotaKey?: string): boolean {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.buckets.get(key);
+		if (!entry || entry.consumptions.length === 0) return false;
 
-    const now = Date.now();
-    const cutoff = now - TOKEN_REFUND_WINDOW_MS;
+		const now = Date.now();
+		const cutoff = now - TOKEN_REFUND_WINDOW_MS;
 
-    const validIndex = entry.consumptions.findIndex(
-      (timestamp) => timestamp >= cutoff
-    );
-    if (validIndex === -1) return false;
+		const validIndex = entry.consumptions.findIndex(
+			(timestamp) => timestamp >= cutoff,
+		);
+		if (validIndex === -1) return false;
 
-    entry.consumptions.splice(validIndex, 1);
-    const currentTokens = this.refillTokens(entry);
-    this.buckets.set(key, {
-      tokens: Math.min(currentTokens + 1, this.config.maxTokens),
-      lastRefill: now,
-      consumptions: entry.consumptions,
-    });
+		entry.consumptions.splice(validIndex, 1);
+		const currentTokens = this.refillTokens(entry);
+		this.buckets.set(key, {
+			tokens: Math.min(currentTokens + 1, this.config.maxTokens),
+			lastRefill: now,
+			consumptions: entry.consumptions,
+		});
 
-    return true;
-  }
+		return true;
+	}
 
-  /**
-   * Drain tokens on rate limit to prevent immediate retries.
-   */
-  drain(accountKey: TrackerKey, quotaKey?: string, drainAmount: number = 10): void {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.buckets.get(key);
-    const currentTokens = entry ? this.refillTokens(entry) : this.config.maxTokens;
-    this.buckets.set(key, {
-      tokens: Math.max(0, currentTokens - drainAmount),
-      lastRefill: Date.now(),
-      consumptions: entry?.consumptions ?? [],
-    });
-  }
+	/**
+	 * Drain tokens on rate limit to prevent immediate retries.
+	 */
+	drain(
+		accountKey: TrackerKey,
+		quotaKey?: string,
+		drainAmount: number = 10,
+	): void {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.buckets.get(key);
+		const currentTokens = entry
+			? this.refillTokens(entry)
+			: this.config.maxTokens;
+		this.buckets.set(key, {
+			tokens: Math.max(0, currentTokens - drainAmount),
+			lastRefill: Date.now(),
+			consumptions: entry?.consumptions ?? [],
+		});
+	}
 
-  reset(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    this.buckets.delete(key);
-  }
+	reset(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		this.buckets.delete(key);
+	}
 
-  clear(): void {
-    this.buckets.clear();
-  }
+	clear(): void {
+		this.buckets.clear();
+	}
 }
 
 // ============================================================================
@@ -273,25 +299,25 @@ export class TokenBucketTracker {
 // ============================================================================
 
 export interface AccountWithMetrics {
-  index: number;
-  trackerKey?: TrackerKey;
-  isAvailable: boolean;
-  lastUsed: number;
+	index: number;
+	trackerKey?: TrackerKey;
+	isAvailable: boolean;
+	lastUsed: number;
 }
 
 export interface HybridSelectionConfig {
-  /** Weight for health score (default: 2) */
-  healthWeight: number;
-  /** Weight for token count (default: 5) */
-  tokenWeight: number;
-  /** Weight for freshness/last used (default: 0.1) */
-  freshnessWeight: number;
+	/** Weight for health score (default: 2) */
+	healthWeight: number;
+	/** Weight for token count (default: 5) */
+	tokenWeight: number;
+	/** Weight for freshness/last used (default: 0.1) */
+	freshnessWeight: number;
 }
 
 export const DEFAULT_HYBRID_SELECTION_CONFIG: HybridSelectionConfig = {
-  healthWeight: 2,
-  tokenWeight: 5,
-  freshnessWeight: 2.0,
+	healthWeight: 2,
+	tokenWeight: 5,
+	freshnessWeight: 2.0,
 };
 
 /**
@@ -305,20 +331,20 @@ export const DEFAULT_HYBRID_SELECTION_CONFIG: HybridSelectionConfig = {
  * - freshness: Hours since last used (higher = more fresh for rotation)
  */
 export interface HybridSelectionOptions {
-  pidOffsetEnabled?: boolean;
-  scoreBoostByAccount?: Record<number, number>;
+	pidOffsetEnabled?: boolean;
+	scoreBoostByAccount?: Record<number, number>;
 }
 
 /**
  * Named-parameter alternative for selectHybridAccount to avoid brittle positional arguments.
  */
 export interface SelectHybridAccountParams {
-  accounts: AccountWithMetrics[];
-  healthTracker: HealthScoreTracker;
-  tokenTracker: TokenBucketTracker;
-  quotaKey?: string;
-  config?: Partial<HybridSelectionConfig>;
-  options?: HybridSelectionOptions;
+	accounts: AccountWithMetrics[];
+	healthTracker: HealthScoreTracker;
+	tokenTracker: TokenBucketTracker;
+	quotaKey?: string;
+	config?: Partial<HybridSelectionConfig>;
+	options?: HybridSelectionOptions;
 }
 
 /**
@@ -337,113 +363,124 @@ export interface SelectHybridAccountParams {
  * - The function is purely in-memory and performs no filesystem operations (no Windows filesystem considerations).
  */
 export function selectHybridAccount(
-  params: SelectHybridAccountParams,
+	params: SelectHybridAccountParams,
 ): AccountWithMetrics | null;
 export function selectHybridAccount(
-  accounts: AccountWithMetrics[],
-  healthTracker: HealthScoreTracker,
-  tokenTracker: TokenBucketTracker,
-  quotaKey?: string,
-  config?: Partial<HybridSelectionConfig>,
-  options?: HybridSelectionOptions,
+	accounts: AccountWithMetrics[],
+	healthTracker: HealthScoreTracker,
+	tokenTracker: TokenBucketTracker,
+	quotaKey?: string,
+	config?: Partial<HybridSelectionConfig>,
+	options?: HybridSelectionOptions,
 ): AccountWithMetrics | null;
 export function selectHybridAccount(
-  accountsOrParams: AccountWithMetrics[] | SelectHybridAccountParams,
-  healthTracker?: HealthScoreTracker,
-  tokenTracker?: TokenBucketTracker,
-  quotaKey?: string,
-  config: Partial<HybridSelectionConfig> = {},
-  options: HybridSelectionOptions = {},
+	accountsOrParams: AccountWithMetrics[] | SelectHybridAccountParams,
+	healthTracker?: HealthScoreTracker,
+	tokenTracker?: TokenBucketTracker,
+	quotaKey?: string,
+	config: Partial<HybridSelectionConfig> = {},
+	options: HybridSelectionOptions = {},
 ): AccountWithMetrics | null {
-  const namedParams =
-    !Array.isArray(accountsOrParams) &&
-    accountsOrParams !== null &&
-    typeof accountsOrParams === "object"
-      ? accountsOrParams
-      : null;
-  const resolvedAccounts = namedParams ? namedParams.accounts : accountsOrParams;
-  const resolvedHealthTracker = namedParams ? namedParams.healthTracker : healthTracker;
-  const resolvedTokenTracker = namedParams ? namedParams.tokenTracker : tokenTracker;
-  const resolvedQuotaKey = namedParams ? namedParams.quotaKey : quotaKey;
-  const resolvedConfig = namedParams ? (namedParams.config ?? {}) : config;
-  const resolvedOptions = namedParams ? (namedParams.options ?? {}) : options;
+	const namedParams =
+		!Array.isArray(accountsOrParams) &&
+		accountsOrParams !== null &&
+		typeof accountsOrParams === "object"
+			? accountsOrParams
+			: null;
+	const resolvedAccounts = namedParams
+		? namedParams.accounts
+		: accountsOrParams;
+	const resolvedHealthTracker = namedParams
+		? namedParams.healthTracker
+		: healthTracker;
+	const resolvedTokenTracker = namedParams
+		? namedParams.tokenTracker
+		: tokenTracker;
+	const resolvedQuotaKey = namedParams ? namedParams.quotaKey : quotaKey;
+	const resolvedConfig = namedParams ? (namedParams.config ?? {}) : config;
+	const resolvedOptions = namedParams ? (namedParams.options ?? {}) : options;
 
-  if (!Array.isArray(resolvedAccounts)) {
-    throw new TypeError("selectHybridAccount requires accounts to be an array");
-  }
-  if (!resolvedHealthTracker || !resolvedTokenTracker) {
-    throw new TypeError("selectHybridAccount requires healthTracker and tokenTracker");
-  }
+	if (!Array.isArray(resolvedAccounts)) {
+		throw new TypeError("selectHybridAccount requires accounts to be an array");
+	}
+	if (!resolvedHealthTracker || !resolvedTokenTracker) {
+		throw new TypeError(
+			"selectHybridAccount requires healthTracker and tokenTracker",
+		);
+	}
 
-  const cfg = { ...DEFAULT_HYBRID_SELECTION_CONFIG, ...resolvedConfig };
-  const available = resolvedAccounts.filter((a) => a.isAvailable);
+	const cfg = { ...DEFAULT_HYBRID_SELECTION_CONFIG, ...resolvedConfig };
+	const available = resolvedAccounts.filter((a) => a.isAvailable);
 
-  if (available.length === 0) {
-    if (resolvedAccounts.length === 0) return null;
-    let leastRecentlyUsed: AccountWithMetrics | null = null;
-    let oldestTime = Infinity;
-    for (const account of resolvedAccounts) {
-      if (account.lastUsed < oldestTime) {
-        oldestTime = account.lastUsed;
-        leastRecentlyUsed = account;
-      }
-    }
-    return leastRecentlyUsed;
-  }
-  // istanbul ignore next -- defensive: available[0] always exists when length === 1
-  if (available.length === 1) return available[0] ?? null;
+	// Contract: if NO account is currently available (all cooling down, rate-limited,
+	// circuit-open, or otherwise blocked) the selector returns null rather than
+	// handing back a known-unavailable candidate via an LRU fallback. Returning an
+	// unavailable account caused avoidable churn when the fetch loop trusted the
+	// result without re-validating (AUDIT-H2 / D-01). The caller is now responsible
+	// for surfacing the "no available accounts" condition (pool-wide cooldown,
+	// fast-fail, etc.) instead of retrying through a blocked candidate.
+	if (available.length === 0) {
+		return null;
+	}
+	// istanbul ignore next -- defensive: available[0] always exists when length === 1
+	if (available.length === 1) return available[0] ?? null;
 
-  const now = Date.now();
-  let bestAccount: AccountWithMetrics | null = null;
-  let bestScore = -Infinity;
+	const now = Date.now();
+	let bestAccount: AccountWithMetrics | null = null;
+	let bestScore = -Infinity;
 
-  // PID offset: distribute account selection across parallel processes
-  // Each process gets a small deterministic bonus based on its PID
-  const pidBonus = resolvedOptions.pidOffsetEnabled ? (process.pid % 100) * 0.01 : 0;
+	// PID offset: distribute account selection across parallel processes
+	// Each process gets a small deterministic bonus based on its PID
+	const pidBonus = resolvedOptions.pidOffsetEnabled
+		? (process.pid % 100) * 0.01
+		: 0;
 
-  for (const account of available) {
-    const trackerKey = account.trackerKey ?? account.index;
-    const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
-    const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
-    const hoursSinceUsed = (now - account.lastUsed) / (1000 * 60 * 60);
+	for (const account of available) {
+		const trackerKey = account.trackerKey ?? account.index;
+		const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
+		const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
+		const hoursSinceUsed = (now - account.lastUsed) / (1000 * 60 * 60);
 
-    const capabilityBoost =
-      typeof resolvedOptions.scoreBoostByAccount?.[account.index] === "number"
-        ? resolvedOptions.scoreBoostByAccount[account.index] ?? 0
-        : 0;
-    const safeCapabilityBoost = Number.isFinite(capabilityBoost) ? capabilityBoost : 0;
+		const capabilityBoost =
+			typeof resolvedOptions.scoreBoostByAccount?.[account.index] === "number"
+				? (resolvedOptions.scoreBoostByAccount[account.index] ?? 0)
+				: 0;
+		const safeCapabilityBoost = Number.isFinite(capabilityBoost)
+			? capabilityBoost
+			: 0;
 
-    let score =
-      health * cfg.healthWeight +
-      tokens * cfg.tokenWeight +
-      hoursSinceUsed * cfg.freshnessWeight +
-      safeCapabilityBoost;
+		let score =
+			health * cfg.healthWeight +
+			tokens * cfg.tokenWeight +
+			hoursSinceUsed * cfg.freshnessWeight +
+			safeCapabilityBoost;
 
-    // PID-based offset distributes selection across parallel agents
-    if (resolvedOptions.pidOffsetEnabled) {
-      score += ((account.index * 0.131 + pidBonus) % 1) * cfg.freshnessWeight * 0.1;
-    }
+		// PID-based offset distributes selection across parallel agents
+		if (resolvedOptions.pidOffsetEnabled) {
+			score +=
+				((account.index * 0.131 + pidBonus) % 1) * cfg.freshnessWeight * 0.1;
+		}
 
-    if (score > bestScore) {
-      bestScore = score;
-      bestAccount = account;
-    }
-  }
+		if (score > bestScore) {
+			bestScore = score;
+			bestAccount = account;
+		}
+	}
 
-  if (bestAccount && available.length > 1) {
-    const trackerKey = bestAccount.trackerKey ?? bestAccount.index;
-    const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
-    const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
-    log.debug("Selected account", {
-      index: bestAccount.index,
-      health: Math.round(health),
-      tokens: Math.round(tokens),
-      score: Math.round(bestScore),
-      candidateCount: available.length,
-    });
-  }
+	if (bestAccount && available.length > 1) {
+		const trackerKey = bestAccount.trackerKey ?? bestAccount.index;
+		const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
+		const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
+		log.debug("Selected account", {
+			index: bestAccount.index,
+			health: Math.round(health),
+			tokens: Math.round(tokens),
+			score: Math.round(bestScore),
+			candidateCount: available.length,
+		});
+	}
 
-  return bestAccount;
+	return bestAccount;
 }
 
 // ============================================================================
@@ -457,8 +494,8 @@ export function selectHybridAccount(
  * @returns Delay with jitter applied
  */
 export function addJitter(baseMs: number, jitterFactor: number = 0.1): number {
-  const jitter = baseMs * jitterFactor * (Math.random() * 2 - 1);
-  return Math.max(0, Math.floor(baseMs + jitter));
+	const jitter = baseMs * jitterFactor * (Math.random() * 2 - 1);
+	return Math.max(0, Math.floor(baseMs + jitter));
 }
 
 /**
@@ -468,14 +505,14 @@ export function addJitter(baseMs: number, jitterFactor: number = 0.1): number {
  * @returns Random delay within range
  */
 export function randomDelay(minMs: number, maxMs: number): number {
-  return Math.floor(minMs + Math.random() * (maxMs - minMs));
+	return Math.floor(minMs + Math.random() * (maxMs - minMs));
 }
 
 export interface ExponentialBackoffOptions {
-  attempt: number;
-  baseMs?: number;
-  maxMs?: number;
-  jitterFactor?: number;
+	attempt: number;
+	baseMs?: number;
+	maxMs?: number;
+	jitterFactor?: number;
 }
 
 /**
@@ -488,52 +525,60 @@ export interface ExponentialBackoffOptions {
  */
 export function exponentialBackoff(options: ExponentialBackoffOptions): number;
 export function exponentialBackoff(
-  attempt: number,
-  baseMs?: number,
-  maxMs?: number,
-  jitterFactor?: number,
+	attempt: number,
+	baseMs?: number,
+	maxMs?: number,
+	jitterFactor?: number,
 ): number;
 export function exponentialBackoff(
-  attemptOrOptions: number | ExponentialBackoffOptions,
-  baseMs: number = 1000,
-  maxMs: number = 60000,
-  jitterFactor: number = 0.1,
+	attemptOrOptions: number | ExponentialBackoffOptions,
+	baseMs: number = 1000,
+	maxMs: number = 60000,
+	jitterFactor: number = 0.1,
 ): number {
-  const useNamedParams =
-    typeof attemptOrOptions === "object" && attemptOrOptions !== null;
-  const normalizedAttempt = useNamedParams
-    ? (attemptOrOptions as ExponentialBackoffOptions).attempt
-    : attemptOrOptions;
-  const normalizedBaseMs = useNamedParams
-    ? ((attemptOrOptions as ExponentialBackoffOptions).baseMs ?? 1000)
-    : baseMs;
-  const normalizedMaxMs = useNamedParams
-    ? ((attemptOrOptions as ExponentialBackoffOptions).maxMs ?? 60000)
-    : maxMs;
-  const normalizedJitterFactor = useNamedParams
-    ? ((attemptOrOptions as ExponentialBackoffOptions).jitterFactor ?? 0.1)
-    : jitterFactor;
-  if (!Number.isInteger(normalizedAttempt) || normalizedAttempt < 1) {
-    throw new TypeError("exponentialBackoff requires attempt to be a positive integer");
-  }
-  if (!Number.isFinite(normalizedBaseMs) || normalizedBaseMs < 0) {
-    throw new TypeError("exponentialBackoff requires baseMs to be a finite non-negative number");
-  }
-  if (!Number.isFinite(normalizedMaxMs) || normalizedMaxMs < 0) {
-    throw new TypeError("exponentialBackoff requires maxMs to be a finite non-negative number");
-  }
-  if (
-    !Number.isFinite(normalizedJitterFactor) ||
-    normalizedJitterFactor < 0 ||
-    normalizedJitterFactor > 1
-  ) {
-    throw new TypeError("exponentialBackoff requires jitterFactor to be between 0 and 1");
-  }
-  const delay = Math.min(
-    normalizedBaseMs * Math.pow(2, normalizedAttempt - 1),
-    normalizedMaxMs,
-  );
-  return addJitter(delay, normalizedJitterFactor);
+	const useNamedParams =
+		typeof attemptOrOptions === "object" && attemptOrOptions !== null;
+	const normalizedAttempt = useNamedParams
+		? (attemptOrOptions as ExponentialBackoffOptions).attempt
+		: attemptOrOptions;
+	const normalizedBaseMs = useNamedParams
+		? ((attemptOrOptions as ExponentialBackoffOptions).baseMs ?? 1000)
+		: baseMs;
+	const normalizedMaxMs = useNamedParams
+		? ((attemptOrOptions as ExponentialBackoffOptions).maxMs ?? 60000)
+		: maxMs;
+	const normalizedJitterFactor = useNamedParams
+		? ((attemptOrOptions as ExponentialBackoffOptions).jitterFactor ?? 0.1)
+		: jitterFactor;
+	if (!Number.isInteger(normalizedAttempt) || normalizedAttempt < 1) {
+		throw new TypeError(
+			"exponentialBackoff requires attempt to be a positive integer",
+		);
+	}
+	if (!Number.isFinite(normalizedBaseMs) || normalizedBaseMs < 0) {
+		throw new TypeError(
+			"exponentialBackoff requires baseMs to be a finite non-negative number",
+		);
+	}
+	if (!Number.isFinite(normalizedMaxMs) || normalizedMaxMs < 0) {
+		throw new TypeError(
+			"exponentialBackoff requires maxMs to be a finite non-negative number",
+		);
+	}
+	if (
+		!Number.isFinite(normalizedJitterFactor) ||
+		normalizedJitterFactor < 0 ||
+		normalizedJitterFactor > 1
+	) {
+		throw new TypeError(
+			"exponentialBackoff requires jitterFactor to be between 0 and 1",
+		);
+	}
+	const delay = Math.min(
+		normalizedBaseMs * Math.pow(2, normalizedAttempt - 1),
+		normalizedMaxMs,
+	);
+	return addJitter(delay, normalizedJitterFactor);
 }
 
 // ============================================================================
@@ -543,21 +588,25 @@ export function exponentialBackoff(
 let healthTrackerInstance: HealthScoreTracker | null = null;
 let tokenTrackerInstance: TokenBucketTracker | null = null;
 
-export function getHealthTracker(config?: Partial<HealthScoreConfig>): HealthScoreTracker {
-  if (!healthTrackerInstance) {
-    healthTrackerInstance = new HealthScoreTracker(config);
-  }
-  return healthTrackerInstance;
+export function getHealthTracker(
+	config?: Partial<HealthScoreConfig>,
+): HealthScoreTracker {
+	if (!healthTrackerInstance) {
+		healthTrackerInstance = new HealthScoreTracker(config);
+	}
+	return healthTrackerInstance;
 }
 
-export function getTokenTracker(config?: Partial<TokenBucketConfig>): TokenBucketTracker {
-  if (!tokenTrackerInstance) {
-    tokenTrackerInstance = new TokenBucketTracker(config);
-  }
-  return tokenTrackerInstance;
+export function getTokenTracker(
+	config?: Partial<TokenBucketConfig>,
+): TokenBucketTracker {
+	if (!tokenTrackerInstance) {
+		tokenTrackerInstance = new TokenBucketTracker(config);
+	}
+	return tokenTrackerInstance;
 }
 
 export function resetTrackers(): void {
-  healthTrackerInstance?.clear();
-  tokenTrackerInstance?.clear();
+	healthTrackerInstance?.clear();
+	tokenTrackerInstance?.clear();
 }

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1,3449 +1,3570 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
-  AccountManager,
-  extractAccountEmail,
-  formatAccountLabel,
-  parseRateLimitReason,
-  sanitizeEmail,
-  formatWaitTime,
-  formatCooldown,
-  shouldUpdateAccountIdFromToken,
-  getAccountIdCandidates,
-  getRuntimeTrackerKey,
+	AccountManager,
+	extractAccountEmail,
+	formatAccountLabel,
+	parseRateLimitReason,
+	sanitizeEmail,
+	formatWaitTime,
+	formatCooldown,
+	shouldUpdateAccountIdFromToken,
+	getAccountIdCandidates,
+	getRuntimeTrackerKey,
 } from "../lib/accounts.js";
-import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
+import {
+	getHealthTracker,
+	getTokenTracker,
+	resetTrackers,
+} from "../lib/rotation.js";
 import { CodexAuthError } from "../lib/errors.js";
 import {
-  clearCircuitBreakers,
-  DEFAULT_CIRCUIT_BREAKER_CONFIG,
-  getCircuitBreaker,
+	clearCircuitBreakers,
+	DEFAULT_CIRCUIT_BREAKER_CONFIG,
+	getCircuitBreaker,
 } from "../lib/circuit-breaker.js";
 import {
-  getAccountIdentityKey,
-  getRuntimeAccountIdentityKey,
+	getAccountIdentityKey,
+	getRuntimeAccountIdentityKey,
 } from "../lib/storage/identity.js";
 import {
-  getStoragePathState,
-  setStoragePathState,
+	getStoragePathState,
+	setStoragePathState,
 } from "../lib/storage/path-state.js";
 import type { OAuthAuthDetails } from "../lib/types.js";
 
 vi.mock("../lib/storage.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../lib/storage.js")>();
-  return {
-    ...actual,
-    saveAccounts: vi.fn().mockResolvedValue(undefined),
-    withAccountStorageTransaction: vi.fn(),
-  };
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		saveAccounts: vi.fn().mockResolvedValue(undefined),
+		withAccountStorageTransaction: vi.fn(),
+	};
 });
 
 beforeEach(async () => {
-  resetTrackers();
-  setStoragePathState({
-    currentStoragePath: null,
-    currentLegacyProjectStoragePath: null,
-    currentLegacyWorktreeStoragePath: null,
-    currentProjectRoot: null,
-  });
-  const { saveAccounts, withAccountStorageTransaction } = await import(
-    "../lib/storage.js"
-  );
-  const mockSaveAccounts = vi.mocked(saveAccounts);
-  const mockWithAccountStorageTransaction = vi.mocked(
-    withAccountStorageTransaction,
-  );
+	resetTrackers();
+	setStoragePathState({
+		currentStoragePath: null,
+		currentLegacyProjectStoragePath: null,
+		currentLegacyWorktreeStoragePath: null,
+		currentProjectRoot: null,
+	});
+	const { saveAccounts, withAccountStorageTransaction } = await import(
+		"../lib/storage.js"
+	);
+	const mockSaveAccounts = vi.mocked(saveAccounts);
+	const mockWithAccountStorageTransaction = vi.mocked(
+		withAccountStorageTransaction,
+	);
 
-  mockSaveAccounts.mockReset();
-  mockSaveAccounts.mockResolvedValue(undefined);
-  mockWithAccountStorageTransaction.mockReset();
-  mockWithAccountStorageTransaction.mockImplementation(async (handler) => {
-    let current = null;
-    const persist = async (storage: Parameters<typeof saveAccounts>[0]) => {
-      current = structuredClone(storage);
-      await mockSaveAccounts(storage);
-    };
-    return handler(current as never, persist);
-  });
+	mockSaveAccounts.mockReset();
+	mockSaveAccounts.mockResolvedValue(undefined);
+	mockWithAccountStorageTransaction.mockReset();
+	mockWithAccountStorageTransaction.mockImplementation(async (handler) => {
+		let current = null;
+		const persist = async (storage: Parameters<typeof saveAccounts>[0]) => {
+			current = structuredClone(storage);
+			await mockSaveAccounts(storage);
+		};
+		return handler(current as never, persist);
+	});
 });
 
 afterEach(() => {
-  setStoragePathState({
-    currentStoragePath: null,
-    currentLegacyProjectStoragePath: null,
-    currentLegacyWorktreeStoragePath: null,
-    currentProjectRoot: null,
-  });
+	setStoragePathState({
+		currentStoragePath: null,
+		currentLegacyProjectStoragePath: null,
+		currentLegacyWorktreeStoragePath: null,
+		currentProjectRoot: null,
+	});
 });
 
 describe("parseRateLimitReason", () => {
-  it("returns quota for quota-related codes", () => {
-    expect(parseRateLimitReason("usage_limit_reached")).toBe("quota");
-    expect(parseRateLimitReason("QUOTA_EXCEEDED")).toBe("quota");
-    expect(parseRateLimitReason("monthly_quota_limit")).toBe("quota");
-  });
+	it("returns quota for quota-related codes", () => {
+		expect(parseRateLimitReason("usage_limit_reached")).toBe("quota");
+		expect(parseRateLimitReason("QUOTA_EXCEEDED")).toBe("quota");
+		expect(parseRateLimitReason("monthly_quota_limit")).toBe("quota");
+	});
 
-  it("returns tokens for token-related codes", () => {
-    expect(parseRateLimitReason("tpm_limit")).toBe("tokens");
-    expect(parseRateLimitReason("rpm_exceeded")).toBe("tokens");
-    expect(parseRateLimitReason("token_limit_reached")).toBe("tokens");
-    expect(parseRateLimitReason("TPM_RATE_LIMIT")).toBe("tokens");
-  });
+	it("returns tokens for token-related codes", () => {
+		expect(parseRateLimitReason("tpm_limit")).toBe("tokens");
+		expect(parseRateLimitReason("rpm_exceeded")).toBe("tokens");
+		expect(parseRateLimitReason("token_limit_reached")).toBe("tokens");
+		expect(parseRateLimitReason("TPM_RATE_LIMIT")).toBe("tokens");
+	});
 
-  it("returns concurrent for concurrency codes", () => {
-    expect(parseRateLimitReason("concurrent_limit")).toBe("concurrent");
-    expect(parseRateLimitReason("parallel_requests_exceeded")).toBe("concurrent");
-  });
+	it("returns concurrent for concurrency codes", () => {
+		expect(parseRateLimitReason("concurrent_limit")).toBe("concurrent");
+		expect(parseRateLimitReason("parallel_requests_exceeded")).toBe(
+			"concurrent",
+		);
+	});
 
-  it("returns unknown for undefined", () => {
-    expect(parseRateLimitReason(undefined)).toBe("unknown");
-  });
+	it("returns unknown for undefined", () => {
+		expect(parseRateLimitReason(undefined)).toBe("unknown");
+	});
 
-  it("returns unknown for unrecognized codes", () => {
-    expect(parseRateLimitReason("some_other_error")).toBe("unknown");
-    expect(parseRateLimitReason("random_code")).toBe("unknown");
-  });
+	it("returns unknown for unrecognized codes", () => {
+		expect(parseRateLimitReason("some_other_error")).toBe("unknown");
+		expect(parseRateLimitReason("random_code")).toBe("unknown");
+	});
 });
 
 describe("sanitizeEmail", () => {
-  it("returns undefined for undefined/null", () => {
-    expect(sanitizeEmail(undefined)).toBeUndefined();
-  });
+	it("returns undefined for undefined/null", () => {
+		expect(sanitizeEmail(undefined)).toBeUndefined();
+	});
 
-  it("returns undefined for empty string", () => {
-    expect(sanitizeEmail("")).toBeUndefined();
-    expect(sanitizeEmail("   ")).toBeUndefined();
-  });
+	it("returns undefined for empty string", () => {
+		expect(sanitizeEmail("")).toBeUndefined();
+		expect(sanitizeEmail("   ")).toBeUndefined();
+	});
 
-  it("returns undefined for string without @", () => {
-    expect(sanitizeEmail("notanemail")).toBeUndefined();
-  });
+	it("returns undefined for string without @", () => {
+		expect(sanitizeEmail("notanemail")).toBeUndefined();
+	});
 
-  it("trims and lowercases valid email", () => {
-    expect(sanitizeEmail("  User@Example.COM  ")).toBe("user@example.com");
-  });
+	it("trims and lowercases valid email", () => {
+		expect(sanitizeEmail("  User@Example.COM  ")).toBe("user@example.com");
+	});
 
-  it("preserves valid email structure", () => {
-    expect(sanitizeEmail("test@domain.org")).toBe("test@domain.org");
-  });
+	it("preserves valid email structure", () => {
+		expect(sanitizeEmail("test@domain.org")).toBe("test@domain.org");
+	});
 });
 
 describe("formatWaitTime", () => {
-  it("formats zero as 0s", () => {
-    expect(formatWaitTime(0)).toBe("0s");
-  });
+	it("formats zero as 0s", () => {
+		expect(formatWaitTime(0)).toBe("0s");
+	});
 
-  it("formats negative as 0s", () => {
-    expect(formatWaitTime(-1000)).toBe("0s");
-  });
+	it("formats negative as 0s", () => {
+		expect(formatWaitTime(-1000)).toBe("0s");
+	});
 
-  it("formats seconds only when less than 60s", () => {
-    expect(formatWaitTime(45000)).toBe("45s");
-    expect(formatWaitTime(1000)).toBe("1s");
-  });
+	it("formats seconds only when less than 60s", () => {
+		expect(formatWaitTime(45000)).toBe("45s");
+		expect(formatWaitTime(1000)).toBe("1s");
+	});
 
-  it("formats minutes and seconds when 60s or more", () => {
-    expect(formatWaitTime(60000)).toBe("1m 0s");
-    expect(formatWaitTime(150000)).toBe("2m 30s");
-    expect(formatWaitTime(3600000)).toBe("60m 0s");
-  });
+	it("formats minutes and seconds when 60s or more", () => {
+		expect(formatWaitTime(60000)).toBe("1m 0s");
+		expect(formatWaitTime(150000)).toBe("2m 30s");
+		expect(formatWaitTime(3600000)).toBe("60m 0s");
+	});
 
-  it("rounds down partial seconds", () => {
-    expect(formatWaitTime(45500)).toBe("45s");
-    expect(formatWaitTime(150999)).toBe("2m 30s");
-  });
+	it("rounds down partial seconds", () => {
+		expect(formatWaitTime(45500)).toBe("45s");
+		expect(formatWaitTime(150999)).toBe("2m 30s");
+	});
 });
 
 describe("formatCooldown", () => {
-  it("returns null when coolingDownUntil is undefined", () => {
-    expect(formatCooldown({})).toBeNull();
-  });
+	it("returns null when coolingDownUntil is undefined", () => {
+		expect(formatCooldown({})).toBeNull();
+	});
 
-  it("returns null when cooldown has expired", () => {
-    const now = Date.now();
-    expect(formatCooldown({ coolingDownUntil: now - 1000 }, now)).toBeNull();
-    expect(formatCooldown({ coolingDownUntil: now }, now)).toBeNull();
-  });
+	it("returns null when cooldown has expired", () => {
+		const now = Date.now();
+		expect(formatCooldown({ coolingDownUntil: now - 1000 }, now)).toBeNull();
+		expect(formatCooldown({ coolingDownUntil: now }, now)).toBeNull();
+	});
 
-  it("returns formatted time when cooling down", () => {
-    const now = Date.now();
-    const result = formatCooldown({ coolingDownUntil: now + 30000 }, now);
-    expect(result).toBe("30s");
-  });
+	it("returns formatted time when cooling down", () => {
+		const now = Date.now();
+		const result = formatCooldown({ coolingDownUntil: now + 30000 }, now);
+		expect(result).toBe("30s");
+	});
 
-  it("includes reason when present", () => {
-    const now = Date.now();
-    const result = formatCooldown(
-      { coolingDownUntil: now + 60000, cooldownReason: "auth-failure" },
-      now,
-    );
-    expect(result).toBe("1m 0s (auth-failure)");
-  });
+	it("includes reason when present", () => {
+		const now = Date.now();
+		const result = formatCooldown(
+			{ coolingDownUntil: now + 60000, cooldownReason: "auth-failure" },
+			now,
+		);
+		expect(result).toBe("1m 0s (auth-failure)");
+	});
 
-  it("formats minutes and seconds with reason", () => {
-    const now = Date.now();
-    const result = formatCooldown(
-      { coolingDownUntil: now + 150000, cooldownReason: "network-error" },
-      now,
-    );
-    expect(result).toBe("2m 30s (network-error)");
-  });
+	it("formats minutes and seconds with reason", () => {
+		const now = Date.now();
+		const result = formatCooldown(
+			{ coolingDownUntil: now + 150000, cooldownReason: "network-error" },
+			now,
+		);
+		expect(result).toBe("2m 30s (network-error)");
+	});
 });
 
 describe("shouldUpdateAccountIdFromToken", () => {
-  it("returns true when currentAccountId is undefined", () => {
-    expect(shouldUpdateAccountIdFromToken("token", undefined)).toBe(true);
-  });
+	it("returns true when currentAccountId is undefined", () => {
+		expect(shouldUpdateAccountIdFromToken("token", undefined)).toBe(true);
+	});
 
-  it("returns true when source is undefined", () => {
-    expect(shouldUpdateAccountIdFromToken(undefined, "account-123")).toBe(true);
-  });
+	it("returns true when source is undefined", () => {
+		expect(shouldUpdateAccountIdFromToken(undefined, "account-123")).toBe(true);
+	});
 
-  it("returns true when source is token", () => {
-    expect(shouldUpdateAccountIdFromToken("token", "account-123")).toBe(true);
-  });
+	it("returns true when source is token", () => {
+		expect(shouldUpdateAccountIdFromToken("token", "account-123")).toBe(true);
+	});
 
-  it("returns true when source is id_token", () => {
-    expect(shouldUpdateAccountIdFromToken("id_token", "account-123")).toBe(true);
-  });
+	it("returns true when source is id_token", () => {
+		expect(shouldUpdateAccountIdFromToken("id_token", "account-123")).toBe(
+			true,
+		);
+	});
 
-  it("returns false when source is org (manual selection)", () => {
-    expect(shouldUpdateAccountIdFromToken("org", "account-123")).toBe(false);
-  });
+	it("returns false when source is org (manual selection)", () => {
+		expect(shouldUpdateAccountIdFromToken("org", "account-123")).toBe(false);
+	});
 
-  it("returns false when source is manual", () => {
-    expect(shouldUpdateAccountIdFromToken("manual", "account-123")).toBe(false);
-  });
+	it("returns false when source is manual", () => {
+		expect(shouldUpdateAccountIdFromToken("manual", "account-123")).toBe(false);
+	});
 });
 
 describe("getAccountIdCandidates", () => {
-  it("returns empty array when no tokens provided", () => {
-    expect(getAccountIdCandidates()).toEqual([]);
-  });
+	it("returns empty array when no tokens provided", () => {
+		expect(getAccountIdCandidates()).toEqual([]);
+	});
 
-  it("extracts account from access token", () => {
-    // Create a JWT with account_id in the claim path
-    const payload = {
-      "https://api.openai.com/auth": {
-        chatgpt_account_id: "test-account-123",
-      },
-    };
-    const token = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-    const candidates = getAccountIdCandidates(token);
-    expect(candidates.length).toBeGreaterThanOrEqual(1);
-    expect(candidates[0]?.accountId).toBe("test-account-123");
-    expect(candidates[0]?.source).toBe("token");
-    expect(candidates[0]?.isDefault).toBe(true);
-  });
+	it("extracts account from access token", () => {
+		// Create a JWT with account_id in the claim path
+		const payload = {
+			"https://api.openai.com/auth": {
+				chatgpt_account_id: "test-account-123",
+			},
+		};
+		const token = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+		const candidates = getAccountIdCandidates(token);
+		expect(candidates.length).toBeGreaterThanOrEqual(1);
+		expect(candidates[0]?.accountId).toBe("test-account-123");
+		expect(candidates[0]?.source).toBe("token");
+		expect(candidates[0]?.isDefault).toBe(true);
+	});
 
-  it("extracts email from id_token when present", () => {
-    const idPayload = { email: "user@example.com" };
-    const idToken = `header.${Buffer.from(JSON.stringify(idPayload)).toString("base64")}.signature`;
-    const email = extractAccountEmail(undefined, idToken);
-    expect(email).toBe("user@example.com");
-  });
+	it("extracts email from id_token when present", () => {
+		const idPayload = { email: "user@example.com" };
+		const idToken = `header.${Buffer.from(JSON.stringify(idPayload)).toString("base64")}.signature`;
+		const email = extractAccountEmail(undefined, idToken);
+		expect(email).toBe("user@example.com");
+	});
 });
 
 describe("AccountManager", () => {
-  it("seeds from fallback auth when no storage exists", () => {
-    const auth: OAuthAuthDetails = {
-      type: "oauth",
-      access: "access-token",
-      refresh: "refresh-token",
-      expires: Date.now() + 60_000,
-    };
-
-    const manager = new AccountManager(auth, null);
-    expect(manager.getAccountCount()).toBe(1);
-    expect(manager.getCurrentAccount()?.refreshToken).toBe("refresh-token");
-  });
-
-  it("returns account by index and rejects invalid indexes", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        { refreshToken: "token-2", addedAt: now, lastUsed: now },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    expect(manager.getAccountByIndex(0)?.refreshToken).toBe("token-1");
-    expect(manager.getAccountByIndex(1)?.refreshToken).toBe("token-2");
-    expect(manager.getAccountByIndex(-1)).toBeNull();
-    expect(manager.getAccountByIndex(9)).toBeNull();
-    expect(manager.getAccountByIndex(Number.NaN)).toBeNull();
-  });
-
-  it("does not disable a different current workspace after another request already rotated away", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-          workspaces: [
-            { id: "workspace-1", name: "Workspace 1", enabled: true },
-            { id: "workspace-2", name: "Workspace 2", enabled: true },
-          ],
-          currentWorkspaceIndex: 0,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    const account = manager.getAccountByIndex(0);
-    expect(account).not.toBeNull();
-    if (!account) {
-      throw new Error("account should exist");
-    }
-
-    expect(manager.disableCurrentWorkspace(account, "workspace-1")).toBe(true);
-    expect(manager.rotateToNextWorkspace(account)?.id).toBe("workspace-2");
-
-    expect(manager.disableCurrentWorkspace(account, "workspace-1")).toBe(false);
-    expect(account.enabled).not.toBe(false);
-    expect(manager.hasEnabledWorkspaces(account)).toBe(true);
-    expect(manager.getEnabledWorkspaceCount(account)).toBe(1);
-    expect(manager.getCurrentWorkspace(account)?.id).toBe("workspace-2");
-    expect(account.workspaces?.map((workspace) => workspace.enabled)).toEqual([false, true]);
-  });
-
-  it("re-enabling an exhausted account restores its workspaces", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-          enabled: false,
-          workspaces: [
-            { id: "workspace-1", name: "Workspace 1", enabled: false, disabledAt: now - 2_000, isDefault: true },
-            { id: "workspace-2", name: "Workspace 2", enabled: false, disabledAt: now - 1_000 },
-          ],
-          currentWorkspaceIndex: 1,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    const account = manager.setAccountEnabled(0, true);
-    expect(account).not.toBeNull();
-    if (!account) {
-      throw new Error("account should exist");
-    }
-
-    expect(account.enabled).toBe(true);
-    expect(manager.hasEnabledWorkspaces(account)).toBe(true);
-    expect(manager.getEnabledWorkspaceCount(account)).toBe(2);
-    expect(account.currentWorkspaceIndex).toBe(0);
-    expect(manager.getCurrentWorkspace(account)?.id).toBe("workspace-1");
-    expect(account.workspaces).toEqual([
-      { id: "workspace-1", name: "Workspace 1", enabled: true, isDefault: true },
-      { id: "workspace-2", name: "Workspace 2", enabled: true },
-    ]);
-  });
-
-  it("re-enabling an exhausted account without a default workspace resets to the first workspace", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-          enabled: false,
-          workspaces: [
-            { id: "workspace-1", name: "Workspace 1", enabled: false, disabledAt: now - 2_000 },
-            { id: "workspace-2", name: "Workspace 2", enabled: false, disabledAt: now - 1_000 },
-          ],
-          currentWorkspaceIndex: 1,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    const account = manager.setAccountEnabled(0, true);
-    expect(account).not.toBeNull();
-    if (!account) {
-      throw new Error("account should exist");
-    }
-
-    expect(account.currentWorkspaceIndex).toBe(0);
-    expect(manager.getCurrentWorkspace(account)?.id).toBe("workspace-1");
-    expect(account.workspaces).toEqual([
-      { id: "workspace-1", name: "Workspace 1", enabled: true },
-      { id: "workspace-2", name: "Workspace 2", enabled: true },
-    ]);
-  });
-
-  it("checks account availability by enabled/rate-limit/cooldown state", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-          enabled: false,
-        },
-        {
-          refreshToken: "token-2",
-          addedAt: now,
-          lastUsed: now,
-          rateLimitResetTimes: { codex: now + 60_000 },
-        },
-        {
-          refreshToken: "token-3",
-          addedAt: now,
-          lastUsed: now,
-          coolingDownUntil: now + 60_000,
-          cooldownReason: "network-error" as const,
-        },
-        {
-          refreshToken: "token-4",
-          addedAt: now,
-          lastUsed: now,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-
-    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
-    expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(false);
-    expect(manager.isAccountAvailableForFamily(2, "codex")).toBe(false);
-    expect(manager.isAccountAvailableForFamily(3, "codex")).toBe(true);
-  });
-
-  it("treats accounts with all tracked workspaces disabled as unavailable for selection", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      activeIndexByFamily: { codex: 0 },
-      accounts: [
-        {
-          refreshToken: "token-workspace-disabled",
-          addedAt: now,
-          lastUsed: now,
-          workspaces: [
-            { id: "workspace-1", name: "Workspace 1", enabled: false },
-            { id: "workspace-2", name: "Workspace 2", enabled: false },
-          ],
-          currentWorkspaceIndex: 0,
-        },
-        {
-          refreshToken: "token-ready",
-          addedAt: now,
-          lastUsed: now - 10_000,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored as never);
-
-    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
-    expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe("token-ready");
-    expect(manager.getNextForFamily("codex")?.refreshToken).toBe("token-ready");
-    expect(manager.getCurrentOrNextForFamilyHybrid("codex")?.refreshToken).toBe("token-ready");
-  });
-
-  it("keeps workspace-less legacy accounts eligible for selection", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      activeIndexByFamily: { codex: 0 },
-      accounts: [{ refreshToken: "token-legacy", addedAt: now, lastUsed: now }],
-    };
-
-    const manager = new AccountManager(undefined, stored as never);
-
-    expect(manager.hasEnabledWorkspaces(manager.getAccountByIndex(0)!)).toBe(true);
-    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
-    expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe("token-legacy");
-  });
-
-  it("returns false for invalid account index in availability checks", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
-    };
-    const manager = new AccountManager(undefined, stored);
-    expect(manager.isAccountAvailableForFamily(-1, "codex")).toBe(false);
-    expect(manager.isAccountAvailableForFamily(99, "codex")).toBe(false);
-    expect(manager.isAccountAvailableForFamily(Number.NaN, "codex")).toBe(false);
-  });
-
-  it("clears expired rate-limit windows before availability check", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-          rateLimitResetTimes: { codex: now - 1_000 },
-        },
-      ],
-    };
-    const manager = new AccountManager(undefined, stored);
-    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
-    const account = manager.getAccountByIndex(0);
-    expect(account?.rateLimitResetTimes?.codex).toBeUndefined();
-  });
-
-  it("does not block available accounts just because another token expires later", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-stale",
-          accessToken: "access-stale",
-          expiresAt: now + 60_000,
-          addedAt: now,
-          lastUsed: now,
-        },
-        {
-          refreshToken: "token-fresh",
-          accessToken: "access-fresh",
-          expiresAt: now + 10 * 60_000,
-          addedAt: now,
-          lastUsed: now,
-        },
-      ],
-    };
-    const manager = new AccountManager(undefined, stored);
-
-    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
-    expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
-  });
-
-  it("keeps stale accounts available when the whole pool is stale", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-stale-1",
-          accessToken: "access-stale-1",
-          expiresAt: now + 60_000,
-          addedAt: now,
-          lastUsed: now,
-        },
-        {
-          refreshToken: "token-stale-2",
-          accessToken: "access-stale-2",
-          expiresAt: now + 120_000,
-          addedAt: now,
-          lastUsed: now,
-        },
-      ],
-    };
-    const manager = new AccountManager(undefined, stored);
-
-    expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
-    expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
-  });
-
-  it("rotates when the active account is rate-limited", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-          rateLimitResetTimes: { codex: now + 60_000 },
-        },
-        {
-          refreshToken: "token-2",
-          addedAt: now,
-          lastUsed: now,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    const account = manager.getCurrentOrNext();
-    expect(account?.refreshToken).toBe("token-2");
-    expect(manager.getMinWaitTime()).toBe(0);
-  });
-
-  it("skips accounts that are cooling down", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-          coolingDownUntil: now + 60_000,
-          cooldownReason: "auth-failure" as const,
-        },
-        {
-          refreshToken: "token-2",
-          addedAt: now,
-          lastUsed: now,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    const account = manager.getCurrentOrNext();
-    expect(account?.refreshToken).toBe("token-2");
-    expect(manager.getActiveIndex()).toBe(1);
-  });
-
-  it("returns min wait time when all accounts are blocked", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-          coolingDownUntil: now + 60_000,
-          cooldownReason: "network-error" as const,
-        },
-        {
-          refreshToken: "token-2",
-          addedAt: now,
-          lastUsed: now,
-          rateLimitResetTimes: { codex: now + 120_000 },
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    const waitMs = manager.getMinWaitTime();
-    expect(waitMs).toBeGreaterThan(0);
-    expect(waitMs).toBeLessThanOrEqual(60_000);
-  });
-
-  it("debounces account toasts for the same account index", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        {
-          refreshToken: "token-1",
-          addedAt: now,
-          lastUsed: now,
-        },
-        {
-          refreshToken: "token-2",
-          addedAt: now,
-          lastUsed: now,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    expect(manager.shouldShowAccountToast(0, 60_000)).toBe(true);
-    manager.markToastShown(0);
-    expect(manager.shouldShowAccountToast(0, 60_000)).toBe(false);
-    expect(manager.shouldShowAccountToast(1, 60_000)).toBe(true);
-  });
-
-  it("extracts email from jwt when present", () => {
-    const payload = Buffer.from(JSON.stringify({ email: "user@example.com" })).toString(
-      "base64",
-    );
-    const token = `header.${payload}.signature`;
-    expect(extractAccountEmail(token)).toBe("user@example.com");
-  });
-
-  it("formats account label preferring email and id suffix", () => {
-    expect(formatAccountLabel({ email: "user@example.com", accountId: "abcdef123456" }, 0)).toBe(
-      "Account 1 (user@example.com, id:123456)",
-    );
-    expect(formatAccountLabel({ email: "user@example.com" }, 1)).toBe("Account 2 (user@example.com)");
-    expect(formatAccountLabel({ accountId: "abcdef123456" }, 2)).toBe("Account 3 (123456)");
-    expect(formatAccountLabel(undefined as any, 3)).toBe("Account 4");
-  });
-
-  it("formats account label with accountLabel variations", () => {
-    expect(formatAccountLabel({ accountLabel: "Work" }, 0)).toBe("Account 1 (Work)");
-    expect(formatAccountLabel({ accountLabel: "Work", email: "work@co.com" }, 0)).toBe("Account 1 (Work, work@co.com)");
-    expect(formatAccountLabel({ accountLabel: "Work", accountId: "abcdef123456" }, 0)).toBe("Account 1 (Work, id:123456)");
-    expect(formatAccountLabel({ accountLabel: "Work", email: "work@co.com", accountId: "abcdef123456" }, 0)).toBe("Account 1 (Work, work@co.com, id:123456)");
-  });
-
-  it("formats account label with short accountId", () => {
-    expect(formatAccountLabel({ accountId: "abc" }, 0)).toBe("Account 1 (abc)");
-    expect(formatAccountLabel({ accountId: "123456" }, 0)).toBe("Account 1 (123456)");
-  });
-
-  it("performs true round-robin rotation across multiple requests", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        { refreshToken: "token-2", addedAt: now, lastUsed: now },
-        { refreshToken: "token-3", addedAt: now, lastUsed: now },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    
-    const first = manager.getCurrentOrNext();
-    const second = manager.getCurrentOrNext();
-    const third = manager.getCurrentOrNext();
-    const fourth = manager.getCurrentOrNext();
-
-    expect(first?.refreshToken).toBe("token-1");
-    expect(second?.refreshToken).toBe("token-2");
-    expect(third?.refreshToken).toBe("token-3");
-    expect(fourth?.refreshToken).toBe("token-1");
-  });
-
-  it("skips rate-limited accounts during rotation", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        { refreshToken: "token-2", addedAt: now, lastUsed: now, rateLimitResetTimes: { codex: now + 60_000 } },
-        { refreshToken: "token-3", addedAt: now, lastUsed: now },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    
-    const first = manager.getCurrentOrNext();
-    const second = manager.getCurrentOrNext();
-    const third = manager.getCurrentOrNext();
-
-    expect(first?.refreshToken).toBe("token-1");
-    expect(second?.refreshToken).toBe("token-3");
-    expect(third?.refreshToken).toBe("token-1");
-  });
-
-  it("uses independent cursors per model family", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      accounts: [
-        { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        { refreshToken: "token-2", addedAt: now, lastUsed: now },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored);
-    
-    const codexFirst = manager.getCurrentOrNextForFamily("codex");
-    const gpt51First = manager.getCurrentOrNextForFamily("gpt-5.1");
-    const codexSecond = manager.getCurrentOrNextForFamily("codex");
-    const gpt51Second = manager.getCurrentOrNextForFamily("gpt-5.1");
-
-    expect(codexFirst?.refreshToken).toBe("token-1");
-    expect(gpt51First?.refreshToken).toBe("token-1");
-    expect(codexSecond?.refreshToken).toBe("token-2");
-    expect(gpt51Second?.refreshToken).toBe("token-2");
-  });
-
-  it("keeps cursor ordering even when another access token lives longer", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 0,
-      activeIndexByFamily: { codex: 0 },
-      accounts: [
-        {
-          refreshToken: "token-stale",
-          accessToken: "access-stale",
-          expiresAt: now + 60_000,
-          addedAt: now,
-          lastUsed: now,
-        },
-        {
-          refreshToken: "token-fresh",
-          accessToken: "access-fresh",
-          expiresAt: now + 10 * 60_000,
-          addedAt: now,
-          lastUsed: now - 5_000,
-        },
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored as never);
-    const selected = manager.getCurrentOrNextForFamily("codex");
-
-    expect(selected?.refreshToken).toBe("token-stale");
-  });
-
-  it("hybrid selection prefers the healthier candidate over the active index", () => {
-    const now = Date.now();
-    const stored = {
-      version: 3 as const,
-      activeIndex: 1, // Set active index to second account
-      activeIndexByFamily: { codex: 1 },
-      accounts: [
-        { refreshToken: "token-1", addedAt: now, lastUsed: 0 }, // Very stale (high freshness score)
-        { refreshToken: "token-2", addedAt: now, lastUsed: now }, // Just used (low freshness score)
-      ],
-    };
-
-    const manager = new AccountManager(undefined, stored as any);
-    
-    const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
-    expect(selected?.refreshToken).toBe("token-1");
-    expect(selected?.index).toBe(0);
-  });
-
-  describe("removeAccount", () => {
-    it("removes an account and updates indices", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 1,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          { refreshToken: "token-2", addedAt: now, lastUsed: now },
-          { refreshToken: "token-3", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      expect(manager.getAccountCount()).toBe(3);
-      
-      const accountToRemove = manager.getCurrentAccount();
-      expect(accountToRemove).toBeDefined();
-      expect(accountToRemove?.refreshToken).toBe("token-2");
-      
-      const removed = manager.removeAccount(accountToRemove!);
-      expect(removed).toBe(true);
-      expect(manager.getAccountCount()).toBe(2);
-      
-      const remaining = manager.getAccountsSnapshot();
-      expect(remaining[0]?.refreshToken).toBe("token-1");
-      expect(remaining[1]?.refreshToken).toBe("token-3");
-      expect(remaining[0]?.index).toBe(0);
-      expect(remaining[1]?.index).toBe(1);
-    });
-
-    it("returns false when removing non-existent account", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const fakeAccount = {
-        index: 999,
-        refreshToken: "non-existent",
-        addedAt: now,
-        lastUsed: now,
-        rateLimitResetTimes: {},
-      };
-      
-      const removed = manager.removeAccount(fakeAccount as any);
-      expect(removed).toBe(false);
-      expect(manager.getAccountCount()).toBe(1);
-    });
-
-    it("handles removing the last account", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount();
-      expect(account).not.toBe(null);
-      
-      const removed = manager.removeAccount(account!);
-      expect(removed).toBe(true);
-      expect(manager.getAccountCount()).toBe(0);
-      expect(manager.getCurrentAccount()).toBe(null);
-    });
-  });
-
-  describe("hasRefreshToken", () => {
-    it("returns true when token exists", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          { refreshToken: "token-2", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      expect(manager.hasRefreshToken("token-1")).toBe(true);
-      expect(manager.hasRefreshToken("token-2")).toBe(true);
-    });
-
-    it("returns false when token does not exist", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      expect(manager.hasRefreshToken("non-existent")).toBe(false);
-      expect(manager.hasRefreshToken("")).toBe(false);
-    });
-  });
-
-  describe("markRateLimitedWithReason", () => {
-    it("marks account as rate limited with reason", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      manager.markRateLimitedWithReason(account, 60000, "codex", "quota");
-      
-      expect(account.lastRateLimitReason).toBe("quota");
-      expect(account.rateLimitResetTimes["codex"]).toBeDefined();
-    });
-
-    it("scopes token rate limits to the model-specific key", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      manager.markRateLimitedWithReason(account, 60000, "codex", "tokens", "gpt-5.2");
-      
-      expect(account.rateLimitResetTimes["codex"]).toBeUndefined();
-      expect(account.rateLimitResetTimes["codex:gpt-5.2"]).toBeDefined();
-    });
-
-    it("does not shorten an existing reset when a later retry window is smaller", () => {
-      vi.useFakeTimers();
-      try {
-        const now = new Date("2026-04-05T00:00:00.000Z");
-        vi.setSystemTime(now);
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            { refreshToken: "token-1", addedAt: now.getTime(), lastUsed: now.getTime() },
-          ],
-        };
-
-        const manager = new AccountManager(undefined, stored);
-        const account = manager.getCurrentAccount()!;
-        manager.markRateLimitedWithReason(account, 90 * 60_000, "codex", "quota");
-
-        const expectedResetAt = now.getTime() + 90 * 60_000;
-
-        vi.advanceTimersByTime(30 * 60_000);
-
-        manager.markRateLimitedWithReason(account, 60_000, "codex", "quota");
-
-        expect(account.rateLimitResetTimes["codex"]).toBe(expectedResetAt);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("does not shorten an existing model-scoped reset when a later retry window is smaller", () => {
-      vi.useFakeTimers();
-      try {
-        const now = new Date("2026-04-05T00:00:00.000Z");
-        vi.setSystemTime(now);
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            { refreshToken: "token-1", addedAt: now.getTime(), lastUsed: now.getTime() },
-          ],
-        };
-
-        const manager = new AccountManager(undefined, stored);
-        const account = manager.getCurrentAccount()!;
-        manager.markRateLimitedWithReason(
-          account,
-          90 * 60_000,
-          "codex",
-          "tokens",
-          "gpt-5.2",
-        );
-
-        const expectedResetAt = now.getTime() + 90 * 60_000;
-
-        vi.advanceTimersByTime(30 * 60_000);
-
-        manager.markRateLimitedWithReason(
-          account,
-          60_000,
-          "codex",
-          "tokens",
-          "gpt-5.2",
-        );
-
-        expect(account.rateLimitResetTimes["codex:gpt-5.2"]).toBe(expectedResetAt);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-  });
-
-  describe("cooldown management", () => {
-    it("marks account as cooling down", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      manager.markAccountCoolingDown(account, 30000, "auth-failure");
-      
-      expect(manager.isAccountCoolingDown(account)).toBe(true);
-      expect(account.cooldownReason).toBe("auth-failure");
-    });
-
-    it("clears cooldown when time expires", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now, coolingDownUntil: now - 1000 },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      expect(manager.isAccountCoolingDown(account)).toBe(false);
-    });
-
-    it("clears cooldown manually", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      manager.markAccountCoolingDown(account, 30000, "network-error");
-      expect(manager.isAccountCoolingDown(account)).toBe(true);
-      
-      manager.clearAccountCooldown(account);
-      expect(manager.isAccountCoolingDown(account)).toBe(false);
-      expect(account.cooldownReason).toBeUndefined();
-    });
-  });
-
-  describe("auth failure tracking", () => {
-    it("increments consecutive auth failures", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      
-      expect(manager.incrementAuthFailures(account)).toBe(1);
-      expect(manager.incrementAuthFailures(account)).toBe(2);
-      expect(manager.incrementAuthFailures(account)).toBe(3);
-    });
-
-    it("clears auth failures", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      
-      manager.incrementAuthFailures(account);
-      manager.incrementAuthFailures(account);
-      manager.clearAuthFailures(account);
-      
-      expect(account.consecutiveAuthFailures).toBe(0);
-    });
-  });
-
-  describe("getMinWaitTimeForFamily", () => {
-    it("returns 0 when accounts are available", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      expect(manager.getMinWaitTimeForFamily("codex")).toBe(0);
-    });
-
-    it("returns wait time when all accounts rate limited", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { 
-            refreshToken: "token-1", 
-            addedAt: now, 
-            lastUsed: now,
-            rateLimitResetTimes: { codex: now + 30000 },
-          },
-          { 
-            refreshToken: "token-2", 
-            addedAt: now, 
-            lastUsed: now,
-            rateLimitResetTimes: { codex: now + 60000 },
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const waitTime = manager.getMinWaitTimeForFamily("codex");
-      expect(waitTime).toBeGreaterThan(0);
-      expect(waitTime).toBeLessThanOrEqual(30000);
-    });
-
-    it("considers model-specific rate limits", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { 
-            refreshToken: "token-1", 
-            addedAt: now, 
-            lastUsed: now,
-            rateLimitResetTimes: { "codex:gpt-5.2": now + 45000 },
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const waitTime = manager.getMinWaitTimeForFamily("codex", "gpt-5.2");
-      expect(waitTime).toBeGreaterThan(0);
-      expect(waitTime).toBeLessThanOrEqual(45000);
-    });
-  });
-
-  describe("updateFromAuth", () => {
-    it("updates account tokens from auth", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "old-token", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      
-      const newAuth: OAuthAuthDetails = {
-        type: "oauth",
-        access: "new-access",
-        refresh: "new-refresh",
-        expires: now + 3600000,
-      };
-      
-      manager.updateFromAuth(account, newAuth);
-      
-      expect(account.refreshToken).toBe("new-refresh");
-      expect(account.access).toBe("new-access");
-      expect(account.expires).toBe(now + 3600000);
-    });
-
-    it("updates accountId from token when source is token-derived", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { 
-            refreshToken: "old-token", 
-            addedAt: now, 
-            lastUsed: now,
-            accountId: "old-account-id",
-            accountIdSource: "token" as const,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      
-      const payload = Buffer.from(JSON.stringify({ 
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "new-account-id-from-token",
-        },
-        exp: Math.floor((now + 3600000) / 1000),
-      })).toString("base64url");
-      const accessToken = `header.${payload}.signature`;
-      
-      const newAuth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "new-refresh",
-        expires: now + 3600000,
-      };
-      
-      manager.updateFromAuth(account, newAuth);
-      
-      expect(account.accountId).toBe("new-account-id-from-token");
-      expect(account.accountIdSource).toBe("token");
-    });
-
-    it("does not update accountId when source is org-selected", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { 
-            refreshToken: "old-token", 
-            addedAt: now, 
-            lastUsed: now,
-            accountId: "org-selected-id",
-            accountIdSource: "org" as const,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      
-      const payload = Buffer.from(JSON.stringify({ 
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "new-account-id-from-token",
-        },
-        exp: Math.floor((now + 3600000) / 1000),
-      })).toString("base64url");
-      const accessToken = `header.${payload}.signature`;
-      
-      const newAuth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "new-refresh",
-        expires: now + 3600000,
-      };
-      
-      manager.updateFromAuth(account, newAuth);
-      
-      expect(account.accountId).toBe("org-selected-id");
-      expect(account.accountIdSource).toBe("org");
-    });
-  });
-
-  describe("commitRefreshedAuth", () => {
-    it("persists refreshed auth transactionally and updates the live account", async () => {
-      const { withAccountStorageTransaction } = await import("../lib/storage.js");
-      const mockWithAccountStorageTransaction = vi.mocked(
-        withAccountStorageTransaction,
-      );
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "old-refresh",
-            accessToken: "old-access",
-            expiresAt: now,
-            addedAt: now,
-            lastUsed: now,
-            email: "old@example.com",
-            accountId: "old-account-id",
-            accountIdSource: "token" as const,
-            enabled: false,
-            coolingDownUntil: now + 30_000,
-            cooldownReason: "auth-failure" as const,
-          },
-        ],
-      };
-      const manager = new AccountManager(undefined, stored as any);
-      const account = manager.getAccountByIndex(0)!;
-      account.enabled = false;
-      manager.markAccountCoolingDown(account, 30_000, "auth-failure");
-      manager.incrementAuthFailures(account);
-
-      const payload = Buffer.from(
-        JSON.stringify({
-          email: "new@example.com",
-          "https://api.openai.com/auth": {
-            chatgpt_account_id: "new-account-id",
-          },
-        }),
-      ).toString("base64url");
-      const refreshedAuth: OAuthAuthDetails = {
-        type: "oauth",
-        access: `header.${payload}.signature`,
-        refresh: "new-refresh",
-        expires: now + 3_600_000,
-      };
-
-      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
-        const persist = vi.fn().mockResolvedValue(undefined);
-        const result = await handler(stored as any, persist);
-
-        expect(persist).toHaveBeenCalledTimes(1);
-        const persistedStorage = persist.mock.calls[0]?.[0];
-        expect(persistedStorage?.accounts[0]?.refreshToken).toBe("new-refresh");
-        expect(persistedStorage?.accounts[0]?.accessToken).toBe(
-          refreshedAuth.access,
-        );
-        expect(persistedStorage?.accounts[0]?.expiresAt).toBe(
-          refreshedAuth.expires,
-        );
-        expect(persistedStorage?.accounts[0]?.accountId).toBe("new-account-id");
-        expect(persistedStorage?.accounts[0]?.accountIdSource).toBe("token");
-        expect(persistedStorage?.accounts[0]?.email).toBe("new@example.com");
-        expect(persistedStorage?.accounts[0]?.enabled).toBeUndefined();
-        expect(persistedStorage?.accounts[0]?.coolingDownUntil).toBeUndefined();
-        expect(persistedStorage?.accounts[0]?.cooldownReason).toBeUndefined();
-
-        return result;
-      });
-
-      const updated = await manager.commitRefreshedAuth(account, refreshedAuth);
-
-      expect(updated).toBe(account);
-      expect(account.refreshToken).toBe("new-refresh");
-      expect(account.access).toBe(refreshedAuth.access);
-      expect(account.expires).toBe(refreshedAuth.expires);
-      expect(account.accountId).toBe("new-account-id");
-      expect(account.accountIdSource).toBe("token");
-      expect(account.email).toBe("new@example.com");
-      expect(account.enabled).toBe(true);
-      expect(account.coolingDownUntil).toBeUndefined();
-      expect(account.cooldownReason).toBeUndefined();
-      expect(account.consecutiveAuthFailures).toBe(0);
-    });
-
-    it("preserves unsaved live pool state when persisting refreshed auth", async () => {
-      const { withAccountStorageTransaction } = await import("../lib/storage.js");
-      const mockWithAccountStorageTransaction = vi.mocked(
-        withAccountStorageTransaction,
-      );
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        activeIndexByFamily: {
-          codex: 0,
-        },
-        accounts: [
-          {
-            refreshToken: "old-refresh-a",
-            accessToken: "old-access-a",
-            expiresAt: now,
-            addedAt: now,
-            lastUsed: now,
-            email: "a@example.com",
-          },
-          {
-            refreshToken: "old-refresh-b",
-            accessToken: "old-access-b",
-            expiresAt: now,
-            addedAt: now,
-            lastUsed: now,
-            email: "b@example.com",
-          },
-        ],
-      };
-      const manager = new AccountManager(undefined, stored as any);
-      const accountA = manager.getAccountByIndex(0)!;
-      const accountB = manager.getAccountByIndex(1)!;
-      manager.markSwitched(accountB, "rotation", "codex");
-      manager.markRateLimited(accountB, 45_000, "codex");
-      manager.markAccountCoolingDown(accountB, 30_000, "network-error");
-
-      const refreshedAuth: OAuthAuthDetails = {
-        type: "oauth",
-        access: "header.payload.signature",
-        refresh: "new-refresh-a",
-        expires: now + 3_600_000,
-      };
-
-      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
-        const persist = vi.fn().mockResolvedValue(undefined);
-        const result = await handler(stored as any, persist);
-
-        expect(persist).toHaveBeenCalledTimes(1);
-        const persistedStorage = persist.mock.calls[0]?.[0];
-        expect(persistedStorage?.activeIndex).toBe(1);
-        expect(persistedStorage?.activeIndexByFamily?.codex).toBe(1);
-        expect(persistedStorage?.accounts[0]?.refreshToken).toBe("new-refresh-a");
-        expect(persistedStorage?.accounts[1]?.rateLimitResetTimes?.codex).toBeGreaterThan(
-          now,
-        );
-        expect(persistedStorage?.accounts[1]?.cooldownReason).toBe(
-          "network-error",
-        );
-        expect(persistedStorage?.accounts[1]?.coolingDownUntil).toBeGreaterThan(
-          now,
-        );
-
-        return result;
-      });
-
-      await manager.commitRefreshedAuth(accountA, refreshedAuth);
-    });
-
-    it("keeps trimmed token accountId identical in memory and persisted storage", async () => {
-      const { withAccountStorageTransaction } = await import("../lib/storage.js");
-      const mockWithAccountStorageTransaction = vi.mocked(
-        withAccountStorageTransaction,
-      );
-      const now = Date.now();
-      const payload = Buffer.from(
-        JSON.stringify({
-          "https://api.openai.com/auth": {
-            chatgpt_account_id: "  matching-account-id  ",
-          },
-        }),
-      ).toString("base64url");
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "old-refresh",
-            accessToken: "old-access",
-            expiresAt: now,
-            addedAt: now,
-            lastUsed: now,
-            accountId: "matching-account-id",
-            accountIdSource: "token" as const,
-          },
-        ],
-      };
-      const manager = new AccountManager(undefined, stored as any);
-      const account = manager.getAccountByIndex(0)!;
-      const refreshedAuth: OAuthAuthDetails = {
-        type: "oauth",
-        access: `header.${payload}.signature`,
-        refresh: "new-refresh",
-        expires: now + 3_600_000,
-      };
-
-      mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
-        const persist = vi.fn().mockResolvedValue(undefined);
-        const result = await handler(stored as any, persist);
-
-        expect(persist).toHaveBeenCalledTimes(1);
-        const persistedStorage = persist.mock.calls[0]?.[0];
-        expect(persistedStorage?.accounts[0]?.accountId).toBe("matching-account-id");
-
-        return result;
-      });
-
-      await manager.commitRefreshedAuth(account, refreshedAuth);
-
-      expect(account.accountId).toBe("matching-account-id");
-    });
-
-    it("propagates storage write failure as retryable CodexAuthError", async () => {
-      const { withAccountStorageTransaction } = await import("../lib/storage.js");
-      const mockWithAccountStorageTransaction = vi.mocked(
-        withAccountStorageTransaction,
-      );
-      mockWithAccountStorageTransaction.mockRejectedValueOnce(
-        Object.assign(new Error("EBUSY"), { code: "EBUSY" }),
-      );
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "old-refresh",
-            accessToken: "old-access",
-            expiresAt: now,
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-      const manager = new AccountManager(undefined, stored as any);
-      const account = manager.getAccountByIndex(0)!;
-      const refreshedAuth: OAuthAuthDetails = {
-        type: "oauth",
-        access: "header.payload.signature",
-        refresh: "new-refresh",
-        expires: now + 3_600_000,
-      };
-
-      const error = await manager.commitRefreshedAuth(account, refreshedAuth).catch(
-        (err) => err as CodexAuthError,
-      );
-
-      expect(error).toBeInstanceOf(CodexAuthError);
-      expect(error.retryable).toBe(true);
-      expect(account.refreshToken).toBe("old-refresh");
-    });
-
-    it("propagates non-transient storage write failure as terminal CodexAuthError", async () => {
-      const { withAccountStorageTransaction } = await import("../lib/storage.js");
-      const mockWithAccountStorageTransaction = vi.mocked(
-        withAccountStorageTransaction,
-      );
-      mockWithAccountStorageTransaction.mockRejectedValueOnce(
-        Object.assign(new Error("EACCES"), { code: "EACCES" }),
-      );
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "old-refresh",
-            accessToken: "old-access",
-            expiresAt: now,
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-      const manager = new AccountManager(undefined, stored as any);
-      const account = manager.getAccountByIndex(0)!;
-      const refreshedAuth: OAuthAuthDetails = {
-        type: "oauth",
-        access: "header.payload.signature",
-        refresh: "new-refresh",
-        expires: now + 3_600_000,
-      };
-
-      const error = await manager.commitRefreshedAuth(account, refreshedAuth).catch(
-        (err) => err as CodexAuthError,
-      );
-
-      expect(error).toBeInstanceOf(CodexAuthError);
-      expect(error.retryable).toBe(false);
-      expect(account.refreshToken).toBe("old-refresh");
-    });
-
-    it("prevents debounced saves from writing stale auth during refresh persistence", async () => {
-      vi.useFakeTimers();
-      try {
-        const { saveAccounts, withAccountStorageTransaction } = await import(
-          "../lib/storage.js"
-        );
-        const mockSaveAccounts = vi.mocked(saveAccounts);
-        const mockWithAccountStorageTransaction = vi.mocked(
-          withAccountStorageTransaction,
-        );
-
-        const now = Date.now();
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            {
-              refreshToken: "old-refresh",
-              accessToken: "old-access",
-              expiresAt: now,
-              addedAt: now,
-              lastUsed: now,
-            },
-          ],
-        };
-        const manager = new AccountManager(undefined, stored as any);
-        const account = manager.getAccountByIndex(0)!;
-        const refreshedAuth: OAuthAuthDetails = {
-          type: "oauth",
-          access: "new-access",
-          refresh: "new-refresh",
-          expires: now + 3_600_000,
-        };
-
-        let storageState = structuredClone(stored) as typeof stored;
-        let lock = Promise.resolve();
-        let releasePersist!: () => void;
-        const persistBlocked = new Promise<void>((resolve) => {
-          releasePersist = resolve;
-        });
-        let notifyPersistStarted!: () => void;
-        const persistStarted = new Promise<void>((resolve) => {
-          notifyPersistStarted = resolve;
-        });
-
-        mockWithAccountStorageTransaction.mockImplementation((handler) => {
-          const run = async () => {
-            const current = structuredClone(storageState) as typeof storageState;
-            const persist = async (
-              nextStorage: Parameters<typeof saveAccounts>[0],
-            ) => {
-              if (
-                nextStorage.accounts[0]?.refreshToken === "new-refresh" &&
-                nextStorage.accounts[0]?.accessToken === "new-access"
-              ) {
-                notifyPersistStarted();
-                await persistBlocked;
-              }
-              storageState = structuredClone(nextStorage) as typeof storageState;
-              await mockSaveAccounts(nextStorage);
-            };
-            return handler(current as never, persist);
-          };
-
-          const result = lock.then(run, run);
-          lock = result.then(
-            () => undefined,
-            () => undefined,
-          );
-          return result;
-        });
-
-        const commitPromise = manager.commitRefreshedAuth(account, refreshedAuth);
-        await persistStarted;
-
-        manager.saveToDiskDebounced(0);
-        await vi.advanceTimersByTimeAsync(0);
-
-        releasePersist();
-        await commitPromise;
-        await manager.flushPendingSave();
-
-        expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
-        expect(mockSaveAccounts.mock.calls[0]?.[0]?.accounts[0]?.refreshToken).toBe(
-          "new-refresh",
-        );
-        expect(mockSaveAccounts.mock.calls[1]?.[0]?.accounts[0]?.refreshToken).toBe(
-          "new-refresh",
-        );
-        expect(mockSaveAccounts.mock.calls[1]?.[0]?.accounts[0]?.accessToken).toBe(
-          "new-access",
-        );
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-  });
-
-  describe("toAuthDetails", () => {
-    it("converts account to Auth object", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      account.access = "access-token";
-      account.expires = now + 3600000;
-      
-      const auth = manager.toAuthDetails(account);
-      
-      expect(auth.type).toBe("oauth");
-      if (auth.type === "oauth") {
-        expect(auth.access).toBe("access-token");
-        expect(auth.refresh).toBe("token-1");
-        expect(auth.expires).toBe(now + 3600000);
-      }
-    });
-
-    it("handles missing access token", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      
-      const auth = manager.toAuthDetails(account);
-      
-      expect(auth.type).toBe("oauth");
-      if (auth.type === "oauth") {
-        expect(auth.access).toBe("");
-        expect(auth.expires).toBe(0);
-      }
-    });
-  });
-
-  describe("setActiveIndex", () => {
-    it("sets active index and returns account", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          { refreshToken: "token-2", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const result = manager.setActiveIndex(1);
-      
-      expect(result?.refreshToken).toBe("token-2");
-      expect(manager.getActiveIndex()).toBe(1);
-    });
-
-    it("returns null for invalid index", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      expect(manager.setActiveIndex(-1)).toBeNull();
-      expect(manager.setActiveIndex(999)).toBeNull();
-      expect(manager.setActiveIndex(NaN)).toBeNull();
-      expect(manager.setActiveIndex(Infinity)).toBeNull();
-    });
-  });
-
-  describe("markSwitched", () => {
-    it("records switch reason on account", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      
-      manager.markSwitched(account, "rate-limit", "codex");
-      expect(account.lastSwitchReason).toBe("rate-limit");
-    });
-  });
-
-  describe("saveToDisk", () => {
-    it("saves accounts with all fields", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockResolvedValueOnce();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { 
-            refreshToken: "token-1", 
-            addedAt: now, 
-            lastUsed: now,
-            email: "test@example.com",
-            accountId: "acc123",
-            accountLabel: "Test",
-            rateLimitResetTimes: { quota: now + 60000 },
-            coolingDownUntil: now + 30000,
-            cooldownReason: "transient",
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored as any);
-      await manager.saveToDisk();
-
-      expect(mockSaveAccounts).toHaveBeenCalled();
-      const savedData = mockSaveAccounts.mock.calls[0]?.[0];
-      expect(savedData?.version).toBe(3);
-      expect(savedData?.accounts[0]?.email).toBe("test@example.com");
-      expect(savedData?.accounts[0]?.rateLimitResetTimes).toBeDefined();
-    });
-  });
-
-  describe("saveToDiskDebounced", () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("debounces multiple calls", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-      mockSaveAccounts.mockResolvedValue();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      
-      manager.saveToDiskDebounced(100);
-      manager.saveToDiskDebounced(100);
-      manager.saveToDiskDebounced(100);
-
-      await vi.advanceTimersByTimeAsync(150);
-
-      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
-    });
-
-    it("logs warning when debounced save fails", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-      mockSaveAccounts.mockRejectedValueOnce(new Error("Save failed"));
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      
-      manager.saveToDiskDebounced(100);
-      await vi.advanceTimersByTimeAsync(150);
-
-      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
-    });
-
-    it("awaits existing pendingSave before starting new save", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-
-      let resolveFirst: () => void;
-      const firstSave = new Promise<void>((resolve) => { resolveFirst = resolve; });
-      mockSaveAccounts.mockImplementationOnce(() => firstSave);
-      mockSaveAccounts.mockResolvedValue();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      
-      manager.saveToDiskDebounced(50);
-      await vi.advanceTimersByTimeAsync(60);
-      
-      manager.saveToDiskDebounced(50);
-      resolveFirst!();
-      await vi.advanceTimersByTimeAsync(100);
-
-      expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
-    });
-
-    it("uses the manager's captured storage path state for delayed saves", async () => {
-      const { saveAccounts, withAccountStorageTransaction } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      const mockWithAccountStorageTransaction = vi.mocked(
-        withAccountStorageTransaction,
-      );
-      mockSaveAccounts.mockClear();
-
-      vi.useFakeTimers();
-      try {
-        const now = Date.now();
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          ],
-        };
-
-        setStoragePathState({
-          currentStoragePath: "/repo-a/storage.json",
-          currentLegacyProjectStoragePath: null,
-          currentLegacyWorktreeStoragePath: null,
-          currentProjectRoot: "/repo-a",
-        });
-        const manager = new AccountManager(undefined, stored);
-
-        const seenStates: Array<ReturnType<typeof getStoragePathState>> = [];
-        mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
-          seenStates.push({ ...getStoragePathState() });
-          let current = null;
-          const persist = async (storage: Parameters<typeof saveAccounts>[0]) => {
-            current = structuredClone(storage);
-            await mockSaveAccounts(storage);
-          };
-          return handler(current as never, persist);
-        });
-
-        setStoragePathState({
-          currentStoragePath: "/repo-b/storage.json",
-          currentLegacyProjectStoragePath: null,
-          currentLegacyWorktreeStoragePath: null,
-          currentProjectRoot: "/repo-b",
-        });
-
-        manager.saveToDiskDebounced(50);
-        await vi.advanceTimersByTimeAsync(60);
-
-        expect(seenStates).toEqual([
-          expect.objectContaining({
-            currentStoragePath: "/repo-a/storage.json",
-            currentProjectRoot: "/repo-a",
-          }),
-        ]);
-        expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("uses the manager's captured Windows-style storage path state for delayed saves", async () => {
-      const { saveAccounts, withAccountStorageTransaction } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      const mockWithAccountStorageTransaction = vi.mocked(
-        withAccountStorageTransaction,
-      );
-      mockSaveAccounts.mockClear();
-
-      const repoAStoragePath = String.raw`C:\repo-a\storage.json`;
-      const repoARoot = String.raw`C:\repo-a`;
-      const repoBStoragePath = String.raw`C:\repo-b\storage.json`;
-      const repoBRoot = String.raw`C:\repo-b`;
-
-      vi.useFakeTimers();
-      try {
-        const now = Date.now();
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          ],
-        };
-
-        setStoragePathState({
-          currentStoragePath: repoAStoragePath,
-          currentLegacyProjectStoragePath: null,
-          currentLegacyWorktreeStoragePath: null,
-          currentProjectRoot: repoARoot,
-        });
-        const manager = new AccountManager(undefined, stored);
-
-        const seenStates: Array<ReturnType<typeof getStoragePathState>> = [];
-        mockWithAccountStorageTransaction.mockImplementationOnce(async (handler) => {
-          seenStates.push({ ...getStoragePathState() });
-          let current = null;
-          const persist = async (storage: Parameters<typeof saveAccounts>[0]) => {
-            current = structuredClone(storage);
-            await mockSaveAccounts(storage);
-          };
-          return handler(current as never, persist);
-        });
-
-        setStoragePathState({
-          currentStoragePath: repoBStoragePath,
-          currentLegacyProjectStoragePath: null,
-          currentLegacyWorktreeStoragePath: null,
-          currentProjectRoot: repoBRoot,
-        });
-
-        manager.saveToDiskDebounced(50);
-        await vi.advanceTimersByTimeAsync(60);
-
-        expect(seenStates).toEqual([
-          expect.objectContaining({
-            currentStoragePath: repoAStoragePath,
-            currentProjectRoot: repoARoot,
-          }),
-        ]);
-        expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("keeps ambient storage path state stable during concurrent saves", async () => {
-      const { withAccountStorageTransaction } = await import("../lib/storage.js");
-      const mockWithAccountStorageTransaction = vi.mocked(
-        withAccountStorageTransaction,
-      );
-      const createDeferred = () => {
-        let resolve!: () => void;
-        const promise = new Promise<void>((resolvePromise) => {
-          resolve = resolvePromise;
-        });
-        return { promise, resolve };
-      };
-      const enteredResolvers = [createDeferred(), createDeferred()];
-      const releaseResolvers = [createDeferred(), createDeferred()];
-      const seenStates: Array<ReturnType<typeof getStoragePathState>> = [];
-      let callIndex = 0;
-
-      mockWithAccountStorageTransaction.mockImplementation(async (handler) => {
-        const currentCall = callIndex;
-        callIndex += 1;
-        seenStates.push({ ...getStoragePathState() });
-        enteredResolvers[currentCall]?.resolve();
-        if (currentCall === 0) {
-          await enteredResolvers[1]?.promise;
-        }
-        await releaseResolvers[currentCall]?.promise;
-        return handler(null, async () => undefined);
-      });
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
-      };
-
-      setStoragePathState({
-        currentStoragePath: "/ambient/storage.json",
-        currentLegacyProjectStoragePath: null,
-        currentLegacyWorktreeStoragePath: null,
-        currentProjectRoot: "/ambient",
-      });
-      setStoragePathState({
-        currentStoragePath: "/repo-a/storage.json",
-        currentLegacyProjectStoragePath: null,
-        currentLegacyWorktreeStoragePath: null,
-        currentProjectRoot: "/repo-a",
-      });
-      const managerA = new AccountManager(undefined, stored);
-      setStoragePathState({
-        currentStoragePath: "/repo-b/storage.json",
-        currentLegacyProjectStoragePath: null,
-        currentLegacyWorktreeStoragePath: null,
-        currentProjectRoot: "/repo-b",
-      });
-      const managerB = new AccountManager(undefined, stored);
-      setStoragePathState({
-        currentStoragePath: "/ambient/storage.json",
-        currentLegacyProjectStoragePath: null,
-        currentLegacyWorktreeStoragePath: null,
-        currentProjectRoot: "/ambient",
-      });
-
-      const saveA = managerA.saveToDisk();
-      await enteredResolvers[0]?.promise;
-      const saveB = managerB.saveToDisk();
-      await enteredResolvers[1]?.promise;
-
-      expect(getStoragePathState()).toEqual(
-        expect.objectContaining({
-          currentStoragePath: "/ambient/storage.json",
-          currentProjectRoot: "/ambient",
-        }),
-      );
-
-      releaseResolvers[0]?.resolve();
-      await saveA;
-      releaseResolvers[1]?.resolve();
-      await saveB;
-
-      expect(seenStates).toEqual([
-        expect.objectContaining({
-          currentStoragePath: "/repo-a/storage.json",
-          currentProjectRoot: "/repo-a",
-        }),
-        expect.objectContaining({
-          currentStoragePath: "/repo-b/storage.json",
-          currentProjectRoot: "/repo-b",
-        }),
-      ]);
-      expect(getStoragePathState()).toEqual(
-        expect.objectContaining({
-          currentStoragePath: "/ambient/storage.json",
-          currentProjectRoot: "/ambient",
-        }),
-      );
-    });
-  });
-
-  describe("constructor edge cases", () => {
-    it("filters out accounts with missing refreshToken", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "valid-token", addedAt: now, lastUsed: now },
-          { refreshToken: "", addedAt: now, lastUsed: now },
-          { refreshToken: null as unknown as string, addedAt: now, lastUsed: now },
-          { refreshToken: undefined as unknown as string, addedAt: now, lastUsed: now },
-          { refreshToken: "another-valid", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      expect(manager.getAccountCount()).toBe(2);
-      const accounts = manager.getAccountsSnapshot();
-      expect(accounts[0]?.refreshToken).toBe("valid-token");
-      expect(accounts[1]?.refreshToken).toBe("another-valid");
-    });
-
-    it("merges fallback auth when matching by accountId", () => {
-      const now = Date.now();
-      const payload = {
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "matching-account-id",
-        },
-        email: "fallback@example.com",
-      };
-      const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-      
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { 
-            refreshToken: "stored-token", 
-            accountId: "matching-account-id",
-            addedAt: now, 
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "new-refresh-token",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, stored);
-      expect(manager.getAccountCount()).toBe(1);
-      const account = manager.getCurrentAccount();
-      expect(account?.refreshToken).toBe("new-refresh-token");
-      expect(account?.access).toBe(accessToken);
-    });
-
-    it("trims fallback accountId before matching and persisting it", () => {
-      const now = Date.now();
-      const payload = {
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "  matching-account-id  ",
-        },
-      };
-      const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "stored-token",
-            accountId: "matching-account-id",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "new-refresh-token",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, stored);
-      expect(manager.getAccountCount()).toBe(1);
-      const account = manager.getCurrentAccount();
-      expect(account?.refreshToken).toBe("new-refresh-token");
-      expect(account?.accountId).toBe("matching-account-id");
-    });
-
-    it("ignores malformed stored rows when checking shared accountId uniqueness for fallback matching", () => {
-      const now = Date.now();
-      const payload = {
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "matching-account-id",
-        },
-      };
-      const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "stored-token",
-            accountId: "matching-account-id",
-            addedAt: now,
-            lastUsed: now,
-          },
-          {
-            refreshToken: "",
-            accountId: "matching-account-id",
-            addedAt: now,
-            lastUsed: now,
-          },
-          {
-            refreshToken: "   ",
-            accountId: "matching-account-id",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "new-refresh-token",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, stored);
-      expect(manager.getAccountCount()).toBe(1);
-      const account = manager.getCurrentAccount();
-      expect(account?.refreshToken).toBe("new-refresh-token");
-      expect(account?.accountId).toBe("matching-account-id");
-    });
-
-    it("merges fallback auth when matching by email", () => {
-      const now = Date.now();
-      const payload = {
-        email: "fallback@example.com",
-      };
-      const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "stored-token",
-            email: "fallback@example.com",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "new-refresh-token",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, stored);
-      expect(manager.getAccountCount()).toBe(1);
-      const account = manager.getCurrentAccount();
-      expect(account?.refreshToken).toBe("new-refresh-token");
-      expect(account?.access).toBe(accessToken);
-      expect(account?.email).toBe("fallback@example.com");
-    });
-
-    it("does not add fallback as duplicate when matching stored email", () => {
-      const now = Date.now();
-      const payload = {
-        email: "fallback@example.com",
-      };
-      const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "stored-token",
-            email: "fallback@example.com",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "different-refresh-token",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, stored);
-      expect(manager.getAccountCount()).toBe(1);
-      const account = manager.getCurrentAccount();
-      expect(account?.refreshToken).toBe("different-refresh-token");
-    });
-
-    it("adds fallback as a distinct account when the same email spans multiple accountIds", () => {
-      const now = Date.now();
-      const payload = {
-        email: "shared@example.com",
-      };
-      const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            accountId: "workspace-alpha",
-            email: "shared@example.com",
-            refreshToken: "refresh-alpha",
-            addedAt: now,
-            lastUsed: now,
-          },
-          {
-            accountId: "workspace-beta",
-            email: "shared@example.com",
-            refreshToken: "refresh-beta",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "refresh-gamma",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, stored);
-
-      expect(manager.getAccountCount()).toBe(3);
-      expect(manager.getAccountsSnapshot().map((account) => account.refreshToken)).toEqual([
-        "refresh-alpha",
-        "refresh-beta",
-        "refresh-gamma",
-      ]);
-    });
-
-    it("adds fallback as new account when no match found", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "existing-token", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: "new-access",
-        refresh: "new-refresh",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, stored);
-      expect(manager.getAccountCount()).toBe(2);
-      const accounts = manager.getAccountsSnapshot();
-      expect(accounts[0]?.refreshToken).toBe("existing-token");
-      expect(accounts[1]?.refreshToken).toBe("new-refresh");
-    });
-
-    it("adds fallback as a distinct account when duplicate business accounts share one accountId", () => {
-      const now = Date.now();
-      const payload = {
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "workspace-shared",
-        },
-        email: "gamma@example.com",
-      };
-      const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            accountId: "workspace-shared",
-            email: "alpha@example.com",
-            refreshToken: "refresh-alpha",
-            addedAt: now,
-            lastUsed: now,
-          },
-          {
-            accountId: "workspace-shared",
-            email: "beta@example.com",
-            refreshToken: "refresh-beta",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "refresh-gamma",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, stored);
-
-      expect(manager.getAccountCount()).toBe(3);
-      expect(manager.getAccountsSnapshot().map((account) => account.email)).toEqual([
-        "alpha@example.com",
-        "beta@example.com",
-        "gamma@example.com",
-      ]);
-      expect(manager.getAccountsSnapshot().map((account) => account.refreshToken)).toEqual([
-        "refresh-alpha",
-        "refresh-beta",
-        "refresh-gamma",
-      ]);
-    });
-
-    it("sets accountIdSource to token when fallbackAccountId exists", () => {
-      const now = Date.now();
-      const payload = {
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "fallback-id",
-        },
-      };
-      const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
-      
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: accessToken,
-        refresh: "refresh-token",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, null);
-      expect(manager.getAccountCount()).toBe(1);
-      const account = manager.getCurrentAccount();
-      expect(account?.accountIdSource).toBe("token");
-      expect(account?.accountId).toBe("fallback-id");
-    });
-
-    it("sets accountIdSource to undefined when no accountId in token", () => {
-      const now = Date.now();
-      const auth: OAuthAuthDetails = {
-        type: "oauth",
-        access: "invalid-jwt",
-        refresh: "refresh-token",
-        expires: now + 60_000,
-      };
-
-      const manager = new AccountManager(auth, null);
-      expect(manager.getAccountCount()).toBe(1);
-      const account = manager.getCurrentAccount();
-      expect(account?.accountIdSource).toBeUndefined();
-    });
-  });
-
-  describe("removeAccount cursor adjustment", () => {
-    it("adjusts cursor when removing account before cursor position", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          { refreshToken: "token-2", addedAt: now, lastUsed: now },
-          { refreshToken: "token-3", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      
-      manager.getCurrentOrNextForFamily("codex");
-      manager.getCurrentOrNextForFamily("codex");
-      manager.getCurrentOrNextForFamily("codex");
-      
-      const firstAccount = manager.getCurrentAccountForFamily("codex");
-      expect(firstAccount).not.toBeNull();
-      const removed = manager.removeAccount(firstAccount!);
-      
-      expect(removed).toBe(true);
-      expect(manager.getAccountCount()).toBe(2);
-    });
-
-    it("adjusts currentAccountIndexByFamily when removing account before current", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 2,
-        activeIndexByFamily: { codex: 2 },
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          { refreshToken: "token-2", addedAt: now, lastUsed: now },
-          { refreshToken: "token-3", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored as never);
-      
-      const initialAccount = manager.getCurrentAccountForFamily("codex");
-      expect(initialAccount?.refreshToken).toBe("token-3");
-      
-      manager.setActiveIndex(0);
-      const accountToRemove = manager.getCurrentAccountForFamily("codex");
-      expect(accountToRemove?.refreshToken).toBe("token-1");
-      
-      manager.setActiveIndex(2);
-      manager.removeAccount(accountToRemove!);
-      
-      expect(manager.getAccountCount()).toBe(2);
-      expect(manager.getActiveIndexForFamily("codex")).toBe(1);
-    });
-
-    it("decrements currentAccountIndex when removing first account", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 1,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          { refreshToken: "token-2", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      
-      manager.setActiveIndex(0);
-      const firstAccount = manager.getCurrentAccount();
-      expect(firstAccount?.refreshToken).toBe("token-1");
-      
-      manager.setActiveIndex(1);
-      manager.removeAccount(firstAccount!);
-      
-      expect(manager.getAccountCount()).toBe(1);
-      expect(manager.getActiveIndexForFamily("codex")).toBe(0);
-    });
-
-    it("resets indices when removing last remaining account", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      manager.removeAccount(account);
-      
-      expect(manager.getAccountCount()).toBe(0);
-      expect(manager.getActiveIndexForFamily("codex")).toBe(-1);
-    });
-  });
-
-  describe("flushPendingSave", () => {
-    it("flushes pending debounced save", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockResolvedValue();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      
-      manager.saveToDiskDebounced(10000);
-      await manager.flushPendingSave();
-
-      expect(mockSaveAccounts).toHaveBeenCalled();
-    });
-
-    it("does nothing when no pending save", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      await manager.flushPendingSave();
-
-      expect(mockSaveAccounts).not.toHaveBeenCalled();
-    });
-
-    it("waits for pendingSave if it exists during flush", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-      
-      let resolveFirst: () => void;
-      const firstSave = new Promise<void>((resolve) => { resolveFirst = resolve; });
-      mockSaveAccounts.mockImplementationOnce(() => firstSave);
-      mockSaveAccounts.mockResolvedValue();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      
-      const savePromise = manager.saveToDisk();
-      const flushPromise = manager.flushPendingSave();
-      
-      resolveFirst!();
-      await savePromise;
-      await flushPromise;
-      
-      expect(mockSaveAccounts).toHaveBeenCalled();
-    });
-
-    it("waits for in-flight pendingSave without timer", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-
-      let resolveInFlight: () => void;
-      const inFlightSave = new Promise<void>((resolve) => { resolveInFlight = resolve; });
-      mockSaveAccounts.mockImplementation(() => inFlightSave);
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      
-      const savePromise = manager.saveToDisk();
-      
-      queueMicrotask(() => resolveInFlight!());
-      
-      await manager.flushPendingSave();
-      await savePromise;
-    });
-  });
-
-  describe("health and token tracking methods", () => {
-    beforeEach(() => {
-      resetTrackers();
-      clearCircuitBreakers();
-    });
-
-    afterEach(() => {
-      resetTrackers();
-      clearCircuitBreakers();
-    });
-
-    it("recordSuccess updates health tracker with model-specific quotaKey", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const healthTracker = getHealthTracker();
-      const trackerKey = getRuntimeAccountIdentityKey(account)!;
-
-      manager.recordSuccess(account, "codex", "gpt-5.1");
-      
-      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
-      expect(score).toBe(100);
-    });
-
-    it("recordSuccess updates health tracker with family-only quotaKey when model is null", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const healthTracker = getHealthTracker();
-      const trackerKey = getRuntimeAccountIdentityKey(account)!;
-
-      manager.recordSuccess(account, "codex", null);
-      
-      const score = healthTracker.getScore(trackerKey, "codex");
-      expect(score).toBe(100);
-    });
-
-    it("recordSuccess closes the circuit breaker after a half-open retry succeeds", () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date(0));
-
-      try {
-        const now = Date.now();
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            {
-              refreshToken: "token-1",
-              email: "breaker@example.com",
-              addedAt: now,
-              lastUsed: now,
-            },
-          ],
-        };
-
-        const manager = new AccountManager(undefined, stored);
-        const account = manager.getCurrentAccount()!;
-        const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
-
-        manager.recordFailure(account, "codex");
-        manager.recordFailure(account, "codex");
-        manager.recordFailure(account, "codex");
-        expect(breaker.getState()).toBe("open");
-
-        vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
-        expect(manager.consumeToken(account, "codex")).toBe(true);
-        manager.recordSuccess(account, "codex");
-        expect(breaker.getState()).toBe("closed");
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("recordSuccess clears stale auth failure state and persists the healed account", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "token-1",
-            addedAt: now,
-            lastUsed: now,
-            consecutiveAuthFailures: 2,
-            coolingDownUntil: now - 1000,
-            cooldownReason: "network-error" as const,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      account.consecutiveAuthFailures = 2;
-
-      manager.recordSuccess(account, "codex", "gpt-5.1");
-      await manager.flushPendingSave();
-
-      expect(account.consecutiveAuthFailures).toBe(0);
-      expect(account.coolingDownUntil).toBeUndefined();
-      expect(account.cooldownReason).toBeUndefined();
-      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
-      const persisted = mockSaveAccounts.mock.calls[0]?.[0];
-      expect(persisted?.accounts[0]?.consecutiveAuthFailures ?? 0).toBe(0);
-      expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
-      expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
-    });
-
-    it("recordSuccess clears stale cooldown metadata when only the reason remains", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "token-1",
-            addedAt: now,
-            lastUsed: now,
-            cooldownReason: "network-error" as const,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-
-      manager.recordSuccess(account, "codex", "gpt-5.1");
-      await manager.flushPendingSave();
-
-      expect(account.coolingDownUntil).toBeUndefined();
-      expect(account.cooldownReason).toBeUndefined();
-      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
-      const persisted = mockSaveAccounts.mock.calls[0]?.[0];
-      expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
-      expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
-    });
-
-    it("recordSuccess does not clear an active cooldown from a newer concurrent failure", async () => {
-      const { saveAccounts } = await import("../lib/storage.js");
-      const mockSaveAccounts = vi.mocked(saveAccounts);
-      mockSaveAccounts.mockClear();
-
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "token-1",
-            addedAt: now,
-            lastUsed: now,
-            consecutiveAuthFailures: 2,
-            coolingDownUntil: now + 60_000,
-            cooldownReason: "auth-failure" as const,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      account.consecutiveAuthFailures = 2;
-
-      manager.recordSuccess(account, "codex", "gpt-5.1");
-      await manager.flushPendingSave();
-
-      expect(account.consecutiveAuthFailures).toBe(2);
-      expect(account.coolingDownUntil).toBe(now + 60_000);
-      expect(account.cooldownReason).toBe("auth-failure");
-      expect(mockSaveAccounts).not.toHaveBeenCalled();
-    });
-
-    it("recordRateLimit updates health and drains token bucket", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const healthTracker = getHealthTracker();
-      const tokenTracker = getTokenTracker();
-      const trackerKey = getRuntimeAccountIdentityKey(account)!;
-
-      manager.recordRateLimit(account, "codex", "gpt-5.1");
-      
-      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
-      const tokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
-      expect(score).toBeLessThan(100);
-      expect(tokens).toBeLessThan(50);
-    });
-
-    it("recordRateLimit uses family-only quotaKey when model is undefined", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const healthTracker = getHealthTracker();
-      const trackerKey = getRuntimeAccountIdentityKey(account)!;
-
-      manager.recordRateLimit(account, "gpt-5.2");
-      
-      const score = healthTracker.getScore(trackerKey, "gpt-5.2");
-      expect(score).toBeLessThan(100);
-    });
-
-    it("scopes quota rate limits to the family bucket only", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-
-      manager.markRateLimitedWithReason(
-        account,
-        60_000,
-        "codex",
-        "quota",
-        "gpt-5.1",
-      );
-
-      expect(account.rateLimitResetTimes.codex).toBeTypeOf("number");
-      expect(account.rateLimitResetTimes["codex:gpt-5.1"]).toBeUndefined();
-    });
-
-    it("scopes token rate limits to the model bucket", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-
-      manager.markRateLimitedWithReason(
-        account,
-        60_000,
-        "codex",
-        "tokens",
-        "gpt-5.1",
-      );
-
-      expect(account.rateLimitResetTimes.codex).toBeUndefined();
-      expect(account.rateLimitResetTimes["codex:gpt-5.1"]).toBeTypeOf("number");
-    });
-
-    it("recordFailure updates health tracker", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const healthTracker = getHealthTracker();
-      const trackerKey = getRuntimeAccountIdentityKey(account)!;
-
-      manager.recordFailure(account, "codex", "gpt-5.2");
-      
-      const score = healthTracker.getScore(trackerKey, "codex:gpt-5.2");
-      expect(score).toBeLessThan(100);
-    });
-
-    it("recordFailure opens the circuit breaker after repeated failures", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "token-1",
-            email: "breaker@example.com",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
-
-      manager.recordFailure(account, "codex");
-      manager.recordFailure(account, "codex");
-      manager.recordFailure(account, "codex");
-
-      expect(breaker.getState()).toBe("open");
-    });
-
-    it("recordFailure uses family-only quotaKey when model is null", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const healthTracker = getHealthTracker();
-      const trackerKey = getRuntimeAccountIdentityKey(account)!;
-
-      manager.recordFailure(account, "gpt-5.1", null);
-      
-      const score = healthTracker.getScore(trackerKey, "gpt-5.1");
-      expect(score).toBeLessThan(100);
-    });
-
-    it("consumeToken returns true and consumes from token bucket", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const tokenTracker = getTokenTracker();
-      const trackerKey = getRuntimeAccountIdentityKey(account)!;
-
-      const initialTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
-      const result = manager.consumeToken(account, "codex", "gpt-5.1");
-      const afterTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
-
-      expect(result).toBe(true);
-      expect(afterTokens).toBeLessThan(initialTokens);
-    });
-
-    it("consumeToken uses family-only quotaKey when model is undefined", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-
-      const result = manager.consumeToken(account, "codex");
-
-      expect(result).toBe(true);
-    });
-
-    it("consumeToken returns false and refunds the token when the circuit is open", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        accounts: [
-          {
-            refreshToken: "token-1",
-            email: "breaker@example.com",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored);
-      const account = manager.getCurrentAccount()!;
-      const tokenTracker = getTokenTracker();
-      const trackerKey = getRuntimeTrackerKey(account);
-      const initialTokens = tokenTracker.getTokens(trackerKey, "codex");
-
-      manager.recordFailure(account, "codex");
-      manager.recordFailure(account, "codex");
-      manager.recordFailure(account, "codex");
-
-      expect(manager.consumeToken(account, "codex")).toBe(false);
-      expect(tokenTracker.getTokens(trackerKey, "codex")).toBe(initialTokens);
-    });
-
-    it("consumeToken returns false and refunds when the half-open slot is exhausted", () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date(0));
-
-      try {
-        const now = Date.now();
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            {
-              refreshToken: "token-1",
-              email: "breaker@example.com",
-              addedAt: now,
-              lastUsed: now,
-            },
-          ],
-        };
-
-        const manager = new AccountManager(undefined, stored);
-        const account = manager.getCurrentAccount()!;
-        const tokenTracker = getTokenTracker();
-        const trackerKey = getRuntimeTrackerKey(account);
-        const initialTokens = tokenTracker.getTokens(trackerKey, "codex");
-
-        manager.recordFailure(account, "codex");
-        manager.recordFailure(account, "codex");
-        manager.recordFailure(account, "codex");
-
-        vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1);
-
-        expect(manager.consumeToken(account, "codex")).toBe(true);
-        expect(manager.consumeToken(account, "codex")).toBe(false);
-        expect(tokenTracker.getTokens(trackerKey, "codex")).toBe(initialTokens - 1);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("keeps refresh-only tracker state stable when the refresh token rotates", () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-      try {
-        const now = Date.now();
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          ],
-        };
-
-        const manager = new AccountManager(undefined, stored);
-        const account = manager.getCurrentAccount()!;
-        const healthTracker = getHealthTracker();
-        const tokenTracker = getTokenTracker();
-        const trackerKey = getRuntimeTrackerKey(account);
-
-        manager.recordFailure(account, "codex", "gpt-5.1");
-        const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
-        expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
-
-        account.refreshToken = "token-1-rotated";
-
-        const rotatedAccount = manager.getCurrentAccount()!;
-        expect(getRuntimeTrackerKey(rotatedAccount)).toBe(trackerKey);
-        expect(getRuntimeAccountIdentityKey(rotatedAccount)).toBe(trackerKey);
-        expect(getAccountIdentityKey(rotatedAccount)).not.toBe(`${trackerKey}`);
-        expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
-          degradedScore,
-          6,
-        );
-        expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("keeps pinned runtime tracker state stable after updateFromAuth enriches identity", () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-      try {
-        const now = Date.now();
-        const stored = {
-          version: 3 as const,
-          activeIndex: 0,
-          accounts: [
-            { refreshToken: "token-1", addedAt: now, lastUsed: now },
-            {
-              refreshToken: "token-2",
-              email: "healthy@example.com",
-              addedAt: now,
-              lastUsed: now,
-            },
-          ],
-        };
-
-        const manager = new AccountManager(undefined, stored);
-        const account = manager.getAccountByIndex(0)!;
-        const healthTracker = getHealthTracker();
-        const tokenTracker = getTokenTracker();
-        const trackerKey = getRuntimeTrackerKey(account);
-
-        manager.recordFailure(account, "codex", "gpt-5.1");
-        const degradedScore = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
-        expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
-
-        const payload = Buffer.from(JSON.stringify({
-          email: "enriched@example.com",
-          "https://api.openai.com/auth": {
-            chatgpt_account_id: "account-enriched",
-          },
-          exp: Math.floor((now + 3600000) / 1000),
-        })).toString("base64url");
-        const accessToken = `header.${payload}.signature`;
-
-        manager.updateFromAuth(account, {
-          type: "oauth",
-          access: accessToken,
-          refresh: "token-1-rotated",
-          expires: now + 3600000,
-        });
-
-        expect(account.accountId).toBe("account-enriched");
-        expect(account.email).toBe("enriched@example.com");
-        expect(getRuntimeAccountIdentityKey(account)).toBe(
-          "account:account-enriched::email:enriched@example.com",
-        );
-        expect(getRuntimeTrackerKey(account)).toBe(trackerKey);
-        expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
-          degradedScore,
-          5,
-        );
-        expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("preserves tracker state when account indexes shift", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 1,
-        activeIndexByFamily: { codex: 1 },
-        accounts: [
-          {
-            refreshToken: "token-1",
-            email: "first@example.com",
-            addedAt: now,
-            lastUsed: now,
-          },
-          {
-            refreshToken: "token-2",
-            email: "second@example.com",
-            addedAt: now,
-            lastUsed: now,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored as never);
-      const trackedAccount = manager.getAccountByIndex(1)!;
-      const trackerKey = getAccountIdentityKey(trackedAccount)!;
-      const healthTracker = getHealthTracker();
-      const tokenTracker = getTokenTracker();
-
-      manager.recordFailure(trackedAccount, "codex", "gpt-5.1");
-      expect(manager.consumeToken(trackedAccount, "codex", "gpt-5.1")).toBe(true);
-
-      expect(manager.removeAccountByIndex(0)).toBe(true);
-
-      const remainingAccount = manager.getAccountByIndex(0)!;
-      expect(remainingAccount.email).toBe("second@example.com");
-      expect(remainingAccount.index).toBe(0);
-      expect(getAccountIdentityKey(remainingAccount)).toBe(trackerKey);
-      expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeLessThan(100);
-      expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(50);
-    });
-  });
-
-  describe("hybrid selection fallback path", () => {
-    beforeEach(() => {
-      resetTrackers();
-      clearCircuitBreakers();
-    });
-
-    afterEach(() => {
-      resetTrackers();
-      clearCircuitBreakers();
-    });
-
-    it("selects alternate account when current is rate-limited via selectHybridAccount", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        activeIndexByFamily: { codex: 0 },
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          { refreshToken: "token-2", addedAt: now, lastUsed: now - 10000 },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored as never);
-      
-      const account0 = manager.setActiveIndex(0)!;
-      manager.markRateLimited(account0, 60000, "codex");
-      
-      const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
-      
-      expect(selected).not.toBeNull();
-      expect(selected?.refreshToken).toBe("token-2");
-      expect(selected?.index).toBe(1);
-    });
-
-    it("re-scores on the next call instead of sticking to the prior hybrid winner", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        activeIndexByFamily: { codex: 0 },
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-          { refreshToken: "token-2", addedAt: now, lastUsed: now - 5000 },
-          { refreshToken: "token-3", addedAt: now, lastUsed: now - 10000 },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored as never);
-      
-      const account0 = manager.getAccountsSnapshot()[0]!;
-      manager.markRateLimited(account0, 60000, "codex");
-      
-      const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
-      expect(selected).not.toBeNull();
-      
-      const secondCall = manager.getCurrentOrNextForFamilyHybrid("codex");
-      expect(secondCall?.index).toBe(1);
-      expect(secondCall?.index).not.toBe(selected?.index);
-    });
-
-    it("skips accounts whose circuit breaker is open", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        activeIndexByFamily: { codex: 0 },
-        accounts: [
-          {
-            refreshToken: "token-1",
-            email: "first@example.com",
-            addedAt: now,
-            lastUsed: now,
-          },
-          {
-            refreshToken: "token-2",
-            email: "second@example.com",
-            addedAt: now,
-            lastUsed: now - 10_000,
-          },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored as never);
-      const blocked = manager.getAccountByIndex(0)!;
-
-      manager.recordFailure(blocked, "codex");
-      manager.recordFailure(blocked, "codex");
-      manager.recordFailure(blocked, "codex");
-
-      const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
-
-      expect(selected?.refreshToken).toBe("token-2");
-      expect(selected?.index).toBe(1);
-      expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
-    });
-
-    it("falls back to least-recently-used when all accounts are rate-limited", () => {
-      const now = Date.now();
-      const stored = {
-        version: 3 as const,
-        activeIndex: 0,
-        activeIndexByFamily: { codex: 0 },
-        accounts: [
-          { refreshToken: "token-1", addedAt: now, lastUsed: now },
-        ],
-      };
-
-      const manager = new AccountManager(undefined, stored as never);
-      
-      const account0 = manager.setActiveIndex(0)!;
-      manager.markRateLimited(account0, 60000, "codex");
-      
-      const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
-      expect(selected).not.toBeNull();
-      expect(selected?.index).toBe(0);
-    });
-  });
+	it("seeds from fallback auth when no storage exists", () => {
+		const auth: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		};
+
+		const manager = new AccountManager(auth, null);
+		expect(manager.getAccountCount()).toBe(1);
+		expect(manager.getCurrentAccount()?.refreshToken).toBe("refresh-token");
+	});
+
+	it("returns account by index and rejects invalid indexes", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+				{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		expect(manager.getAccountByIndex(0)?.refreshToken).toBe("token-1");
+		expect(manager.getAccountByIndex(1)?.refreshToken).toBe("token-2");
+		expect(manager.getAccountByIndex(-1)).toBeNull();
+		expect(manager.getAccountByIndex(9)).toBeNull();
+		expect(manager.getAccountByIndex(Number.NaN)).toBeNull();
+	});
+
+	it("does not disable a different current workspace after another request already rotated away", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+					workspaces: [
+						{ id: "workspace-1", name: "Workspace 1", enabled: true },
+						{ id: "workspace-2", name: "Workspace 2", enabled: true },
+					],
+					currentWorkspaceIndex: 0,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const account = manager.getAccountByIndex(0);
+		expect(account).not.toBeNull();
+		if (!account) {
+			throw new Error("account should exist");
+		}
+
+		expect(manager.disableCurrentWorkspace(account, "workspace-1")).toBe(true);
+		expect(manager.rotateToNextWorkspace(account)?.id).toBe("workspace-2");
+
+		expect(manager.disableCurrentWorkspace(account, "workspace-1")).toBe(false);
+		expect(account.enabled).not.toBe(false);
+		expect(manager.hasEnabledWorkspaces(account)).toBe(true);
+		expect(manager.getEnabledWorkspaceCount(account)).toBe(1);
+		expect(manager.getCurrentWorkspace(account)?.id).toBe("workspace-2");
+		expect(account.workspaces?.map((workspace) => workspace.enabled)).toEqual([
+			false,
+			true,
+		]);
+	});
+
+	it("re-enabling an exhausted account restores its workspaces", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+					enabled: false,
+					workspaces: [
+						{
+							id: "workspace-1",
+							name: "Workspace 1",
+							enabled: false,
+							disabledAt: now - 2_000,
+							isDefault: true,
+						},
+						{
+							id: "workspace-2",
+							name: "Workspace 2",
+							enabled: false,
+							disabledAt: now - 1_000,
+						},
+					],
+					currentWorkspaceIndex: 1,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const account = manager.setAccountEnabled(0, true);
+		expect(account).not.toBeNull();
+		if (!account) {
+			throw new Error("account should exist");
+		}
+
+		expect(account.enabled).toBe(true);
+		expect(manager.hasEnabledWorkspaces(account)).toBe(true);
+		expect(manager.getEnabledWorkspaceCount(account)).toBe(2);
+		expect(account.currentWorkspaceIndex).toBe(0);
+		expect(manager.getCurrentWorkspace(account)?.id).toBe("workspace-1");
+		expect(account.workspaces).toEqual([
+			{
+				id: "workspace-1",
+				name: "Workspace 1",
+				enabled: true,
+				isDefault: true,
+			},
+			{ id: "workspace-2", name: "Workspace 2", enabled: true },
+		]);
+	});
+
+	it("re-enabling an exhausted account without a default workspace resets to the first workspace", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+					enabled: false,
+					workspaces: [
+						{
+							id: "workspace-1",
+							name: "Workspace 1",
+							enabled: false,
+							disabledAt: now - 2_000,
+						},
+						{
+							id: "workspace-2",
+							name: "Workspace 2",
+							enabled: false,
+							disabledAt: now - 1_000,
+						},
+					],
+					currentWorkspaceIndex: 1,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const account = manager.setAccountEnabled(0, true);
+		expect(account).not.toBeNull();
+		if (!account) {
+			throw new Error("account should exist");
+		}
+
+		expect(account.currentWorkspaceIndex).toBe(0);
+		expect(manager.getCurrentWorkspace(account)?.id).toBe("workspace-1");
+		expect(account.workspaces).toEqual([
+			{ id: "workspace-1", name: "Workspace 1", enabled: true },
+			{ id: "workspace-2", name: "Workspace 2", enabled: true },
+		]);
+	});
+
+	it("checks account availability by enabled/rate-limit/cooldown state", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+					enabled: false,
+				},
+				{
+					refreshToken: "token-2",
+					addedAt: now,
+					lastUsed: now,
+					rateLimitResetTimes: { codex: now + 60_000 },
+				},
+				{
+					refreshToken: "token-3",
+					addedAt: now,
+					lastUsed: now,
+					coolingDownUntil: now + 60_000,
+					cooldownReason: "network-error" as const,
+				},
+				{
+					refreshToken: "token-4",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+
+		expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
+		expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(false);
+		expect(manager.isAccountAvailableForFamily(2, "codex")).toBe(false);
+		expect(manager.isAccountAvailableForFamily(3, "codex")).toBe(true);
+	});
+
+	it("treats accounts with all tracked workspaces disabled as unavailable for selection", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					refreshToken: "token-workspace-disabled",
+					addedAt: now,
+					lastUsed: now,
+					workspaces: [
+						{ id: "workspace-1", name: "Workspace 1", enabled: false },
+						{ id: "workspace-2", name: "Workspace 2", enabled: false },
+					],
+					currentWorkspaceIndex: 0,
+				},
+				{
+					refreshToken: "token-ready",
+					addedAt: now,
+					lastUsed: now - 10_000,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored as never);
+
+		expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
+		expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe(
+			"token-ready",
+		);
+		expect(manager.getNextForFamily("codex")?.refreshToken).toBe("token-ready");
+		expect(manager.getCurrentOrNextForFamilyHybrid("codex")?.refreshToken).toBe(
+			"token-ready",
+		);
+	});
+
+	it("keeps workspace-less legacy accounts eligible for selection", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [{ refreshToken: "token-legacy", addedAt: now, lastUsed: now }],
+		};
+
+		const manager = new AccountManager(undefined, stored as never);
+
+		expect(manager.hasEnabledWorkspaces(manager.getAccountByIndex(0)!)).toBe(
+			true,
+		);
+		expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
+		expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe(
+			"token-legacy",
+		);
+	});
+
+	it("returns false for invalid account index in availability checks", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+		};
+		const manager = new AccountManager(undefined, stored);
+		expect(manager.isAccountAvailableForFamily(-1, "codex")).toBe(false);
+		expect(manager.isAccountAvailableForFamily(99, "codex")).toBe(false);
+		expect(manager.isAccountAvailableForFamily(Number.NaN, "codex")).toBe(
+			false,
+		);
+	});
+
+	it("clears expired rate-limit windows before availability check", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+					rateLimitResetTimes: { codex: now - 1_000 },
+				},
+			],
+		};
+		const manager = new AccountManager(undefined, stored);
+		expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
+		const account = manager.getAccountByIndex(0);
+		expect(account?.rateLimitResetTimes?.codex).toBeUndefined();
+	});
+
+	it("does not block available accounts just because another token expires later", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-stale",
+					accessToken: "access-stale",
+					expiresAt: now + 60_000,
+					addedAt: now,
+					lastUsed: now,
+				},
+				{
+					refreshToken: "token-fresh",
+					accessToken: "access-fresh",
+					expiresAt: now + 10 * 60_000,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+		const manager = new AccountManager(undefined, stored);
+
+		expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
+		expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
+	});
+
+	it("keeps stale accounts available when the whole pool is stale", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-stale-1",
+					accessToken: "access-stale-1",
+					expiresAt: now + 60_000,
+					addedAt: now,
+					lastUsed: now,
+				},
+				{
+					refreshToken: "token-stale-2",
+					accessToken: "access-stale-2",
+					expiresAt: now + 120_000,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+		const manager = new AccountManager(undefined, stored);
+
+		expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(true);
+		expect(manager.isAccountAvailableForFamily(1, "codex")).toBe(true);
+	});
+
+	it("rotates when the active account is rate-limited", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+					rateLimitResetTimes: { codex: now + 60_000 },
+				},
+				{
+					refreshToken: "token-2",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const account = manager.getCurrentOrNext();
+		expect(account?.refreshToken).toBe("token-2");
+		expect(manager.getMinWaitTime()).toBe(0);
+	});
+
+	it("skips accounts that are cooling down", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+					coolingDownUntil: now + 60_000,
+					cooldownReason: "auth-failure" as const,
+				},
+				{
+					refreshToken: "token-2",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const account = manager.getCurrentOrNext();
+		expect(account?.refreshToken).toBe("token-2");
+		expect(manager.getActiveIndex()).toBe(1);
+	});
+
+	it("returns min wait time when all accounts are blocked", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+					coolingDownUntil: now + 60_000,
+					cooldownReason: "network-error" as const,
+				},
+				{
+					refreshToken: "token-2",
+					addedAt: now,
+					lastUsed: now,
+					rateLimitResetTimes: { codex: now + 120_000 },
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const waitMs = manager.getMinWaitTime();
+		expect(waitMs).toBeGreaterThan(0);
+		expect(waitMs).toBeLessThanOrEqual(60_000);
+	});
+
+	it("debounces account toasts for the same account index", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "token-1",
+					addedAt: now,
+					lastUsed: now,
+				},
+				{
+					refreshToken: "token-2",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		expect(manager.shouldShowAccountToast(0, 60_000)).toBe(true);
+		manager.markToastShown(0);
+		expect(manager.shouldShowAccountToast(0, 60_000)).toBe(false);
+		expect(manager.shouldShowAccountToast(1, 60_000)).toBe(true);
+	});
+
+	it("extracts email from jwt when present", () => {
+		const payload = Buffer.from(
+			JSON.stringify({ email: "user@example.com" }),
+		).toString("base64");
+		const token = `header.${payload}.signature`;
+		expect(extractAccountEmail(token)).toBe("user@example.com");
+	});
+
+	it("formats account label preferring email and id suffix", () => {
+		expect(
+			formatAccountLabel(
+				{ email: "user@example.com", accountId: "abcdef123456" },
+				0,
+			),
+		).toBe("Account 1 (user@example.com, id:123456)");
+		expect(formatAccountLabel({ email: "user@example.com" }, 1)).toBe(
+			"Account 2 (user@example.com)",
+		);
+		expect(formatAccountLabel({ accountId: "abcdef123456" }, 2)).toBe(
+			"Account 3 (123456)",
+		);
+		expect(formatAccountLabel(undefined as any, 3)).toBe("Account 4");
+	});
+
+	it("formats account label with accountLabel variations", () => {
+		expect(formatAccountLabel({ accountLabel: "Work" }, 0)).toBe(
+			"Account 1 (Work)",
+		);
+		expect(
+			formatAccountLabel({ accountLabel: "Work", email: "work@co.com" }, 0),
+		).toBe("Account 1 (Work, work@co.com)");
+		expect(
+			formatAccountLabel(
+				{ accountLabel: "Work", accountId: "abcdef123456" },
+				0,
+			),
+		).toBe("Account 1 (Work, id:123456)");
+		expect(
+			formatAccountLabel(
+				{
+					accountLabel: "Work",
+					email: "work@co.com",
+					accountId: "abcdef123456",
+				},
+				0,
+			),
+		).toBe("Account 1 (Work, work@co.com, id:123456)");
+	});
+
+	it("formats account label with short accountId", () => {
+		expect(formatAccountLabel({ accountId: "abc" }, 0)).toBe("Account 1 (abc)");
+		expect(formatAccountLabel({ accountId: "123456" }, 0)).toBe(
+			"Account 1 (123456)",
+		);
+	});
+
+	it("performs true round-robin rotation across multiple requests", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+				{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+				{ refreshToken: "token-3", addedAt: now, lastUsed: now },
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+
+		const first = manager.getCurrentOrNext();
+		const second = manager.getCurrentOrNext();
+		const third = manager.getCurrentOrNext();
+		const fourth = manager.getCurrentOrNext();
+
+		expect(first?.refreshToken).toBe("token-1");
+		expect(second?.refreshToken).toBe("token-2");
+		expect(third?.refreshToken).toBe("token-3");
+		expect(fourth?.refreshToken).toBe("token-1");
+	});
+
+	it("skips rate-limited accounts during rotation", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+				{
+					refreshToken: "token-2",
+					addedAt: now,
+					lastUsed: now,
+					rateLimitResetTimes: { codex: now + 60_000 },
+				},
+				{ refreshToken: "token-3", addedAt: now, lastUsed: now },
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+
+		const first = manager.getCurrentOrNext();
+		const second = manager.getCurrentOrNext();
+		const third = manager.getCurrentOrNext();
+
+		expect(first?.refreshToken).toBe("token-1");
+		expect(second?.refreshToken).toBe("token-3");
+		expect(third?.refreshToken).toBe("token-1");
+	});
+
+	it("uses independent cursors per model family", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+				{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+
+		const codexFirst = manager.getCurrentOrNextForFamily("codex");
+		const gpt51First = manager.getCurrentOrNextForFamily("gpt-5.1");
+		const codexSecond = manager.getCurrentOrNextForFamily("codex");
+		const gpt51Second = manager.getCurrentOrNextForFamily("gpt-5.1");
+
+		expect(codexFirst?.refreshToken).toBe("token-1");
+		expect(gpt51First?.refreshToken).toBe("token-1");
+		expect(codexSecond?.refreshToken).toBe("token-2");
+		expect(gpt51Second?.refreshToken).toBe("token-2");
+	});
+
+	it("keeps cursor ordering even when another access token lives longer", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					refreshToken: "token-stale",
+					accessToken: "access-stale",
+					expiresAt: now + 60_000,
+					addedAt: now,
+					lastUsed: now,
+				},
+				{
+					refreshToken: "token-fresh",
+					accessToken: "access-fresh",
+					expiresAt: now + 10 * 60_000,
+					addedAt: now,
+					lastUsed: now - 5_000,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored as never);
+		const selected = manager.getCurrentOrNextForFamily("codex");
+
+		expect(selected?.refreshToken).toBe("token-stale");
+	});
+
+	it("hybrid selection prefers the healthier candidate over the active index", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 1, // Set active index to second account
+			activeIndexByFamily: { codex: 1 },
+			accounts: [
+				{ refreshToken: "token-1", addedAt: now, lastUsed: 0 }, // Very stale (high freshness score)
+				{ refreshToken: "token-2", addedAt: now, lastUsed: now }, // Just used (low freshness score)
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored as any);
+
+		const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
+		expect(selected?.refreshToken).toBe("token-1");
+		expect(selected?.index).toBe(0);
+	});
+
+	describe("removeAccount", () => {
+		it("removes an account and updates indices", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 1,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-3", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			expect(manager.getAccountCount()).toBe(3);
+
+			const accountToRemove = manager.getCurrentAccount();
+			expect(accountToRemove).toBeDefined();
+			expect(accountToRemove?.refreshToken).toBe("token-2");
+
+			const removed = manager.removeAccount(accountToRemove!);
+			expect(removed).toBe(true);
+			expect(manager.getAccountCount()).toBe(2);
+
+			const remaining = manager.getAccountsSnapshot();
+			expect(remaining[0]?.refreshToken).toBe("token-1");
+			expect(remaining[1]?.refreshToken).toBe("token-3");
+			expect(remaining[0]?.index).toBe(0);
+			expect(remaining[1]?.index).toBe(1);
+		});
+
+		it("returns false when removing non-existent account", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const fakeAccount = {
+				index: 999,
+				refreshToken: "non-existent",
+				addedAt: now,
+				lastUsed: now,
+				rateLimitResetTimes: {},
+			};
+
+			const removed = manager.removeAccount(fakeAccount as any);
+			expect(removed).toBe(false);
+			expect(manager.getAccountCount()).toBe(1);
+		});
+
+		it("handles removing the last account", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount();
+			expect(account).not.toBe(null);
+
+			const removed = manager.removeAccount(account!);
+			expect(removed).toBe(true);
+			expect(manager.getAccountCount()).toBe(0);
+			expect(manager.getCurrentAccount()).toBe(null);
+		});
+	});
+
+	describe("hasRefreshToken", () => {
+		it("returns true when token exists", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			expect(manager.hasRefreshToken("token-1")).toBe(true);
+			expect(manager.hasRefreshToken("token-2")).toBe(true);
+		});
+
+		it("returns false when token does not exist", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			expect(manager.hasRefreshToken("non-existent")).toBe(false);
+			expect(manager.hasRefreshToken("")).toBe(false);
+		});
+	});
+
+	describe("markRateLimitedWithReason", () => {
+		it("marks account as rate limited with reason", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			manager.markRateLimitedWithReason(account, 60000, "codex", "quota");
+
+			expect(account.lastRateLimitReason).toBe("quota");
+			expect(account.rateLimitResetTimes["codex"]).toBeDefined();
+		});
+
+		it("scopes token rate limits to the model-specific key", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			manager.markRateLimitedWithReason(
+				account,
+				60000,
+				"codex",
+				"tokens",
+				"gpt-5.2",
+			);
+
+			expect(account.rateLimitResetTimes["codex"]).toBeUndefined();
+			expect(account.rateLimitResetTimes["codex:gpt-5.2"]).toBeDefined();
+		});
+
+		it("does not shorten an existing reset when a later retry window is smaller", () => {
+			vi.useFakeTimers();
+			try {
+				const now = new Date("2026-04-05T00:00:00.000Z");
+				vi.setSystemTime(now);
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [
+						{
+							refreshToken: "token-1",
+							addedAt: now.getTime(),
+							lastUsed: now.getTime(),
+						},
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored);
+				const account = manager.getCurrentAccount()!;
+				manager.markRateLimitedWithReason(
+					account,
+					90 * 60_000,
+					"codex",
+					"quota",
+				);
+
+				const expectedResetAt = now.getTime() + 90 * 60_000;
+
+				vi.advanceTimersByTime(30 * 60_000);
+
+				manager.markRateLimitedWithReason(account, 60_000, "codex", "quota");
+
+				expect(account.rateLimitResetTimes["codex"]).toBe(expectedResetAt);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("does not shorten an existing model-scoped reset when a later retry window is smaller", () => {
+			vi.useFakeTimers();
+			try {
+				const now = new Date("2026-04-05T00:00:00.000Z");
+				vi.setSystemTime(now);
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [
+						{
+							refreshToken: "token-1",
+							addedAt: now.getTime(),
+							lastUsed: now.getTime(),
+						},
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored);
+				const account = manager.getCurrentAccount()!;
+				manager.markRateLimitedWithReason(
+					account,
+					90 * 60_000,
+					"codex",
+					"tokens",
+					"gpt-5.2",
+				);
+
+				const expectedResetAt = now.getTime() + 90 * 60_000;
+
+				vi.advanceTimersByTime(30 * 60_000);
+
+				manager.markRateLimitedWithReason(
+					account,
+					60_000,
+					"codex",
+					"tokens",
+					"gpt-5.2",
+				);
+
+				expect(account.rateLimitResetTimes["codex:gpt-5.2"]).toBe(
+					expectedResetAt,
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	});
+
+	describe("cooldown management", () => {
+		it("marks account as cooling down", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			manager.markAccountCoolingDown(account, 30000, "auth-failure");
+
+			expect(manager.isAccountCoolingDown(account)).toBe(true);
+			expect(account.cooldownReason).toBe("auth-failure");
+		});
+
+		it("clears cooldown when time expires", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						addedAt: now,
+						lastUsed: now,
+						coolingDownUntil: now - 1000,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			expect(manager.isAccountCoolingDown(account)).toBe(false);
+		});
+
+		it("clears cooldown manually", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			manager.markAccountCoolingDown(account, 30000, "network-error");
+			expect(manager.isAccountCoolingDown(account)).toBe(true);
+
+			manager.clearAccountCooldown(account);
+			expect(manager.isAccountCoolingDown(account)).toBe(false);
+			expect(account.cooldownReason).toBeUndefined();
+		});
+	});
+
+	describe("auth failure tracking", () => {
+		it("increments consecutive auth failures", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			expect(manager.incrementAuthFailures(account)).toBe(1);
+			expect(manager.incrementAuthFailures(account)).toBe(2);
+			expect(manager.incrementAuthFailures(account)).toBe(3);
+		});
+
+		it("clears auth failures", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			manager.incrementAuthFailures(account);
+			manager.incrementAuthFailures(account);
+			manager.clearAuthFailures(account);
+
+			expect(account.consecutiveAuthFailures).toBe(0);
+		});
+	});
+
+	describe("getMinWaitTimeForFamily", () => {
+		it("returns 0 when accounts are available", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			expect(manager.getMinWaitTimeForFamily("codex")).toBe(0);
+		});
+
+		it("returns wait time when all accounts rate limited", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						addedAt: now,
+						lastUsed: now,
+						rateLimitResetTimes: { codex: now + 30000 },
+					},
+					{
+						refreshToken: "token-2",
+						addedAt: now,
+						lastUsed: now,
+						rateLimitResetTimes: { codex: now + 60000 },
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const waitTime = manager.getMinWaitTimeForFamily("codex");
+			expect(waitTime).toBeGreaterThan(0);
+			expect(waitTime).toBeLessThanOrEqual(30000);
+		});
+
+		it("considers model-specific rate limits", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						addedAt: now,
+						lastUsed: now,
+						rateLimitResetTimes: { "codex:gpt-5.2": now + 45000 },
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const waitTime = manager.getMinWaitTimeForFamily("codex", "gpt-5.2");
+			expect(waitTime).toBeGreaterThan(0);
+			expect(waitTime).toBeLessThanOrEqual(45000);
+		});
+	});
+
+	describe("updateFromAuth", () => {
+		it("updates account tokens from auth", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "old-token", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			const newAuth: OAuthAuthDetails = {
+				type: "oauth",
+				access: "new-access",
+				refresh: "new-refresh",
+				expires: now + 3600000,
+			};
+
+			manager.updateFromAuth(account, newAuth);
+
+			expect(account.refreshToken).toBe("new-refresh");
+			expect(account.access).toBe("new-access");
+			expect(account.expires).toBe(now + 3600000);
+		});
+
+		it("updates accountId from token when source is token-derived", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "old-token",
+						addedAt: now,
+						lastUsed: now,
+						accountId: "old-account-id",
+						accountIdSource: "token" as const,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			const payload = Buffer.from(
+				JSON.stringify({
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "new-account-id-from-token",
+					},
+					exp: Math.floor((now + 3600000) / 1000),
+				}),
+			).toString("base64url");
+			const accessToken = `header.${payload}.signature`;
+
+			const newAuth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "new-refresh",
+				expires: now + 3600000,
+			};
+
+			manager.updateFromAuth(account, newAuth);
+
+			expect(account.accountId).toBe("new-account-id-from-token");
+			expect(account.accountIdSource).toBe("token");
+		});
+
+		it("does not update accountId when source is org-selected", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "old-token",
+						addedAt: now,
+						lastUsed: now,
+						accountId: "org-selected-id",
+						accountIdSource: "org" as const,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			const payload = Buffer.from(
+				JSON.stringify({
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "new-account-id-from-token",
+					},
+					exp: Math.floor((now + 3600000) / 1000),
+				}),
+			).toString("base64url");
+			const accessToken = `header.${payload}.signature`;
+
+			const newAuth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "new-refresh",
+				expires: now + 3600000,
+			};
+
+			manager.updateFromAuth(account, newAuth);
+
+			expect(account.accountId).toBe("org-selected-id");
+			expect(account.accountIdSource).toBe("org");
+		});
+	});
+
+	describe("commitRefreshedAuth", () => {
+		it("persists refreshed auth transactionally and updates the live account", async () => {
+			const { withAccountStorageTransaction } = await import(
+				"../lib/storage.js"
+			);
+			const mockWithAccountStorageTransaction = vi.mocked(
+				withAccountStorageTransaction,
+			);
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "old-refresh",
+						accessToken: "old-access",
+						expiresAt: now,
+						addedAt: now,
+						lastUsed: now,
+						email: "old@example.com",
+						accountId: "old-account-id",
+						accountIdSource: "token" as const,
+						enabled: false,
+						coolingDownUntil: now + 30_000,
+						cooldownReason: "auth-failure" as const,
+					},
+				],
+			};
+			const manager = new AccountManager(undefined, stored as any);
+			const account = manager.getAccountByIndex(0)!;
+			account.enabled = false;
+			manager.markAccountCoolingDown(account, 30_000, "auth-failure");
+			manager.incrementAuthFailures(account);
+
+			const payload = Buffer.from(
+				JSON.stringify({
+					email: "new@example.com",
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "new-account-id",
+					},
+				}),
+			).toString("base64url");
+			const refreshedAuth: OAuthAuthDetails = {
+				type: "oauth",
+				access: `header.${payload}.signature`,
+				refresh: "new-refresh",
+				expires: now + 3_600_000,
+			};
+
+			mockWithAccountStorageTransaction.mockImplementationOnce(
+				async (handler) => {
+					const persist = vi.fn().mockResolvedValue(undefined);
+					const result = await handler(stored as any, persist);
+
+					expect(persist).toHaveBeenCalledTimes(1);
+					const persistedStorage = persist.mock.calls[0]?.[0];
+					expect(persistedStorage?.accounts[0]?.refreshToken).toBe(
+						"new-refresh",
+					);
+					expect(persistedStorage?.accounts[0]?.accessToken).toBe(
+						refreshedAuth.access,
+					);
+					expect(persistedStorage?.accounts[0]?.expiresAt).toBe(
+						refreshedAuth.expires,
+					);
+					expect(persistedStorage?.accounts[0]?.accountId).toBe(
+						"new-account-id",
+					);
+					expect(persistedStorage?.accounts[0]?.accountIdSource).toBe("token");
+					expect(persistedStorage?.accounts[0]?.email).toBe("new@example.com");
+					expect(persistedStorage?.accounts[0]?.enabled).toBeUndefined();
+					expect(
+						persistedStorage?.accounts[0]?.coolingDownUntil,
+					).toBeUndefined();
+					expect(persistedStorage?.accounts[0]?.cooldownReason).toBeUndefined();
+
+					return result;
+				},
+			);
+
+			const updated = await manager.commitRefreshedAuth(account, refreshedAuth);
+
+			expect(updated).toBe(account);
+			expect(account.refreshToken).toBe("new-refresh");
+			expect(account.access).toBe(refreshedAuth.access);
+			expect(account.expires).toBe(refreshedAuth.expires);
+			expect(account.accountId).toBe("new-account-id");
+			expect(account.accountIdSource).toBe("token");
+			expect(account.email).toBe("new@example.com");
+			expect(account.enabled).toBe(true);
+			expect(account.coolingDownUntil).toBeUndefined();
+			expect(account.cooldownReason).toBeUndefined();
+			expect(account.consecutiveAuthFailures).toBe(0);
+		});
+
+		it("preserves unsaved live pool state when persisting refreshed auth", async () => {
+			const { withAccountStorageTransaction } = await import(
+				"../lib/storage.js"
+			);
+			const mockWithAccountStorageTransaction = vi.mocked(
+				withAccountStorageTransaction,
+			);
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: {
+					codex: 0,
+				},
+				accounts: [
+					{
+						refreshToken: "old-refresh-a",
+						accessToken: "old-access-a",
+						expiresAt: now,
+						addedAt: now,
+						lastUsed: now,
+						email: "a@example.com",
+					},
+					{
+						refreshToken: "old-refresh-b",
+						accessToken: "old-access-b",
+						expiresAt: now,
+						addedAt: now,
+						lastUsed: now,
+						email: "b@example.com",
+					},
+				],
+			};
+			const manager = new AccountManager(undefined, stored as any);
+			const accountA = manager.getAccountByIndex(0)!;
+			const accountB = manager.getAccountByIndex(1)!;
+			manager.markSwitched(accountB, "rotation", "codex");
+			manager.markRateLimited(accountB, 45_000, "codex");
+			manager.markAccountCoolingDown(accountB, 30_000, "network-error");
+
+			const refreshedAuth: OAuthAuthDetails = {
+				type: "oauth",
+				access: "header.payload.signature",
+				refresh: "new-refresh-a",
+				expires: now + 3_600_000,
+			};
+
+			mockWithAccountStorageTransaction.mockImplementationOnce(
+				async (handler) => {
+					const persist = vi.fn().mockResolvedValue(undefined);
+					const result = await handler(stored as any, persist);
+
+					expect(persist).toHaveBeenCalledTimes(1);
+					const persistedStorage = persist.mock.calls[0]?.[0];
+					expect(persistedStorage?.activeIndex).toBe(1);
+					expect(persistedStorage?.activeIndexByFamily?.codex).toBe(1);
+					expect(persistedStorage?.accounts[0]?.refreshToken).toBe(
+						"new-refresh-a",
+					);
+					expect(
+						persistedStorage?.accounts[1]?.rateLimitResetTimes?.codex,
+					).toBeGreaterThan(now);
+					expect(persistedStorage?.accounts[1]?.cooldownReason).toBe(
+						"network-error",
+					);
+					expect(
+						persistedStorage?.accounts[1]?.coolingDownUntil,
+					).toBeGreaterThan(now);
+
+					return result;
+				},
+			);
+
+			await manager.commitRefreshedAuth(accountA, refreshedAuth);
+		});
+
+		it("keeps trimmed token accountId identical in memory and persisted storage", async () => {
+			const { withAccountStorageTransaction } = await import(
+				"../lib/storage.js"
+			);
+			const mockWithAccountStorageTransaction = vi.mocked(
+				withAccountStorageTransaction,
+			);
+			const now = Date.now();
+			const payload = Buffer.from(
+				JSON.stringify({
+					"https://api.openai.com/auth": {
+						chatgpt_account_id: "  matching-account-id  ",
+					},
+				}),
+			).toString("base64url");
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "old-refresh",
+						accessToken: "old-access",
+						expiresAt: now,
+						addedAt: now,
+						lastUsed: now,
+						accountId: "matching-account-id",
+						accountIdSource: "token" as const,
+					},
+				],
+			};
+			const manager = new AccountManager(undefined, stored as any);
+			const account = manager.getAccountByIndex(0)!;
+			const refreshedAuth: OAuthAuthDetails = {
+				type: "oauth",
+				access: `header.${payload}.signature`,
+				refresh: "new-refresh",
+				expires: now + 3_600_000,
+			};
+
+			mockWithAccountStorageTransaction.mockImplementationOnce(
+				async (handler) => {
+					const persist = vi.fn().mockResolvedValue(undefined);
+					const result = await handler(stored as any, persist);
+
+					expect(persist).toHaveBeenCalledTimes(1);
+					const persistedStorage = persist.mock.calls[0]?.[0];
+					expect(persistedStorage?.accounts[0]?.accountId).toBe(
+						"matching-account-id",
+					);
+
+					return result;
+				},
+			);
+
+			await manager.commitRefreshedAuth(account, refreshedAuth);
+
+			expect(account.accountId).toBe("matching-account-id");
+		});
+
+		it("propagates storage write failure as retryable CodexAuthError", async () => {
+			const { withAccountStorageTransaction } = await import(
+				"../lib/storage.js"
+			);
+			const mockWithAccountStorageTransaction = vi.mocked(
+				withAccountStorageTransaction,
+			);
+			mockWithAccountStorageTransaction.mockRejectedValueOnce(
+				Object.assign(new Error("EBUSY"), { code: "EBUSY" }),
+			);
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "old-refresh",
+						accessToken: "old-access",
+						expiresAt: now,
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+			const manager = new AccountManager(undefined, stored as any);
+			const account = manager.getAccountByIndex(0)!;
+			const refreshedAuth: OAuthAuthDetails = {
+				type: "oauth",
+				access: "header.payload.signature",
+				refresh: "new-refresh",
+				expires: now + 3_600_000,
+			};
+
+			const error = await manager
+				.commitRefreshedAuth(account, refreshedAuth)
+				.catch((err) => err as CodexAuthError);
+
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(true);
+			expect(account.refreshToken).toBe("old-refresh");
+		});
+
+		it("propagates non-transient storage write failure as terminal CodexAuthError", async () => {
+			const { withAccountStorageTransaction } = await import(
+				"../lib/storage.js"
+			);
+			const mockWithAccountStorageTransaction = vi.mocked(
+				withAccountStorageTransaction,
+			);
+			mockWithAccountStorageTransaction.mockRejectedValueOnce(
+				Object.assign(new Error("EACCES"), { code: "EACCES" }),
+			);
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "old-refresh",
+						accessToken: "old-access",
+						expiresAt: now,
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+			const manager = new AccountManager(undefined, stored as any);
+			const account = manager.getAccountByIndex(0)!;
+			const refreshedAuth: OAuthAuthDetails = {
+				type: "oauth",
+				access: "header.payload.signature",
+				refresh: "new-refresh",
+				expires: now + 3_600_000,
+			};
+
+			const error = await manager
+				.commitRefreshedAuth(account, refreshedAuth)
+				.catch((err) => err as CodexAuthError);
+
+			expect(error).toBeInstanceOf(CodexAuthError);
+			expect(error.retryable).toBe(false);
+			expect(account.refreshToken).toBe("old-refresh");
+		});
+
+		it("prevents debounced saves from writing stale auth during refresh persistence", async () => {
+			vi.useFakeTimers();
+			try {
+				const { saveAccounts, withAccountStorageTransaction } = await import(
+					"../lib/storage.js"
+				);
+				const mockSaveAccounts = vi.mocked(saveAccounts);
+				const mockWithAccountStorageTransaction = vi.mocked(
+					withAccountStorageTransaction,
+				);
+
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [
+						{
+							refreshToken: "old-refresh",
+							accessToken: "old-access",
+							expiresAt: now,
+							addedAt: now,
+							lastUsed: now,
+						},
+					],
+				};
+				const manager = new AccountManager(undefined, stored as any);
+				const account = manager.getAccountByIndex(0)!;
+				const refreshedAuth: OAuthAuthDetails = {
+					type: "oauth",
+					access: "new-access",
+					refresh: "new-refresh",
+					expires: now + 3_600_000,
+				};
+
+				let storageState = structuredClone(stored) as typeof stored;
+				let lock = Promise.resolve();
+				let releasePersist!: () => void;
+				const persistBlocked = new Promise<void>((resolve) => {
+					releasePersist = resolve;
+				});
+				let notifyPersistStarted!: () => void;
+				const persistStarted = new Promise<void>((resolve) => {
+					notifyPersistStarted = resolve;
+				});
+
+				mockWithAccountStorageTransaction.mockImplementation((handler) => {
+					const run = async () => {
+						const current = structuredClone(
+							storageState,
+						) as typeof storageState;
+						const persist = async (
+							nextStorage: Parameters<typeof saveAccounts>[0],
+						) => {
+							if (
+								nextStorage.accounts[0]?.refreshToken === "new-refresh" &&
+								nextStorage.accounts[0]?.accessToken === "new-access"
+							) {
+								notifyPersistStarted();
+								await persistBlocked;
+							}
+							storageState = structuredClone(
+								nextStorage,
+							) as typeof storageState;
+							await mockSaveAccounts(nextStorage);
+						};
+						return handler(current as never, persist);
+					};
+
+					const result = lock.then(run, run);
+					lock = result.then(
+						() => undefined,
+						() => undefined,
+					);
+					return result;
+				});
+
+				const commitPromise = manager.commitRefreshedAuth(
+					account,
+					refreshedAuth,
+				);
+				await persistStarted;
+
+				manager.saveToDiskDebounced(0);
+				await vi.advanceTimersByTimeAsync(0);
+
+				releasePersist();
+				await commitPromise;
+				await manager.flushPendingSave();
+
+				expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
+				expect(
+					mockSaveAccounts.mock.calls[0]?.[0]?.accounts[0]?.refreshToken,
+				).toBe("new-refresh");
+				expect(
+					mockSaveAccounts.mock.calls[1]?.[0]?.accounts[0]?.refreshToken,
+				).toBe("new-refresh");
+				expect(
+					mockSaveAccounts.mock.calls[1]?.[0]?.accounts[0]?.accessToken,
+				).toBe("new-access");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	});
+
+	describe("toAuthDetails", () => {
+		it("converts account to Auth object", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			account.access = "access-token";
+			account.expires = now + 3600000;
+
+			const auth = manager.toAuthDetails(account);
+
+			expect(auth.type).toBe("oauth");
+			if (auth.type === "oauth") {
+				expect(auth.access).toBe("access-token");
+				expect(auth.refresh).toBe("token-1");
+				expect(auth.expires).toBe(now + 3600000);
+			}
+		});
+
+		it("handles missing access token", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			const auth = manager.toAuthDetails(account);
+
+			expect(auth.type).toBe("oauth");
+			if (auth.type === "oauth") {
+				expect(auth.access).toBe("");
+				expect(auth.expires).toBe(0);
+			}
+		});
+	});
+
+	describe("setActiveIndex", () => {
+		it("sets active index and returns account", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const result = manager.setActiveIndex(1);
+
+			expect(result?.refreshToken).toBe("token-2");
+			expect(manager.getActiveIndex()).toBe(1);
+		});
+
+		it("returns null for invalid index", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			expect(manager.setActiveIndex(-1)).toBeNull();
+			expect(manager.setActiveIndex(999)).toBeNull();
+			expect(manager.setActiveIndex(NaN)).toBeNull();
+			expect(manager.setActiveIndex(Infinity)).toBeNull();
+		});
+	});
+
+	describe("markSwitched", () => {
+		it("records switch reason on account", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			manager.markSwitched(account, "rate-limit", "codex");
+			expect(account.lastSwitchReason).toBe("rate-limit");
+		});
+	});
+
+	describe("saveToDisk", () => {
+		it("saves accounts with all fields", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockResolvedValueOnce();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						addedAt: now,
+						lastUsed: now,
+						email: "test@example.com",
+						accountId: "acc123",
+						accountLabel: "Test",
+						rateLimitResetTimes: { quota: now + 60000 },
+						coolingDownUntil: now + 30000,
+						cooldownReason: "transient",
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored as any);
+			await manager.saveToDisk();
+
+			expect(mockSaveAccounts).toHaveBeenCalled();
+			const savedData = mockSaveAccounts.mock.calls[0]?.[0];
+			expect(savedData?.version).toBe(3);
+			expect(savedData?.accounts[0]?.email).toBe("test@example.com");
+			expect(savedData?.accounts[0]?.rateLimitResetTimes).toBeDefined();
+		});
+	});
+
+	describe("saveToDiskDebounced", () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("debounces multiple calls", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+			mockSaveAccounts.mockResolvedValue();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			manager.saveToDiskDebounced(100);
+			manager.saveToDiskDebounced(100);
+			manager.saveToDiskDebounced(100);
+
+			await vi.advanceTimersByTimeAsync(150);
+
+			expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+		});
+
+		it("logs warning when debounced save fails", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+			mockSaveAccounts.mockRejectedValueOnce(new Error("Save failed"));
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			manager.saveToDiskDebounced(100);
+			await vi.advanceTimersByTimeAsync(150);
+
+			expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+		});
+
+		it("awaits existing pendingSave before starting new save", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+
+			let resolveFirst: () => void;
+			const firstSave = new Promise<void>((resolve) => {
+				resolveFirst = resolve;
+			});
+			mockSaveAccounts.mockImplementationOnce(() => firstSave);
+			mockSaveAccounts.mockResolvedValue();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			manager.saveToDiskDebounced(50);
+			await vi.advanceTimersByTimeAsync(60);
+
+			manager.saveToDiskDebounced(50);
+			resolveFirst!();
+			await vi.advanceTimersByTimeAsync(100);
+
+			expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
+		});
+
+		it("uses the manager's captured storage path state for delayed saves", async () => {
+			const { saveAccounts, withAccountStorageTransaction } = await import(
+				"../lib/storage.js"
+			);
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			const mockWithAccountStorageTransaction = vi.mocked(
+				withAccountStorageTransaction,
+			);
+			mockSaveAccounts.mockClear();
+
+			vi.useFakeTimers();
+			try {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+				};
+
+				setStoragePathState({
+					currentStoragePath: "/repo-a/storage.json",
+					currentLegacyProjectStoragePath: null,
+					currentLegacyWorktreeStoragePath: null,
+					currentProjectRoot: "/repo-a",
+				});
+				const manager = new AccountManager(undefined, stored);
+
+				const seenStates: Array<ReturnType<typeof getStoragePathState>> = [];
+				mockWithAccountStorageTransaction.mockImplementationOnce(
+					async (handler) => {
+						seenStates.push({ ...getStoragePathState() });
+						let current = null;
+						const persist = async (
+							storage: Parameters<typeof saveAccounts>[0],
+						) => {
+							current = structuredClone(storage);
+							await mockSaveAccounts(storage);
+						};
+						return handler(current as never, persist);
+					},
+				);
+
+				setStoragePathState({
+					currentStoragePath: "/repo-b/storage.json",
+					currentLegacyProjectStoragePath: null,
+					currentLegacyWorktreeStoragePath: null,
+					currentProjectRoot: "/repo-b",
+				});
+
+				manager.saveToDiskDebounced(50);
+				await vi.advanceTimersByTimeAsync(60);
+
+				expect(seenStates).toEqual([
+					expect.objectContaining({
+						currentStoragePath: "/repo-a/storage.json",
+						currentProjectRoot: "/repo-a",
+					}),
+				]);
+				expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("uses the manager's captured Windows-style storage path state for delayed saves", async () => {
+			const { saveAccounts, withAccountStorageTransaction } = await import(
+				"../lib/storage.js"
+			);
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			const mockWithAccountStorageTransaction = vi.mocked(
+				withAccountStorageTransaction,
+			);
+			mockSaveAccounts.mockClear();
+
+			const repoAStoragePath = String.raw`C:\repo-a\storage.json`;
+			const repoARoot = String.raw`C:\repo-a`;
+			const repoBStoragePath = String.raw`C:\repo-b\storage.json`;
+			const repoBRoot = String.raw`C:\repo-b`;
+
+			vi.useFakeTimers();
+			try {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+				};
+
+				setStoragePathState({
+					currentStoragePath: repoAStoragePath,
+					currentLegacyProjectStoragePath: null,
+					currentLegacyWorktreeStoragePath: null,
+					currentProjectRoot: repoARoot,
+				});
+				const manager = new AccountManager(undefined, stored);
+
+				const seenStates: Array<ReturnType<typeof getStoragePathState>> = [];
+				mockWithAccountStorageTransaction.mockImplementationOnce(
+					async (handler) => {
+						seenStates.push({ ...getStoragePathState() });
+						let current = null;
+						const persist = async (
+							storage: Parameters<typeof saveAccounts>[0],
+						) => {
+							current = structuredClone(storage);
+							await mockSaveAccounts(storage);
+						};
+						return handler(current as never, persist);
+					},
+				);
+
+				setStoragePathState({
+					currentStoragePath: repoBStoragePath,
+					currentLegacyProjectStoragePath: null,
+					currentLegacyWorktreeStoragePath: null,
+					currentProjectRoot: repoBRoot,
+				});
+
+				manager.saveToDiskDebounced(50);
+				await vi.advanceTimersByTimeAsync(60);
+
+				expect(seenStates).toEqual([
+					expect.objectContaining({
+						currentStoragePath: repoAStoragePath,
+						currentProjectRoot: repoARoot,
+					}),
+				]);
+				expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("keeps ambient storage path state stable during concurrent saves", async () => {
+			const { withAccountStorageTransaction } = await import(
+				"../lib/storage.js"
+			);
+			const mockWithAccountStorageTransaction = vi.mocked(
+				withAccountStorageTransaction,
+			);
+			const createDeferred = () => {
+				let resolve!: () => void;
+				const promise = new Promise<void>((resolvePromise) => {
+					resolve = resolvePromise;
+				});
+				return { promise, resolve };
+			};
+			const enteredResolvers = [createDeferred(), createDeferred()];
+			const releaseResolvers = [createDeferred(), createDeferred()];
+			const seenStates: Array<ReturnType<typeof getStoragePathState>> = [];
+			let callIndex = 0;
+
+			mockWithAccountStorageTransaction.mockImplementation(async (handler) => {
+				const currentCall = callIndex;
+				callIndex += 1;
+				seenStates.push({ ...getStoragePathState() });
+				enteredResolvers[currentCall]?.resolve();
+				if (currentCall === 0) {
+					await enteredResolvers[1]?.promise;
+				}
+				await releaseResolvers[currentCall]?.promise;
+				return handler(null, async () => undefined);
+			});
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			setStoragePathState({
+				currentStoragePath: "/ambient/storage.json",
+				currentLegacyProjectStoragePath: null,
+				currentLegacyWorktreeStoragePath: null,
+				currentProjectRoot: "/ambient",
+			});
+			setStoragePathState({
+				currentStoragePath: "/repo-a/storage.json",
+				currentLegacyProjectStoragePath: null,
+				currentLegacyWorktreeStoragePath: null,
+				currentProjectRoot: "/repo-a",
+			});
+			const managerA = new AccountManager(undefined, stored);
+			setStoragePathState({
+				currentStoragePath: "/repo-b/storage.json",
+				currentLegacyProjectStoragePath: null,
+				currentLegacyWorktreeStoragePath: null,
+				currentProjectRoot: "/repo-b",
+			});
+			const managerB = new AccountManager(undefined, stored);
+			setStoragePathState({
+				currentStoragePath: "/ambient/storage.json",
+				currentLegacyProjectStoragePath: null,
+				currentLegacyWorktreeStoragePath: null,
+				currentProjectRoot: "/ambient",
+			});
+
+			const saveA = managerA.saveToDisk();
+			await enteredResolvers[0]?.promise;
+			const saveB = managerB.saveToDisk();
+			await enteredResolvers[1]?.promise;
+
+			expect(getStoragePathState()).toEqual(
+				expect.objectContaining({
+					currentStoragePath: "/ambient/storage.json",
+					currentProjectRoot: "/ambient",
+				}),
+			);
+
+			releaseResolvers[0]?.resolve();
+			await saveA;
+			releaseResolvers[1]?.resolve();
+			await saveB;
+
+			expect(seenStates).toEqual([
+				expect.objectContaining({
+					currentStoragePath: "/repo-a/storage.json",
+					currentProjectRoot: "/repo-a",
+				}),
+				expect.objectContaining({
+					currentStoragePath: "/repo-b/storage.json",
+					currentProjectRoot: "/repo-b",
+				}),
+			]);
+			expect(getStoragePathState()).toEqual(
+				expect.objectContaining({
+					currentStoragePath: "/ambient/storage.json",
+					currentProjectRoot: "/ambient",
+				}),
+			);
+		});
+	});
+
+	describe("constructor edge cases", () => {
+		it("filters out accounts with missing refreshToken", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "valid-token", addedAt: now, lastUsed: now },
+					{ refreshToken: "", addedAt: now, lastUsed: now },
+					{
+						refreshToken: null as unknown as string,
+						addedAt: now,
+						lastUsed: now,
+					},
+					{
+						refreshToken: undefined as unknown as string,
+						addedAt: now,
+						lastUsed: now,
+					},
+					{ refreshToken: "another-valid", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			expect(manager.getAccountCount()).toBe(2);
+			const accounts = manager.getAccountsSnapshot();
+			expect(accounts[0]?.refreshToken).toBe("valid-token");
+			expect(accounts[1]?.refreshToken).toBe("another-valid");
+		});
+
+		it("merges fallback auth when matching by accountId", () => {
+			const now = Date.now();
+			const payload = {
+				"https://api.openai.com/auth": {
+					chatgpt_account_id: "matching-account-id",
+				},
+				email: "fallback@example.com",
+			};
+			const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "stored-token",
+						accountId: "matching-account-id",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "new-refresh-token",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, stored);
+			expect(manager.getAccountCount()).toBe(1);
+			const account = manager.getCurrentAccount();
+			expect(account?.refreshToken).toBe("new-refresh-token");
+			expect(account?.access).toBe(accessToken);
+		});
+
+		it("trims fallback accountId before matching and persisting it", () => {
+			const now = Date.now();
+			const payload = {
+				"https://api.openai.com/auth": {
+					chatgpt_account_id: "  matching-account-id  ",
+				},
+			};
+			const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "stored-token",
+						accountId: "matching-account-id",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "new-refresh-token",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, stored);
+			expect(manager.getAccountCount()).toBe(1);
+			const account = manager.getCurrentAccount();
+			expect(account?.refreshToken).toBe("new-refresh-token");
+			expect(account?.accountId).toBe("matching-account-id");
+		});
+
+		it("ignores malformed stored rows when checking shared accountId uniqueness for fallback matching", () => {
+			const now = Date.now();
+			const payload = {
+				"https://api.openai.com/auth": {
+					chatgpt_account_id: "matching-account-id",
+				},
+			};
+			const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "stored-token",
+						accountId: "matching-account-id",
+						addedAt: now,
+						lastUsed: now,
+					},
+					{
+						refreshToken: "",
+						accountId: "matching-account-id",
+						addedAt: now,
+						lastUsed: now,
+					},
+					{
+						refreshToken: "   ",
+						accountId: "matching-account-id",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "new-refresh-token",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, stored);
+			expect(manager.getAccountCount()).toBe(1);
+			const account = manager.getCurrentAccount();
+			expect(account?.refreshToken).toBe("new-refresh-token");
+			expect(account?.accountId).toBe("matching-account-id");
+		});
+
+		it("merges fallback auth when matching by email", () => {
+			const now = Date.now();
+			const payload = {
+				email: "fallback@example.com",
+			};
+			const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "stored-token",
+						email: "fallback@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "new-refresh-token",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, stored);
+			expect(manager.getAccountCount()).toBe(1);
+			const account = manager.getCurrentAccount();
+			expect(account?.refreshToken).toBe("new-refresh-token");
+			expect(account?.access).toBe(accessToken);
+			expect(account?.email).toBe("fallback@example.com");
+		});
+
+		it("does not add fallback as duplicate when matching stored email", () => {
+			const now = Date.now();
+			const payload = {
+				email: "fallback@example.com",
+			};
+			const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "stored-token",
+						email: "fallback@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "different-refresh-token",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, stored);
+			expect(manager.getAccountCount()).toBe(1);
+			const account = manager.getCurrentAccount();
+			expect(account?.refreshToken).toBe("different-refresh-token");
+		});
+
+		it("adds fallback as a distinct account when the same email spans multiple accountIds", () => {
+			const now = Date.now();
+			const payload = {
+				email: "shared@example.com",
+			};
+			const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "workspace-alpha",
+						email: "shared@example.com",
+						refreshToken: "refresh-alpha",
+						addedAt: now,
+						lastUsed: now,
+					},
+					{
+						accountId: "workspace-beta",
+						email: "shared@example.com",
+						refreshToken: "refresh-beta",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "refresh-gamma",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, stored);
+
+			expect(manager.getAccountCount()).toBe(3);
+			expect(
+				manager.getAccountsSnapshot().map((account) => account.refreshToken),
+			).toEqual(["refresh-alpha", "refresh-beta", "refresh-gamma"]);
+		});
+
+		it("adds fallback as new account when no match found", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "existing-token", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: "new-access",
+				refresh: "new-refresh",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, stored);
+			expect(manager.getAccountCount()).toBe(2);
+			const accounts = manager.getAccountsSnapshot();
+			expect(accounts[0]?.refreshToken).toBe("existing-token");
+			expect(accounts[1]?.refreshToken).toBe("new-refresh");
+		});
+
+		it("adds fallback as a distinct account when duplicate business accounts share one accountId", () => {
+			const now = Date.now();
+			const payload = {
+				"https://api.openai.com/auth": {
+					chatgpt_account_id: "workspace-shared",
+				},
+				email: "gamma@example.com",
+			};
+			const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountId: "workspace-shared",
+						email: "alpha@example.com",
+						refreshToken: "refresh-alpha",
+						addedAt: now,
+						lastUsed: now,
+					},
+					{
+						accountId: "workspace-shared",
+						email: "beta@example.com",
+						refreshToken: "refresh-beta",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "refresh-gamma",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, stored);
+
+			expect(manager.getAccountCount()).toBe(3);
+			expect(
+				manager.getAccountsSnapshot().map((account) => account.email),
+			).toEqual(["alpha@example.com", "beta@example.com", "gamma@example.com"]);
+			expect(
+				manager.getAccountsSnapshot().map((account) => account.refreshToken),
+			).toEqual(["refresh-alpha", "refresh-beta", "refresh-gamma"]);
+		});
+
+		it("sets accountIdSource to token when fallbackAccountId exists", () => {
+			const now = Date.now();
+			const payload = {
+				"https://api.openai.com/auth": {
+					chatgpt_account_id: "fallback-id",
+				},
+			};
+			const accessToken = `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: accessToken,
+				refresh: "refresh-token",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, null);
+			expect(manager.getAccountCount()).toBe(1);
+			const account = manager.getCurrentAccount();
+			expect(account?.accountIdSource).toBe("token");
+			expect(account?.accountId).toBe("fallback-id");
+		});
+
+		it("sets accountIdSource to undefined when no accountId in token", () => {
+			const now = Date.now();
+			const auth: OAuthAuthDetails = {
+				type: "oauth",
+				access: "invalid-jwt",
+				refresh: "refresh-token",
+				expires: now + 60_000,
+			};
+
+			const manager = new AccountManager(auth, null);
+			expect(manager.getAccountCount()).toBe(1);
+			const account = manager.getCurrentAccount();
+			expect(account?.accountIdSource).toBeUndefined();
+		});
+	});
+
+	describe("removeAccount cursor adjustment", () => {
+		it("adjusts cursor when removing account before cursor position", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-3", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			manager.getCurrentOrNextForFamily("codex");
+			manager.getCurrentOrNextForFamily("codex");
+			manager.getCurrentOrNextForFamily("codex");
+
+			const firstAccount = manager.getCurrentAccountForFamily("codex");
+			expect(firstAccount).not.toBeNull();
+			const removed = manager.removeAccount(firstAccount!);
+
+			expect(removed).toBe(true);
+			expect(manager.getAccountCount()).toBe(2);
+		});
+
+		it("adjusts currentAccountIndexByFamily when removing account before current", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 2,
+				activeIndexByFamily: { codex: 2 },
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-3", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored as never);
+
+			const initialAccount = manager.getCurrentAccountForFamily("codex");
+			expect(initialAccount?.refreshToken).toBe("token-3");
+
+			manager.setActiveIndex(0);
+			const accountToRemove = manager.getCurrentAccountForFamily("codex");
+			expect(accountToRemove?.refreshToken).toBe("token-1");
+
+			manager.setActiveIndex(2);
+			manager.removeAccount(accountToRemove!);
+
+			expect(manager.getAccountCount()).toBe(2);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(1);
+		});
+
+		it("decrements currentAccountIndex when removing first account", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 1,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			manager.setActiveIndex(0);
+			const firstAccount = manager.getCurrentAccount();
+			expect(firstAccount?.refreshToken).toBe("token-1");
+
+			manager.setActiveIndex(1);
+			manager.removeAccount(firstAccount!);
+
+			expect(manager.getAccountCount()).toBe(1);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(0);
+		});
+
+		it("resets indices when removing last remaining account", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			manager.removeAccount(account);
+
+			expect(manager.getAccountCount()).toBe(0);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(-1);
+		});
+	});
+
+	describe("flushPendingSave", () => {
+		it("flushes pending debounced save", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockResolvedValue();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			manager.saveToDiskDebounced(10000);
+			await manager.flushPendingSave();
+
+			expect(mockSaveAccounts).toHaveBeenCalled();
+		});
+
+		it("does nothing when no pending save", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			await manager.flushPendingSave();
+
+			expect(mockSaveAccounts).not.toHaveBeenCalled();
+		});
+
+		it("waits for pendingSave if it exists during flush", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+
+			let resolveFirst: () => void;
+			const firstSave = new Promise<void>((resolve) => {
+				resolveFirst = resolve;
+			});
+			mockSaveAccounts.mockImplementationOnce(() => firstSave);
+			mockSaveAccounts.mockResolvedValue();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			const savePromise = manager.saveToDisk();
+			const flushPromise = manager.flushPendingSave();
+
+			resolveFirst!();
+			await savePromise;
+			await flushPromise;
+
+			expect(mockSaveAccounts).toHaveBeenCalled();
+		});
+
+		it("waits for in-flight pendingSave without timer", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+
+			let resolveInFlight: () => void;
+			const inFlightSave = new Promise<void>((resolve) => {
+				resolveInFlight = resolve;
+			});
+			mockSaveAccounts.mockImplementation(() => inFlightSave);
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			const savePromise = manager.saveToDisk();
+
+			queueMicrotask(() => resolveInFlight!());
+
+			await manager.flushPendingSave();
+			await savePromise;
+		});
+	});
+
+	describe("health and token tracking methods", () => {
+		beforeEach(() => {
+			resetTrackers();
+			clearCircuitBreakers();
+		});
+
+		afterEach(() => {
+			resetTrackers();
+			clearCircuitBreakers();
+		});
+
+		it("recordSuccess updates health tracker with model-specific quotaKey", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const healthTracker = getHealthTracker();
+			const trackerKey = getRuntimeAccountIdentityKey(account)!;
+
+			manager.recordSuccess(account, "codex", "gpt-5.1");
+
+			const score = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+			expect(score).toBe(100);
+		});
+
+		it("recordSuccess updates health tracker with family-only quotaKey when model is null", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const healthTracker = getHealthTracker();
+			const trackerKey = getRuntimeAccountIdentityKey(account)!;
+
+			manager.recordSuccess(account, "codex", null);
+
+			const score = healthTracker.getScore(trackerKey, "codex");
+			expect(score).toBe(100);
+		});
+
+		it("recordSuccess closes the circuit breaker after a half-open retry succeeds", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date(0));
+
+			try {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [
+						{
+							refreshToken: "token-1",
+							email: "breaker@example.com",
+							addedAt: now,
+							lastUsed: now,
+						},
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored);
+				const account = manager.getCurrentAccount()!;
+				const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
+
+				manager.recordFailure(account, "codex");
+				manager.recordFailure(account, "codex");
+				manager.recordFailure(account, "codex");
+				expect(breaker.getState()).toBe("open");
+
+				vi.advanceTimersByTime(
+					DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1,
+				);
+				expect(manager.consumeToken(account, "codex")).toBe(true);
+				manager.recordSuccess(account, "codex");
+				expect(breaker.getState()).toBe("closed");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("recordSuccess clears stale auth failure state and persists the healed account", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						addedAt: now,
+						lastUsed: now,
+						consecutiveAuthFailures: 2,
+						coolingDownUntil: now - 1000,
+						cooldownReason: "network-error" as const,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			account.consecutiveAuthFailures = 2;
+
+			manager.recordSuccess(account, "codex", "gpt-5.1");
+			await manager.flushPendingSave();
+
+			expect(account.consecutiveAuthFailures).toBe(0);
+			expect(account.coolingDownUntil).toBeUndefined();
+			expect(account.cooldownReason).toBeUndefined();
+			expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+			const persisted = mockSaveAccounts.mock.calls[0]?.[0];
+			expect(persisted?.accounts[0]?.consecutiveAuthFailures ?? 0).toBe(0);
+			expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
+			expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
+		});
+
+		it("recordSuccess clears stale cooldown metadata when only the reason remains", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						addedAt: now,
+						lastUsed: now,
+						cooldownReason: "network-error" as const,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			manager.recordSuccess(account, "codex", "gpt-5.1");
+			await manager.flushPendingSave();
+
+			expect(account.coolingDownUntil).toBeUndefined();
+			expect(account.cooldownReason).toBeUndefined();
+			expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+			const persisted = mockSaveAccounts.mock.calls[0]?.[0];
+			expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
+			expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
+		});
+
+		it("recordSuccess does not clear an active cooldown from a newer concurrent failure", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						addedAt: now,
+						lastUsed: now,
+						consecutiveAuthFailures: 2,
+						coolingDownUntil: now + 60_000,
+						cooldownReason: "auth-failure" as const,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			account.consecutiveAuthFailures = 2;
+
+			manager.recordSuccess(account, "codex", "gpt-5.1");
+			await manager.flushPendingSave();
+
+			expect(account.consecutiveAuthFailures).toBe(2);
+			expect(account.coolingDownUntil).toBe(now + 60_000);
+			expect(account.cooldownReason).toBe("auth-failure");
+			expect(mockSaveAccounts).not.toHaveBeenCalled();
+		});
+
+		it("recordRateLimit updates health and drains token bucket", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const healthTracker = getHealthTracker();
+			const tokenTracker = getTokenTracker();
+			const trackerKey = getRuntimeAccountIdentityKey(account)!;
+
+			manager.recordRateLimit(account, "codex", "gpt-5.1");
+
+			const score = healthTracker.getScore(trackerKey, "codex:gpt-5.1");
+			const tokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
+			expect(score).toBeLessThan(100);
+			expect(tokens).toBeLessThan(50);
+		});
+
+		it("recordRateLimit uses family-only quotaKey when model is undefined", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const healthTracker = getHealthTracker();
+			const trackerKey = getRuntimeAccountIdentityKey(account)!;
+
+			manager.recordRateLimit(account, "gpt-5.2");
+
+			const score = healthTracker.getScore(trackerKey, "gpt-5.2");
+			expect(score).toBeLessThan(100);
+		});
+
+		it("scopes quota rate limits to the family bucket only", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			manager.markRateLimitedWithReason(
+				account,
+				60_000,
+				"codex",
+				"quota",
+				"gpt-5.1",
+			);
+
+			expect(account.rateLimitResetTimes.codex).toBeTypeOf("number");
+			expect(account.rateLimitResetTimes["codex:gpt-5.1"]).toBeUndefined();
+		});
+
+		it("scopes token rate limits to the model bucket", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			manager.markRateLimitedWithReason(
+				account,
+				60_000,
+				"codex",
+				"tokens",
+				"gpt-5.1",
+			);
+
+			expect(account.rateLimitResetTimes.codex).toBeUndefined();
+			expect(account.rateLimitResetTimes["codex:gpt-5.1"]).toBeTypeOf("number");
+		});
+
+		it("recordFailure updates health tracker", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const healthTracker = getHealthTracker();
+			const trackerKey = getRuntimeAccountIdentityKey(account)!;
+
+			manager.recordFailure(account, "codex", "gpt-5.2");
+
+			const score = healthTracker.getScore(trackerKey, "codex:gpt-5.2");
+			expect(score).toBeLessThan(100);
+		});
+
+		it("recordFailure opens the circuit breaker after repeated failures", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						email: "breaker@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const breaker = getCircuitBreaker(getAccountIdentityKey(account)!);
+
+			manager.recordFailure(account, "codex");
+			manager.recordFailure(account, "codex");
+			manager.recordFailure(account, "codex");
+
+			expect(breaker.getState()).toBe("open");
+		});
+
+		it("recordFailure uses family-only quotaKey when model is null", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const healthTracker = getHealthTracker();
+			const trackerKey = getRuntimeAccountIdentityKey(account)!;
+
+			manager.recordFailure(account, "gpt-5.1", null);
+
+			const score = healthTracker.getScore(trackerKey, "gpt-5.1");
+			expect(score).toBeLessThan(100);
+		});
+
+		it("consumeToken returns true and consumes from token bucket", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const tokenTracker = getTokenTracker();
+			const trackerKey = getRuntimeAccountIdentityKey(account)!;
+
+			const initialTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
+			const result = manager.consumeToken(account, "codex", "gpt-5.1");
+			const afterTokens = tokenTracker.getTokens(trackerKey, "codex:gpt-5.1");
+
+			expect(result).toBe(true);
+			expect(afterTokens).toBeLessThan(initialTokens);
+		});
+
+		it("consumeToken uses family-only quotaKey when model is undefined", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+
+			const result = manager.consumeToken(account, "codex");
+
+			expect(result).toBe(true);
+		});
+
+		it("consumeToken returns false and refunds the token when the circuit is open", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						email: "breaker@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const tokenTracker = getTokenTracker();
+			const trackerKey = getRuntimeTrackerKey(account);
+			const initialTokens = tokenTracker.getTokens(trackerKey, "codex");
+
+			manager.recordFailure(account, "codex");
+			manager.recordFailure(account, "codex");
+			manager.recordFailure(account, "codex");
+
+			expect(manager.consumeToken(account, "codex")).toBe(false);
+			expect(tokenTracker.getTokens(trackerKey, "codex")).toBe(initialTokens);
+		});
+
+		it("consumeToken returns false and refunds when the half-open slot is exhausted", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date(0));
+
+			try {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [
+						{
+							refreshToken: "token-1",
+							email: "breaker@example.com",
+							addedAt: now,
+							lastUsed: now,
+						},
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored);
+				const account = manager.getCurrentAccount()!;
+				const tokenTracker = getTokenTracker();
+				const trackerKey = getRuntimeTrackerKey(account);
+				const initialTokens = tokenTracker.getTokens(trackerKey, "codex");
+
+				manager.recordFailure(account, "codex");
+				manager.recordFailure(account, "codex");
+				manager.recordFailure(account, "codex");
+
+				vi.advanceTimersByTime(
+					DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs + 1,
+				);
+
+				expect(manager.consumeToken(account, "codex")).toBe(true);
+				expect(manager.consumeToken(account, "codex")).toBe(false);
+				expect(tokenTracker.getTokens(trackerKey, "codex")).toBe(
+					initialTokens - 1,
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("keeps refresh-only tracker state stable when the refresh token rotates", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+			try {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+				};
+
+				const manager = new AccountManager(undefined, stored);
+				const account = manager.getCurrentAccount()!;
+				const healthTracker = getHealthTracker();
+				const tokenTracker = getTokenTracker();
+				const trackerKey = getRuntimeTrackerKey(account);
+
+				manager.recordFailure(account, "codex", "gpt-5.1");
+				const degradedScore = healthTracker.getScore(
+					trackerKey,
+					"codex:gpt-5.1",
+				);
+				expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
+
+				account.refreshToken = "token-1-rotated";
+
+				const rotatedAccount = manager.getCurrentAccount()!;
+				expect(getRuntimeTrackerKey(rotatedAccount)).toBe(trackerKey);
+				expect(getRuntimeAccountIdentityKey(rotatedAccount)).toBe(trackerKey);
+				expect(getAccountIdentityKey(rotatedAccount)).not.toBe(`${trackerKey}`);
+				expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
+					degradedScore,
+					6,
+				);
+				expect(
+					tokenTracker.getTokens(trackerKey, "codex:gpt-5.1"),
+				).toBeLessThan(50);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("keeps pinned runtime tracker state stable after updateFromAuth enriches identity", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+			try {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [
+						{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+						{
+							refreshToken: "token-2",
+							email: "healthy@example.com",
+							addedAt: now,
+							lastUsed: now,
+						},
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored);
+				const account = manager.getAccountByIndex(0)!;
+				const healthTracker = getHealthTracker();
+				const tokenTracker = getTokenTracker();
+				const trackerKey = getRuntimeTrackerKey(account);
+
+				manager.recordFailure(account, "codex", "gpt-5.1");
+				const degradedScore = healthTracker.getScore(
+					trackerKey,
+					"codex:gpt-5.1",
+				);
+				expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(true);
+
+				const payload = Buffer.from(
+					JSON.stringify({
+						email: "enriched@example.com",
+						"https://api.openai.com/auth": {
+							chatgpt_account_id: "account-enriched",
+						},
+						exp: Math.floor((now + 3600000) / 1000),
+					}),
+				).toString("base64url");
+				const accessToken = `header.${payload}.signature`;
+
+				manager.updateFromAuth(account, {
+					type: "oauth",
+					access: accessToken,
+					refresh: "token-1-rotated",
+					expires: now + 3600000,
+				});
+
+				expect(account.accountId).toBe("account-enriched");
+				expect(account.email).toBe("enriched@example.com");
+				expect(getRuntimeAccountIdentityKey(account)).toBe(
+					"account:account-enriched::email:enriched@example.com",
+				);
+				expect(getRuntimeTrackerKey(account)).toBe(trackerKey);
+				expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeCloseTo(
+					degradedScore,
+					5,
+				);
+				expect(
+					tokenTracker.getTokens(trackerKey, "codex:gpt-5.1"),
+				).toBeLessThan(50);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("preserves tracker state when account indexes shift", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 1,
+				activeIndexByFamily: { codex: 1 },
+				accounts: [
+					{
+						refreshToken: "token-1",
+						email: "first@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+					{
+						refreshToken: "token-2",
+						email: "second@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored as never);
+			const trackedAccount = manager.getAccountByIndex(1)!;
+			const trackerKey = getAccountIdentityKey(trackedAccount)!;
+			const healthTracker = getHealthTracker();
+			const tokenTracker = getTokenTracker();
+
+			manager.recordFailure(trackedAccount, "codex", "gpt-5.1");
+			expect(manager.consumeToken(trackedAccount, "codex", "gpt-5.1")).toBe(
+				true,
+			);
+
+			expect(manager.removeAccountByIndex(0)).toBe(true);
+
+			const remainingAccount = manager.getAccountByIndex(0)!;
+			expect(remainingAccount.email).toBe("second@example.com");
+			expect(remainingAccount.index).toBe(0);
+			expect(getAccountIdentityKey(remainingAccount)).toBe(trackerKey);
+			expect(healthTracker.getScore(trackerKey, "codex:gpt-5.1")).toBeLessThan(
+				100,
+			);
+			expect(tokenTracker.getTokens(trackerKey, "codex:gpt-5.1")).toBeLessThan(
+				50,
+			);
+		});
+	});
+
+	describe("hybrid selection fallback path", () => {
+		beforeEach(() => {
+			resetTrackers();
+			clearCircuitBreakers();
+		});
+
+		afterEach(() => {
+			resetTrackers();
+			clearCircuitBreakers();
+		});
+
+		it("selects alternate account when current is rate-limited via selectHybridAccount", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now - 10000 },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored as never);
+
+			const account0 = manager.setActiveIndex(0)!;
+			manager.markRateLimited(account0, 60000, "codex");
+
+			const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
+
+			expect(selected).not.toBeNull();
+			expect(selected?.refreshToken).toBe("token-2");
+			expect(selected?.index).toBe(1);
+		});
+
+		it("re-scores on the next call instead of sticking to the prior hybrid winner", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now - 5000 },
+					{ refreshToken: "token-3", addedAt: now, lastUsed: now - 10000 },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored as never);
+
+			const account0 = manager.getAccountsSnapshot()[0]!;
+			manager.markRateLimited(account0, 60000, "codex");
+
+			const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
+			expect(selected).not.toBeNull();
+
+			const secondCall = manager.getCurrentOrNextForFamilyHybrid("codex");
+			expect(secondCall?.index).toBe(1);
+			expect(secondCall?.index).not.toBe(selected?.index);
+		});
+
+		it("skips accounts whose circuit breaker is open", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{
+						refreshToken: "token-1",
+						email: "first@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+					{
+						refreshToken: "token-2",
+						email: "second@example.com",
+						addedAt: now,
+						lastUsed: now - 10_000,
+					},
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored as never);
+			const blocked = manager.getAccountByIndex(0)!;
+
+			manager.recordFailure(blocked, "codex");
+			manager.recordFailure(blocked, "codex");
+			manager.recordFailure(blocked, "codex");
+
+			const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
+
+			expect(selected?.refreshToken).toBe("token-2");
+			expect(selected?.index).toBe(1);
+			expect(manager.isAccountAvailableForFamily(0, "codex")).toBe(false);
+		});
+
+		it("returns null when all accounts are rate-limited (AUDIT-H2 contract)", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored as never);
+
+			const account0 = manager.setActiveIndex(0)!;
+			manager.markRateLimited(account0, 60000, "codex");
+
+			// Contract change (AUDIT-H2 / D-01): hybrid selector returns null when no
+			// account is currently available instead of returning the blocked LRU
+			// account via a "fallback". The caller is responsible for surfacing the
+			// pool-wide unavailable condition.
+			const selected = manager.getCurrentOrNextForFamilyHybrid("codex");
+			expect(selected).toBeNull();
+		});
+	});
 });

--- a/test/property/rotation.property.test.ts
+++ b/test/property/rotation.property.test.ts
@@ -1,280 +1,318 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import * as fc from "fast-check";
 import {
-  HealthScoreTracker,
-  TokenBucketTracker,
-  selectHybridAccount,
-  DEFAULT_HEALTH_SCORE_CONFIG,
-  DEFAULT_TOKEN_BUCKET_CONFIG,
-  type AccountWithMetrics,
+	HealthScoreTracker,
+	TokenBucketTracker,
+	selectHybridAccount,
+	DEFAULT_HEALTH_SCORE_CONFIG,
+	DEFAULT_TOKEN_BUCKET_CONFIG,
+	type AccountWithMetrics,
 } from "../../lib/rotation.js";
 import { arbAccountIndex, arbQuotaKey } from "./helpers.js";
 
 describe("HealthScoreTracker property tests", () => {
-  let tracker: HealthScoreTracker;
+	let tracker: HealthScoreTracker;
 
-  beforeEach(() => {
-    tracker = new HealthScoreTracker();
-  });
+	beforeEach(() => {
+		tracker = new HealthScoreTracker();
+	});
 
-  it("score is always in [0, 100] range after any operation", () => {
-    fc.assert(
-      fc.property(
-        arbAccountIndex,
-        arbQuotaKey,
-        fc.array(fc.constantFrom("success", "rateLimit", "failure"), { minLength: 1, maxLength: 50 }),
-        (accountIndex, quotaKey, operations) => {
-          const t = new HealthScoreTracker();
-          for (const op of operations) {
-            switch (op) {
-              case "success":
-                t.recordSuccess(accountIndex, quotaKey);
-                break;
-              case "rateLimit":
-                t.recordRateLimit(accountIndex, quotaKey);
-                break;
-              case "failure":
-                t.recordFailure(accountIndex, quotaKey);
-                break;
-            }
-            const score = t.getScore(accountIndex, quotaKey);
-            expect(score).toBeGreaterThanOrEqual(DEFAULT_HEALTH_SCORE_CONFIG.minScore);
-            expect(score).toBeLessThanOrEqual(DEFAULT_HEALTH_SCORE_CONFIG.maxScore);
-          }
-          return true;
-        }
-      )
-    );
-  });
+	it("score is always in [0, 100] range after any operation", () => {
+		fc.assert(
+			fc.property(
+				arbAccountIndex,
+				arbQuotaKey,
+				fc.array(fc.constantFrom("success", "rateLimit", "failure"), {
+					minLength: 1,
+					maxLength: 50,
+				}),
+				(accountIndex, quotaKey, operations) => {
+					const t = new HealthScoreTracker();
+					for (const op of operations) {
+						switch (op) {
+							case "success":
+								t.recordSuccess(accountIndex, quotaKey);
+								break;
+							case "rateLimit":
+								t.recordRateLimit(accountIndex, quotaKey);
+								break;
+							case "failure":
+								t.recordFailure(accountIndex, quotaKey);
+								break;
+						}
+						const score = t.getScore(accountIndex, quotaKey);
+						expect(score).toBeGreaterThanOrEqual(
+							DEFAULT_HEALTH_SCORE_CONFIG.minScore,
+						);
+						expect(score).toBeLessThanOrEqual(
+							DEFAULT_HEALTH_SCORE_CONFIG.maxScore,
+						);
+					}
+					return true;
+				},
+			),
+		);
+	});
 
-  it("recordSuccess never decreases score below current", () => {
-    fc.assert(
-      fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
-        const t = new HealthScoreTracker();
-        t.recordFailure(accountIndex, quotaKey);
-        const scoreBefore = t.getScore(accountIndex, quotaKey);
-        t.recordSuccess(accountIndex, quotaKey);
-        const scoreAfter = t.getScore(accountIndex, quotaKey);
-        expect(scoreAfter).toBeGreaterThanOrEqual(scoreBefore);
-        return true;
-      })
-    );
-  });
+	it("recordSuccess never decreases score below current", () => {
+		fc.assert(
+			fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
+				const t = new HealthScoreTracker();
+				t.recordFailure(accountIndex, quotaKey);
+				const scoreBefore = t.getScore(accountIndex, quotaKey);
+				t.recordSuccess(accountIndex, quotaKey);
+				const scoreAfter = t.getScore(accountIndex, quotaKey);
+				expect(scoreAfter).toBeGreaterThanOrEqual(scoreBefore);
+				return true;
+			}),
+		);
+	});
 
-  it("recordFailure never increases score", () => {
-    fc.assert(
-      fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
-        const t = new HealthScoreTracker();
-        const scoreBefore = t.getScore(accountIndex, quotaKey);
-        t.recordFailure(accountIndex, quotaKey);
-        const scoreAfter = t.getScore(accountIndex, quotaKey);
-        expect(scoreAfter).toBeLessThanOrEqual(scoreBefore);
-        return true;
-      })
-    );
-  });
+	it("recordFailure never increases score", () => {
+		fc.assert(
+			fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
+				const t = new HealthScoreTracker();
+				const scoreBefore = t.getScore(accountIndex, quotaKey);
+				t.recordFailure(accountIndex, quotaKey);
+				const scoreAfter = t.getScore(accountIndex, quotaKey);
+				expect(scoreAfter).toBeLessThanOrEqual(scoreBefore);
+				return true;
+			}),
+		);
+	});
 
-  it("consecutiveFailures resets to 0 on success", () => {
-    fc.assert(
-      fc.property(
-        arbAccountIndex,
-        arbQuotaKey,
-        fc.integer({ min: 1, max: 5 }),
-        (accountIndex, quotaKey, failureCount) => {
-          const t = new HealthScoreTracker();
-          for (let i = 0; i < failureCount; i++) {
-            t.recordFailure(accountIndex, quotaKey);
-          }
-          expect(t.getConsecutiveFailures(accountIndex, quotaKey)).toBe(failureCount);
-          t.recordSuccess(accountIndex, quotaKey);
-          expect(t.getConsecutiveFailures(accountIndex, quotaKey)).toBe(0);
-          return true;
-        }
-      )
-    );
-  });
+	it("consecutiveFailures resets to 0 on success", () => {
+		fc.assert(
+			fc.property(
+				arbAccountIndex,
+				arbQuotaKey,
+				fc.integer({ min: 1, max: 5 }),
+				(accountIndex, quotaKey, failureCount) => {
+					const t = new HealthScoreTracker();
+					for (let i = 0; i < failureCount; i++) {
+						t.recordFailure(accountIndex, quotaKey);
+					}
+					expect(t.getConsecutiveFailures(accountIndex, quotaKey)).toBe(
+						failureCount,
+					);
+					t.recordSuccess(accountIndex, quotaKey);
+					expect(t.getConsecutiveFailures(accountIndex, quotaKey)).toBe(0);
+					return true;
+				},
+			),
+		);
+	});
 
-  it("fresh account has maximum health score", () => {
-    fc.assert(
-      fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
-        const t = new HealthScoreTracker();
-        const score = t.getScore(accountIndex, quotaKey);
-        expect(score).toBe(DEFAULT_HEALTH_SCORE_CONFIG.maxScore);
-        return true;
-      })
-    );
-  });
+	it("fresh account has maximum health score", () => {
+		fc.assert(
+			fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
+				const t = new HealthScoreTracker();
+				const score = t.getScore(accountIndex, quotaKey);
+				expect(score).toBe(DEFAULT_HEALTH_SCORE_CONFIG.maxScore);
+				return true;
+			}),
+		);
+	});
 
-  it("reset restores account to fresh state", () => {
-    fc.assert(
-      fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
-        const t = new HealthScoreTracker();
-        t.recordFailure(accountIndex, quotaKey);
-        t.recordFailure(accountIndex, quotaKey);
-        t.reset(accountIndex, quotaKey);
-        expect(t.getScore(accountIndex, quotaKey)).toBe(DEFAULT_HEALTH_SCORE_CONFIG.maxScore);
-        expect(t.getConsecutiveFailures(accountIndex, quotaKey)).toBe(0);
-        return true;
-      })
-    );
-  });
+	it("reset restores account to fresh state", () => {
+		fc.assert(
+			fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
+				const t = new HealthScoreTracker();
+				t.recordFailure(accountIndex, quotaKey);
+				t.recordFailure(accountIndex, quotaKey);
+				t.reset(accountIndex, quotaKey);
+				expect(t.getScore(accountIndex, quotaKey)).toBe(
+					DEFAULT_HEALTH_SCORE_CONFIG.maxScore,
+				);
+				expect(t.getConsecutiveFailures(accountIndex, quotaKey)).toBe(0);
+				return true;
+			}),
+		);
+	});
 });
 
 describe("TokenBucketTracker property tests", () => {
-  it("tokens never go negative", () => {
-    fc.assert(
-      fc.property(
-        arbAccountIndex,
-        arbQuotaKey,
-        fc.integer({ min: 1, max: 100 }),
-        (accountIndex, quotaKey, consumeAttempts) => {
-          const t = new TokenBucketTracker();
-          for (let i = 0; i < consumeAttempts; i++) {
-            t.tryConsume(accountIndex, quotaKey);
-            const tokens = t.getTokens(accountIndex, quotaKey);
-            expect(tokens).toBeGreaterThanOrEqual(0);
-          }
-          return true;
-        }
-      )
-    );
-  });
+	it("tokens never go negative", () => {
+		fc.assert(
+			fc.property(
+				arbAccountIndex,
+				arbQuotaKey,
+				fc.integer({ min: 1, max: 100 }),
+				(accountIndex, quotaKey, consumeAttempts) => {
+					const t = new TokenBucketTracker();
+					for (let i = 0; i < consumeAttempts; i++) {
+						t.tryConsume(accountIndex, quotaKey);
+						const tokens = t.getTokens(accountIndex, quotaKey);
+						expect(tokens).toBeGreaterThanOrEqual(0);
+					}
+					return true;
+				},
+			),
+		);
+	});
 
-  it("tryConsume returns false when bucket is empty", () => {
-    fc.assert(
-      fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
-        const t = new TokenBucketTracker({ maxTokens: 5, tokensPerMinute: 0 });
-        for (let i = 0; i < 5; i++) {
-          expect(t.tryConsume(accountIndex, quotaKey)).toBe(true);
-        }
-        expect(t.tryConsume(accountIndex, quotaKey)).toBe(false);
-        return true;
-      })
-    );
-  });
+	it("tryConsume returns false when bucket is empty", () => {
+		fc.assert(
+			fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
+				const t = new TokenBucketTracker({ maxTokens: 5, tokensPerMinute: 0 });
+				for (let i = 0; i < 5; i++) {
+					expect(t.tryConsume(accountIndex, quotaKey)).toBe(true);
+				}
+				expect(t.tryConsume(accountIndex, quotaKey)).toBe(false);
+				return true;
+			}),
+		);
+	});
 
-  it("fresh bucket has maximum tokens", () => {
-    fc.assert(
-      fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
-        const t = new TokenBucketTracker();
-        const tokens = t.getTokens(accountIndex, quotaKey);
-        expect(tokens).toBe(DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens);
-        return true;
-      })
-    );
-  });
+	it("fresh bucket has maximum tokens", () => {
+		fc.assert(
+			fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
+				const t = new TokenBucketTracker();
+				const tokens = t.getTokens(accountIndex, quotaKey);
+				expect(tokens).toBe(DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens);
+				return true;
+			}),
+		);
+	});
 
-  it("drain reduces tokens but never below 0", () => {
-    fc.assert(
-      fc.property(
-        arbAccountIndex,
-        arbQuotaKey,
-        fc.integer({ min: 1, max: 100 }),
-        (accountIndex, quotaKey, drainAmount) => {
-          const t = new TokenBucketTracker();
-          t.drain(accountIndex, quotaKey, drainAmount);
-          const tokens = t.getTokens(accountIndex, quotaKey);
-          expect(tokens).toBeGreaterThanOrEqual(0);
-          expect(tokens).toBeLessThanOrEqual(DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens);
-          return true;
-        }
-      )
-    );
-  });
+	it("drain reduces tokens but never below 0", () => {
+		fc.assert(
+			fc.property(
+				arbAccountIndex,
+				arbQuotaKey,
+				fc.integer({ min: 1, max: 100 }),
+				(accountIndex, quotaKey, drainAmount) => {
+					const t = new TokenBucketTracker();
+					t.drain(accountIndex, quotaKey, drainAmount);
+					const tokens = t.getTokens(accountIndex, quotaKey);
+					expect(tokens).toBeGreaterThanOrEqual(0);
+					expect(tokens).toBeLessThanOrEqual(
+						DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens,
+					);
+					return true;
+				},
+			),
+		);
+	});
 
-  it("reset restores maximum tokens", () => {
-    fc.assert(
-      fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
-        const t = new TokenBucketTracker();
-        t.drain(accountIndex, quotaKey, 50);
-        t.reset(accountIndex, quotaKey);
-        expect(t.getTokens(accountIndex, quotaKey)).toBe(DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens);
-        return true;
-      })
-    );
-  });
+	it("reset restores maximum tokens", () => {
+		fc.assert(
+			fc.property(arbAccountIndex, arbQuotaKey, (accountIndex, quotaKey) => {
+				const t = new TokenBucketTracker();
+				t.drain(accountIndex, quotaKey, 50);
+				t.reset(accountIndex, quotaKey);
+				expect(t.getTokens(accountIndex, quotaKey)).toBe(
+					DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens,
+				);
+				return true;
+			}),
+		);
+	});
 });
 
 describe("selectHybridAccount property tests", () => {
-  const arbAccount = fc.record({
-    index: arbAccountIndex,
-    isAvailable: fc.boolean(),
-    lastUsed: fc.integer({ min: 0, max: Date.now() }),
-  });
+	const arbAccount = fc.record({
+		index: arbAccountIndex,
+		isAvailable: fc.boolean(),
+		lastUsed: fc.integer({ min: 0, max: Date.now() }),
+	});
 
-  const arbAccounts = fc.array(arbAccount, { minLength: 1, maxLength: 10 });
+	const arbAccounts = fc.array(arbAccount, { minLength: 1, maxLength: 10 });
 
-  it("returns null only when accounts array is empty", () => {
-    const healthTracker = new HealthScoreTracker();
-    const tokenTracker = new TokenBucketTracker();
-    const result = selectHybridAccount([], healthTracker, tokenTracker);
-    expect(result).toBeNull();
-  });
+	it("returns null only when accounts array is empty", () => {
+		const healthTracker = new HealthScoreTracker();
+		const tokenTracker = new TokenBucketTracker();
+		const result = selectHybridAccount([], healthTracker, tokenTracker);
+		expect(result).toBeNull();
+	});
 
-  it("returns a valid account from the input list", () => {
-    fc.assert(
-      fc.property(arbAccounts, arbQuotaKey, (accounts, quotaKey) => {
-        const healthTracker = new HealthScoreTracker();
-        const tokenTracker = new TokenBucketTracker();
-        const result = selectHybridAccount(accounts, healthTracker, tokenTracker, quotaKey);
-        if (result !== null) {
-          const found = accounts.some((a) => a.index === result.index);
-          expect(found).toBe(true);
-        }
-        return true;
-      })
-    );
-  });
+	it("returns a valid account from the input list", () => {
+		fc.assert(
+			fc.property(arbAccounts, arbQuotaKey, (accounts, quotaKey) => {
+				const healthTracker = new HealthScoreTracker();
+				const tokenTracker = new TokenBucketTracker();
+				const result = selectHybridAccount(
+					accounts,
+					healthTracker,
+					tokenTracker,
+					quotaKey,
+				);
+				if (result !== null) {
+					const found = accounts.some((a) => a.index === result.index);
+					expect(found).toBe(true);
+				}
+				return true;
+			}),
+		);
+	});
 
-  it("prefers available accounts over unavailable ones", () => {
-    fc.assert(
-      fc.property(arbQuotaKey, (quotaKey) => {
-        const accounts: AccountWithMetrics[] = [
-          { index: 0, isAvailable: false, lastUsed: 0 },
-          { index: 1, isAvailable: true, lastUsed: Date.now() },
-        ];
-        const healthTracker = new HealthScoreTracker();
-        const tokenTracker = new TokenBucketTracker();
-        const result = selectHybridAccount(accounts, healthTracker, tokenTracker, quotaKey);
-        expect(result).not.toBeNull();
-        expect(result!.index).toBe(1);
-        return true;
-      })
-    );
-  });
+	it("prefers available accounts over unavailable ones", () => {
+		fc.assert(
+			fc.property(arbQuotaKey, (quotaKey) => {
+				const accounts: AccountWithMetrics[] = [
+					{ index: 0, isAvailable: false, lastUsed: 0 },
+					{ index: 1, isAvailable: true, lastUsed: Date.now() },
+				];
+				const healthTracker = new HealthScoreTracker();
+				const tokenTracker = new TokenBucketTracker();
+				const result = selectHybridAccount(
+					accounts,
+					healthTracker,
+					tokenTracker,
+					quotaKey,
+				);
+				expect(result).not.toBeNull();
+				expect(result!.index).toBe(1);
+				return true;
+			}),
+		);
+	});
 
-  it("returns least recently used when all unavailable", () => {
-    const accounts: AccountWithMetrics[] = [
-      { index: 0, isAvailable: false, lastUsed: 1000 },
-      { index: 1, isAvailable: false, lastUsed: 500 },
-      { index: 2, isAvailable: false, lastUsed: 2000 },
-    ];
-    const healthTracker = new HealthScoreTracker();
-    const tokenTracker = new TokenBucketTracker();
-    const result = selectHybridAccount(accounts, healthTracker, tokenTracker);
-    expect(result).not.toBeNull();
-    expect(result!.index).toBe(1);
-  });
+	it("returns null when all accounts are unavailable (AUDIT-H2 contract)", () => {
+		const accounts: AccountWithMetrics[] = [
+			{ index: 0, isAvailable: false, lastUsed: 1000 },
+			{ index: 1, isAvailable: false, lastUsed: 500 },
+			{ index: 2, isAvailable: false, lastUsed: 2000 },
+		];
+		const healthTracker = new HealthScoreTracker();
+		const tokenTracker = new TokenBucketTracker();
+		const result = selectHybridAccount(accounts, healthTracker, tokenTracker);
+		// Old behavior returned the LRU account as a "fallback" even when every
+		// candidate was blocked, which caused the fetch loop to churn through
+		// known-unavailable accounts (D-01). New contract returns null and lets
+		// the caller surface the pool-wide unavailable condition explicitly.
+		expect(result).toBeNull();
+	});
 
-  it("selection is deterministic for same inputs", () => {
-    fc.assert(
-      fc.property(arbAccounts, arbQuotaKey, (accounts, quotaKey) => {
-        const healthTracker1 = new HealthScoreTracker();
-        const tokenTracker1 = new TokenBucketTracker();
-        const healthTracker2 = new HealthScoreTracker();
-        const tokenTracker2 = new TokenBucketTracker();
+	it("selection is deterministic for same inputs", () => {
+		fc.assert(
+			fc.property(arbAccounts, arbQuotaKey, (accounts, quotaKey) => {
+				const healthTracker1 = new HealthScoreTracker();
+				const tokenTracker1 = new TokenBucketTracker();
+				const healthTracker2 = new HealthScoreTracker();
+				const tokenTracker2 = new TokenBucketTracker();
 
-        const result1 = selectHybridAccount(accounts, healthTracker1, tokenTracker1, quotaKey);
-        const result2 = selectHybridAccount(accounts, healthTracker2, tokenTracker2, quotaKey);
+				const result1 = selectHybridAccount(
+					accounts,
+					healthTracker1,
+					tokenTracker1,
+					quotaKey,
+				);
+				const result2 = selectHybridAccount(
+					accounts,
+					healthTracker2,
+					tokenTracker2,
+					quotaKey,
+				);
 
-        if (result1 === null) {
-          expect(result2).toBeNull();
-        } else {
-          expect(result2).not.toBeNull();
-          expect(result1.index).toBe(result2!.index);
-        }
-        return true;
-      })
-    );
-  });
+				if (result1 === null) {
+					expect(result2).toBeNull();
+				} else {
+					expect(result2).not.toBeNull();
+					expect(result1.index).toBe(result2!.index);
+				}
+				return true;
+			}),
+		);
+	});
 });

--- a/test/rotation.test.ts
+++ b/test/rotation.test.ts
@@ -31,7 +31,7 @@ describe("HealthScoreTracker", () => {
 
 		it("returns maxScore for accounts with quotaKey", () => {
 			expect(tracker.getScore(0, "quota-a")).toBe(
-				DEFAULT_HEALTH_SCORE_CONFIG.maxScore
+				DEFAULT_HEALTH_SCORE_CONFIG.maxScore,
 			);
 		});
 	});
@@ -61,7 +61,7 @@ describe("HealthScoreTracker", () => {
 				tracker.recordSuccess(0);
 			}
 			expect(tracker.getScore(0)).toBeLessThanOrEqual(
-				DEFAULT_HEALTH_SCORE_CONFIG.maxScore
+				DEFAULT_HEALTH_SCORE_CONFIG.maxScore,
 			);
 		});
 	});
@@ -109,7 +109,8 @@ describe("HealthScoreTracker", () => {
 			vi.advanceTimersByTime(1000 * 60 * 60);
 			const afterOneHour = tracker.getScore(0);
 
-			const expectedRecovery = DEFAULT_HEALTH_SCORE_CONFIG.passiveRecoveryPerHour;
+			const expectedRecovery =
+				DEFAULT_HEALTH_SCORE_CONFIG.passiveRecoveryPerHour;
 			expect(afterOneHour).toBeCloseTo(afterRateLimit + expectedRecovery, 1);
 		});
 
@@ -118,7 +119,7 @@ describe("HealthScoreTracker", () => {
 
 			vi.advanceTimersByTime(1000 * 60 * 60 * 100);
 			expect(tracker.getScore(0)).toBeLessThanOrEqual(
-				DEFAULT_HEALTH_SCORE_CONFIG.maxScore
+				DEFAULT_HEALTH_SCORE_CONFIG.maxScore,
 			);
 		});
 	});
@@ -132,7 +133,7 @@ describe("HealthScoreTracker", () => {
 
 			expect(tracker.getScore(0)).toBe(DEFAULT_HEALTH_SCORE_CONFIG.maxScore);
 			expect(tracker.getScore(1)).toBeLessThan(
-				DEFAULT_HEALTH_SCORE_CONFIG.maxScore
+				DEFAULT_HEALTH_SCORE_CONFIG.maxScore,
 			);
 		});
 
@@ -155,10 +156,10 @@ describe("HealthScoreTracker", () => {
 			tracker.recordSuccess(0, "quota-b");
 
 			expect(tracker.getScore(0, "quota-a")).toBeLessThan(
-				DEFAULT_HEALTH_SCORE_CONFIG.maxScore
+				DEFAULT_HEALTH_SCORE_CONFIG.maxScore,
 			);
 			expect(tracker.getScore(0, "quota-b")).toBe(
-				DEFAULT_HEALTH_SCORE_CONFIG.maxScore
+				DEFAULT_HEALTH_SCORE_CONFIG.maxScore,
 			);
 		});
 	});
@@ -188,7 +189,7 @@ describe("TokenBucketTracker", () => {
 			const result = tracker.tryConsume(0);
 			expect(result).toBe(true);
 			expect(tracker.getTokens(0)).toBe(
-				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens - 1
+				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens - 1,
 			);
 		});
 
@@ -251,7 +252,7 @@ describe("TokenBucketTracker", () => {
 
 			vi.advanceTimersByTime(1000 * 60 * 60);
 			expect(tracker.getTokens(0)).toBeLessThanOrEqual(
-				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens
+				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens,
 			);
 		});
 	});
@@ -260,7 +261,7 @@ describe("TokenBucketTracker", () => {
 		it("removes specified tokens", () => {
 			tracker.drain(0, undefined, 20);
 			expect(tracker.getTokens(0)).toBe(
-				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens - 20
+				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens - 20,
 			);
 		});
 
@@ -272,7 +273,7 @@ describe("TokenBucketTracker", () => {
 		it("uses maxTokens when no prior entry exists for drain (line 205 coverage)", () => {
 			tracker.drain(5, "new-quota", 5);
 			expect(tracker.getTokens(5, "new-quota")).toBe(
-				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens - 5
+				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens - 5,
 			);
 		});
 	});
@@ -286,7 +287,7 @@ describe("TokenBucketTracker", () => {
 
 			expect(tracker.getTokens(0)).toBe(DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens);
 			expect(tracker.getTokens(1)).toBeLessThan(
-				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens
+				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens,
 			);
 		});
 
@@ -322,14 +323,25 @@ describe("selectHybridAccount", () => {
 		expect(result).toBe(null);
 	});
 
-	it("returns least-recently-used account when all accounts unavailable (fallback)", () => {
+	it("returns null when all accounts are unavailable (AUDIT-H2 contract)", () => {
 		const accounts: AccountWithMetrics[] = [
 			{ index: 0, isAvailable: false, lastUsed: 100 },
 			{ index: 1, isAvailable: false, lastUsed: 50 },
 		];
 		const result = selectHybridAccount(accounts, healthTracker, tokenTracker);
-		// When all accounts unavailable, returns the least-recently-used one as fallback
-		expect(result?.index).toBe(1); // index 1 has lastUsed: 50 (older)
+		// Previously returned the least-recently-used unavailable account as a
+		// "fallback"; the fetch loop trusted it and churned through blocked
+		// candidates (AUDIT-H2 / D-01). New contract: return null so the caller
+		// surfaces the pool-wide unavailable condition explicitly.
+		expect(result).toBe(null);
+	});
+
+	it("returns null when a single account is unavailable", () => {
+		const accounts: AccountWithMetrics[] = [
+			{ index: 0, isAvailable: false, lastUsed: 0 },
+		];
+		const result = selectHybridAccount(accounts, healthTracker, tokenTracker);
+		expect(result).toBe(null);
 	});
 
 	it("returns the only available account", () => {
@@ -405,7 +417,14 @@ describe("selectHybridAccount", () => {
 			{ index: 1, isAvailable: true, lastUsed: Date.now() },
 		];
 
-		const result1 = selectHybridAccount(accounts, healthTracker, tokenTracker, undefined, undefined, { pidOffsetEnabled: false });
+		const result1 = selectHybridAccount(
+			accounts,
+			healthTracker,
+			tokenTracker,
+			undefined,
+			undefined,
+			{ pidOffsetEnabled: false },
+		);
 		const result2 = selectHybridAccount(accounts, healthTracker, tokenTracker);
 
 		expect(result1?.index).toBe(result2?.index);
@@ -417,7 +436,14 @@ describe("selectHybridAccount", () => {
 			{ index: 1, isAvailable: true, lastUsed: Date.now() },
 		];
 
-		const result = selectHybridAccount(accounts, healthTracker, tokenTracker, undefined, undefined, { pidOffsetEnabled: true });
+		const result = selectHybridAccount(
+			accounts,
+			healthTracker,
+			tokenTracker,
+			undefined,
+			undefined,
+			{ pidOffsetEnabled: true },
+		);
 
 		expect(result).not.toBe(null);
 		expect([0, 1]).toContain(result?.index);
@@ -433,10 +459,20 @@ describe("selectHybridAccount", () => {
 				{ index: 1, isAvailable: true, lastUsed: Date.now() },
 			];
 
-			const result = selectHybridAccount(accounts, healthTracker, tokenTracker, undefined, undefined, { pidOffsetEnabled: true });
+			const result = selectHybridAccount(
+				accounts,
+				healthTracker,
+				tokenTracker,
+				undefined,
+				undefined,
+				{ pidOffsetEnabled: true },
+			);
 			expect(result).not.toBe(null);
 		} finally {
-			Object.defineProperty(process, "pid", { value: originalPid, configurable: true });
+			Object.defineProperty(process, "pid", {
+				value: originalPid,
+				configurable: true,
+			});
 		}
 	});
 
@@ -453,14 +489,27 @@ describe("selectHybridAccount", () => {
 		const selectedIndices = new Set<number>();
 		try {
 			for (let pid = 0; pid < 100; pid += 10) {
-				Object.defineProperty(process, "pid", { value: pid, configurable: true });
-				const result = selectHybridAccount(accounts, healthTracker, tokenTracker, undefined, undefined, { pidOffsetEnabled: true });
+				Object.defineProperty(process, "pid", {
+					value: pid,
+					configurable: true,
+				});
+				const result = selectHybridAccount(
+					accounts,
+					healthTracker,
+					tokenTracker,
+					undefined,
+					undefined,
+					{ pidOffsetEnabled: true },
+				);
 				if (result) {
 					selectedIndices.add(result.index);
 				}
 			}
 		} finally {
-			Object.defineProperty(process, "pid", { value: originalPid, configurable: true });
+			Object.defineProperty(process, "pid", {
+				value: originalPid,
+				configurable: true,
+			});
 		}
 
 		expect(selectedIndices.size).toBeGreaterThan(1);
@@ -659,25 +708,42 @@ describe("utility functions", () => {
 				);
 				expect(() =>
 					exponentialBackoff(Number.NaN as unknown as number, 1000, 60000, 0.1),
-				).toThrowError("exponentialBackoff requires attempt to be a positive integer");
+				).toThrowError(
+					"exponentialBackoff requires attempt to be a positive integer",
+				);
 				expect(() =>
-					exponentialBackoff(Number.POSITIVE_INFINITY as unknown as number, 1000, 60000, 0.1),
-				).toThrowError("exponentialBackoff requires attempt to be a positive integer");
+					exponentialBackoff(
+						Number.POSITIVE_INFINITY as unknown as number,
+						1000,
+						60000,
+						0.1,
+					),
+				).toThrowError(
+					"exponentialBackoff requires attempt to be a positive integer",
+				);
 				expect(() =>
 					exponentialBackoff(undefined as unknown as number, 1000, 60000, 0.1),
-				).toThrowError("exponentialBackoff requires attempt to be a positive integer");
+				).toThrowError(
+					"exponentialBackoff requires attempt to be a positive integer",
+				);
 				expect(() => exponentialBackoff(1, -1, 60000, 0.1)).toThrowError(
 					"exponentialBackoff requires baseMs to be a finite non-negative number",
 				);
 				expect(() => exponentialBackoff(1, 1000, -1, 0.1)).toThrowError(
 					"exponentialBackoff requires maxMs to be a finite non-negative number",
 				);
-				expect(() => exponentialBackoff({} as unknown as Parameters<typeof exponentialBackoff>[0])).toThrowError(
+				expect(() =>
+					exponentialBackoff(
+						{} as unknown as Parameters<typeof exponentialBackoff>[0],
+					),
+				).toThrowError(
 					"exponentialBackoff requires attempt to be a positive integer",
 				);
 				expect(() =>
 					exponentialBackoff({ attempt: 1, jitterFactor: 2 }),
-				).toThrowError("exponentialBackoff requires jitterFactor to be between 0 and 1");
+				).toThrowError(
+					"exponentialBackoff requires jitterFactor to be between 0 and 1",
+				);
 				expect(randomSpy).not.toHaveBeenCalled();
 			} finally {
 				randomSpy.mockRestore();


### PR DESCRIPTION
## Summary

Changes the `selectHybridAccount()` contract: when every account is unavailable (cooling down, rate-limited, circuit-open, or otherwise blocked), the selector now returns `null` instead of returning the least-recently-used unavailable account as a "fallback".

## Problem

The fetch loop in `index.ts` trusted the selector's result without re-validating account availability. The old LRU "fallback" handed back a known-unavailable account, which caused:

- Avoidable retries through blocked candidates
- Noisy cross-account 5xx bursts when the pool was already stalling
- Misleading failover behavior in pool-wide-unavailable situations
- Confusing user output ("using account 3" for a candidate that was just cooled down)

Audit (`docs/audits/MASTER_AUDIT.md` §5 HIGH / `dim-D-routing.md` D-01) flagged this as a HIGH finding; Oracle confirmed the severity and recommended: "Change the hybrid selector contract to return null when no account is available, or re-run `isAccountAvailableForFamily()` after hybrid selection before using the account."

## Change

`lib/rotation.ts` `selectHybridAccount()`:

```ts
- if (available.length === 0) {
-   if (resolvedAccounts.length === 0) return null;
-   let leastRecentlyUsed: AccountWithMetrics | null = null;
-   let oldestTime = Infinity;
-   for (const account of resolvedAccounts) {
-     if (account.lastUsed < oldestTime) {
-       oldestTime = account.lastUsed;
-       leastRecentlyUsed = account;
-     }
-   }
-   return leastRecentlyUsed;
- }
+ if (available.length === 0) {
+   return null;
+ }
```

The caller is now responsible for surfacing the pool-wide unavailable condition (burst cooldown, fast-fail, or user-facing error) instead of churning through blocked candidates.

## Test updates

Three existing tests documented the old LRU fallback behavior. All three are updated to assert the new `null` contract, with comments referencing AUDIT-H2 so future readers understand why:

- `test/rotation.test.ts` — `returns least-recently-used account when all accounts unavailable (fallback)` → `returns null when all accounts are unavailable (AUDIT-H2 contract)`. Added a regression for the single-unavailable-account case.
- `test/accounts.test.ts` — `falls back to least-recently-used when all accounts are rate-limited` → `returns null when all accounts are rate-limited (AUDIT-H2 contract)`
- `test/property/rotation.property.test.ts` — `returns least recently used when all unavailable` → `returns null when all accounts are unavailable (AUDIT-H2 contract)`

## Verification

- **Full suite: 225/225 files, 3419/3419 tests pass** (+1 new regression test)
- `npm run typecheck` exit 0
- `npm run lint` exit 0
- No new dependencies
- No new public API

## Audit reference

- `docs/audits/MASTER_AUDIT.md` §5 HIGH `AUDIT-H2`
- `docs/audits/evidence/dim-D-routing.md` D-01
- `docs/audits/evidence/oracle-verdicts.md` §1.1 (confirmed HIGH), §2 Rank 3 R4 (this bug is one of three that R4 routing mutex closes holistically; this PR is the tactical point-fix)

## Caller expectations

The caller in `index.ts` around line 1149-1161 already has a null-guard (`if (!account || attempted.has(account.index)) { break; }`), so the new null return is handled gracefully: the fetch loop breaks out and surfaces the pool-wide unavailable condition through existing burst-cooldown / pool-exhaustion pathways. No additional caller changes needed in this PR.

## Scope guarantees

- ✅ One concern — selector null contract
- ✅ No refactor beyond the affected branch
- ✅ All three tests updated with AUDIT-ID references
- ✅ New regression test for the single-unavailable case
- ✅ Full test suite green

## Note on diff size

The commit stat shows a larger insertion/deletion count than the minimal behavioral change because the repository's `lint-staged` pre-commit hook (biome/prettier) applied trailing-comma and wrapping normalizations to the files touched. The meaningful functional change is:
- `lib/rotation.ts`: ~15 lines replaced (the all-unavailable branch)
- Three test files: ~5-10 lines each for the contract update + one new test

Use GitHub's "Hide whitespace" diff option or `git diff -w` for a clearer read.

## Follow-up

Phase 1 continues with **PR-E** (short-429 race fix — AUDIT-H3) and **PR-F** (active-pointer normalization — AUDIT-H10). Tracked in `.sisyphus/plans/phase1-implementation.md`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes the `selectHybridAccount` contract: when every account is unavailable the selector now returns `null` instead of the LRU fallback candidate. the caller in `index.ts` already has a null-guard at line 1159 (`if (!account || attempted.has(account.index)) { break; }`) so no additional caller changes are needed. three test files are updated and one regression test is added; all 3419 tests pass.

<h3>Confidence Score: 5/5</h3>

safe to merge — only remaining findings are P2 doc/test-description cleanups.

the behavioral change is minimal and correct, the null-guard in `index.ts` already handles the new return value, full suite passes, and no concurrency or windows filesystem issues are introduced. both open findings are P2 style/docs only.

lib/rotation.ts — stale JSDoc @param/@returns still describes old LRU fallback behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/rotation.ts | Core contract change: `available.length === 0` now returns null instead of LRU fallback. Logic and inline comment (AUDIT-H2/D-01) are correct. JSDoc @param/@returns still describe the old behavior and need updating. |
| test/rotation.test.ts | Three old LRU-fallback tests updated to assert null; new regression test added for single-unavailable-account case. AUDIT-H2 comments wired. Coverage looks complete for the changed branch. |
| test/accounts.test.ts | Rate-limited test updated to assert null via `getCurrentOrNextForFamilyHybrid`; contract-change comment referencing AUDIT-H2/D-01 added. No issues found. |
| test/property/rotation.property.test.ts | Property test contract test updated to assert null for all-unavailable case; however the existing "returns null only when accounts array is empty" description is now incorrect after the contract change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FL as fetch loop (index.ts)
    participant AM as AccountManager
    participant SH as selectHybridAccount

    FL->>AM: getCurrentOrNextForFamilyHybrid(family)
    AM->>SH: selectHybridAccount(accounts, healthTracker, tokenTracker)

    alt available.length > 0
        SH-->>AM: AccountWithMetrics (best scored)
        AM-->>FL: account
        FL->>FL: proceed with request
    else available.length === 0 (all blocked) — new contract
        SH-->>AM: null
        AM-->>FL: null
        FL->>FL: break loop → surface pool-wide unavailable condition
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fhybrid-selector-null-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhybrid-selector-null-contract%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Frotation.ts%3A362-368%0A**Stale%20JSDoc%20contradicts%20the%20new%20null%20contract**%0A%0AThe%20%60%40param%20accounts%60%20description%20on%20line%20362%20still%20says%20*%22when%20none%20are%20available%20the%20least-recently-used%20account%20is%20returned%22*%20%E2%80%94%20the%20old%20LRU%20fallback%20behavior%20this%20PR%20removes.%20The%20%60%40returns%60%20on%20line%20368%20only%20mentions%20null%20*%22if%20no%20accounts%20exist%22*%2C%20missing%20the%20new%20case%20where%20null%20is%20returned%20because%20all%20accounts%20are%20unavailable.%0A%0A%60%60%60suggestion%0A%20*%20%40param%20accounts%20-%20Candidate%20accounts%20with%20availability%20%28%60isAvailable%60%29%20and%20last-used%20timestamp%20%28%60lastUsed%60%29%3B%20when%20none%20are%20available%20%60null%60%20is%20returned%20%28AUDIT-H2%20contract%20%E2%80%94%20the%20caller%20is%20responsible%20for%20surfacing%20pool-wide%20unavailability%29.%0A%20*%20%40param%20healthTracker%20-%20Tracker%20used%20to%20obtain%20per-account%20health%20scores%20%28scoped%20by%20%60quotaKey%60%20when%20provided%29.%0A%20*%20%40param%20tokenTracker%20-%20Tracker%20used%20to%20obtain%20per-account%20token%20counts%20%28scoped%20by%20%60quotaKey%60%20when%20provided%29.%20Logged%20token%20values%20are%20rounded%20for%20telemetry%20and%20sensitive%20tokens%20are%20not%20emitted.%0A%20*%20%40param%20quotaKey%20-%20Optional%20quota%20key%20to%20scope%20health%20and%20token%20lookups.%0A%20*%20%40param%20config%20-%20Partial%20selection%20weights%20that%20override%20defaults%20%28healthWeight%2C%20tokenWeight%2C%20freshnessWeight%29.%0A%20*%20%40param%20options%20-%20Selection%20options.%20%60pidOffsetEnabled%60%20adds%20a%20small%20PID-based%20deterministic%20offset%20to%20distribute%20selection%20across%20processes.%20%60scoreBoostByAccount%60%20is%20an%20optional%20per-account%20numeric%20boost%20keyed%20by%20account%20index.%0A%20*%20%40returns%20The%20chosen%20%60AccountWithMetrics%60%20for%20the%20next%20request%2C%20or%20%60null%60%20if%20the%20accounts%20array%20is%20empty%20or%20all%20candidates%20are%20currently%20unavailable.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fproperty%2Frotation.property.test.ts%3A222-227%0A**Test%20description%20now%20misleading%20after%20contract%20change**%0A%0AThe%20word%20%22only%22%20makes%20this%20description%20incorrect%20%E2%80%94%20under%20the%20new%20AUDIT-H2%20contract%20null%20is%20also%20returned%20when%20all%20accounts%20are%20unavailable%2C%20which%20is%20asserted%20by%20the%20test%20added%20at%20line%20271.%20A%20future%20reader%20tracing%20the%20null%20path%20will%20be%20misled.%0A%0A%60%60%60suggestion%0A%09it%28%22returns%20null%20when%20accounts%20array%20is%20empty%22%2C%20%28%29%20%3D%3E%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/rotation.ts
Line: 362-368

Comment:
**Stale JSDoc contradicts the new null contract**

The `@param accounts` description on line 362 still says *"when none are available the least-recently-used account is returned"* — the old LRU fallback behavior this PR removes. The `@returns` on line 368 only mentions null *"if no accounts exist"*, missing the new case where null is returned because all accounts are unavailable.

```suggestion
 * @param accounts - Candidate accounts with availability (`isAvailable`) and last-used timestamp (`lastUsed`); when none are available `null` is returned (AUDIT-H2 contract — the caller is responsible for surfacing pool-wide unavailability).
 * @param healthTracker - Tracker used to obtain per-account health scores (scoped by `quotaKey` when provided).
 * @param tokenTracker - Tracker used to obtain per-account token counts (scoped by `quotaKey` when provided). Logged token values are rounded for telemetry and sensitive tokens are not emitted.
 * @param quotaKey - Optional quota key to scope health and token lookups.
 * @param config - Partial selection weights that override defaults (healthWeight, tokenWeight, freshnessWeight).
 * @param options - Selection options. `pidOffsetEnabled` adds a small PID-based deterministic offset to distribute selection across processes. `scoreBoostByAccount` is an optional per-account numeric boost keyed by account index.
 * @returns The chosen `AccountWithMetrics` for the next request, or `null` if the accounts array is empty or all candidates are currently unavailable.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/property/rotation.property.test.ts
Line: 222-227

Comment:
**Test description now misleading after contract change**

The word "only" makes this description incorrect — under the new AUDIT-H2 contract null is also returned when all accounts are unavailable, which is asserted by the test added at line 271. A future reader tracing the null path will be misled.

```suggestion
	it("returns null when accounts array is empty", () => {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(routing): hybrid selector returns nu..."](https://github.com/ndycode/codex-multi-auth/commit/5c953e859b1507eec78ae2a0d463288cd3245d61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28720768)</sub>

<!-- /greptile_comment -->