### PR TITLE
fix(request): surface malformed SSE JSON chunks as structured warnings

### DIFF
--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -81,7 +81,10 @@ function cloneContentArray(content: unknown): MutableRecord[] {
 	return content.filter(isRecord).map((part) => ({ ...part }));
 }
 
-function mergeRecord(base: MutableRecord | null, update: MutableRecord): MutableRecord {
+function mergeRecord(
+	base: MutableRecord | null,
+	update: MutableRecord,
+): MutableRecord {
 	if (!base) return { ...update };
 	const merged: MutableRecord = { ...base, ...update };
 	if ("content" in update || "content" in base) {
@@ -94,7 +97,10 @@ function mergeRecord(base: MutableRecord | null, update: MutableRecord): Mutable
 	return merged;
 }
 
-function makeOutputTextKey(outputIndex: number | null, contentIndex: number | null): string | null {
+function makeOutputTextKey(
+	outputIndex: number | null,
+	contentIndex: number | null,
+): string | null {
 	if (
 		!isValidSynthesizedIndex(outputIndex) ||
 		!isValidSynthesizedIndex(contentIndex)
@@ -108,7 +114,10 @@ function makePhaseTextSegmentKey(phase: string, outputTextKey: string): string {
 	return `${phase}\u0000${outputTextKey}`;
 }
 
-function makeSummaryKey(outputIndex: number | null, summaryIndex: number | null): string | null {
+function makeSummaryKey(
+	outputIndex: number | null,
+	summaryIndex: number | null,
+): string | null {
 	if (
 		!isValidSynthesizedIndex(outputIndex) ||
 		!isValidSynthesizedIndex(summaryIndex)
@@ -125,10 +134,7 @@ function getPartText(part: unknown): string | null {
 	return null;
 }
 
-function capturePhase(
-	state: ParsedResponseState,
-	phase: unknown,
-): void {
+function capturePhase(state: ParsedResponseState, phase: unknown): void {
 	if (typeof phase !== "string" || phase.trim().length === 0) return;
 	state.lastPhase = phase.trim();
 }
@@ -184,7 +190,7 @@ function setPhaseTextSegment(
 	const normalizedPhase =
 		typeof phase === "string" && phase.trim().length > 0
 			? phase.trim()
-			: state.outputTextPhases.get(outputTextKey) ?? null;
+			: (state.outputTextPhases.get(outputTextKey) ?? null);
 	if (!normalizedPhase) return;
 	state.outputTextPhases.set(outputTextKey, normalizedPhase);
 	state.lastPhase = normalizedPhase;
@@ -212,12 +218,16 @@ function appendPhaseTextSegment(
 	const normalizedPhase =
 		typeof phase === "string" && phase.trim().length > 0
 			? phase.trim()
-			: state.outputTextPhases.get(outputTextKey) ?? null;
+			: (state.outputTextPhases.get(outputTextKey) ?? null);
 	if (!normalizedPhase) return;
 	state.outputTextPhases.set(outputTextKey, normalizedPhase);
 	state.lastPhase = normalizedPhase;
 	const segmentKey = makePhaseTextSegmentKey(normalizedPhase, outputTextKey);
-	const phaseOrder = rememberPhaseSegmentOrder(state, normalizedPhase, segmentKey);
+	const phaseOrder = rememberPhaseSegmentOrder(
+		state,
+		normalizedPhase,
+		segmentKey,
+	);
 	const existing = state.phaseTextSegments.get(segmentKey) ?? "";
 	state.phaseTextSegments.set(segmentKey, `${existing}${delta}`);
 	if (phaseOrder[phaseOrder.length - 1] === segmentKey) {
@@ -228,7 +238,11 @@ function appendPhaseTextSegment(
 	rebuildPhaseText(state, normalizedPhase);
 }
 
-function upsertOutputItem(state: ParsedResponseState, outputIndex: number | null, item: unknown): void {
+function upsertOutputItem(
+	state: ParsedResponseState,
+	outputIndex: number | null,
+	item: unknown,
+): void {
 	if (!isValidSynthesizedIndex(outputIndex) || !isRecord(item)) return;
 	const current = state.outputItems.get(outputIndex) ?? null;
 	const merged = mergeRecord(current, item);
@@ -297,7 +311,10 @@ function appendReasoningSummaryValue(
 	state.reasoningSummaryText.set(key, `${existing}${delta}`);
 }
 
-function ensureOutputItemAtIndex(output: unknown[], index: number): MutableRecord | null {
+function ensureOutputItemAtIndex(
+	output: unknown[],
+	index: number,
+): MutableRecord | null {
 	if (!isValidSynthesizedIndex(index)) return null;
 	while (output.length <= index) {
 		output.push({});
@@ -309,7 +326,10 @@ function ensureOutputItemAtIndex(output: unknown[], index: number): MutableRecor
 	return isRecord(output[index]) ? (output[index] as MutableRecord) : null;
 }
 
-function ensureContentPartAtIndex(item: MutableRecord, index: number): MutableRecord | null {
+function ensureContentPartAtIndex(
+	item: MutableRecord,
+	index: number,
+): MutableRecord | null {
 	if (!isValidSynthesizedIndex(index)) return null;
 	const content = Array.isArray(item.content) ? [...item.content] : [];
 	while (content.length <= index) {
@@ -323,7 +343,10 @@ function ensureContentPartAtIndex(item: MutableRecord, index: number): MutableRe
 	return isRecord(content[index]) ? (content[index] as MutableRecord) : null;
 }
 
-function applyAccumulatedOutputText(response: MutableRecord, state: ParsedResponseState): void {
+function applyAccumulatedOutputText(
+	response: MutableRecord,
+	state: ParsedResponseState,
+): void {
 	if (state.outputText.size === 0) return;
 	const output = Array.isArray(response.output) ? [...response.output] : [];
 
@@ -356,7 +379,10 @@ function applyAccumulatedOutputText(response: MutableRecord, state: ParsedRespon
 	}
 }
 
-function mergeOutputItemsIntoResponse(response: MutableRecord, state: ParsedResponseState): void {
+function mergeOutputItemsIntoResponse(
+	response: MutableRecord,
+	state: ParsedResponseState,
+): void {
 	if (state.outputItems.size === 0) return;
 	const output = Array.isArray(response.output) ? [...response.output] : [];
 
@@ -365,7 +391,10 @@ function mergeOutputItemsIntoResponse(response: MutableRecord, state: ParsedResp
 		while (output.length <= outputIndex) {
 			output.push({});
 		}
-		output[outputIndex] = mergeRecord(toMutableRecord(output[outputIndex]), item);
+		output[outputIndex] = mergeRecord(
+			toMutableRecord(output[outputIndex]),
+			item,
+		);
 	}
 
 	response.output = output;
@@ -405,7 +434,10 @@ function collectReasoningSummaryText(output: unknown[]): string {
 		.join("\n\n");
 }
 
-function applyReasoningSummaries(response: MutableRecord, state: ParsedResponseState): void {
+function applyReasoningSummaries(
+	response: MutableRecord,
+	state: ParsedResponseState,
+): void {
 	if (state.reasoningSummaryText.size === 0) return;
 	const output = Array.isArray(response.output) ? [...response.output] : [];
 
@@ -446,7 +478,9 @@ function applyReasoningSummaries(response: MutableRecord, state: ParsedResponseS
 	}
 }
 
-function finalizeParsedResponse(state: ParsedResponseState): MutableRecord | null {
+function finalizeParsedResponse(
+	state: ParsedResponseState,
+): MutableRecord | null {
 	const response = state.finalResponse ? { ...state.finalResponse } : null;
 	if (!response) return null;
 	if (state.encounteredError) return null;
@@ -501,7 +535,8 @@ function notifyResponseId(
 	response: unknown,
 ): void {
 	const responseId = extractResponseId(response);
-	if (!responseId || !onResponseId || state.seenResponseIds.has(responseId)) return;
+	if (!responseId || !onResponseId || state.seenResponseIds.has(responseId))
+		return;
 	state.seenResponseIds.add(responseId);
 	try {
 		onResponseId(responseId);
@@ -513,11 +548,16 @@ function notifyResponseId(
 	}
 }
 
-function truncateDiagnosticText(value: unknown, maxLength = 400): string | undefined {
+function truncateDiagnosticText(
+	value: unknown,
+	maxLength = 400,
+): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const trimmed = value.trim();
 	if (trimmed.length === 0) return undefined;
-	return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength)}...` : trimmed;
+	return trimmed.length > maxLength
+		? `${trimmed.slice(0, maxLength)}...`
+		: trimmed;
 }
 
 function logStreamDiagnostics(finalResponse: unknown): void {
@@ -528,8 +568,12 @@ function logStreamDiagnostics(finalResponse: unknown): void {
 	const responseId = extractResponseId(finalResponse);
 	const phase = getStringField(finalResponse, "phase");
 	const commentaryText = truncateDiagnosticText(finalResponse.commentary_text);
-	const finalAnswerText = truncateDiagnosticText(finalResponse.final_answer_text);
-	const reasoningSummaryText = truncateDiagnosticText(finalResponse.reasoning_summary_text);
+	const finalAnswerText = truncateDiagnosticText(
+		finalResponse.final_answer_text,
+	);
+	const reasoningSummaryText = truncateDiagnosticText(
+		finalResponse.reasoning_summary_text,
+	);
 	if (phase || commentaryText || finalAnswerText || reasoningSummaryText) {
 		logRequest("stream-diagnostics", {
 			...(responseId ? { responseId } : {}),
@@ -564,7 +608,10 @@ function maybeCaptureResponseEvent(
 	if (!eventRecord) return;
 	const outputIndex = getNumberField(eventRecord, "output_index");
 
-	if (data.type === "response.output_item.added" || data.type === "response.output_item.done") {
+	if (
+		data.type === "response.output_item.added" ||
+		data.type === "response.output_item.done"
+	) {
 		upsertOutputItem(state, outputIndex, eventRecord.item);
 		return;
 	}
@@ -591,7 +638,10 @@ function maybeCaptureResponseEvent(
 		return;
 	}
 
-	if (data.type === "response.content_part.added" || data.type === "response.content_part.done") {
+	if (
+		data.type === "response.content_part.added" ||
+		data.type === "response.content_part.done"
+	) {
 		const part = toMutableRecord(eventRecord.part);
 		if (!part || getStringField(part, "type") !== "output_text") {
 			capturePhase(state, part?.phase);
@@ -656,19 +706,42 @@ function parseSseStream(
 	const lines = sseText.split(/\r?\n/);
 	const state = createParsedResponseState();
 
+	let malformedChunkCount = 0;
+	let firstMalformedSample: string | null = null;
 	for (const line of lines) {
 		const trimmedLine = line.trim();
-		if (trimmedLine.startsWith('data: ')) {
+		if (trimmedLine.startsWith("data: ")) {
 			const payload = trimmedLine.substring(6).trim();
-			if (!payload || payload === '[DONE]') continue;
+			if (!payload || payload === "[DONE]") continue;
 			try {
 				const data = JSON.parse(payload) as SSEEventData;
 				maybeCaptureResponseEvent(state, data, onResponseId);
 				if (state.encounteredError) return null;
-			} catch {
-				// Skip malformed JSON
+			} catch (error) {
+				// AUDIT-H9 / H-03: previously these malformed chunks were
+				// silently discarded, masking upstream protocol drift + the
+				// downstream "empty response" symptom. Surface a structured
+				// warn with bounded context (first 120 chars + error message)
+				// and a running tally so operators can see frequency at a glance.
+				malformedChunkCount += 1;
+				if (firstMalformedSample === null) {
+					firstMalformedSample = payload.slice(0, 120);
+				}
+				if (malformedChunkCount === 1) {
+					log.warn("SSE malformed JSON chunk discarded", {
+						reason: error instanceof Error ? error.message : String(error),
+						sample: firstMalformedSample,
+					});
+				}
 			}
 		}
+	}
+
+	if (malformedChunkCount > 1) {
+		log.warn("SSE malformed JSON chunks discarded (rollup)", {
+			totalCount: malformedChunkCount,
+			firstSample: firstMalformedSample,
+		});
 	}
 
 	return finalizeParsedResponse(state);
@@ -693,16 +766,21 @@ export async function convertSseToJson(
 	}
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();
-	let fullText = '';
+	let fullText = "";
 	const streamStallTimeoutMs = Math.max(
 		1_000,
-		Math.floor(options?.streamStallTimeoutMs ?? DEFAULT_STREAM_STALL_TIMEOUT_MS),
+		Math.floor(
+			options?.streamStallTimeoutMs ?? DEFAULT_STREAM_STALL_TIMEOUT_MS,
+		),
 	);
 
 	try {
 		// Consume the entire stream
 		while (true) {
-			const { done, value } = await readWithTimeout(reader, streamStallTimeoutMs);
+			const { done, value } = await readWithTimeout(
+				reader,
+				streamStallTimeoutMs,
+			);
 			if (done) break;
 			fullText += decoder.decode(value, { stream: true });
 			if (fullText.length > MAX_SSE_SIZE) {
@@ -736,14 +814,13 @@ export async function convertSseToJson(
 
 		// Return as plain JSON (not SSE)
 		const jsonHeaders = new Headers(headers);
-		jsonHeaders.set('content-type', 'application/json; charset=utf-8');
+		jsonHeaders.set("content-type", "application/json; charset=utf-8");
 
 		return new Response(JSON.stringify(finalResponse), {
 			status: response.status,
 			statusText: response.statusText,
 			headers: jsonHeaders,
 		});
-
 	} catch (error) {
 		log.error("Error converting stream", { error: String(error) });
 		logRequest("stream-error", { error: String(error) });
@@ -755,7 +832,6 @@ export async function convertSseToJson(
 		// Release the reader lock to prevent resource leaks
 		reader.releaseLock();
 	}
-
 }
 
 function createResponseIdCapturingStream(
@@ -764,6 +840,7 @@ function createResponseIdCapturingStream(
 ): ReadableStream<Uint8Array> {
 	const decoder = new TextDecoder();
 	let bufferedText = "";
+	let loggedMalformedStreamChunk = false;
 	const state = createParsedResponseState();
 
 	const processBufferedLines = (flush = false): void => {
@@ -784,8 +861,19 @@ function createResponseIdCapturingStream(
 				const data = JSON.parse(payload) as SSEEventData;
 				maybeCaptureResponseEvent(state, data, onResponseId);
 				if (state.encounteredError) break;
-			} catch {
-				// Ignore malformed SSE lines and keep forwarding the raw stream.
+			} catch (error) {
+				// AUDIT-H9 / H-03: stream passthrough. The raw bytes still
+				// reach the downstream consumer so malformed JSON does not
+				// break streaming — but we now warn ONCE with bounded
+				// context so operators can see the event rather than it
+				// being a silent black hole in the logs.
+				if (!loggedMalformedStreamChunk) {
+					loggedMalformedStreamChunk = true;
+					log.warn("SSE malformed JSON chunk in stream passthrough", {
+						reason: error instanceof Error ? error.message : String(error),
+						sample: payload.slice(0, 120),
+					});
+				}
 			}
 		}
 	};
@@ -813,8 +901,8 @@ function createResponseIdCapturingStream(
 export function ensureContentType(headers: Headers): Headers {
 	const responseHeaders = new Headers(headers);
 
-	if (!responseHeaders.has('content-type')) {
-		responseHeaders.set('content-type', 'text/event-stream; charset=utf-8');
+	if (!responseHeaders.has("content-type")) {
+		responseHeaders.set("content-type", "text/event-stream; charset=utf-8");
 	}
 
 	return responseHeaders;
@@ -853,20 +941,32 @@ async function readWithTimeout(
  */
 export function isEmptyResponse(body: unknown): boolean {
 	if (body === null || body === undefined) return true;
-	if (typeof body === 'string' && body.trim() === '') return true;
-	if (typeof body !== 'object') return false;
+	if (typeof body === "string" && body.trim() === "") return true;
+	if (typeof body !== "object") return false;
 
 	const obj = body as Record<string, unknown>;
 
 	if (Object.keys(obj).length === 0) return true;
 
-	const hasOutput = 'output' in obj && obj.output !== null && obj.output !== undefined;
-	const hasChoices = 'choices' in obj && Array.isArray(obj.choices) && 
-		obj.choices.some(c => c !== null && c !== undefined && typeof c === 'object' && Object.keys(c as object).length > 0);
-	const hasContent = 'content' in obj && obj.content !== null && obj.content !== undefined &&
-		(typeof obj.content !== 'string' || obj.content.trim() !== '');
+	const hasOutput =
+		"output" in obj && obj.output !== null && obj.output !== undefined;
+	const hasChoices =
+		"choices" in obj &&
+		Array.isArray(obj.choices) &&
+		obj.choices.some(
+			(c) =>
+				c !== null &&
+				c !== undefined &&
+				typeof c === "object" &&
+				Object.keys(c as object).length > 0,
+		);
+	const hasContent =
+		"content" in obj &&
+		obj.content !== null &&
+		obj.content !== undefined &&
+		(typeof obj.content !== "string" || obj.content.trim() !== "");
 
-	if ('id' in obj || 'object' in obj || 'model' in obj) {
+	if ("id" in obj || "object" in obj || "model" in obj) {
 		return !hasOutput && !hasChoices && !hasContent;
 	}
 
@@ -886,9 +986,12 @@ export function attachResponseIdCapture(
 		});
 	}
 
-	return new Response(createResponseIdCapturingStream(response.body, onResponseId), {
-		status: response.status,
-		statusText: response.statusText,
-		headers,
-	});
+	return new Response(
+		createResponseIdCapturingStream(response.body, onResponseId),
+		{
+			status: response.status,
+			statusText: response.statusText,
+			headers,
+		},
+	);
 }


### PR DESCRIPTION
## Summary

Surfaces malformed SSE JSON chunks as structured warnings in both of the project's SSE entry points. Fail-open semantics are preserved — bad chunks do NOT break streaming — but operators now get a signal when the upstream protocol drifts instead of silent discards.

## Problem

Audit (`docs/audits/MASTER_AUDIT.md` §5 HIGH (reconciled to MEDIUM by Oracle) `AUDIT-H9` / `dim-H-request.md` H-03) flagged that both SSE code paths in `lib/request/response-handler.ts` silently discarded malformed JSON chunks:

```ts
try {
  const data = JSON.parse(payload) as SSEEventData;
  ...
} catch {
  // Skip malformed JSON   ← silent black hole
}
```

Consequences:
- Non-streaming `convertSseToJson` returns `null` when the terminal event is missing, giving the empty-response retry path no root-cause signal.
- Streaming `createResponseIdCapturingStream` keeps forwarding bytes (correct) but hides the fact that the parser fell behind.

## Change

Both call sites now log a structured `log.warn` with bounded context:

- `convertSseToJson` (non-streaming): the **first** malformed chunk emits a warn with the first 120 chars of the payload + the parse error message. If additional chunks fail inside the same request, a single **rollup** warn at the end reports `totalCount` + `firstSample`. This avoids per-chunk log spam while keeping the full frequency visible.

- `createResponseIdCapturingStream` (stream passthrough): a per-stream `loggedMalformedStreamChunk` flag emits exactly **one** warn per stream so a recurring malformed event does not flood the logs.

Both warnings include a truncated 120-char sample so operators can see the actual content without committing a full payload to the log stream.

## Deliberately NOT changed in this PR

Audit §6 `AUDIT-M16` (distinct connect timeout) and `AUDIT-M18` (deprecation headers in error paths) will land in a dedicated follow-up — they touch `lib/request/fetch-helpers.ts` and deserve their own review surface. This PR is scoped to the SSE parser only.

## Verification

- **Full suite: 225/225 test files, 3418/3418 tests pass**
- `npm run typecheck` exit 0
- `npm run lint` exit 0
- No new dependencies
- No public API changes
- No behavioral change on the happy path — malformed chunks are still skipped; only the logging is new

## Audit reference

- `docs/audits/MASTER_AUDIT.md` §6 MEDIUM (post-Oracle) `AUDIT-H9`
- `docs/audits/evidence/dim-H-request.md` H-03
- `docs/audits/evidence/oracle-verdicts.md` §1.1 (Oracle reconciled H9 → MEDIUM to match dim-H)

## Scope guarantees

- ✅ One concern — SSE malformed-chunk observability
- ✅ Fail-open semantics preserved (no breaking change for streaming)
- ✅ Bounded sample size (120 chars) keeps logs small even under drift
- ✅ Warn-once discipline per stream / per request (no spam)
- ✅ Full suite green

## Follow-up

Phase 1 continues with **PR-L** (Zod at storage `JSON.parse` boundaries — R3 staged), then **PR-M** (settings-hub split — R1). Tracked in `.sisyphus/plans/phase1-implementation.md`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds structured `log.warn` calls to both SSE parsing paths (`parseSseStream` and `createResponseIdCapturingStream`) that previously silently discarded malformed JSON chunks. fail-open semantics are preserved — malformed chunks are still skipped — but operators now get bounded (120-char) sample context plus a running tally. the diff is otherwise pure cosmetic reformatting (function signature line-wrapping, quote normalization) with no behavioral changes.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are p2 style/observability suggestions with no behavioral impact on the happy or error paths

the core change (surfacing malformed-chunk warns with bounded samples and spam suppression) is correct and well-scoped. the three p2 findings — double-log for n=2 chunks, field-key mismatch between individual/rollup warns, and missing vitest assertions for the new warn branches — are all quality improvements rather than blockers. fail-open semantics are preserved, no public api changes, and the pr description's scope guarantees hold.

lib/request/response-handler.ts — review the rollup predicate and field-key consistency; test/response-handler-logging.test.ts — missing warn-path assertions

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/response-handler.ts | adds malformed-chunk warn logging to both SSE paths; minor double-logging edge case for exactly 2 malformed chunks and field-key inconsistency (sample vs firstSample) between individual and rollup warns; no new tests cover the warn branches |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Frequest-observability%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frequest-observability%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Frequest%2Fresponse-handler.ts%3A740-745%0A**double-log%20for%20exactly%202%20malformed%20chunks**%0A%0Awhen%20%60malformedChunkCount%20%3D%3D%3D%202%60%2C%20both%20the%20in-loop%20individual%20warn%20%28fired%20when%20count%20became%201%29%20and%20this%20rollup%20fire%2C%20so%20operators%20see%20two%20log%20lines%20%E2%80%94%20the%20rollup's%20%60totalCount%3A%202%60%20re-counts%20the%20chunk%20that%20was%20already%20individually%20reported.%20for%203%2B%20chunks%20the%20rollup%20is%20the%20only%20additional%20line%20and%20makes%20sense%2C%20but%20for%20exactly%202%20the%20pair%20is%20redundant%20noise.%0A%0Aconsider%20suppressing%20the%20in-loop%20individual%20warn%20when%20a%20rollup%20will%20follow%2C%20or%20changing%20the%20rollup%20predicate%20to%20%60%3E%202%60%20and%20letting%20the%20individual%20handle%20the%20n%3D2%20case%20without%20a%20rollup%3A%0A%0A%60%60%60suggestion%0A%09if%20%28malformedChunkCount%20%3E%201%29%20%7B%0A%09%09log.warn%28%22SSE%20malformed%20JSON%20chunks%20discarded%20%28rollup%29%22%2C%20%7B%0A%09%09%09totalCount%3A%20malformedChunkCount%2C%0A%09%09%09additionalCount%3A%20malformedChunkCount%20-%201%2C%0A%09%09%09firstSample%3A%20firstMalformedSample%2C%0A%09%09%7D%29%3B%0A%09%7D%0A%60%60%60%0A%0A%28%60additionalCount%60%20makes%20it%20explicit%20the%20rollup%20reports%20chunks%20*beyond*%20the%20first%20individually-logged%20one.%29%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Frequest%2Fresponse-handler.ts%3A730-735%0A**field%20key%20mismatch%20between%20individual%20warn%20and%20rollup**%0A%0Athe%20individual%20warn%20uses%20%60sample%60%20%28line%20733%29%20while%20the%20rollup%20uses%20%60firstSample%60%20%28line%20742%29%20for%20the%20same%20datum.%20log-aggregation%20queries%20that%20filter%20on%20%60sample%60%20will%20miss%20rollup%20entries%20and%20vice%20versa.%20using%20a%20consistent%20key%20across%20both%20callsites%20makes%20alerting%20simpler.%0A%0A%60%60%60suggestion%0A%09%09%09%09log.warn%28%22SSE%20malformed%20JSON%20chunk%20discarded%22%2C%20%7B%0A%09%09%09%09%09reason%3A%20error%20instanceof%20Error%20%3F%20error.message%20%3A%20String%28error%29%2C%0A%09%09%09%09%09firstSample%3A%20firstMalformedSample%2C%0A%09%09%09%09%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Frequest%2Fresponse-handler.ts%3A709%0A**missing%20vitest%20coverage%20for%20both%20new%20warn%20paths**%0A%0Athe%20existing%20%60response-handler-logging.test.ts%60%20only%20covers%20happy-path%20logging%20%28stream-full%2C%20stream-diagnostics%29.%20no%20test%20spies%20on%20%60log.warn%60%20to%20verify%3A%0A-%20exactly%20one%20warn%20fires%20for%20a%20single%20malformed%20chunk%20in%20%60parseSseStream%60%0A-%20a%20rollup%20%28and%20only%20one%20rollup%29%20fires%20for%202%2B%20malformed%20chunks%0A-%20%60loggedMalformedStreamChunk%60%20gates%20the%20stream-passthrough%20warn%20to%20exactly%20one%20call%20per%20stream%0A%0A%60test%2Fchaos%2Ffault-injection.test.ts%60%20line%20326%20confirms%20fail-open%20behavior%20but%20does%20not%20assert%20warn%20calls.%20given%20the%2080%25%20coverage%20threshold%20enforced%20in%20this%20repo%2C%20adding%20these%20assertions%20to%20%60response-handler-logging.test.ts%60%20would%20be%20the%20natural%20home.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/request/response-handler.ts
Line: 740-745

Comment:
**double-log for exactly 2 malformed chunks**

when `malformedChunkCount === 2`, both the in-loop individual warn (fired when count became 1) and this rollup fire, so operators see two log lines — the rollup's `totalCount: 2` re-counts the chunk that was already individually reported. for 3+ chunks the rollup is the only additional line and makes sense, but for exactly 2 the pair is redundant noise.

consider suppressing the in-loop individual warn when a rollup will follow, or changing the rollup predicate to `> 2` and letting the individual handle the n=2 case without a rollup:

```suggestion
	if (malformedChunkCount > 1) {
		log.warn("SSE malformed JSON chunks discarded (rollup)", {
			totalCount: malformedChunkCount,
			additionalCount: malformedChunkCount - 1,
			firstSample: firstMalformedSample,
		});
	}
```

(`additionalCount` makes it explicit the rollup reports chunks *beyond* the first individually-logged one.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/request/response-handler.ts
Line: 730-735

Comment:
**field key mismatch between individual warn and rollup**

the individual warn uses `sample` (line 733) while the rollup uses `firstSample` (line 742) for the same datum. log-aggregation queries that filter on `sample` will miss rollup entries and vice versa. using a consistent key across both callsites makes alerting simpler.

```suggestion
				log.warn("SSE malformed JSON chunk discarded", {
					reason: error instanceof Error ? error.message : String(error),
					firstSample: firstMalformedSample,
				});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/request/response-handler.ts
Line: 709

Comment:
**missing vitest coverage for both new warn paths**

the existing `response-handler-logging.test.ts` only covers happy-path logging (stream-full, stream-diagnostics). no test spies on `log.warn` to verify:
- exactly one warn fires for a single malformed chunk in `parseSseStream`
- a rollup (and only one rollup) fires for 2+ malformed chunks
- `loggedMalformedStreamChunk` gates the stream-passthrough warn to exactly one call per stream

`test/chaos/fault-injection.test.ts` line 326 confirms fail-open behavior but does not assert warn calls. given the 80% coverage threshold enforced in this repo, adding these assertions to `response-handler-logging.test.ts` would be the natural home.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(request): surface malformed SSE JSON..."](https://github.com/ndycode/codex-multi-auth/commit/936d1a4ff2787599ad697eb810bf059eb66bb5a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28722656)</sub>

<!-- /greptile_comment -->