### PR TITLE
fix(routing): surface the per-project vs CLI-sync config conflict

### DIFF
--- a/lib/runtime/storage-scope.ts
+++ b/lib/runtime/storage-scope.ts
@@ -22,8 +22,24 @@ export function applyAccountStorageScopeFromConfig(
 	if (deps.isCodexCliSyncEnabled()) {
 		if (perProjectAccounts && !deps.getWarningShown()) {
 			deps.setWarningShown(true);
+			// AUDIT-M09 / D-06: this is a hard config conflict that silently
+			// collapses per-project isolation to global storage. Surface it as
+			// a loud, actionable warning with explicit remediation so users
+			// who picked per-project accounts on purpose do NOT learn about
+			// the collapse via a post-hoc audit. We keep the warn-once gate
+			// so the log is not repeated every request — the signal is the
+			// fact that the user sees it, not its repetition.
 			deps.logWarn(
-				`[${deps.pluginName}] CODEX_AUTH_PER_PROJECT_ACCOUNTS is ignored while Codex CLI sync is enabled. Using global account storage.`,
+				`[${deps.pluginName}] Config conflict: perProjectAccounts = true ` +
+					`is ignored while Codex CLI sync is enabled, because Codex CLI ` +
+					`maintains a single shared account set. All multi-auth accounts ` +
+					`are collapsed to the GLOBAL pool (credentials are NOT isolated ` +
+					`per project/worktree). ` +
+					`To restore per-project isolation, either (a) disable Codex CLI ` +
+					`sync via 'codex auth config set codexCliSync false', or ` +
+					`(b) disable perProjectAccounts via ` +
+					`'codex auth config set perProjectAccounts false' (acknowledges ` +
+					`the global scope). This warning is emitted once per process.`,
 			);
 		}
 		deps.setStoragePath(null);


### PR DESCRIPTION
## Summary

Rewrites the warn message emitted when `perProjectAccounts = true` conflicts with Codex CLI sync. The scope decision is unchanged — the collapse to global storage happens identically — but the log now explicitly names the conflict, states the behavior impact, and offers two concrete remediation commands so users do not discover the silent collapse only after an audit.

## Problem

Audit (`docs/audits/MASTER_AUDIT.md` §5 HIGH (Oracle-elevated) `AUDIT-M09` / `dim-D-routing.md` D-06) demonstrated that `applyAccountStorageScopeFromConfig` in `lib/runtime/storage-scope.ts` silently folded per-project accounts back into global storage when Codex CLI sync was enabled. The old warn was a single short line and easy to miss in setup chatter; users who picked per-project isolation on purpose discovered the collapse only after an audit, when they learned their credentials were shared across projects all along.

Oracle verdict (§1.3): "Silent cross-project credential leak: users who chose per-project isolation discover only via audit that enabling sync collapses to global. `setStoragePath(null)` with one-time warn matches 'silent trust breakage' class. Peer to H4/H5."

## Change

`lib/runtime/storage-scope.ts` — message-only rewrite of the warn-once gate:

```diff
-`[${deps.pluginName}] CODEX_AUTH_PER_PROJECT_ACCOUNTS is ignored while Codex CLI sync is enabled. Using global account storage.`
+`[${deps.pluginName}] Config conflict: perProjectAccounts = true ` +
+`is ignored while Codex CLI sync is enabled, because Codex CLI ` +
+`maintains a single shared account set. All multi-auth accounts ` +
+`are collapsed to the GLOBAL pool (credentials are NOT isolated ` +
+`per project/worktree). ` +
+`To restore per-project isolation, either (a) disable Codex CLI ` +
+`sync via 'codex auth config set codexCliSync false', or ` +
+`(b) disable perProjectAccounts via ` +
+`'codex auth config set perProjectAccounts false' (acknowledges ` +
+`the global scope). This warning is emitted once per process.`
```

The warn-once gate is preserved (avoid per-request spam), and the scope decision itself is untouched.

## Why not a hard error?

Hard-failing the plugin on this config combo would break CI environments and setups that intentionally share accounts, so the audit recommended "treat as hard config conflict with explicit surfaced state" — surfaced, not crashing. The new message does exactly that: the user is told what is happening, why, and how to change it, without blocking any legitimate workflow.

## Verification

- **Full suite: 225/225 test files, 3418/3418 tests pass**
- `npm run typecheck` exit 0
- `npm run lint` exit 0
- No new dependencies, no public API changes
- No behavior change — same scope decision; only the log content differs

## Audit reference

- `docs/audits/MASTER_AUDIT.md` §5 HIGH (Oracle-elevated) `AUDIT-M09`
- `docs/audits/evidence/dim-D-routing.md` D-06
- `docs/audits/evidence/oracle-verdicts.md` §1.3 (Oracle promoted from MEDIUM → HIGH)

## Scope guarantees

- ✅ One concern — message clarity for a known silent-conflict path
- ✅ No behavior change to scope selection
- ✅ Warn-once discipline preserved (no per-request log spam)
- ✅ Full test suite green

## Follow-up

Phase 1 continues with **PR-K** (request observability — connect timeout, SSE malformed-chunk warn, deprecation in error paths). Tracked in `.sisyphus/plans/phase1-implementation.md`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

message-only rewrite of the warn-once log in `applyAccountStorageScopeFromConfig` — the conflict path now names the issue explicitly, explains the credential-scope impact, and offers two concrete remediation commands. no behavior change; scope decision and warn-once gate are identical to before.

<h3>Confidence Score: 5/5</h3>

safe to merge — no behavior change, only the log message content differs

single remaining finding is p2 style (missing message-content assertion in vitest); no logic, security, or data-integrity risk introduced

test/storage-scope.test.ts — message content assertions missing

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime/storage-scope.ts | message-only rewrite of the warn-once conflict log; scope decision and warn-once gate are identical to before — clean change |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[applyAccountStorageScopeFromConfig called] --> B{isCodexCliSyncEnabled?}
    B -- yes --> C{perProjectAccounts AND NOT warningShown?}
    C -- yes --> D[setWarningShown true]
    D --> E[logWarn: Config conflict message\nwith remediation commands]
    E --> F[setStoragePath null\nglobal pool]
    C -- no --> F
    B -- no --> G{perProjectAccounts?}
    G -- yes --> H[setStoragePath cwd\nper-project isolation]
    G -- no --> I[setStoragePath null\nglobal pool]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fproject-scope-no-silent-bypass%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fproject-scope-no-silent-bypass%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fstorage-scope.test.ts%3A25%0A**missing%20vitest%20coverage%20on%20message%20content**%0A%0Athe%20entire%20value%20of%20this%20pr%20is%20the%20new%20warning%20text%20%E2%80%94%20remediation%20commands%2C%20%22GLOBAL%20pool%22%20language%2C%20%22once%20per%20process%22%20note%20%E2%80%94%20but%20the%20test%20only%20asserts%20%60toHaveBeenCalled%28%29%60.%20a%20regression%20that%20blanks%20the%20message%20or%20drops%20a%20remediation%20option%20would%20pass%20the%20suite%20silently.%20snapshot%20or%20%60toHaveBeenCalledWith%28expect.stringContaining%28...%29%29%60%20assertions%20would%20lock%20in%20the%20signal.%0A%0A%60%60%60suggestion%0A%09%09expect%28logWarn%29.toHaveBeenCalledWith%28%0A%09%09%09expect.stringContaining%28%22Config%20conflict%3A%20perProjectAccounts%20%3D%20true%22%29%2C%0A%09%09%29%3B%0A%09%09expect%28logWarn%29.toHaveBeenCalledWith%28%0A%09%09%09expect.stringContaining%28%22codex%20auth%20config%20set%20codexCliSync%20false%22%29%2C%0A%09%09%29%3B%0A%09%09expect%28logWarn%29.toHaveBeenCalledWith%28%0A%09%09%09expect.stringContaining%28%22GLOBAL%20pool%22%29%2C%0A%09%09%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/storage-scope.test.ts
Line: 25

Comment:
**missing vitest coverage on message content**

the entire value of this pr is the new warning text — remediation commands, "GLOBAL pool" language, "once per process" note — but the test only asserts `toHaveBeenCalled()`. a regression that blanks the message or drops a remediation option would pass the suite silently. snapshot or `toHaveBeenCalledWith(expect.stringContaining(...))` assertions would lock in the signal.

```suggestion
		expect(logWarn).toHaveBeenCalledWith(
			expect.stringContaining("Config conflict: perProjectAccounts = true"),
		);
		expect(logWarn).toHaveBeenCalledWith(
			expect.stringContaining("codex auth config set codexCliSync false"),
		);
		expect(logWarn).toHaveBeenCalledWith(
			expect.stringContaining("GLOBAL pool"),
		);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(routing): surface the per-project vs..."](https://github.com/ndycode/codex-multi-auth/commit/e6e1702711a6e3deecc74e20f4e931dace2179b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28722539)</sub>

<!-- /greptile_comment -->