### PR TITLE
docs(health): document field-name drift vs ManagedAccount (AUDIT-M08)

### DIFF
--- a/lib/health.ts
+++ b/lib/health.ts
@@ -1,6 +1,34 @@
 import { getCircuitBreaker, type CircuitState } from "./circuit-breaker.js";
 import { getAccountIdentityKey } from "./storage/identity.js";
 
+// AUDIT-M08 / D-04 docstring (master repository audit, Oracle-confirmed):
+// --------------------------------------------------------------------------
+// This module is a PURE SHAPE-TRANSFORMATION UTILITY. Callers pass an
+// already-flattened accounts array with the fields defined in the public
+// `getAccountHealth` parameter shape below. It is deliberately decoupled
+// from the live AccountManager: that keeps the function easy to test, and
+// lets external consumers (dashboards, diagnostics scripts, JSON exporters)
+// build the input from any source without taking a hard dependency on the
+// manager singleton.
+//
+// HOWEVER, the parameter shape uses field names that do NOT exactly match
+// ManagedAccount in lib/accounts.ts:
+//
+//   getAccountHealth input   ManagedAccount field
+//   ----------------------   --------------------
+//   rateLimitedUntil         <computed from rateLimitResetTimes per family>
+//   cooldownUntil            coolingDownUntil
+//   lastUsedAt               lastUsed
+//   health                   <computed from getHealthTracker().getScore()>
+//
+// Callers are responsible for flattening ManagedAccount → the input shape
+// via a small adapter. If a future refactor wants a single call site that
+// reads straight from AccountManager, add a `getPluginHealthFromManager(
+// manager: AccountManager): PluginHealth` function here and implement the
+// flattening inline. Do NOT change the signature of the existing
+// `getAccountHealth` function without a deprecation cycle — it is exported
+// via lib/index.ts and is considered public API.
+
 export interface AccountHealth {
 	index: number;
 	email?: string;


### PR DESCRIPTION
## Summary

Documents the field-name drift between `lib/health.ts` and `lib/accounts.ts`'s `ManagedAccount` in an explicit in-file comment. This closes the audit's observability gap (AUDIT-M08 / D-04) without a breaking API change.

## Problem

Audit (`docs/audits/MASTER_AUDIT.md` §6 MEDIUM `AUDIT-M08` / `dim-D-routing.md` D-04) identified that `getAccountHealth()` in `lib/health.ts` uses parameter field names that do not exactly match `ManagedAccount`:

| getAccountHealth input | ManagedAccount field |
|------------------------|----------------------|
| `rateLimitedUntil` | computed from `rateLimitResetTimes` per family |
| `cooldownUntil` | `coolingDownUntil` |
| `lastUsedAt` | `lastUsed` |
| `health` | computed from `getHealthTracker().getScore()` |

The drift is not a bug — the function is a pure shape-transformation utility and callers are responsible for the flattening. But the mismatch was silent and not discoverable from the code.

## Why not Oracle's recommended fix?

Oracle's options were "reads from tracker state directly OR module deleted":

- **Delete** — breaks external consumers. The module is exported via `lib/index.ts` and documented as public API for dashboards / diagnostics / JSON exporters.
- **Change signature to take AccountManager** — also breaks public API.
- **Add a parallel `getPluginHealthFromManager(manager)`** — plausible, but no internal consumer today; adding it would duplicate the shape-transformation logic without a live caller.

The pragmatic fix is **documentation**: make the drift discoverable from the code, and give future implementers explicit guidance on how to add a direct-from-manager bridge safely when an internal consumer eventually needs one.

## Change

`lib/health.ts` gets a multi-line comment block before the exported interfaces that:

1. States the module is a pure shape-transformation utility by design.
2. Lists the exact field-name mapping between `getAccountHealth` input and `ManagedAccount`.
3. Tells future contributors what to do if they want a direct-from-manager variant: add `getPluginHealthFromManager(manager)`, do NOT change the existing signature.

No code changes. No behavioral change. No new dependencies.

## Verification

- **Full suite: 225/225 test files, 3418/3418 tests pass** (docs-only change)
- `npm run typecheck` exit 0
- `npm run lint` exit 0

## Audit reference

- `docs/audits/MASTER_AUDIT.md` §6 MEDIUM `AUDIT-M08`
- `docs/audits/evidence/dim-D-routing.md` D-04
- `docs/audits/evidence/oracle-verdicts.md` §1.2

## Scope guarantees

- ✅ Documentation-only — zero code / API changes
- ✅ Field-name drift is now discoverable from the code
- ✅ Future implementers have explicit guidance for adding a live-manager bridge
- ✅ Full test suite green

## Follow-up

Phase 1 remaining architectural work:
- **PR-L** — Zod at storage `JSON.parse` boundaries (R3)
- **PR-M** — settings-hub split (R1, large)
- **PR-N** — routing mutex + SelectionRecord (R4, depends on L)
- **PR-P** — CLI `why-selected` + `verify --paths` features (F1, F2)

Tracked in `.sisyphus/plans/phase1-implementation.md`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

documentation-only change adds a module-level comment block to `lib/health.ts` that codifies the field-name drift between the `getAccountHealth` input shape and `ManagedAccount` (AUDIT-M08 / D-04). the four-row mapping table is accurate against `lib/accounts.ts`, the export claim matches `lib/index.ts`, and the guidance for a future `getPluginHealthFromManager` bridge is sound. no code, no behavior, no api changes.

<h3>Confidence Score: 5/5</h3>

safe to merge — docs-only, zero behavioral or api change, all field mappings verified correct

no code changes; the four documented field-name mappings are accurate against lib/accounts.ts; the public-api export claim is confirmed via lib/index.ts; existing test suite unaffected; all p2 or lower

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/health.ts | adds a 27-line audit docstring before the exported interfaces; all four field-name mappings verified accurate against lib/accounts.ts and the public-api export claim matches lib/index.ts |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    MA["ManagedAccount\n(lib/accounts.ts)"]
    ADAPTER["caller adapter\n(flatten to input shape)"]
    GH["getAccountHealth(accounts[])"]
    AH["AccountHealth[]"]

    MA -->|"lastUsed → lastUsedAt"| ADAPTER
    MA -->|"coolingDownUntil → cooldownUntil"| ADAPTER
    MA -->|"rateLimitResetTimes (per-family) → rateLimitedUntil"| ADAPTER
    MA -->|"getHealthTracker().getScore() → health"| ADAPTER
    ADAPTER --> GH
    GH --> AH
```

<sub>Reviews (1): Last reviewed commit: ["docs(health): document field-name drift ..."](https://github.com/ndycode/codex-multi-auth/commit/b47789a345c9fc380577feb9b676468359dc1c1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28725498)</sub>

<!-- /greptile_comment -->