### PR TITLE
fix(release): pack:check builds first + tests use os.tmpdir

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"test:model-matrix:report": "node scripts/test-model-matrix.js --smoke --report-json=.tmp/model-matrix-report.json",
 		"clean:repo": "node scripts/repo-hygiene.js clean --mode aggressive",
 		"clean:repo:check": "node scripts/repo-hygiene.js check",
-		"pack:check": "node scripts/check-pack-budget.mjs",
+		"pack:check": "npm run build && node scripts/check-pack-budget.mjs",
 		"bench:edit-formats": "node scripts/benchmark-edit-formats.mjs --preset=codex-core",
 		"bench:edit-formats:smoke": "node scripts/benchmark-edit-formats.mjs --smoke --preset=codex-core",
 		"bench:edit-formats:render": "node scripts/benchmark-render-dashboard.mjs",

--- a/test/account-clear.test.ts
+++ b/test/account-clear.test.ts
@@ -1,52 +1,70 @@
 import { promises as fs } from "node:fs";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearAccountStorageArtifacts } from "../lib/storage/account-clear.js";
 
+// Use os.tmpdir() instead of process.cwd() so the test never leaves stray
+// tmp-accounts.* artifacts at the repo root. Previously these files leaked
+// into the worktree and tripped repo hygiene checks (AUDIT-M31 / E-02).
+const testTmpRoot = join(tmpdir(), "codex-multi-auth-account-clear-tests");
+
 describe("account clear helper", () => {
-	afterEach(() => {
+	beforeEach(async () => {
+		await fs.mkdir(testTmpRoot, { recursive: true });
+	});
+
+	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.useRealTimers();
+		// Best-effort cleanup so re-running the suite does not accumulate state.
+		try {
+			await fs.rm(testTmpRoot, { recursive: true, force: true });
+		} catch {
+			// Ignore: rm can race with antivirus scanners on Windows; next run
+			// will retry the directory creation.
+		}
 	});
 
 	it("clears primary, wal, and backups after writing marker", async () => {
 		await expect(
 			clearAccountStorageArtifacts({
-				path: `${process.cwd()}/tmp-accounts.json`,
-				resetMarkerPath: `${process.cwd()}/tmp-accounts.marker`,
-				walPath: `${process.cwd()}/tmp-accounts.wal`,
-				backupPaths: [`${process.cwd()}/tmp-accounts.json.bak`],
+				path: join(testTmpRoot, "tmp-accounts.json"),
+				resetMarkerPath: join(testTmpRoot, "tmp-accounts.marker"),
+				walPath: join(testTmpRoot, "tmp-accounts.wal"),
+				backupPaths: [join(testTmpRoot, "tmp-accounts.json.bak")],
 				logError: vi.fn(),
 			}),
 		).resolves.toBeUndefined();
 	});
 
-	it.each(["EBUSY", "EPERM"] as const)(
-		"retries transient %s errors when clearing required artifacts",
-		async (code) => {
-			vi.useFakeTimers();
-			const unlinkSpy = vi.spyOn(fs, "unlink");
-			let attempts = 0;
-			unlinkSpy.mockImplementation(async (targetPath) => {
-				if (String(targetPath).endsWith("tmp-accounts.json") && attempts < 2) {
-					attempts += 1;
-					const error = new Error(code) as NodeJS.ErrnoException;
-					error.code = code;
-					throw error;
-				}
-				return undefined as never;
-			});
+	it.each([
+		"EBUSY",
+		"EPERM",
+	] as const)("retries transient %s errors when clearing required artifacts", async (code) => {
+		vi.useFakeTimers();
+		const unlinkSpy = vi.spyOn(fs, "unlink");
+		let attempts = 0;
+		unlinkSpy.mockImplementation(async (targetPath) => {
+			if (String(targetPath).endsWith("tmp-accounts.json") && attempts < 2) {
+				attempts += 1;
+				const error = new Error(code) as NodeJS.ErrnoException;
+				error.code = code;
+				throw error;
+			}
+			return undefined as never;
+		});
 
-			const clearPromise = clearAccountStorageArtifacts({
-				path: `${process.cwd()}/tmp-accounts.json`,
-				resetMarkerPath: `${process.cwd()}/tmp-accounts.marker`,
-				walPath: `${process.cwd()}/tmp-accounts.wal`,
-				backupPaths: [],
-				logError: vi.fn(),
-			});
+		const clearPromise = clearAccountStorageArtifacts({
+			path: join(testTmpRoot, "tmp-accounts.json"),
+			resetMarkerPath: join(testTmpRoot, "tmp-accounts.marker"),
+			walPath: join(testTmpRoot, "tmp-accounts.wal"),
+			backupPaths: [],
+			logError: vi.fn(),
+		});
 
-			await vi.runAllTimersAsync();
-			await expect(clearPromise).resolves.toBeUndefined();
-			expect(unlinkSpy).toHaveBeenCalled();
-		},
-	);
+		await vi.runAllTimersAsync();
+		await expect(clearPromise).resolves.toBeUndefined();
+		expect(unlinkSpy).toHaveBeenCalled();
+	});
 });

--- a/test/flagged-storage-io.test.ts
+++ b/test/flagged-storage-io.test.ts
@@ -1,16 +1,36 @@
-import { describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	clearFlaggedAccountsOnDisk,
 	loadFlaggedAccountsState,
 	saveFlaggedAccountsUnlockedToDisk,
 } from "../lib/storage/flagged-storage-io.js";
 
+// Use os.tmpdir() instead of process.cwd() so the test never leaves stray
+// tmp-flagged.* artifacts at the repo root. Previously these files leaked
+// into the worktree and tripped repo hygiene checks (AUDIT-M31 / E-02).
+const testTmpRoot = join(tmpdir(), "codex-multi-auth-flagged-storage-tests");
+
 describe("flagged storage io helpers", () => {
+	beforeEach(async () => {
+		await fs.mkdir(testTmpRoot, { recursive: true });
+	});
+
+	afterEach(async () => {
+		try {
+			await fs.rm(testTmpRoot, { recursive: true, force: true });
+		} catch {
+			// Ignore: rm can race with antivirus scanners on Windows.
+		}
+	});
+
 	it("returns empty storage when files are missing", async () => {
 		const result = await loadFlaggedAccountsState({
-			path: "/tmp/flagged.json",
-			legacyPath: "/tmp/legacy.json",
-			resetMarkerPath: "/tmp/reset",
+			path: join(testTmpRoot, "flagged.json"),
+			legacyPath: join(testTmpRoot, "legacy.json"),
+			resetMarkerPath: join(testTmpRoot, "reset"),
 			normalizeFlaggedStorage: () => ({
 				version: 1,
 				accounts: [{ refreshToken: "x" }],
@@ -29,8 +49,8 @@ describe("flagged storage io helpers", () => {
 		await saveFlaggedAccountsUnlockedToDisk(
 			{ version: 1, accounts: [] },
 			{
-				path: `${process.cwd()}/tmp-flagged.json`,
-				markerPath: `${process.cwd()}/tmp-flagged.marker`,
+				path: join(testTmpRoot, "tmp-flagged.json"),
+				markerPath: join(testTmpRoot, "tmp-flagged.marker"),
 				normalizeFlaggedStorage: (data) => data as never,
 				copyFileWithRetry,
 				renameFileWithRetry,
@@ -46,9 +66,9 @@ describe("flagged storage io helpers", () => {
 	it("clears flagged account files with best-effort backup cleanup", async () => {
 		await expect(
 			clearFlaggedAccountsOnDisk({
-				path: `${process.cwd()}/tmp-flagged.json`,
-				markerPath: `${process.cwd()}/tmp-flagged.marker`,
-				backupPaths: [`${process.cwd()}/tmp-flagged.json.bak`],
+				path: join(testTmpRoot, "tmp-flagged.json"),
+				markerPath: join(testTmpRoot, "tmp-flagged.marker"),
+				backupPaths: [join(testTmpRoot, "tmp-flagged.json.bak")],
 				logError: vi.fn(),
 			}),
 		).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

Two independent release-hygiene fixes surfaced by the master audit (PR #393). AGENTS.md truthup (AUDIT-H8) is deferred to a dedicated docs PR (PR-Q) so the regen does not land mixed with release hygiene.

## Problem 1 — `npm run pack:check` exited 1 locally (AUDIT-H7)

`pack:check` runs `scripts/check-pack-budget.mjs`, which calls `npm pack --dry-run --json` and then validates that `dist/` content is present. Without a prior `npm run build`, `dist/` is empty and the pack dry-run has no dist entries, so `validatePackMetadata()` fails:

```
Error: Failed to validate npm pack output:
Required package content missing from npm pack output: dist/
```

**Fix**: chain `npm run build` in front of the budget checker, matching the pattern already in use by `bench:runtime-path` and `coverage`:

```diff
- "pack:check": "node scripts/check-pack-budget.mjs",
+ "pack:check": "npm run build && node scripts/check-pack-budget.mjs",
```

Pack budget now reports:
```
Pack budget ok: 786934 bytes across 936 files
```

## Problem 2 — Test artifacts leaking to repo root (AUDIT-M31 / E-02)

`test/account-clear.test.ts` and `test/flagged-storage-io.test.ts` built scratch paths from `${process.cwd()}/tmp-accounts.*` and `${process.cwd()}/tmp-flagged.*`. The tests passed but left physical files at the repo root:

```
tmp-accounts.marker
tmp-flagged.json.<pid>.<ts>.<rand>.tmp
```

These tripped repo hygiene checks and made audit runs dirty.

**Fix**: relocate every scratch path to a per-suite subdirectory under `os.tmpdir()` with a `beforeEach` `fs.mkdir({recursive: true})` + `afterEach` `fs.rm({recursive, force})` lifecycle.

```diff
-path: `${process.cwd()}/tmp-accounts.json`,
+path: join(testTmpRoot, "tmp-accounts.json"),
```

`afterEach` catches and ignores cleanup errors so Windows antivirus scans cannot fail the suite after the functional assertions have already passed.

## Verification

- `npm run pack:check` — exit 0 (previously exit 1)
- `npm run clean:repo:check` — passes on HEAD with **zero `tmp-*` files at repo root**
- `npm test` — **225/225 test files, 3418/3418 tests pass**
- `npm run typecheck` — exit 0
- `npm run lint` — exit 0
- Zero source-of-truth changes: the only non-test code change is the `pack:check` script composition in `package.json`

## Audit reference

- `docs/audits/MASTER_AUDIT.md` §5 HIGH `AUDIT-H7` — pack budget violation (release blocker)
- `docs/audits/MASTER_AUDIT.md` §6 MEDIUM `AUDIT-M31` — repo-root tmp leakage
- `docs/audits/evidence/dim-E-storage.md` E-02 — leaking tests identified
- `docs/audits/evidence/dim-LM-release-docs.md` LM-01 / LM-06 — pack-check and clean-repo signals
- `docs/audits/evidence/oracle-verdicts.md` §4.1 — "tarball bloat oversize only, not secret-leaking" (verified: pack budget includes expected LICENSE, README, dist/, no secrets)

## Scope guarantees

- ✅ One hygiene concern per problem, resolved in the same PR because they share the release-readiness review surface
- ✅ No public-API changes, no dependency changes
- ✅ AGENTS.md truthup deferred to PR-Q so reviewers see only release-readiness fixes here
- ✅ Test changes are limited to temp-path relocation; no assertion / expectation changes

## Follow-up

Phase 1 continues with **PR-H** (atomic recovery writes — R6 / AUDIT-M01). Tracked in `.sisyphus/plans/phase1-implementation.md`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

two independent release-hygiene fixes: `pack:check` now chains `npm run build &&` before the budget checker (matching `bench:runtime-path` / `coverage`), and both test suites relocate scratch paths from `process.cwd()` to a per-suite subdirectory under `os.tmpdir()` with `beforeEach`/`afterEach` lifecycle guards. no api changes, no dependency changes.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are p2 style/quality suggestions, no functional regressions

the `pack:check` fix is correct and unambiguous. both test files correctly move artifacts out of the repo root. the two p2 findings (bare `fs.rm` and a dead assertion) don't affect test correctness or ci outcomes.

both test files need `removeWithRetry` in cleanup and `flagged-storage-io.test.ts` needs the `.not.toThrow()` parens fix

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | adds `npm run build &&` prefix to `pack:check` — correct fix, matches established `bench:runtime-path` / `coverage` pattern |
| test/account-clear.test.ts | relocates temp paths to `os.tmpdir()`; `afterEach` uses bare `fs.rm` with catch-all instead of project-mandated `removeWithRetry` |
| test/flagged-storage-io.test.ts | relocates temp paths to `os.tmpdir()`; bare `fs.rm` without retry + dead assertion `not.toThrow` missing `()` |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm run pack:check] --> B[npm run build]
    B --> C{dist/ populated?}
    C -- yes --> D[node scripts/check-pack-budget.mjs]
    C -- no --> E[❌ validatePackMetadata fails]
    D --> F{budget ok?}
    F -- yes --> G[✅ exit 0]
    F -- no --> H[❌ exit 1]

    subgraph test lifecycle
        I[beforeEach] --> J[fs.mkdir os.tmpdir/suite — recursive]
        J --> K[test runs in isolated dir]
        K --> L[afterEach]
        L --> M[fs.rm recursive+force — bare catch]
        M --> N{Windows EBUSY?}
        N -- yes --> O[⚠️ dir leaks to tmpdir — no retry]
        N -- no --> P[✅ cleaned]
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Frelease-hygiene%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frelease-hygiene%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Faccount-clear.test.ts%3A22-25%0A**bare%20%60fs.rm%60%20without%20retry%20violates%20project%20anti-pattern**%0A%0A%60test%2FAGENTS.md%60%20and%20%60AGENTS.md%60%20both%20explicitly%20forbid%20bare%20%60fs.rm%60%20in%20test%20cleanup%20and%20require%20%60removeWithRetry%60%20with%20EBUSY%2FEPERM%2FENOTEMPTY%20backoff.%20on%20windows%2C%20antivirus%20can%20hold%20a%20lock%20long%20enough%20that%20a%20single%20%60rm%60%20call%20fails%20and%20the%20directory%20is%20never%20cleaned%20%E2%80%94%20silently%2C%20because%20the%20catch%20swallows%20everything.%20%60beforeEach%28%7B%20recursive%3A%20true%20%7D%29%60%20keeps%20subsequent%20runs%20working%2C%20but%20stale%20dirs%20accumulate%20in%20%60os.tmpdir%28%29%60%20indefinitely.%20same%20issue%20exists%20in%20%60flagged-storage-io.test.ts%60.%0A%0A%60%60%60suggestion%0A%09%09try%20%7B%0A%09%09%09await%20removeWithRetry%28testTmpRoot%29%3B%0A%09%09%7D%20catch%20%7B%0A%09%09%09%2F%2F%20best-effort%3B%20beforeEach%20re-creates%20the%20directory%20with%20%7B%20recursive%3A%20true%20%7D%0A%09%09%7D%0A%60%60%60%0A%0A**Context%20Used%3A**%20test%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6e2636a9-e514-4bab-b249-4b4a84aa4ae3%29%29%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fflagged-storage-io.test.ts%3A63%0A**dead%20assertion%20%E2%80%94%20missing%20%60%28%29%60%20on%20%60.not.toThrow%60**%0A%0A%60expect%28fn%29.not.toThrow%60%20without%20parentheses%20just%20reads%20the%20property%20and%20discards%20it%20%E2%80%94%20vitest%20never%20evaluates%20the%20matcher.%20the%20line%20silently%20passes%20no%20matter%20what%20%60copyFileWithRetry%60%20does.%20either%20call%20it%20as%20%60.not.toThrow%28%29%60%20or%2C%20since%20the%20intent%20is%20to%20verify%20the%20mock%20was%20invoked%20without%20error%2C%20use%20%60.toHaveBeenCalled%28%29%60.%0A%0A%60%60%60suggestion%0A%09%09expect%28copyFileWithRetry%29.toHaveBeenCalled%28%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/account-clear.test.ts
Line: 22-25

Comment:
**bare `fs.rm` without retry violates project anti-pattern**

`test/AGENTS.md` and `AGENTS.md` both explicitly forbid bare `fs.rm` in test cleanup and require `removeWithRetry` with EBUSY/EPERM/ENOTEMPTY backoff. on windows, antivirus can hold a lock long enough that a single `rm` call fails and the directory is never cleaned — silently, because the catch swallows everything. `beforeEach({ recursive: true })` keeps subsequent runs working, but stale dirs accumulate in `os.tmpdir()` indefinitely. same issue exists in `flagged-storage-io.test.ts`.

```suggestion
		try {
			await removeWithRetry(testTmpRoot);
		} catch {
			// best-effort; beforeEach re-creates the directory with { recursive: true }
		}
```

**Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/flagged-storage-io.test.ts
Line: 63

Comment:
**dead assertion — missing `()` on `.not.toThrow`**

`expect(fn).not.toThrow` without parentheses just reads the property and discards it — vitest never evaluates the matcher. the line silently passes no matter what `copyFileWithRetry` does. either call it as `.not.toThrow()` or, since the intent is to verify the mock was invoked without error, use `.toHaveBeenCalled()`.

```suggestion
		expect(copyFileWithRetry).toHaveBeenCalled();
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): pack:check builds first + ..."](https://github.com/ndycode/codex-multi-auth/commit/250edfd1b23ed144a5550fce4e08f47b5741cc33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28721646)</sub>

<!-- /greptile_comment -->