### PR TITLE
refactor(routing): add feature-flagged routing mutex and SelectionRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This repository's current stable release line is `1.x`.
 Current stable release notes live in `docs/releases/`.
 This top-level changelog preserves the foundational `0.x` milestones and points older iteration history to `docs/releases/legacy-pre-0.1-history.md`.
 
+## [Unreleased]
+
+### Added
+
+- `routingMutex` plugin config flag (PR-N / R4) with values `"enabled" | "legacy"` (default `"legacy"`). When `"enabled"`, cursor-mutation sites in the account pool (`markSwitchedLocked`, `markAccountCoolingDownLocked`, `setActiveIndexLocked`) are serialized through a promise-chain async mutex in `lib/routing-mutex.ts`, closing the TOCTOU race described in design items D-02/D-09. The flag defaults to `"legacy"` for one full release cycle so existing deployments see zero behavior change; users can opt in via settings or the `CODEX_AUTH_ROUTING_MUTEX=enabled` environment variable. A new `SelectionRecord` type is threaded out of the rotation decision path so the fetch loop can hand structured selection metadata to observability, why-selected, and failure-policy consumers.
+
+### Rollout plan
+
+- Release N: flag shipped with default `"legacy"`. Advanced users opt in via config or env.
+- Release N+1: evaluate enablement based on telemetry and flip default to `"enabled"`.
+
 ## [0.1.8] - 2026-03-11
 
 ### Fixed

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -18,6 +18,11 @@ import {
 	type AccountWithMetrics,
 	type HybridSelectionOptions,
 } from "./rotation.js";
+import {
+	withRoutingMutex,
+	type RoutingMutexMode,
+	type SelectionRecord,
+} from "./routing-mutex.js";
 import { nowMs } from "./utils.js";
 import { ERROR_MESSAGES, HTTP_STATUS } from "./constants.js";
 import { CodexAuthError } from "./errors.js";
@@ -97,9 +102,7 @@ function getAccountCircuitKey(account: ManagedAccount): string {
 	return account.circuitKeyId;
 }
 
-export function getRuntimeTrackerKey(
-	account: ManagedAccount,
-): string | number {
+export function getRuntimeTrackerKey(account: ManagedAccount): string | number {
 	if (account._runtimeTrackerKey !== undefined) {
 		return account._runtimeTrackerKey;
 	}
@@ -173,7 +176,10 @@ function buildAccountIdentityCandidates(
 }
 
 function findAccountIndexByIdentity<
-	T extends Pick<AccountIdentityCandidate, "accountId" | "email" | "refreshToken">,
+	T extends Pick<
+		AccountIdentityCandidate,
+		"accountId" | "email" | "refreshToken"
+	>,
 >(
 	accounts: readonly T[],
 	source: AccountIdentityCandidate,
@@ -243,12 +249,7 @@ export interface ManagedAccount {
 	expires?: number;
 	addedAt: number;
 	lastUsed: number;
-	lastSwitchReason?:
-		| "rate-limit"
-		| "initial"
-		| "rotation"
-		| "best"
-		| "restore";
+	lastSwitchReason?: "rate-limit" | "initial" | "rotation" | "best" | "restore";
 	lastRateLimitReason?: RateLimitReason;
 	rateLimitResetTimes: RateLimitStateV3;
 	coolingDownUntil?: number;
@@ -261,14 +262,25 @@ export interface ManagedAccount {
 export class AccountManager {
 	private accounts: ManagedAccount[] = [];
 	private cursorByFamily: Record<ModelFamily, number> = initFamilyState(0);
-	private currentAccountIndexByFamily: Record<ModelFamily, number> = initFamilyState(-1);
+	private currentAccountIndexByFamily: Record<ModelFamily, number> =
+		initFamilyState(-1);
 	private lastToastAccountIndex = -1;
 	private lastToastTime = 0;
 	private saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private pendingSave: Promise<void> | null = null;
 	private readonly storagePathState: StoragePathState;
+	/**
+	 * PR-N / R4: feature-flagged routing mutex mode.
+	 * Defaults to `"legacy"` to preserve pre-PR-N behaviour for one release
+	 * cycle. When set to `"enabled"` the cursor-mutation helpers (markSwitched,
+	 * markAccountCoolingDown, setActiveIndex) serialize through the shared
+	 * async mutex in `lib/routing-mutex.ts`.
+	 */
+	private routingMutexMode: RoutingMutexMode = "legacy";
 
-	static async loadFromDisk(authFallback?: OAuthAuthDetails): Promise<AccountManager> {
+	static async loadFromDisk(
+		authFallback?: OAuthAuthDetails,
+	): Promise<AccountManager> {
 		const stored = await loadAccounts();
 		const synced = await syncAccountStorageFromCodexCli(stored);
 		const sourceOfTruthStorage = synced.storage ?? stored;
@@ -288,7 +300,9 @@ export class AccountManager {
 	}
 
 	hasRefreshToken(refreshToken: string): boolean {
-		return this.accounts.some((account) => account.refreshToken === refreshToken);
+		return this.accounts.some(
+			(account) => account.refreshToken === refreshToken,
+		);
 	}
 
 	private async hydrateFromCodexCli(): Promise<void> {
@@ -323,7 +337,9 @@ export class AccountManager {
 			}
 
 			const missingOrExpired =
-				!account.access || account.expires === undefined || account.expires <= now;
+				!account.access ||
+				account.expires === undefined ||
+				account.expires <= now;
 			if (missingOrExpired) {
 				account.access = cached.accessToken;
 				if (typeof cached.expiresAt === "number") {
@@ -335,7 +351,10 @@ export class AccountManager {
 			if (
 				!account.accountId &&
 				cached.accountId &&
-				shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId)
+				shouldUpdateAccountIdFromToken(
+					account.accountIdSource,
+					account.accountId,
+				)
 			) {
 				account.accountId = cached.accountId;
 				account.accountIdSource = account.accountIdSource ?? "token";
@@ -348,14 +367,22 @@ export class AccountManager {
 		try {
 			await this.saveToDisk();
 		} catch (error) {
-			log.debug("Failed to persist Codex CLI cache hydration", { error: String(error) });
+			log.debug("Failed to persist Codex CLI cache hydration", {
+				error: String(error),
+			});
 		}
 	}
 
-	constructor(authFallback?: OAuthAuthDetails, stored?: AccountStorageV3 | null) {
+	constructor(
+		authFallback?: OAuthAuthDetails,
+		stored?: AccountStorageV3 | null,
+	) {
 		this.storagePathState = { ...getStoragePathState() };
-		const fallbackAccountId = extractAccountId(authFallback?.access)?.trim() || undefined;
-		const fallbackAccountEmail = sanitizeEmail(extractAccountEmail(authFallback?.access));
+		const fallbackAccountId =
+			extractAccountId(authFallback?.access)?.trim() || undefined;
+		const fallbackAccountEmail = sanitizeEmail(
+			extractAccountEmail(authFallback?.access),
+		);
 
 		if (stored && stored.accounts.length > 0) {
 			const storedIdentityRows: Array<{
@@ -382,18 +409,18 @@ export class AccountManager {
 			const fallbackMatchedRowIndex =
 				authFallback && storedIdentityRows.length > 0
 					? storedIdentityRows[
-						findMatchingAccountIndex(
-							storedIdentityRows,
-							{
-								accountId: fallbackAccountId,
-								email: fallbackAccountEmail,
-								refreshToken: authFallback.refresh,
-							},
-							{
-								allowUniqueAccountIdFallbackWithoutEmail: true,
-							},
-						) ?? -1
-					]?.index
+							findMatchingAccountIndex(
+								storedIdentityRows,
+								{
+									accountId: fallbackAccountId,
+									email: fallbackAccountEmail,
+									refreshToken: authFallback.refresh,
+								},
+								{
+									allowUniqueAccountIdFallbackWithoutEmail: true,
+								},
+							) ?? -1
+						]?.index
 					: undefined;
 			const baseNow = nowMs();
 			this.accounts = stored.accounts
@@ -406,23 +433,33 @@ export class AccountManager {
 					}
 
 					const matchesFallback =
-						!!authFallback &&
-						fallbackMatchedRowIndex === index;
+						!!authFallback && fallbackMatchedRowIndex === index;
 
-					const refreshToken = matchesFallback && authFallback ? authFallback.refresh : account.refreshToken;
- 
+					const refreshToken =
+						matchesFallback && authFallback
+							? authFallback.refresh
+							: account.refreshToken;
+
 					return {
 						index,
-						accountId: matchesFallback ? fallbackAccountId ?? account.accountId : account.accountId,
+						accountId: matchesFallback
+							? (fallbackAccountId ?? account.accountId)
+							: account.accountId,
 						accountIdSource: account.accountIdSource,
 						accountLabel: account.accountLabel,
 						email: matchesFallback
-							? fallbackAccountEmail ?? sanitizeEmail(account.email)
+							? (fallbackAccountEmail ?? sanitizeEmail(account.email))
 							: sanitizeEmail(account.email),
 						refreshToken,
 						enabled: account.enabled !== false,
-						access: matchesFallback && authFallback ? authFallback.access : account.accessToken,
-						expires: matchesFallback && authFallback ? authFallback.expires : account.expiresAt,
+						access:
+							matchesFallback && authFallback
+								? authFallback.access
+								: account.accessToken,
+						expires:
+							matchesFallback && authFallback
+								? authFallback.expires
+								: account.expiresAt,
 						addedAt: clampNonNegativeInt(account.addedAt, baseNow),
 						lastUsed: clampNonNegativeInt(account.lastUsed, 0),
 						lastSwitchReason: account.lastSwitchReason,
@@ -436,8 +473,7 @@ export class AccountManager {
 				.filter((account): account is ManagedAccount => account !== null);
 
 			const hasMatchingFallback =
-				!!authFallback &&
-				fallbackMatchedRowIndex !== undefined;
+				!!authFallback && fallbackMatchedRowIndex !== undefined;
 
 			if (authFallback && !hasMatchingFallback) {
 				const now = nowMs();
@@ -458,11 +494,13 @@ export class AccountManager {
 			}
 
 			if (this.accounts.length > 0) {
-				const defaultIndex = clampNonNegativeInt(stored.activeIndex, 0) % this.accounts.length;
+				const defaultIndex =
+					clampNonNegativeInt(stored.activeIndex, 0) % this.accounts.length;
 
 				for (const family of MODEL_FAMILIES) {
 					const rawIndex = stored.activeIndexByFamily?.[family];
-					const nextIndex = clampNonNegativeInt(rawIndex, defaultIndex) % this.accounts.length;
+					const nextIndex =
+						clampNonNegativeInt(rawIndex, defaultIndex) % this.accounts.length;
 					this.currentAccountIndexByFamily[family] = nextIndex;
 					this.cursorByFamily[family] = nextIndex;
 				}
@@ -531,7 +569,11 @@ export class AccountManager {
 		return account ?? null;
 	}
 
-	isAccountAvailableForFamily(index: number, family: ModelFamily, model?: string | null): boolean {
+	isAccountAvailableForFamily(
+		index: number,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
 		const account = this.getAccountByIndex(index);
 		if (!account) return false;
 		if (account.enabled === false) return false;
@@ -596,12 +638,15 @@ export class AccountManager {
 		return this.getCurrentOrNextForFamily("codex");
 	}
 
-	getCurrentOrNextForFamily(family: ModelFamily, model?: string | null): ManagedAccount | null {
+	getCurrentOrNextForFamily(
+		family: ModelFamily,
+		model?: string | null,
+	): ManagedAccount | null {
 		const count = this.accounts.length;
 		if (count === 0) return null;
 
 		const cursor = this.cursorByFamily[family];
-		
+
 		for (let i = 0; i < count; i++) {
 			const idx = (cursor + i) % count;
 			const account = this.accounts[idx];
@@ -617,7 +662,7 @@ export class AccountManager {
 			) {
 				continue;
 			}
-			
+
 			this.cursorByFamily[family] = (idx + 1) % count;
 			this.currentAccountIndexByFamily[family] = idx;
 			account.lastUsed = nowMs();
@@ -627,12 +672,15 @@ export class AccountManager {
 		return null;
 	}
 
-	getNextForFamily(family: ModelFamily, model?: string | null): ManagedAccount | null {
+	getNextForFamily(
+		family: ModelFamily,
+		model?: string | null,
+	): ManagedAccount | null {
 		const count = this.accounts.length;
 		if (count === 0) return null;
 
 		const cursor = this.cursorByFamily[family];
-		
+
 		for (let i = 0; i < count; i++) {
 			const idx = (cursor + i) % count;
 			const account = this.accounts[idx];
@@ -648,7 +696,7 @@ export class AccountManager {
 			) {
 				continue;
 			}
-			
+
 			this.cursorByFamily[family] = (idx + 1) % count;
 			account.lastUsed = nowMs();
 			return account;
@@ -657,7 +705,11 @@ export class AccountManager {
 		return null;
 	}
 
-	getCurrentOrNextForFamilyHybrid(family: ModelFamily, model?: string | null, options?: HybridSelectionOptions): ManagedAccount | null {
+	getCurrentOrNextForFamilyHybrid(
+		family: ModelFamily,
+		model?: string | null,
+		options?: HybridSelectionOptions,
+	): ManagedAccount | null {
 		const count = this.accounts.length;
 		if (count === 0) return null;
 
@@ -684,7 +736,14 @@ export class AccountManager {
 			})
 			.filter((a): a is AccountWithMetrics => a !== null);
 
-		const selected = selectHybridAccount(accountsWithMetrics, healthTracker, tokenTracker, quotaKey, {}, options);
+		const selected = selectHybridAccount(
+			accountsWithMetrics,
+			healthTracker,
+			tokenTracker,
+			quotaKey,
+			{},
+			options,
+		);
 		if (!selected) return null;
 
 		const account = this.accounts[selected.index];
@@ -696,12 +755,17 @@ export class AccountManager {
 		return account;
 	}
 
-	recordSuccess(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
+	recordSuccess(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		healthTracker.recordSuccess(getRuntimeTrackerKey(account), quotaKey);
 		const hadCooldownMetadata =
-			account.coolingDownUntil !== undefined || account.cooldownReason !== undefined;
+			account.coolingDownUntil !== undefined ||
+			account.cooldownReason !== undefined;
 		const hadAuthFailures = (account.consecutiveAuthFailures ?? 0) > 0;
 		const isCoolingDown = this.isAccountCoolingDown(account);
 		let healed = false;
@@ -722,7 +786,11 @@ export class AccountManager {
 		getCircuitBreaker(getAccountCircuitKey(account)).recordSuccess();
 	}
 
-	recordRateLimit(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
+	recordRateLimit(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		const tokenTracker = getTokenTracker();
@@ -731,14 +799,22 @@ export class AccountManager {
 		tokenTracker.drain(trackerKey, quotaKey);
 	}
 
-	recordFailure(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
+	recordFailure(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const healthTracker = getHealthTracker();
 		healthTracker.recordFailure(getRuntimeTrackerKey(account), quotaKey);
 		getCircuitBreaker(getAccountCircuitKey(account)).recordFailure();
 	}
 
-	consumeToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
+	consumeToken(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
 		const trackerKey = getRuntimeTrackerKey(account);
@@ -760,19 +836,114 @@ export class AccountManager {
 	 * Use this when a request fails due to network errors (not rate limits).
 	 * @returns true if refund was successful, false if no valid consumption found
 	 */
-	refundToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
+	refundToken(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
 		return tokenTracker.refundToken(getRuntimeTrackerKey(account), quotaKey);
 	}
 
-	markSwitched(account: ManagedAccount, reason: "rate-limit" | "initial" | "rotation", family: ModelFamily): void {
+	markSwitched(
+		account: ManagedAccount,
+		reason: "rate-limit" | "initial" | "rotation",
+		family: ModelFamily,
+	): void {
 		account.lastSwitchReason = reason;
 		this.currentAccountIndexByFamily[family] = account.index;
 	}
 
-	markRateLimited(account: ManagedAccount, retryAfterMs: number, family: ModelFamily, model?: string | null): void {
-		this.markRateLimitedWithReason(account, retryAfterMs, family, "unknown", model);
+	/**
+	 * PR-N / R4: configure routing-mutex mode for this pool.
+	 * Callers typically derive the value from `getRoutingMutexMode(pluginConfig)`
+	 * at plugin init / settings reload. Called frequently during tests too; no
+	 * side effects beyond mutating the private field.
+	 */
+	setRoutingMutexMode(mode: RoutingMutexMode): void {
+		this.routingMutexMode = mode;
+	}
+
+	/** PR-N / R4: expose current mutex mode (mostly for diagnostics/tests). */
+	getRoutingMutexMode(): RoutingMutexMode {
+		return this.routingMutexMode;
+	}
+
+	/**
+	 * PR-N / R4: mutex-serialized variant of `markSwitched`.
+	 *
+	 * Wraps the cursor mutation in the shared async mutex when
+	 * `routingMutexMode === "enabled"`. In legacy mode it runs inline so the
+	 * flag check stays O(1) per call. Returns a `SelectionRecord` describing
+	 * the decision so the fetch loop can thread it through to observability.
+	 */
+	async markSwitchedLocked(
+		account: ManagedAccount,
+		reason: "rate-limit" | "initial" | "rotation",
+		family: ModelFamily,
+		context?: { trackerKeyQuota?: string; score?: number },
+	): Promise<SelectionRecord> {
+		return withRoutingMutex(this.routingMutexMode, () => {
+			account.lastSwitchReason = reason;
+			this.currentAccountIndexByFamily[family] = account.index;
+			const trackerKey = getRuntimeTrackerKey(account);
+			const healthTracker = getHealthTracker();
+			const tokenTracker = getTokenTracker();
+			const trackerKeyQuota = context?.trackerKeyQuota;
+			return {
+				accountIndex: account.index,
+				accountId: account.accountId ?? account.email ?? String(trackerKey),
+				reason,
+				timestamp: nowMs(),
+				trackerKeyQuota,
+				health: healthTracker.getScore(trackerKey, trackerKeyQuota),
+				tokens: tokenTracker.getTokens(trackerKey, trackerKeyQuota),
+				score: context?.score,
+			};
+		});
+	}
+
+	/**
+	 * PR-N / R4: mutex-serialized variant of `markAccountCoolingDown`.
+	 * Same flag-gated behaviour as `markSwitchedLocked`.
+	 */
+	async markAccountCoolingDownLocked(
+		account: ManagedAccount,
+		cooldownMs: number,
+		reason: CooldownReason,
+	): Promise<void> {
+		await withRoutingMutex(this.routingMutexMode, () => {
+			const ms = Math.max(0, Math.floor(cooldownMs));
+			account.coolingDownUntil = nowMs() + ms;
+			account.cooldownReason = reason;
+		});
+	}
+
+	/**
+	 * PR-N / R4: mutex-serialized variant of `setActiveIndex`.
+	 * Returns the newly active account on success, or `null` when the index
+	 * is out of range / disabled (matching sync semantics).
+	 */
+	async setActiveIndexLocked(index: number): Promise<ManagedAccount | null> {
+		return withRoutingMutex(this.routingMutexMode, () => {
+			return this.setActiveIndex(index);
+		});
+	}
+
+	markRateLimited(
+		account: ManagedAccount,
+		retryAfterMs: number,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		this.markRateLimitedWithReason(
+			account,
+			retryAfterMs,
+			family,
+			"unknown",
+			model,
+		);
 	}
 
 	markRateLimitedWithReason(
@@ -803,7 +974,11 @@ export class AccountManager {
 		account.lastRateLimitReason = reason;
 	}
 
-	markAccountCoolingDown(account: ManagedAccount, cooldownMs: number, reason: CooldownReason): void {
+	markAccountCoolingDown(
+		account: ManagedAccount,
+		cooldownMs: number,
+		reason: CooldownReason,
+	): void {
 		const ms = Math.max(0, Math.floor(cooldownMs));
 		account.coolingDownUntil = nowMs() + ms;
 		account.cooldownReason = reason;
@@ -828,7 +1003,8 @@ export class AccountManager {
 	}
 
 	incrementAuthFailures(account: ManagedAccount): number {
-		account.consecutiveAuthFailures = (account.consecutiveAuthFailures ?? 0) + 1;
+		account.consecutiveAuthFailures =
+			(account.consecutiveAuthFailures ?? 0) + 1;
 		return account.consecutiveAuthFailures;
 	}
 
@@ -849,7 +1025,10 @@ export class AccountManager {
 
 	shouldShowAccountToast(accountIndex: number, debounceMs = 30000): boolean {
 		const now = nowMs();
-		if (accountIndex === this.lastToastAccountIndex && now - this.lastToastTime < debounceMs) {
+		if (
+			accountIndex === this.lastToastAccountIndex &&
+			now - this.lastToastTime < debounceMs
+		) {
 			return false;
 		}
 		return true;
@@ -867,12 +1046,13 @@ export class AccountManager {
 		const tokenAccountId = extractAccountId(auth.access)?.trim() || undefined;
 		if (
 			tokenAccountId &&
-			(shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId))
+			shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId)
 		) {
 			account.accountId = tokenAccountId;
 			account.accountIdSource = "token";
 		}
-		account.email = sanitizeEmail(extractAccountEmail(auth.access)) ?? account.email;
+		account.email =
+			sanitizeEmail(extractAccountEmail(auth.access)) ?? account.email;
 	}
 
 	private buildStorageSnapshot(): AccountStorageV3 {
@@ -899,7 +1079,9 @@ export class AccountManager {
 				lastUsed: account.lastUsed,
 				lastSwitchReason: account.lastSwitchReason,
 				rateLimitResetTimes:
-					Object.keys(account.rateLimitResetTimes).length > 0 ? account.rateLimitResetTimes : undefined,
+					Object.keys(account.rateLimitResetTimes).length > 0
+						? account.rateLimitResetTimes
+						: undefined,
 				coolingDownUntil: account.coolingDownUntil,
 				cooldownReason: account.cooldownReason,
 				workspaces: account.workspaces,
@@ -996,9 +1178,7 @@ export class AccountManager {
 						liveAccount.enabled = previousLiveAccountState.enabled;
 						liveAccount.consecutiveAuthFailures =
 							previousLiveAccountState.consecutiveAuthFailures;
-						if (
-							previousLiveAccountState.coolingDownUntil === undefined
-						) {
+						if (previousLiveAccountState.coolingDownUntil === undefined) {
 							delete liveAccount.coolingDownUntil;
 						} else {
 							liveAccount.coolingDownUntil =
@@ -1045,7 +1225,9 @@ export class AccountManager {
 
 	getMinWaitTimeForFamily(family: ModelFamily, model?: string | null): number {
 		const now = nowMs();
-		const enabledAccounts = this.accounts.filter((account) => account.enabled !== false);
+		const enabledAccounts = this.accounts.filter(
+			(account) => account.enabled !== false,
+		);
 		const available = enabledAccounts.filter((account) => {
 			clearExpiredRateLimits(account);
 			return (
@@ -1115,11 +1297,15 @@ export class AccountManager {
 
 		for (const family of MODEL_FAMILIES) {
 			if (this.cursorByFamily[family] > idx) {
-				this.cursorByFamily[family] = Math.max(0, this.cursorByFamily[family] - 1);
+				this.cursorByFamily[family] = Math.max(
+					0,
+					this.cursorByFamily[family] - 1,
+				);
 			}
 		}
 		for (const family of MODEL_FAMILIES) {
-			this.cursorByFamily[family] = this.cursorByFamily[family] % this.accounts.length;
+			this.cursorByFamily[family] =
+				this.cursorByFamily[family] % this.accounts.length;
 		}
 
 		for (const family of MODEL_FAMILIES) {
@@ -1179,7 +1365,9 @@ export class AccountManager {
 					});
 					await this.pendingSave;
 				} catch (error) {
-					log.warn("Debounced save failed", { error: error instanceof Error ? error.message : String(error) });
+					log.warn("Debounced save failed", {
+						error: error instanceof Error ? error.message : String(error),
+					});
 				}
 			};
 			void doSave();
@@ -1203,7 +1391,9 @@ export class AccountManager {
 			return;
 		}
 
-		const resetIndex = account.workspaces.findIndex((workspace) => workspace.isDefault === true);
+		const resetIndex = account.workspaces.findIndex(
+			(workspace) => workspace.isDefault === true,
+		);
 
 		for (const workspace of account.workspaces) {
 			workspace.enabled = true;
@@ -1251,7 +1441,7 @@ export class AccountManager {
 		}
 		const currentIdx = account.currentWorkspaceIndex ?? 0;
 		const totalWorkspaces = account.workspaces.length;
-		
+
 		// Search successor workspaces only; the current slot was just evaluated.
 		for (let i = 1; i < totalWorkspaces; i++) {
 			const nextIdx = (currentIdx + i) % totalWorkspaces;
@@ -1261,7 +1451,7 @@ export class AccountManager {
 				return workspace;
 			}
 		}
-		
+
 		return null; // No enabled workspaces found
 	}
 
@@ -1287,21 +1477,30 @@ export class AccountManager {
 }
 
 export function formatAccountLabel(
-	account: { email?: string; accountId?: string; accountLabel?: string } | undefined,
+	account:
+		| { email?: string; accountId?: string; accountLabel?: string }
+		| undefined,
 	index: number,
 ): string {
 	const accountLabel = account?.accountLabel?.trim();
 	const email = account?.email?.trim();
 	const accountId = account?.accountId?.trim();
-	const idSuffix = accountId ? (accountId.length > 6 ? accountId.slice(-6) : accountId) : null;
+	const idSuffix = accountId
+		? accountId.length > 6
+			? accountId.slice(-6)
+			: accountId
+		: null;
 
 	if (accountLabel && email && idSuffix) {
 		return `Account ${index + 1} (${accountLabel}, ${email}, id:${idSuffix})`;
 	}
-	if (accountLabel && email) return `Account ${index + 1} (${accountLabel}, ${email})`;
-	if (accountLabel && idSuffix) return `Account ${index + 1} (${accountLabel}, id:${idSuffix})`;
+	if (accountLabel && email)
+		return `Account ${index + 1} (${accountLabel}, ${email})`;
+	if (accountLabel && idSuffix)
+		return `Account ${index + 1} (${accountLabel}, id:${idSuffix})`;
 	if (accountLabel) return `Account ${index + 1} (${accountLabel})`;
-	if (email && idSuffix) return `Account ${index + 1} (${email}, id:${idSuffix})`;
+	if (email && idSuffix)
+		return `Account ${index + 1} (${email}, id:${idSuffix})`;
 	if (email) return `Account ${index + 1} (${email})`;
 	if (idSuffix) return `Account ${index + 1} (${idSuffix})`;
 	return `Account ${index + 1}`;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -51,21 +51,14 @@ type ConfigReadState =
 
 export type UnsupportedCodexPolicy = "strict" | "fallback";
 
-type ConfigExplainStorageKind =
-	| "unified"
-	| "file"
-	| "none"
-	| "unreadable";
+type ConfigExplainStorageKind = "unified" | "file" | "none" | "unreadable";
 
 type ConfigExplainStoredSource = Extract<
 	ConfigExplainStorageKind,
 	"unified" | "file"
 >;
 
-export type ConfigExplainSource =
-	| "env"
-	| ConfigExplainStoredSource
-	| "default";
+export type ConfigExplainSource = "env" | ConfigExplainStoredSource | "default";
 
 export interface ConfigExplainEntry {
 	key: keyof PluginConfig;
@@ -208,6 +201,7 @@ export const DEFAULT_PLUGIN_CONFIG: PluginConfig = {
 	preemptiveQuotaRemainingPercent5h: 5,
 	preemptiveQuotaRemainingPercent7d: 5,
 	preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+	routingMutex: "legacy",
 };
 
 const PLUGIN_CONFIG_FIELD_SCHEMAS = PluginConfigSchema.shape;
@@ -485,7 +479,7 @@ async function readConfigRecordForSave(
 				return { status: "invalid", errorMessage };
 			}
 			return { status: "ok", record: parsed };
-	} catch (error) {
+		} catch (error) {
 			const code = (error as NodeJS.ErrnoException | undefined)?.code;
 			if (code === "ENOENT") {
 				return { status: "missing" };
@@ -566,10 +560,13 @@ function resolveStoredPluginConfigRecord(): {
  * Concurrency: synchronous and side-effect free; callers are responsible for coordinating concurrent writes to the filesystem.
  * Filesystem: no Windows-specific path normalization or filesystem I/O is performed by this function.
  */
-function sanitizePluginConfigForSave(
-	config: Partial<PluginConfig>,
-	): { sanitized: Record<string, unknown>; droppedKeys: string[] } {
-	const normalized = sanitizePluginConfigRecord(config as Record<string, unknown>);
+function sanitizePluginConfigForSave(config: Partial<PluginConfig>): {
+	sanitized: Record<string, unknown>;
+	droppedKeys: string[];
+} {
+	const normalized = sanitizePluginConfigRecord(
+		config as Record<string, unknown>,
+	);
 	const entries = Object.entries((normalized ?? {}) as Record<string, unknown>);
 	const sanitized: Record<string, unknown> = {};
 	const inputRecord = isRecord(config) ? config : {};
@@ -665,9 +662,7 @@ export async function savePluginConfig(
 				? sanitizeStoredPluginConfigRecord(legacyConfigState.record)
 				: null;
 		const merged = {
-			...(unifiedConfig ??
-				legacyConfig ??
-				{}),
+			...(unifiedConfig ?? legacyConfig ?? {}),
 			...sanitizedPatch,
 		};
 		await saveUnifiedPluginConfig(merged);
@@ -685,18 +680,10 @@ function parseBooleanEnv(value: string | undefined): boolean | undefined {
 	if (value === undefined) return undefined;
 	const normalized = value.trim().toLowerCase();
 	if (normalized.length === 0) return undefined;
-	if (
-		normalized === "1" ||
-		normalized === "true" ||
-		normalized === "yes"
-	) {
+	if (normalized === "1" || normalized === "true" || normalized === "yes") {
 		return true;
 	}
-	if (
-		normalized === "0" ||
-		normalized === "false" ||
-		normalized === "no"
-	) {
+	if (normalized === "0" || normalized === "false" || normalized === "no") {
 		return false;
 	}
 	return undefined;
@@ -1515,6 +1502,32 @@ export function getPreemptiveQuotaMaxDeferralMs(
 		pluginConfig.preemptiveQuotaMaxDeferralMs,
 		2 * 60 * 60_000,
 		{ min: 1_000 },
+	);
+}
+
+const ROUTING_MUTEX_MODES = new Set<string>(["enabled", "legacy"]);
+
+/**
+ * Resolve the routing-mutex mode (PR-N / R4).
+ *
+ * When `"enabled"` the account pool wraps cursor mutations in a promise-chain
+ * async mutex so concurrent requests cannot race on `activeIndex` or on
+ * `markSwitched` / `markAccountCoolingDown`. Defaults to `"legacy"` for one
+ * release cycle to preserve the pre-PR-N behaviour for existing users. The
+ * `CODEX_AUTH_ROUTING_MUTEX` env var accepts the same two values for opt-in
+ * trials without editing settings.
+ *
+ * Concurrency: pure read; safe for concurrent callers. Performs no I/O and
+ * is unaffected by Windows filesystem semantics. Contains no secrets.
+ */
+export function getRoutingMutexMode(
+	pluginConfig: PluginConfig,
+): "enabled" | "legacy" {
+	return resolveStringSetting(
+		"CODEX_AUTH_ROUTING_MUTEX",
+		pluginConfig.routingMutex,
+		"legacy",
+		ROUTING_MUTEX_MODES,
 	);
 }
 

--- a/lib/rotation.ts
+++ b/lib/rotation.ts
@@ -8,6 +8,21 @@
 
 import { createLogger } from "./logger.js";
 
+// PR-N / R4: re-export SelectionRecord + RoutingMutexMode so rotation.ts
+// remains the canonical entry point for "selection decision" types even
+// though the concrete mutex lives in ./routing-mutex.ts. Callers wiring
+// the fetch loop only need to import from `lib/rotation`.
+export type {
+	SelectionRecord,
+	RoutingMutexMode,
+	AsyncMutex,
+} from "./routing-mutex.js";
+export {
+	createAsyncMutex,
+	getRoutingMutex,
+	withRoutingMutex,
+} from "./routing-mutex.js";
+
 const log = createLogger("rotation");
 
 // ============================================================================
@@ -15,38 +30,41 @@ const log = createLogger("rotation");
 // ============================================================================
 
 export interface HealthScoreConfig {
-  /** Points added on successful request */
-  successDelta: number;
-  /** Points deducted on rate limit (negative) */
-  rateLimitDelta: number;
-  /** Points deducted on other failures (negative) */
-  failureDelta: number;
-  /** Maximum health score */
-  maxScore: number;
-  /** Minimum health score */
-  minScore: number;
-  /** Points recovered per hour of inactivity */
-  passiveRecoveryPerHour: number;
+	/** Points added on successful request */
+	successDelta: number;
+	/** Points deducted on rate limit (negative) */
+	rateLimitDelta: number;
+	/** Points deducted on other failures (negative) */
+	failureDelta: number;
+	/** Maximum health score */
+	maxScore: number;
+	/** Minimum health score */
+	minScore: number;
+	/** Points recovered per hour of inactivity */
+	passiveRecoveryPerHour: number;
 }
 
 export const DEFAULT_HEALTH_SCORE_CONFIG: HealthScoreConfig = {
-  successDelta: 1,
-  rateLimitDelta: -10,
-  failureDelta: -20,
-  maxScore: 100,
-  minScore: 0,
-  passiveRecoveryPerHour: 2,
+	successDelta: 1,
+	rateLimitDelta: -10,
+	failureDelta: -20,
+	maxScore: 100,
+	minScore: 0,
+	passiveRecoveryPerHour: 2,
 };
 
 interface HealthEntry {
-  score: number;
-  lastUpdated: number;
-  consecutiveFailures: number;
+	score: number;
+	lastUpdated: number;
+	consecutiveFailures: number;
 }
 
 type TrackerKey = number | string;
 
-function normalizeTrackerKey(accountKey: TrackerKey, quotaKey?: string): string {
+function normalizeTrackerKey(
+	accountKey: TrackerKey,
+	quotaKey?: string,
+): string {
 	const normalizedKey =
 		typeof accountKey === "number" ? `${accountKey}` : accountKey;
 	return JSON.stringify([normalizedKey, quotaKey ?? null]);
@@ -57,81 +75,96 @@ function normalizeTrackerKey(accountKey: TrackerKey, quotaKey?: string): string 
  * Accounts with higher health scores are preferred for selection.
  */
 export class HealthScoreTracker {
-  private entries: Map<string, HealthEntry> = new Map();
-  private config: HealthScoreConfig;
+	private entries: Map<string, HealthEntry> = new Map();
+	private config: HealthScoreConfig;
 
-  constructor(config: Partial<HealthScoreConfig> = {}) {
-    this.config = { ...DEFAULT_HEALTH_SCORE_CONFIG, ...config };
-  }
+	constructor(config: Partial<HealthScoreConfig> = {}) {
+		this.config = { ...DEFAULT_HEALTH_SCORE_CONFIG, ...config };
+	}
 
-  private getKey(accountKey: TrackerKey, quotaKey?: string): string {
-    return normalizeTrackerKey(accountKey, quotaKey);
-  }
+	private getKey(accountKey: TrackerKey, quotaKey?: string): string {
+		return normalizeTrackerKey(accountKey, quotaKey);
+	}
 
-  private applyPassiveRecovery(entry: HealthEntry): number {
-    const now = Date.now();
-    const hoursSinceUpdate = (now - entry.lastUpdated) / (1000 * 60 * 60);
-    const recovery = hoursSinceUpdate * this.config.passiveRecoveryPerHour;
-    return Math.min(entry.score + recovery, this.config.maxScore);
-  }
+	private applyPassiveRecovery(entry: HealthEntry): number {
+		const now = Date.now();
+		const hoursSinceUpdate = (now - entry.lastUpdated) / (1000 * 60 * 60);
+		const recovery = hoursSinceUpdate * this.config.passiveRecoveryPerHour;
+		return Math.min(entry.score + recovery, this.config.maxScore);
+	}
 
-  getScore(accountKey: TrackerKey, quotaKey?: string): number {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    if (!entry) return this.config.maxScore;
-    return this.applyPassiveRecovery(entry);
-  }
+	getScore(accountKey: TrackerKey, quotaKey?: string): number {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		if (!entry) return this.config.maxScore;
+		return this.applyPassiveRecovery(entry);
+	}
 
-  getConsecutiveFailures(accountKey: TrackerKey, quotaKey?: string): number {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    return entry?.consecutiveFailures ?? 0;
-  }
+	getConsecutiveFailures(accountKey: TrackerKey, quotaKey?: string): number {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		return entry?.consecutiveFailures ?? 0;
+	}
 
-  recordSuccess(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
-    const newScore = Math.min(baseScore + this.config.successDelta, this.config.maxScore);
-    this.entries.set(key, {
-      score: newScore,
-      lastUpdated: Date.now(),
-      consecutiveFailures: 0,
-    });
-  }
+	recordSuccess(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		const baseScore = entry
+			? this.applyPassiveRecovery(entry)
+			: this.config.maxScore;
+		const newScore = Math.min(
+			baseScore + this.config.successDelta,
+			this.config.maxScore,
+		);
+		this.entries.set(key, {
+			score: newScore,
+			lastUpdated: Date.now(),
+			consecutiveFailures: 0,
+		});
+	}
 
-  recordRateLimit(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
-    const newScore = Math.max(baseScore + this.config.rateLimitDelta, this.config.minScore);
-    this.entries.set(key, {
-      score: newScore,
-      lastUpdated: Date.now(),
-      consecutiveFailures: (entry?.consecutiveFailures ?? 0) + 1,
-    });
-  }
+	recordRateLimit(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		const baseScore = entry
+			? this.applyPassiveRecovery(entry)
+			: this.config.maxScore;
+		const newScore = Math.max(
+			baseScore + this.config.rateLimitDelta,
+			this.config.minScore,
+		);
+		this.entries.set(key, {
+			score: newScore,
+			lastUpdated: Date.now(),
+			consecutiveFailures: (entry?.consecutiveFailures ?? 0) + 1,
+		});
+	}
 
-  recordFailure(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.entries.get(key);
-    const baseScore = entry ? this.applyPassiveRecovery(entry) : this.config.maxScore;
-    const newScore = Math.max(baseScore + this.config.failureDelta, this.config.minScore);
-    this.entries.set(key, {
-      score: newScore,
-      lastUpdated: Date.now(),
-      consecutiveFailures: (entry?.consecutiveFailures ?? 0) + 1,
-    });
-  }
+	recordFailure(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.entries.get(key);
+		const baseScore = entry
+			? this.applyPassiveRecovery(entry)
+			: this.config.maxScore;
+		const newScore = Math.max(
+			baseScore + this.config.failureDelta,
+			this.config.minScore,
+		);
+		this.entries.set(key, {
+			score: newScore,
+			lastUpdated: Date.now(),
+			consecutiveFailures: (entry?.consecutiveFailures ?? 0) + 1,
+		});
+	}
 
-  reset(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    this.entries.delete(key);
-  }
+	reset(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		this.entries.delete(key);
+	}
 
-  clear(): void {
-    this.entries.clear();
-  }
+	clear(): void {
+		this.entries.clear();
+	}
 }
 
 // ============================================================================
@@ -139,23 +172,23 @@ export class HealthScoreTracker {
 // ============================================================================
 
 export interface TokenBucketConfig {
-  /** Maximum tokens in bucket */
-  maxTokens: number;
-  /** Tokens regenerated per minute */
-  tokensPerMinute: number;
+	/** Maximum tokens in bucket */
+	maxTokens: number;
+	/** Tokens regenerated per minute */
+	tokensPerMinute: number;
 }
 
 export const DEFAULT_TOKEN_BUCKET_CONFIG: TokenBucketConfig = {
-  maxTokens: 50,
-  tokensPerMinute: 6,
+	maxTokens: 50,
+	tokensPerMinute: 6,
 };
 
 const TOKEN_REFUND_WINDOW_MS = 30_000;
 
 interface TokenBucketEntry {
-  tokens: number;
-  lastRefill: number;
-  consumptions: number[];
+	tokens: number;
+	lastRefill: number;
+	consumptions: number[];
 }
 
 /**
@@ -163,109 +196,117 @@ interface TokenBucketEntry {
  * Prevents sending requests to accounts that are likely to be rate-limited.
  */
 export class TokenBucketTracker {
-  private buckets: Map<string, TokenBucketEntry> = new Map();
-  private config: TokenBucketConfig;
+	private buckets: Map<string, TokenBucketEntry> = new Map();
+	private config: TokenBucketConfig;
 
-  constructor(config: Partial<TokenBucketConfig> = {}) {
-    this.config = { ...DEFAULT_TOKEN_BUCKET_CONFIG, ...config };
-  }
+	constructor(config: Partial<TokenBucketConfig> = {}) {
+		this.config = { ...DEFAULT_TOKEN_BUCKET_CONFIG, ...config };
+	}
 
-  private getKey(accountKey: TrackerKey, quotaKey?: string): string {
-    return normalizeTrackerKey(accountKey, quotaKey);
-  }
+	private getKey(accountKey: TrackerKey, quotaKey?: string): string {
+		return normalizeTrackerKey(accountKey, quotaKey);
+	}
 
-  private refillTokens(entry: TokenBucketEntry): number {
-    const now = Date.now();
-    const minutesSinceRefill = (now - entry.lastRefill) / (1000 * 60);
-    const tokensToAdd = minutesSinceRefill * this.config.tokensPerMinute;
-    return Math.min(entry.tokens + tokensToAdd, this.config.maxTokens);
-  }
+	private refillTokens(entry: TokenBucketEntry): number {
+		const now = Date.now();
+		const minutesSinceRefill = (now - entry.lastRefill) / (1000 * 60);
+		const tokensToAdd = minutesSinceRefill * this.config.tokensPerMinute;
+		return Math.min(entry.tokens + tokensToAdd, this.config.maxTokens);
+	}
 
-  getTokens(accountKey: TrackerKey, quotaKey?: string): number {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.buckets.get(key);
-    if (!entry) return this.config.maxTokens;
-    return this.refillTokens(entry);
-  }
+	getTokens(accountKey: TrackerKey, quotaKey?: string): number {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.buckets.get(key);
+		if (!entry) return this.config.maxTokens;
+		return this.refillTokens(entry);
+	}
 
-  /**
-   * Attempt to consume a token. Returns true if successful, false if bucket is empty.
-   */
-  tryConsume(accountKey: TrackerKey, quotaKey?: string): boolean {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.buckets.get(key);
-    const currentTokens = entry ? this.refillTokens(entry) : this.config.maxTokens;
+	/**
+	 * Attempt to consume a token. Returns true if successful, false if bucket is empty.
+	 */
+	tryConsume(accountKey: TrackerKey, quotaKey?: string): boolean {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.buckets.get(key);
+		const currentTokens = entry
+			? this.refillTokens(entry)
+			: this.config.maxTokens;
 
-    if (currentTokens < 1) {
-      return false;
-    }
+		if (currentTokens < 1) {
+			return false;
+		}
 
-    const now = Date.now();
-    const cutoff = now - TOKEN_REFUND_WINDOW_MS;
-    const consumptions = (entry?.consumptions ?? []).filter(
-      (timestamp) => timestamp >= cutoff
-    );
-    consumptions.push(now);
+		const now = Date.now();
+		const cutoff = now - TOKEN_REFUND_WINDOW_MS;
+		const consumptions = (entry?.consumptions ?? []).filter(
+			(timestamp) => timestamp >= cutoff,
+		);
+		consumptions.push(now);
 
-    this.buckets.set(key, {
-      tokens: currentTokens - 1,
-      lastRefill: now,
-      consumptions,
-    });
-    return true;
-  }
+		this.buckets.set(key, {
+			tokens: currentTokens - 1,
+			lastRefill: now,
+			consumptions,
+		});
+		return true;
+	}
 
-  /**
-   * Attempt to refund a token consumed within the refund window.
-   * Use this when a request fails due to network errors (not rate limits).
-   * @returns true if refund was successful, false if no valid consumption found
-   */
-  refundToken(accountKey: TrackerKey, quotaKey?: string): boolean {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.buckets.get(key);
-    if (!entry || entry.consumptions.length === 0) return false;
+	/**
+	 * Attempt to refund a token consumed within the refund window.
+	 * Use this when a request fails due to network errors (not rate limits).
+	 * @returns true if refund was successful, false if no valid consumption found
+	 */
+	refundToken(accountKey: TrackerKey, quotaKey?: string): boolean {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.buckets.get(key);
+		if (!entry || entry.consumptions.length === 0) return false;
 
-    const now = Date.now();
-    const cutoff = now - TOKEN_REFUND_WINDOW_MS;
+		const now = Date.now();
+		const cutoff = now - TOKEN_REFUND_WINDOW_MS;
 
-    const validIndex = entry.consumptions.findIndex(
-      (timestamp) => timestamp >= cutoff
-    );
-    if (validIndex === -1) return false;
+		const validIndex = entry.consumptions.findIndex(
+			(timestamp) => timestamp >= cutoff,
+		);
+		if (validIndex === -1) return false;
 
-    entry.consumptions.splice(validIndex, 1);
-    const currentTokens = this.refillTokens(entry);
-    this.buckets.set(key, {
-      tokens: Math.min(currentTokens + 1, this.config.maxTokens),
-      lastRefill: now,
-      consumptions: entry.consumptions,
-    });
+		entry.consumptions.splice(validIndex, 1);
+		const currentTokens = this.refillTokens(entry);
+		this.buckets.set(key, {
+			tokens: Math.min(currentTokens + 1, this.config.maxTokens),
+			lastRefill: now,
+			consumptions: entry.consumptions,
+		});
 
-    return true;
-  }
+		return true;
+	}
 
-  /**
-   * Drain tokens on rate limit to prevent immediate retries.
-   */
-  drain(accountKey: TrackerKey, quotaKey?: string, drainAmount: number = 10): void {
-    const key = this.getKey(accountKey, quotaKey);
-    const entry = this.buckets.get(key);
-    const currentTokens = entry ? this.refillTokens(entry) : this.config.maxTokens;
-    this.buckets.set(key, {
-      tokens: Math.max(0, currentTokens - drainAmount),
-      lastRefill: Date.now(),
-      consumptions: entry?.consumptions ?? [],
-    });
-  }
+	/**
+	 * Drain tokens on rate limit to prevent immediate retries.
+	 */
+	drain(
+		accountKey: TrackerKey,
+		quotaKey?: string,
+		drainAmount: number = 10,
+	): void {
+		const key = this.getKey(accountKey, quotaKey);
+		const entry = this.buckets.get(key);
+		const currentTokens = entry
+			? this.refillTokens(entry)
+			: this.config.maxTokens;
+		this.buckets.set(key, {
+			tokens: Math.max(0, currentTokens - drainAmount),
+			lastRefill: Date.now(),
+			consumptions: entry?.consumptions ?? [],
+		});
+	}
 
-  reset(accountKey: TrackerKey, quotaKey?: string): void {
-    const key = this.getKey(accountKey, quotaKey);
-    this.buckets.delete(key);
-  }
+	reset(accountKey: TrackerKey, quotaKey?: string): void {
+		const key = this.getKey(accountKey, quotaKey);
+		this.buckets.delete(key);
+	}
 
-  clear(): void {
-    this.buckets.clear();
-  }
+	clear(): void {
+		this.buckets.clear();
+	}
 }
 
 // ============================================================================
@@ -273,25 +314,25 @@ export class TokenBucketTracker {
 // ============================================================================
 
 export interface AccountWithMetrics {
-  index: number;
-  trackerKey?: TrackerKey;
-  isAvailable: boolean;
-  lastUsed: number;
+	index: number;
+	trackerKey?: TrackerKey;
+	isAvailable: boolean;
+	lastUsed: number;
 }
 
 export interface HybridSelectionConfig {
-  /** Weight for health score (default: 2) */
-  healthWeight: number;
-  /** Weight for token count (default: 5) */
-  tokenWeight: number;
-  /** Weight for freshness/last used (default: 0.1) */
-  freshnessWeight: number;
+	/** Weight for health score (default: 2) */
+	healthWeight: number;
+	/** Weight for token count (default: 5) */
+	tokenWeight: number;
+	/** Weight for freshness/last used (default: 0.1) */
+	freshnessWeight: number;
 }
 
 export const DEFAULT_HYBRID_SELECTION_CONFIG: HybridSelectionConfig = {
-  healthWeight: 2,
-  tokenWeight: 5,
-  freshnessWeight: 2.0,
+	healthWeight: 2,
+	tokenWeight: 5,
+	freshnessWeight: 2.0,
 };
 
 /**
@@ -305,20 +346,20 @@ export const DEFAULT_HYBRID_SELECTION_CONFIG: HybridSelectionConfig = {
  * - freshness: Hours since last used (higher = more fresh for rotation)
  */
 export interface HybridSelectionOptions {
-  pidOffsetEnabled?: boolean;
-  scoreBoostByAccount?: Record<number, number>;
+	pidOffsetEnabled?: boolean;
+	scoreBoostByAccount?: Record<number, number>;
 }
 
 /**
  * Named-parameter alternative for selectHybridAccount to avoid brittle positional arguments.
  */
 export interface SelectHybridAccountParams {
-  accounts: AccountWithMetrics[];
-  healthTracker: HealthScoreTracker;
-  tokenTracker: TokenBucketTracker;
-  quotaKey?: string;
-  config?: Partial<HybridSelectionConfig>;
-  options?: HybridSelectionOptions;
+	accounts: AccountWithMetrics[];
+	healthTracker: HealthScoreTracker;
+	tokenTracker: TokenBucketTracker;
+	quotaKey?: string;
+	config?: Partial<HybridSelectionConfig>;
+	options?: HybridSelectionOptions;
 }
 
 /**
@@ -337,113 +378,126 @@ export interface SelectHybridAccountParams {
  * - The function is purely in-memory and performs no filesystem operations (no Windows filesystem considerations).
  */
 export function selectHybridAccount(
-  params: SelectHybridAccountParams,
+	params: SelectHybridAccountParams,
 ): AccountWithMetrics | null;
 export function selectHybridAccount(
-  accounts: AccountWithMetrics[],
-  healthTracker: HealthScoreTracker,
-  tokenTracker: TokenBucketTracker,
-  quotaKey?: string,
-  config?: Partial<HybridSelectionConfig>,
-  options?: HybridSelectionOptions,
+	accounts: AccountWithMetrics[],
+	healthTracker: HealthScoreTracker,
+	tokenTracker: TokenBucketTracker,
+	quotaKey?: string,
+	config?: Partial<HybridSelectionConfig>,
+	options?: HybridSelectionOptions,
 ): AccountWithMetrics | null;
 export function selectHybridAccount(
-  accountsOrParams: AccountWithMetrics[] | SelectHybridAccountParams,
-  healthTracker?: HealthScoreTracker,
-  tokenTracker?: TokenBucketTracker,
-  quotaKey?: string,
-  config: Partial<HybridSelectionConfig> = {},
-  options: HybridSelectionOptions = {},
+	accountsOrParams: AccountWithMetrics[] | SelectHybridAccountParams,
+	healthTracker?: HealthScoreTracker,
+	tokenTracker?: TokenBucketTracker,
+	quotaKey?: string,
+	config: Partial<HybridSelectionConfig> = {},
+	options: HybridSelectionOptions = {},
 ): AccountWithMetrics | null {
-  const namedParams =
-    !Array.isArray(accountsOrParams) &&
-    accountsOrParams !== null &&
-    typeof accountsOrParams === "object"
-      ? accountsOrParams
-      : null;
-  const resolvedAccounts = namedParams ? namedParams.accounts : accountsOrParams;
-  const resolvedHealthTracker = namedParams ? namedParams.healthTracker : healthTracker;
-  const resolvedTokenTracker = namedParams ? namedParams.tokenTracker : tokenTracker;
-  const resolvedQuotaKey = namedParams ? namedParams.quotaKey : quotaKey;
-  const resolvedConfig = namedParams ? (namedParams.config ?? {}) : config;
-  const resolvedOptions = namedParams ? (namedParams.options ?? {}) : options;
+	const namedParams =
+		!Array.isArray(accountsOrParams) &&
+		accountsOrParams !== null &&
+		typeof accountsOrParams === "object"
+			? accountsOrParams
+			: null;
+	const resolvedAccounts = namedParams
+		? namedParams.accounts
+		: accountsOrParams;
+	const resolvedHealthTracker = namedParams
+		? namedParams.healthTracker
+		: healthTracker;
+	const resolvedTokenTracker = namedParams
+		? namedParams.tokenTracker
+		: tokenTracker;
+	const resolvedQuotaKey = namedParams ? namedParams.quotaKey : quotaKey;
+	const resolvedConfig = namedParams ? (namedParams.config ?? {}) : config;
+	const resolvedOptions = namedParams ? (namedParams.options ?? {}) : options;
 
-  if (!Array.isArray(resolvedAccounts)) {
-    throw new TypeError("selectHybridAccount requires accounts to be an array");
-  }
-  if (!resolvedHealthTracker || !resolvedTokenTracker) {
-    throw new TypeError("selectHybridAccount requires healthTracker and tokenTracker");
-  }
+	if (!Array.isArray(resolvedAccounts)) {
+		throw new TypeError("selectHybridAccount requires accounts to be an array");
+	}
+	if (!resolvedHealthTracker || !resolvedTokenTracker) {
+		throw new TypeError(
+			"selectHybridAccount requires healthTracker and tokenTracker",
+		);
+	}
 
-  const cfg = { ...DEFAULT_HYBRID_SELECTION_CONFIG, ...resolvedConfig };
-  const available = resolvedAccounts.filter((a) => a.isAvailable);
+	const cfg = { ...DEFAULT_HYBRID_SELECTION_CONFIG, ...resolvedConfig };
+	const available = resolvedAccounts.filter((a) => a.isAvailable);
 
-  if (available.length === 0) {
-    if (resolvedAccounts.length === 0) return null;
-    let leastRecentlyUsed: AccountWithMetrics | null = null;
-    let oldestTime = Infinity;
-    for (const account of resolvedAccounts) {
-      if (account.lastUsed < oldestTime) {
-        oldestTime = account.lastUsed;
-        leastRecentlyUsed = account;
-      }
-    }
-    return leastRecentlyUsed;
-  }
-  // istanbul ignore next -- defensive: available[0] always exists when length === 1
-  if (available.length === 1) return available[0] ?? null;
+	if (available.length === 0) {
+		if (resolvedAccounts.length === 0) return null;
+		let leastRecentlyUsed: AccountWithMetrics | null = null;
+		let oldestTime = Infinity;
+		for (const account of resolvedAccounts) {
+			if (account.lastUsed < oldestTime) {
+				oldestTime = account.lastUsed;
+				leastRecentlyUsed = account;
+			}
+		}
+		return leastRecentlyUsed;
+	}
+	// istanbul ignore next -- defensive: available[0] always exists when length === 1
+	if (available.length === 1) return available[0] ?? null;
 
-  const now = Date.now();
-  let bestAccount: AccountWithMetrics | null = null;
-  let bestScore = -Infinity;
+	const now = Date.now();
+	let bestAccount: AccountWithMetrics | null = null;
+	let bestScore = -Infinity;
 
-  // PID offset: distribute account selection across parallel processes
-  // Each process gets a small deterministic bonus based on its PID
-  const pidBonus = resolvedOptions.pidOffsetEnabled ? (process.pid % 100) * 0.01 : 0;
+	// PID offset: distribute account selection across parallel processes
+	// Each process gets a small deterministic bonus based on its PID
+	const pidBonus = resolvedOptions.pidOffsetEnabled
+		? (process.pid % 100) * 0.01
+		: 0;
 
-  for (const account of available) {
-    const trackerKey = account.trackerKey ?? account.index;
-    const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
-    const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
-    const hoursSinceUsed = (now - account.lastUsed) / (1000 * 60 * 60);
+	for (const account of available) {
+		const trackerKey = account.trackerKey ?? account.index;
+		const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
+		const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
+		const hoursSinceUsed = (now - account.lastUsed) / (1000 * 60 * 60);
 
-    const capabilityBoost =
-      typeof resolvedOptions.scoreBoostByAccount?.[account.index] === "number"
-        ? resolvedOptions.scoreBoostByAccount[account.index] ?? 0
-        : 0;
-    const safeCapabilityBoost = Number.isFinite(capabilityBoost) ? capabilityBoost : 0;
+		const capabilityBoost =
+			typeof resolvedOptions.scoreBoostByAccount?.[account.index] === "number"
+				? (resolvedOptions.scoreBoostByAccount[account.index] ?? 0)
+				: 0;
+		const safeCapabilityBoost = Number.isFinite(capabilityBoost)
+			? capabilityBoost
+			: 0;
 
-    let score =
-      health * cfg.healthWeight +
-      tokens * cfg.tokenWeight +
-      hoursSinceUsed * cfg.freshnessWeight +
-      safeCapabilityBoost;
+		let score =
+			health * cfg.healthWeight +
+			tokens * cfg.tokenWeight +
+			hoursSinceUsed * cfg.freshnessWeight +
+			safeCapabilityBoost;
 
-    // PID-based offset distributes selection across parallel agents
-    if (resolvedOptions.pidOffsetEnabled) {
-      score += ((account.index * 0.131 + pidBonus) % 1) * cfg.freshnessWeight * 0.1;
-    }
+		// PID-based offset distributes selection across parallel agents
+		if (resolvedOptions.pidOffsetEnabled) {
+			score +=
+				((account.index * 0.131 + pidBonus) % 1) * cfg.freshnessWeight * 0.1;
+		}
 
-    if (score > bestScore) {
-      bestScore = score;
-      bestAccount = account;
-    }
-  }
+		if (score > bestScore) {
+			bestScore = score;
+			bestAccount = account;
+		}
+	}
 
-  if (bestAccount && available.length > 1) {
-    const trackerKey = bestAccount.trackerKey ?? bestAccount.index;
-    const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
-    const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
-    log.debug("Selected account", {
-      index: bestAccount.index,
-      health: Math.round(health),
-      tokens: Math.round(tokens),
-      score: Math.round(bestScore),
-      candidateCount: available.length,
-    });
-  }
+	if (bestAccount && available.length > 1) {
+		const trackerKey = bestAccount.trackerKey ?? bestAccount.index;
+		const health = resolvedHealthTracker.getScore(trackerKey, resolvedQuotaKey);
+		const tokens = resolvedTokenTracker.getTokens(trackerKey, resolvedQuotaKey);
+		log.debug("Selected account", {
+			index: bestAccount.index,
+			health: Math.round(health),
+			tokens: Math.round(tokens),
+			score: Math.round(bestScore),
+			candidateCount: available.length,
+		});
+	}
 
-  return bestAccount;
+	return bestAccount;
 }
 
 // ============================================================================
@@ -457,8 +511,8 @@ export function selectHybridAccount(
  * @returns Delay with jitter applied
  */
 export function addJitter(baseMs: number, jitterFactor: number = 0.1): number {
-  const jitter = baseMs * jitterFactor * (Math.random() * 2 - 1);
-  return Math.max(0, Math.floor(baseMs + jitter));
+	const jitter = baseMs * jitterFactor * (Math.random() * 2 - 1);
+	return Math.max(0, Math.floor(baseMs + jitter));
 }
 
 /**
@@ -468,14 +522,14 @@ export function addJitter(baseMs: number, jitterFactor: number = 0.1): number {
  * @returns Random delay within range
  */
 export function randomDelay(minMs: number, maxMs: number): number {
-  return Math.floor(minMs + Math.random() * (maxMs - minMs));
+	return Math.floor(minMs + Math.random() * (maxMs - minMs));
 }
 
 export interface ExponentialBackoffOptions {
-  attempt: number;
-  baseMs?: number;
-  maxMs?: number;
-  jitterFactor?: number;
+	attempt: number;
+	baseMs?: number;
+	maxMs?: number;
+	jitterFactor?: number;
 }
 
 /**
@@ -488,52 +542,60 @@ export interface ExponentialBackoffOptions {
  */
 export function exponentialBackoff(options: ExponentialBackoffOptions): number;
 export function exponentialBackoff(
-  attempt: number,
-  baseMs?: number,
-  maxMs?: number,
-  jitterFactor?: number,
+	attempt: number,
+	baseMs?: number,
+	maxMs?: number,
+	jitterFactor?: number,
 ): number;
 export function exponentialBackoff(
-  attemptOrOptions: number | ExponentialBackoffOptions,
-  baseMs: number = 1000,
-  maxMs: number = 60000,
-  jitterFactor: number = 0.1,
+	attemptOrOptions: number | ExponentialBackoffOptions,
+	baseMs: number = 1000,
+	maxMs: number = 60000,
+	jitterFactor: number = 0.1,
 ): number {
-  const useNamedParams =
-    typeof attemptOrOptions === "object" && attemptOrOptions !== null;
-  const normalizedAttempt = useNamedParams
-    ? (attemptOrOptions as ExponentialBackoffOptions).attempt
-    : attemptOrOptions;
-  const normalizedBaseMs = useNamedParams
-    ? ((attemptOrOptions as ExponentialBackoffOptions).baseMs ?? 1000)
-    : baseMs;
-  const normalizedMaxMs = useNamedParams
-    ? ((attemptOrOptions as ExponentialBackoffOptions).maxMs ?? 60000)
-    : maxMs;
-  const normalizedJitterFactor = useNamedParams
-    ? ((attemptOrOptions as ExponentialBackoffOptions).jitterFactor ?? 0.1)
-    : jitterFactor;
-  if (!Number.isInteger(normalizedAttempt) || normalizedAttempt < 1) {
-    throw new TypeError("exponentialBackoff requires attempt to be a positive integer");
-  }
-  if (!Number.isFinite(normalizedBaseMs) || normalizedBaseMs < 0) {
-    throw new TypeError("exponentialBackoff requires baseMs to be a finite non-negative number");
-  }
-  if (!Number.isFinite(normalizedMaxMs) || normalizedMaxMs < 0) {
-    throw new TypeError("exponentialBackoff requires maxMs to be a finite non-negative number");
-  }
-  if (
-    !Number.isFinite(normalizedJitterFactor) ||
-    normalizedJitterFactor < 0 ||
-    normalizedJitterFactor > 1
-  ) {
-    throw new TypeError("exponentialBackoff requires jitterFactor to be between 0 and 1");
-  }
-  const delay = Math.min(
-    normalizedBaseMs * Math.pow(2, normalizedAttempt - 1),
-    normalizedMaxMs,
-  );
-  return addJitter(delay, normalizedJitterFactor);
+	const useNamedParams =
+		typeof attemptOrOptions === "object" && attemptOrOptions !== null;
+	const normalizedAttempt = useNamedParams
+		? (attemptOrOptions as ExponentialBackoffOptions).attempt
+		: attemptOrOptions;
+	const normalizedBaseMs = useNamedParams
+		? ((attemptOrOptions as ExponentialBackoffOptions).baseMs ?? 1000)
+		: baseMs;
+	const normalizedMaxMs = useNamedParams
+		? ((attemptOrOptions as ExponentialBackoffOptions).maxMs ?? 60000)
+		: maxMs;
+	const normalizedJitterFactor = useNamedParams
+		? ((attemptOrOptions as ExponentialBackoffOptions).jitterFactor ?? 0.1)
+		: jitterFactor;
+	if (!Number.isInteger(normalizedAttempt) || normalizedAttempt < 1) {
+		throw new TypeError(
+			"exponentialBackoff requires attempt to be a positive integer",
+		);
+	}
+	if (!Number.isFinite(normalizedBaseMs) || normalizedBaseMs < 0) {
+		throw new TypeError(
+			"exponentialBackoff requires baseMs to be a finite non-negative number",
+		);
+	}
+	if (!Number.isFinite(normalizedMaxMs) || normalizedMaxMs < 0) {
+		throw new TypeError(
+			"exponentialBackoff requires maxMs to be a finite non-negative number",
+		);
+	}
+	if (
+		!Number.isFinite(normalizedJitterFactor) ||
+		normalizedJitterFactor < 0 ||
+		normalizedJitterFactor > 1
+	) {
+		throw new TypeError(
+			"exponentialBackoff requires jitterFactor to be between 0 and 1",
+		);
+	}
+	const delay = Math.min(
+		normalizedBaseMs * Math.pow(2, normalizedAttempt - 1),
+		normalizedMaxMs,
+	);
+	return addJitter(delay, normalizedJitterFactor);
 }
 
 // ============================================================================
@@ -543,21 +605,25 @@ export function exponentialBackoff(
 let healthTrackerInstance: HealthScoreTracker | null = null;
 let tokenTrackerInstance: TokenBucketTracker | null = null;
 
-export function getHealthTracker(config?: Partial<HealthScoreConfig>): HealthScoreTracker {
-  if (!healthTrackerInstance) {
-    healthTrackerInstance = new HealthScoreTracker(config);
-  }
-  return healthTrackerInstance;
+export function getHealthTracker(
+	config?: Partial<HealthScoreConfig>,
+): HealthScoreTracker {
+	if (!healthTrackerInstance) {
+		healthTrackerInstance = new HealthScoreTracker(config);
+	}
+	return healthTrackerInstance;
 }
 
-export function getTokenTracker(config?: Partial<TokenBucketConfig>): TokenBucketTracker {
-  if (!tokenTrackerInstance) {
-    tokenTrackerInstance = new TokenBucketTracker(config);
-  }
-  return tokenTrackerInstance;
+export function getTokenTracker(
+	config?: Partial<TokenBucketConfig>,
+): TokenBucketTracker {
+	if (!tokenTrackerInstance) {
+		tokenTrackerInstance = new TokenBucketTracker(config);
+	}
+	return tokenTrackerInstance;
 }
 
 export function resetTrackers(): void {
-  healthTrackerInstance?.clear();
-  tokenTrackerInstance?.clear();
+	healthTrackerInstance?.clear();
+	tokenTrackerInstance?.clear();
 }

--- a/lib/routing-mutex.ts
+++ b/lib/routing-mutex.ts
@@ -1,0 +1,162 @@
+/**
+ * Routing Mutex Module (PR-N / R4)
+ *
+ * Provides an in-memory, promise-chain-based async mutex used to serialize
+ * cursor mutation sites in the account rotation pipeline (see `lib/accounts.ts`).
+ *
+ * Concurrency background:
+ *   The legacy rotation path reads `activeIndex` / `activeIndexByFamily`, picks
+ *   a candidate, and then writes the cursor back without any lock. Two
+ *   simultaneous requests can therefore (a) observe the same `activeIndex`,
+ *   (b) both decide to rotate to the same candidate, and (c) race on
+ *   `markSwitched` / `markAccountCoolingDown`. The resulting "lost update"
+ *   window allows the same account to be chosen twice inside a single
+ *   cooldown window.
+ *
+ * Rollout:
+ *   Gated behind `PluginConfig.routingMutex` = `"legacy" | "enabled"`.
+ *   Default is `"legacy"` for one full release cycle so existing users see
+ *   zero behaviour change. When flipped to `"enabled"` the mutex serializes
+ *   every cursor-mutation critical section through `runExclusive`.
+ *
+ * Non-goals:
+ *   - No new runtime dependency. This file intentionally avoids importing
+ *     `async-mutex` or similar npm packages.
+ *   - No cross-process coordination. The pool manager is a single in-process
+ *     singleton; OS-level mutexes are out of scope for this PR.
+ */
+
+export type RoutingMutexMode = "enabled" | "legacy";
+
+/**
+ * Single selection decision emitted by the rotation pipeline.
+ *
+ * Threaded through the fetch loop so downstream consumers (observability,
+ * why-selected trace, failure-policy telemetry) can inspect *why* a
+ * particular account was picked for a given request without recomputing
+ * scores.
+ *
+ * All fields are optional except the core identity + reason + timestamp so
+ * the record can be produced from both the legacy fast-path and the full
+ * scoring path.
+ */
+export interface SelectionRecord {
+	/** Index of the selected account inside the managed pool. */
+	accountIndex: number;
+	/** Stable account identifier (accountId, email, or runtime key). */
+	accountId: string;
+	/** Coarse-grained classification of why this account was selected. */
+	reason: "initial" | "rotation" | "rate-limit" | "best" | "restore";
+	/** Wall-clock timestamp (ms since epoch) when the decision was made. */
+	timestamp: number;
+	/** Quota tracker key (e.g. `"codex"` or `"codex:gpt-5-codex"`) when scoped. */
+	trackerKeyQuota?: string;
+	/** Health score (0-100) used when ranking candidates. */
+	health?: number;
+	/** Token bucket remaining count used when ranking candidates. */
+	tokens?: number;
+	/** Final hybrid score used during selection. */
+	score?: number;
+}
+
+/**
+ * Minimal async mutex contract. Intentionally small so we can swap in a
+ * different implementation (e.g. with debounced fairness) without breaking
+ * callers.
+ */
+export interface AsyncMutex {
+	/**
+	 * Run `fn` while holding the mutex. The mutex is released automatically
+	 * whether `fn` resolves or throws. Errors are propagated to the caller.
+	 */
+	runExclusive<T>(fn: () => Promise<T> | T): Promise<T>;
+	/** Returns true while some critical section is executing. */
+	isLocked(): boolean;
+	/** Number of queued (not yet running) tasks. */
+	queueLength(): number;
+}
+
+/**
+ * Create a promise-chain async mutex.
+ *
+ * Implementation notes:
+ *   - Serialization is achieved by chaining each new task onto the previous
+ *     task's completion settle. Using `.catch(() => {})` on the chain head
+ *     prevents a rejected task from poisoning subsequent waiters.
+ *   - `runExclusive` always returns a fresh promise that resolves/rejects
+ *     with the task's own result.
+ *   - `isLocked` and `queueLength` are bookkeeping counters; they do not
+ *     influence execution order.
+ */
+export function createAsyncMutex(): AsyncMutex {
+	let tail: Promise<void> = Promise.resolve();
+	let running = 0;
+	let queued = 0;
+
+	const runExclusive = async <T>(fn: () => Promise<T> | T): Promise<T> => {
+		queued += 1;
+		const previous = tail;
+		let release: (() => void) | undefined;
+		const next = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		tail = next;
+		try {
+			await previous.catch(() => {
+				// Swallow upstream failures; each task reports its own error
+				// via the returned promise. This keeps the chain alive.
+			});
+			queued = Math.max(0, queued - 1);
+			running += 1;
+			return await fn();
+		} finally {
+			running = Math.max(0, running - 1);
+			release?.();
+		}
+	};
+
+	return {
+		runExclusive,
+		isLocked: () => running > 0,
+		queueLength: () => queued,
+	};
+}
+
+let routingMutexInstance: AsyncMutex | null = null;
+
+/**
+ * Singleton accessor for the rotation critical-section mutex.
+ *
+ * Callers in `lib/accounts.ts` use this when the plugin config flag
+ * `routingMutex === "enabled"`; the legacy mode bypasses the mutex entirely
+ * (no wait, no allocation).
+ */
+export function getRoutingMutex(): AsyncMutex {
+	if (!routingMutexInstance) {
+		routingMutexInstance = createAsyncMutex();
+	}
+	return routingMutexInstance;
+}
+
+/**
+ * Test-only reset so each vitest file starts from a clean mutex state.
+ * Not exported through `lib/index.ts`.
+ */
+export function __resetRoutingMutexForTests(): void {
+	routingMutexInstance = null;
+}
+
+/**
+ * Run `fn` under the routing mutex when `mode === "enabled"`, otherwise run
+ * it inline. Hot-path helper used by account-pool mutation sites so the
+ * flag check stays O(1) per call.
+ */
+export async function withRoutingMutex<T>(
+	mode: RoutingMutexMode,
+	fn: () => Promise<T> | T,
+): Promise<T> {
+	if (mode === "enabled") {
+		return getRoutingMutex().runExclusive(fn);
+	}
+	return await fn();
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -24,10 +24,9 @@ export const PluginConfigSchema = z.object({
 	unsupportedCodexPolicy: z.enum(["strict", "fallback"]).optional(),
 	fallbackOnUnsupportedCodexModel: z.boolean().optional(),
 	fallbackToGpt52OnUnsupportedGpt53: z.boolean().optional(),
-	unsupportedCodexFallbackChain: z.record(
-		z.string(),
-		z.array(z.string().min(1)),
-	).optional(),
+	unsupportedCodexFallbackChain: z
+		.record(z.string(), z.array(z.string().min(1)))
+		.optional(),
 	tokenRefreshSkewMs: z.number().min(0).optional(),
 	rateLimitToastDebounceMs: z.number().min(0).optional(),
 	toastDurationMs: z.number().min(1000).optional(),
@@ -63,6 +62,7 @@ export const PluginConfigSchema = z.object({
 	preemptiveQuotaRemainingPercent5h: z.number().min(0).max(100).optional(),
 	preemptiveQuotaRemainingPercent7d: z.number().min(0).max(100).optional(),
 	preemptiveQuotaMaxDeferralMs: z.number().min(1_000).optional(),
+	routingMutex: z.enum(["enabled", "legacy"]).optional(),
 });
 
 export type PluginConfigFromSchema = z.infer<typeof PluginConfigSchema>;
@@ -74,14 +74,24 @@ export type PluginConfigFromSchema = z.infer<typeof PluginConfigSchema>;
 /**
  * Source of the accountId used for ChatGPT requests.
  */
-export const AccountIdSourceSchema = z.enum(["token", "id_token", "org", "manual"]);
+export const AccountIdSourceSchema = z.enum([
+	"token",
+	"id_token",
+	"org",
+	"manual",
+]);
 
 export type AccountIdSourceFromSchema = z.infer<typeof AccountIdSourceSchema>;
 
 /**
  * Cooldown reason for temporary account suspension.
  */
-export const CooldownReasonSchema = z.enum(["auth-failure", "network-error", "server-error", "rate-limit"]);
+export const CooldownReasonSchema = z.enum([
+	"auth-failure",
+	"network-error",
+	"server-error",
+	"rate-limit",
+]);
 
 export type CooldownReasonFromSchema = z.infer<typeof CooldownReasonSchema>;
 
@@ -101,7 +111,10 @@ export type SwitchReasonFromSchema = z.infer<typeof SwitchReasonSchema>;
 /**
  * Rate limit state - maps model family to reset timestamp.
  */
-export const RateLimitStateV3Schema = z.record(z.string(), z.number().optional());
+export const RateLimitStateV3Schema = z.record(
+	z.string(),
+	z.number().optional(),
+);
 
 export type RateLimitStateV3FromSchema = z.infer<typeof RateLimitStateV3Schema>;
 
@@ -125,17 +138,29 @@ export const AccountMetadataV3Schema = z.object({
 	cooldownReason: CooldownReasonSchema.optional(),
 });
 
-export type AccountMetadataV3FromSchema = z.infer<typeof AccountMetadataV3Schema>;
+export type AccountMetadataV3FromSchema = z.infer<
+	typeof AccountMetadataV3Schema
+>;
 
 /**
  * Build activeIndexByFamily schema dynamically from MODEL_FAMILIES.
  */
-const modelFamilyEntries = MODEL_FAMILIES.map((family) => [family, z.number().optional()]);
-export const ActiveIndexByFamilySchema = z.object(
-	Object.fromEntries(modelFamilyEntries) as Record<ModelFamily, z.ZodOptional<z.ZodNumber>>
-).partial();
+const modelFamilyEntries = MODEL_FAMILIES.map((family) => [
+	family,
+	z.number().optional(),
+]);
+export const ActiveIndexByFamilySchema = z
+	.object(
+		Object.fromEntries(modelFamilyEntries) as Record<
+			ModelFamily,
+			z.ZodOptional<z.ZodNumber>
+		>,
+	)
+	.partial();
 
-export type ActiveIndexByFamilyFromSchema = z.infer<typeof ActiveIndexByFamilySchema>;
+export type ActiveIndexByFamilyFromSchema = z.infer<
+	typeof ActiveIndexByFamilySchema
+>;
 
 /**
  * Account storage V3 - current storage format with per-family active indices.
@@ -169,7 +194,9 @@ export const AccountMetadataV1Schema = z.object({
 	cooldownReason: CooldownReasonSchema.optional(),
 });
 
-export type AccountMetadataV1FromSchema = z.infer<typeof AccountMetadataV1Schema>;
+export type AccountMetadataV1FromSchema = z.infer<
+	typeof AccountMetadataV1Schema
+>;
 
 /**
  * Legacy V1 storage format for migration support.
@@ -190,7 +217,9 @@ export const AnyAccountStorageSchema = z.discriminatedUnion("version", [
 	AccountStorageV3Schema,
 ]);
 
-export type AnyAccountStorageFromSchema = z.infer<typeof AnyAccountStorageSchema>;
+export type AnyAccountStorageFromSchema = z.infer<
+	typeof AnyAccountStorageSchema
+>;
 
 // ============================================================================
 // Token Result Schemas
@@ -207,7 +236,9 @@ export const TokenFailureReasonSchema = z.enum([
 	"unknown",
 ]);
 
-export type TokenFailureReasonFromSchema = z.infer<typeof TokenFailureReasonSchema>;
+export type TokenFailureReasonFromSchema = z.infer<
+	typeof TokenFailureReasonSchema
+>;
 
 /**
  * Successful token exchange result.
@@ -261,7 +292,9 @@ export const OAuthTokenResponseSchema = z.object({
 	scope: z.string().optional(),
 });
 
-export type OAuthTokenResponseFromSchema = z.infer<typeof OAuthTokenResponseSchema>;
+export type OAuthTokenResponseFromSchema = z.infer<
+	typeof OAuthTokenResponseSchema
+>;
 
 // ============================================================================
 // Helper Functions
@@ -271,7 +304,9 @@ export type OAuthTokenResponseFromSchema = z.infer<typeof OAuthTokenResponseSche
  * Safely parse plugin configuration with detailed error logging.
  * Returns null on failure, allowing graceful degradation.
  */
-export function safeParsePluginConfig(data: unknown): PluginConfigFromSchema | null {
+export function safeParsePluginConfig(
+	data: unknown,
+): PluginConfigFromSchema | null {
 	const result = PluginConfigSchema.safeParse(data);
 	if (!result.success) {
 		return null;
@@ -283,7 +318,9 @@ export function safeParsePluginConfig(data: unknown): PluginConfigFromSchema | n
  * Safely parse account storage (any version).
  * Returns null on failure, allowing graceful degradation.
  */
-export function safeParseAccountStorage(data: unknown): AnyAccountStorageFromSchema | null {
+export function safeParseAccountStorage(
+	data: unknown,
+): AnyAccountStorageFromSchema | null {
 	const result = AnyAccountStorageSchema.safeParse(data);
 	if (!result.success) {
 		return null;
@@ -295,7 +332,9 @@ export function safeParseAccountStorage(data: unknown): AnyAccountStorageFromSch
  * Safely parse V3 account storage specifically.
  * Returns null on failure.
  */
-export function safeParseAccountStorageV3(data: unknown): AccountStorageV3FromSchema | null {
+export function safeParseAccountStorageV3(
+	data: unknown,
+): AccountStorageV3FromSchema | null {
 	const result = AccountStorageV3Schema.safeParse(data);
 	if (!result.success) {
 		return null;
@@ -307,7 +346,9 @@ export function safeParseAccountStorageV3(data: unknown): AccountStorageV3FromSc
  * Safely parse token result.
  * Returns null on failure.
  */
-export function safeParseTokenResult(data: unknown): TokenResultFromSchema | null {
+export function safeParseTokenResult(
+	data: unknown,
+): TokenResultFromSchema | null {
 	const result = TokenResultSchema.safeParse(data);
 	if (!result.success) {
 		return null;
@@ -319,7 +360,9 @@ export function safeParseTokenResult(data: unknown): TokenResultFromSchema | nul
  * Safely parse OAuth token response from API.
  * Returns null on failure.
  */
-export function safeParseOAuthTokenResponse(data: unknown): OAuthTokenResponseFromSchema | null {
+export function safeParseOAuthTokenResponse(
+	data: unknown,
+): OAuthTokenResponseFromSchema | null {
 	const result = OAuthTokenResponseSchema.safeParse(data);
 	if (!result.success) {
 		return null;
@@ -331,7 +374,10 @@ export function safeParseOAuthTokenResponse(data: unknown): OAuthTokenResponseFr
  * Get validation errors as a flat array of strings.
  * Useful for logging and error messages.
  */
-export function getValidationErrors(schema: z.ZodType, data: unknown): string[] {
+export function getValidationErrors(
+	schema: z.ZodType,
+	data: unknown,
+): string[] {
 	const result = schema.safeParse(data);
 	if (result.success) {
 		return [];

--- a/test/accounts-routing-mutex.test.ts
+++ b/test/accounts-routing-mutex.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { AccountManager } from "../lib/accounts.js";
+import { __resetRoutingMutexForTests } from "../lib/routing-mutex.js";
+
+function buildStored(now: number) {
+	return {
+		version: 3 as const,
+		activeIndex: 0,
+		accounts: [
+			{
+				refreshToken: "rt-0",
+				email: "a@example.com",
+				addedAt: now,
+				lastUsed: now,
+			},
+			{
+				refreshToken: "rt-1",
+				email: "b@example.com",
+				addedAt: now,
+				lastUsed: now,
+			},
+			{
+				refreshToken: "rt-2",
+				email: "c@example.com",
+				addedAt: now,
+				lastUsed: now,
+			},
+		],
+	};
+}
+
+describe("AccountManager routing-mutex integration (PR-N / R4)", () => {
+	afterEach(() => __resetRoutingMutexForTests());
+
+	it("defaults to legacy mode on construction", () => {
+		const manager = new AccountManager(undefined, buildStored(Date.now()));
+		expect(manager.getRoutingMutexMode()).toBe("legacy");
+	});
+
+	it("setRoutingMutexMode toggles to enabled", () => {
+		const manager = new AccountManager(undefined, buildStored(Date.now()));
+		manager.setRoutingMutexMode("enabled");
+		expect(manager.getRoutingMutexMode()).toBe("enabled");
+	});
+
+	it("markSwitchedLocked returns a SelectionRecord in legacy mode", async () => {
+		const manager = new AccountManager(undefined, buildStored(Date.now()));
+		const account = manager.getAccountByIndex(1);
+		expect(account).not.toBeNull();
+		const record = await manager.markSwitchedLocked(
+			account!,
+			"rotation",
+			"codex",
+			{ trackerKeyQuota: "codex:gpt-5-codex", score: 512 },
+		);
+		expect(record.accountIndex).toBe(1);
+		expect(record.reason).toBe("rotation");
+		expect(record.trackerKeyQuota).toBe("codex:gpt-5-codex");
+		expect(record.score).toBe(512);
+		expect(typeof record.health).toBe("number");
+		expect(typeof record.tokens).toBe("number");
+	});
+
+	it("markSwitchedLocked serializes concurrent mutations in enabled mode", async () => {
+		const manager = new AccountManager(undefined, buildStored(Date.now()));
+		manager.setRoutingMutexMode("enabled");
+
+		const a0 = manager.getAccountByIndex(0)!;
+		const a1 = manager.getAccountByIndex(1)!;
+		const a2 = manager.getAccountByIndex(2)!;
+
+		const results = await Promise.all([
+			manager.markSwitchedLocked(a0, "rotation", "codex"),
+			manager.markSwitchedLocked(a1, "rotation", "codex"),
+			manager.markSwitchedLocked(a2, "rotation", "codex"),
+		]);
+
+		expect(results.map((r) => r.accountIndex)).toEqual([0, 1, 2]);
+		// Final committed active index is the last serialized write.
+		expect(manager.getActiveIndex()).toBe(2);
+	});
+
+	it("markAccountCoolingDownLocked applies cooldown atomically", async () => {
+		const manager = new AccountManager(undefined, buildStored(Date.now()));
+		manager.setRoutingMutexMode("enabled");
+
+		const account = manager.getAccountByIndex(1)!;
+		await manager.markAccountCoolingDownLocked(
+			account,
+			30_000,
+			"network-error",
+		);
+
+		expect(account.cooldownReason).toBe("network-error");
+		expect(account.coolingDownUntil).toBeGreaterThan(Date.now());
+	});
+
+	it("setActiveIndexLocked preserves sync semantics (out of range → null)", async () => {
+		const manager = new AccountManager(undefined, buildStored(Date.now()));
+		manager.setRoutingMutexMode("enabled");
+
+		expect(await manager.setActiveIndexLocked(-1)).toBeNull();
+		expect(await manager.setActiveIndexLocked(99)).toBeNull();
+		const chosen = await manager.setActiveIndexLocked(2);
+		expect(chosen).not.toBeNull();
+		expect(manager.getActiveIndex()).toBe(2);
+	});
+
+	it("flag flip is O(1) per call (no leaked state)", async () => {
+		const manager = new AccountManager(undefined, buildStored(Date.now()));
+		const account = manager.getAccountByIndex(1)!;
+
+		manager.setRoutingMutexMode("enabled");
+		await manager.markSwitchedLocked(account, "rotation", "codex");
+		manager.setRoutingMutexMode("legacy");
+		await manager.markSwitchedLocked(account, "rotation", "codex");
+		manager.setRoutingMutexMode("enabled");
+		await manager.markSwitchedLocked(account, "rotation", "codex");
+
+		expect(manager.getRoutingMutexMode()).toBe("enabled");
+	});
+});

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
 	__resetConfigWarningCacheForTests,
 	loadPluginConfig,
@@ -27,16 +27,16 @@ import {
 	getPreemptiveQuotaMaxDeferralMs,
 	getResponseContinuation,
 	getBackgroundResponses,
-} from '../lib/config.js';
-import type { PluginConfig } from '../lib/types.js';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
-import * as logger from '../lib/logger.js';
+} from "../lib/config.js";
+import type { PluginConfig } from "../lib/types.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as logger from "../lib/logger.js";
 
 // Mock the fs module
-vi.mock('node:fs', async () => {
-	const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+vi.mock("node:fs", async () => {
+	const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
 	return {
 		...actual,
 		existsSync: vi.fn(),
@@ -45,42 +45,47 @@ vi.mock('node:fs', async () => {
 });
 
 // Mock the logger module to track warnings
-vi.mock('../lib/logger.js', async () => {
-	const actual = await vi.importActual<typeof import('../lib/logger.js')>('../lib/logger.js');
+vi.mock("../lib/logger.js", async () => {
+	const actual =
+		await vi.importActual<typeof import("../lib/logger.js")>(
+			"../lib/logger.js",
+		);
 	return {
 		...actual,
 		logWarn: vi.fn(),
 	};
 });
 
-describe('Plugin Configuration', () => {
+describe("Plugin Configuration", () => {
 	const mockExistsSync = vi.mocked(fs.existsSync);
 	const mockReadFileSync = vi.mocked(fs.readFileSync);
 	const envKeys = [
-		'CODEX_HOME',
-		'CODEX_MULTI_AUTH_DIR',
-		'CODEX_MODE',
-		'CODEX_TUI_V2',
-		'CODEX_TUI_COLOR_PROFILE',
-		'CODEX_TUI_GLYPHS',
-		'CODEX_AUTH_FAST_SESSION',
-		'CODEX_AUTH_FAST_SESSION_STRATEGY',
-		'CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS',
-		'CODEX_AUTH_UNSUPPORTED_MODEL_POLICY',
-		'CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL',
-		'CODEX_AUTH_FALLBACK_GPT53_TO_GPT52',
-		'CODEX_AUTH_RESPONSE_CONTINUATION',
-		'CODEX_AUTH_BACKGROUND_RESPONSES',
-		'CODEX_AUTH_PREEMPTIVE_QUOTA_ENABLED',
-		'CODEX_AUTH_PREEMPTIVE_QUOTA_5H_REMAINING_PCT',
-		'CODEX_AUTH_PREEMPTIVE_QUOTA_7D_REMAINING_PCT',
-		'CODEX_AUTH_PREEMPTIVE_QUOTA_MAX_DEFERRAL_MS',
-		'CODEX_AUTH_RATE_LIMIT_DEDUP_WINDOW_MS',
-		'CODEX_AUTH_RATE_LIMIT_STATE_RESET_MS',
-		'CODEX_AUTH_RATE_LIMIT_MAX_BACKOFF_MS',
-		'CODEX_AUTH_RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS',
+		"CODEX_HOME",
+		"CODEX_MULTI_AUTH_DIR",
+		"CODEX_MODE",
+		"CODEX_TUI_V2",
+		"CODEX_TUI_COLOR_PROFILE",
+		"CODEX_TUI_GLYPHS",
+		"CODEX_AUTH_FAST_SESSION",
+		"CODEX_AUTH_FAST_SESSION_STRATEGY",
+		"CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS",
+		"CODEX_AUTH_UNSUPPORTED_MODEL_POLICY",
+		"CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL",
+		"CODEX_AUTH_FALLBACK_GPT53_TO_GPT52",
+		"CODEX_AUTH_RESPONSE_CONTINUATION",
+		"CODEX_AUTH_BACKGROUND_RESPONSES",
+		"CODEX_AUTH_PREEMPTIVE_QUOTA_ENABLED",
+		"CODEX_AUTH_PREEMPTIVE_QUOTA_5H_REMAINING_PCT",
+		"CODEX_AUTH_PREEMPTIVE_QUOTA_7D_REMAINING_PCT",
+		"CODEX_AUTH_PREEMPTIVE_QUOTA_MAX_DEFERRAL_MS",
+		"CODEX_AUTH_RATE_LIMIT_DEDUP_WINDOW_MS",
+		"CODEX_AUTH_RATE_LIMIT_STATE_RESET_MS",
+		"CODEX_AUTH_RATE_LIMIT_MAX_BACKOFF_MS",
+		"CODEX_AUTH_RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS",
 	] as const;
-	const originalEnv: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
+	const originalEnv: Partial<
+		Record<(typeof envKeys)[number], string | undefined>
+	> = {};
 
 	beforeEach(() => {
 		for (const key of envKeys) {
@@ -101,8 +106,8 @@ describe('Plugin Configuration', () => {
 		}
 	});
 
-	describe('loadPluginConfig', () => {
-		it('should return default config when file does not exist', () => {
+	describe("loadPluginConfig", () => {
+		it("should return default config when file does not exist", () => {
 			mockExistsSync.mockReturnValue(false);
 
 			const config = loadPluginConfig();
@@ -110,15 +115,15 @@ describe('Plugin Configuration', () => {
 			expect(config).toEqual({
 				codexMode: true,
 				codexTuiV2: true,
-				codexTuiColorProfile: 'truecolor',
-				codexTuiGlyphMode: 'ascii',
+				codexTuiColorProfile: "truecolor",
+				codexTuiGlyphMode: "ascii",
 				fastSession: false,
-				fastSessionStrategy: 'hybrid',
+				fastSessionStrategy: "hybrid",
 				fastSessionMaxInputItems: 30,
 				retryAllAccountsRateLimited: false,
 				retryAllAccountsMaxWaitMs: 0,
 				retryAllAccountsMaxRetries: 0,
-				unsupportedCodexPolicy: 'strict',
+				unsupportedCodexPolicy: "strict",
 				fallbackOnUnsupportedCodexModel: false,
 				fallbackToGpt52OnUnsupportedGpt53: true,
 				unsupportedCodexFallbackChain: {},
@@ -157,15 +162,21 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				routingMutex: "legacy",
 			});
 			// existsSync is called with multiple candidate config paths (primary + legacy fallbacks)
 			expect(mockExistsSync).toHaveBeenCalled();
-			expect(mockExistsSync.mock.calls.some(([p]) =>
-				typeof p === 'string' && p.includes('config') && p.includes('codex')
-			)).toBe(true);
+			expect(
+				mockExistsSync.mock.calls.some(
+					([p]) =>
+						typeof p === "string" &&
+						p.includes("config") &&
+						p.includes("codex"),
+				),
+			).toBe(true);
 		});
 
-		it('should load config from file when it exists', () => {
+		it("should load config from file when it exists", () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue(JSON.stringify({ codexMode: false }));
 
@@ -174,15 +185,15 @@ describe('Plugin Configuration', () => {
 			expect(config).toEqual({
 				codexMode: false,
 				codexTuiV2: true,
-				codexTuiColorProfile: 'truecolor',
-				codexTuiGlyphMode: 'ascii',
+				codexTuiColorProfile: "truecolor",
+				codexTuiGlyphMode: "ascii",
 				fastSession: false,
-				fastSessionStrategy: 'hybrid',
+				fastSessionStrategy: "hybrid",
 				fastSessionMaxInputItems: 30,
 				retryAllAccountsRateLimited: false,
 				retryAllAccountsMaxWaitMs: 0,
 				retryAllAccountsMaxRetries: 0,
-				unsupportedCodexPolicy: 'strict',
+				unsupportedCodexPolicy: "strict",
 				fallbackOnUnsupportedCodexModel: false,
 				fallbackToGpt52OnUnsupportedGpt53: true,
 				unsupportedCodexFallbackChain: {},
@@ -221,10 +232,11 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				routingMutex: "legacy",
 			});
 		});
 
-		it('loads responseContinuation from disk config', () => {
+		it("loads responseContinuation from disk config", () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue(
 				JSON.stringify({ responseContinuation: true }),
@@ -233,96 +245,41 @@ describe('Plugin Configuration', () => {
 			expect(loadPluginConfig().responseContinuation).toBe(true);
 		});
 
-		it('should detect CODEX_HOME legacy auth config path before global legacy path', async () => {
+		it("should detect CODEX_HOME legacy auth config path before global legacy path", async () => {
 			const runWithCodexHome = async (codexHomePath: string) => {
 				vi.resetModules();
 				process.env.CODEX_HOME = codexHomePath;
-				const expectedPath = path.join(codexHomePath, 'openai-codex-auth-config.json');
-
-				const existsSyncMock = vi.fn((candidate: unknown) =>
-					typeof candidate === 'string' && candidate === expectedPath
+				const expectedPath = path.join(
+					codexHomePath,
+					"openai-codex-auth-config.json",
 				);
-				const readFileSyncMock = vi.fn((filePath: unknown) => {
-					if (filePath === expectedPath) {
-						return JSON.stringify({ codexMode: false });
-					}
-					throw new Error('ENOENT');
-				});
-				const logWarnMock = vi.fn();
-
-				vi.doMock('node:fs', async () => {
-					const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
-					return {
-						...actual,
-						existsSync: existsSyncMock,
-						readFileSync: readFileSyncMock,
-					};
-				});
-				vi.doMock('../lib/logger.js', async () => {
-					const actual = await vi.importActual<typeof import('../lib/logger.js')>('../lib/logger.js');
-					return {
-						...actual,
-						logWarn: logWarnMock,
-					};
-				});
-
-				try {
-					const cfg = await import('../lib/config.js');
-					const config = cfg.loadPluginConfig();
-					return { config, expectedPath, readFileSyncMock, logWarnMock };
-				} finally {
-					vi.doUnmock('node:fs');
-					vi.doUnmock('../lib/logger.js');
-				}
-			};
-
-			const posixResult = await runWithCodexHome(path.join(process.cwd(), '.tmp-codex-home'));
-			expect(posixResult.config.codexMode).toBe(false);
-			expect(posixResult.readFileSyncMock).toHaveBeenCalledWith(posixResult.expectedPath, 'utf-8');
-			expect(posixResult.logWarnMock).toHaveBeenCalledWith(
-				expect.stringContaining(posixResult.expectedPath),
-			);
-
-			const windowsHome = String.raw`C:\Users\test\.codex-home`;
-			const windowsResult = await runWithCodexHome(windowsHome);
-			expect(windowsResult.config.codexMode).toBe(false);
-			expect(windowsResult.expectedPath).toContain('\\');
-			expect(windowsResult.readFileSyncMock).toHaveBeenCalledWith(
-				windowsResult.expectedPath,
-				'utf-8',
-			);
-			expect(windowsResult.logWarnMock).toHaveBeenCalledWith(
-				expect.stringContaining(windowsResult.expectedPath),
-			);
-		});
-
-		it('should detect CODEX_HOME legacy plugin config path before global legacy path', async () => {
-			const runWithCodexHome = async (codexHomePath: string) => {
-				vi.resetModules();
-				process.env.CODEX_HOME = codexHomePath;
-				const expectedPath = path.join(codexHomePath, 'codex-multi-auth-config.json');
 
 				const existsSyncMock = vi.fn(
-					(candidate: unknown) => typeof candidate === 'string' && candidate === expectedPath,
+					(candidate: unknown) =>
+						typeof candidate === "string" && candidate === expectedPath,
 				);
 				const readFileSyncMock = vi.fn((filePath: unknown) => {
 					if (filePath === expectedPath) {
 						return JSON.stringify({ codexMode: false });
 					}
-					throw new Error('ENOENT');
+					throw new Error("ENOENT");
 				});
 				const logWarnMock = vi.fn();
 
-				vi.doMock('node:fs', async () => {
-					const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+				vi.doMock("node:fs", async () => {
+					const actual =
+						await vi.importActual<typeof import("node:fs")>("node:fs");
 					return {
 						...actual,
 						existsSync: existsSyncMock,
 						readFileSync: readFileSyncMock,
 					};
 				});
-				vi.doMock('../lib/logger.js', async () => {
-					const actual = await vi.importActual<typeof import('../lib/logger.js')>('../lib/logger.js');
+				vi.doMock("../lib/logger.js", async () => {
+					const actual =
+						await vi.importActual<typeof import("../lib/logger.js")>(
+							"../lib/logger.js",
+						);
 					return {
 						...actual,
 						logWarn: logWarnMock,
@@ -330,18 +287,23 @@ describe('Plugin Configuration', () => {
 				});
 
 				try {
-					const cfg = await import('../lib/config.js');
+					const cfg = await import("../lib/config.js");
 					const config = cfg.loadPluginConfig();
 					return { config, expectedPath, readFileSyncMock, logWarnMock };
 				} finally {
-					vi.doUnmock('node:fs');
-					vi.doUnmock('../lib/logger.js');
+					vi.doUnmock("node:fs");
+					vi.doUnmock("../lib/logger.js");
 				}
 			};
 
-			const posixResult = await runWithCodexHome(path.join(process.cwd(), '.tmp-codex-home'));
+			const posixResult = await runWithCodexHome(
+				path.join(process.cwd(), ".tmp-codex-home"),
+			);
 			expect(posixResult.config.codexMode).toBe(false);
-			expect(posixResult.readFileSyncMock).toHaveBeenCalledWith(posixResult.expectedPath, 'utf-8');
+			expect(posixResult.readFileSyncMock).toHaveBeenCalledWith(
+				posixResult.expectedPath,
+				"utf-8",
+			);
 			expect(posixResult.logWarnMock).toHaveBeenCalledWith(
 				expect.stringContaining(posixResult.expectedPath),
 			);
@@ -349,54 +311,137 @@ describe('Plugin Configuration', () => {
 			const windowsHome = String.raw`C:\Users\test\.codex-home`;
 			const windowsResult = await runWithCodexHome(windowsHome);
 			expect(windowsResult.config.codexMode).toBe(false);
-			expect(windowsResult.expectedPath).toContain('\\');
+			expect(windowsResult.expectedPath).toContain("\\");
 			expect(windowsResult.readFileSyncMock).toHaveBeenCalledWith(
 				windowsResult.expectedPath,
-				'utf-8',
+				"utf-8",
 			);
 			expect(windowsResult.logWarnMock).toHaveBeenCalledWith(
 				expect.stringContaining(windowsResult.expectedPath),
 			);
 		});
 
-		it('prefers primary CONFIG_PATH over CODEX_HOME legacy path when both exist', async () => {
+		it("should detect CODEX_HOME legacy plugin config path before global legacy path", async () => {
 			const runWithCodexHome = async (codexHomePath: string) => {
 				vi.resetModules();
 				process.env.CODEX_HOME = codexHomePath;
-				const expectedLegacyPath = path.join(codexHomePath, 'codex-multi-auth-config.json');
-				const isWindowsStyle = codexHomePath.includes('\\');
+				const expectedPath = path.join(
+					codexHomePath,
+					"codex-multi-auth-config.json",
+				);
+
+				const existsSyncMock = vi.fn(
+					(candidate: unknown) =>
+						typeof candidate === "string" && candidate === expectedPath,
+				);
+				const readFileSyncMock = vi.fn((filePath: unknown) => {
+					if (filePath === expectedPath) {
+						return JSON.stringify({ codexMode: false });
+					}
+					throw new Error("ENOENT");
+				});
+				const logWarnMock = vi.fn();
+
+				vi.doMock("node:fs", async () => {
+					const actual =
+						await vi.importActual<typeof import("node:fs")>("node:fs");
+					return {
+						...actual,
+						existsSync: existsSyncMock,
+						readFileSync: readFileSyncMock,
+					};
+				});
+				vi.doMock("../lib/logger.js", async () => {
+					const actual =
+						await vi.importActual<typeof import("../lib/logger.js")>(
+							"../lib/logger.js",
+						);
+					return {
+						...actual,
+						logWarn: logWarnMock,
+					};
+				});
+
+				try {
+					const cfg = await import("../lib/config.js");
+					const config = cfg.loadPluginConfig();
+					return { config, expectedPath, readFileSyncMock, logWarnMock };
+				} finally {
+					vi.doUnmock("node:fs");
+					vi.doUnmock("../lib/logger.js");
+				}
+			};
+
+			const posixResult = await runWithCodexHome(
+				path.join(process.cwd(), ".tmp-codex-home"),
+			);
+			expect(posixResult.config.codexMode).toBe(false);
+			expect(posixResult.readFileSyncMock).toHaveBeenCalledWith(
+				posixResult.expectedPath,
+				"utf-8",
+			);
+			expect(posixResult.logWarnMock).toHaveBeenCalledWith(
+				expect.stringContaining(posixResult.expectedPath),
+			);
+
+			const windowsHome = String.raw`C:\Users\test\.codex-home`;
+			const windowsResult = await runWithCodexHome(windowsHome);
+			expect(windowsResult.config.codexMode).toBe(false);
+			expect(windowsResult.expectedPath).toContain("\\");
+			expect(windowsResult.readFileSyncMock).toHaveBeenCalledWith(
+				windowsResult.expectedPath,
+				"utf-8",
+			);
+			expect(windowsResult.logWarnMock).toHaveBeenCalledWith(
+				expect.stringContaining(windowsResult.expectedPath),
+			);
+		});
+
+		it("prefers primary CONFIG_PATH over CODEX_HOME legacy path when both exist", async () => {
+			const runWithCodexHome = async (codexHomePath: string) => {
+				vi.resetModules();
+				process.env.CODEX_HOME = codexHomePath;
+				const expectedLegacyPath = path.join(
+					codexHomePath,
+					"codex-multi-auth-config.json",
+				);
+				const isWindowsStyle = codexHomePath.includes("\\");
 
 				const existsSyncMock = vi.fn((candidate: unknown) => {
-					if (typeof candidate !== 'string') return false;
-					const normalized = candidate.replace(/\\/g, '/');
+					if (typeof candidate !== "string") return false;
+					const normalized = candidate.replace(/\\/g, "/");
 					return (
-						normalized.endsWith('/multi-auth/config.json') ||
+						normalized.endsWith("/multi-auth/config.json") ||
 						candidate === expectedLegacyPath
 					);
 				});
 				const readFileSyncMock = vi.fn((filePath: unknown) => {
-					if (typeof filePath !== 'string') throw new Error('ENOENT');
-					const normalized = filePath.replace(/\\/g, '/');
-					if (normalized.endsWith('/multi-auth/config.json')) {
+					if (typeof filePath !== "string") throw new Error("ENOENT");
+					const normalized = filePath.replace(/\\/g, "/");
+					if (normalized.endsWith("/multi-auth/config.json")) {
 						return JSON.stringify({ codexMode: true });
 					}
 					if (filePath === expectedLegacyPath) {
 						return JSON.stringify({ codexMode: false });
 					}
-					throw new Error('ENOENT');
+					throw new Error("ENOENT");
 				});
 				const logWarnMock = vi.fn();
 
-				vi.doMock('node:fs', async () => {
-					const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+				vi.doMock("node:fs", async () => {
+					const actual =
+						await vi.importActual<typeof import("node:fs")>("node:fs");
 					return {
 						...actual,
 						existsSync: existsSyncMock,
 						readFileSync: readFileSyncMock,
 					};
 				});
-				vi.doMock('../lib/logger.js', async () => {
-					const actual = await vi.importActual<typeof import('../lib/logger.js')>('../lib/logger.js');
+				vi.doMock("../lib/logger.js", async () => {
+					const actual =
+						await vi.importActual<typeof import("../lib/logger.js")>(
+							"../lib/logger.js",
+						);
 					return {
 						...actual,
 						logWarn: logWarnMock,
@@ -404,38 +449,48 @@ describe('Plugin Configuration', () => {
 				});
 
 				try {
-					const cfg = await import('../lib/config.js');
+					const cfg = await import("../lib/config.js");
 					const config = cfg.loadPluginConfig();
-					return { config, expectedLegacyPath, readFileSyncMock, logWarnMock, isWindowsStyle };
+					return {
+						config,
+						expectedLegacyPath,
+						readFileSyncMock,
+						logWarnMock,
+						isWindowsStyle,
+					};
 				} finally {
-					vi.doUnmock('node:fs');
-					vi.doUnmock('../lib/logger.js');
+					vi.doUnmock("node:fs");
+					vi.doUnmock("../lib/logger.js");
 				}
 			};
 
-			const posixResult = await runWithCodexHome(path.join(process.cwd(), '.tmp-codex-home'));
+			const posixResult = await runWithCodexHome(
+				path.join(process.cwd(), ".tmp-codex-home"),
+			);
 			expect(posixResult.config.codexMode).toBe(true);
 			expect(posixResult.readFileSyncMock).toHaveBeenCalledWith(
 				expect.stringMatching(/multi-auth[\\/]config\.json$/),
-				'utf-8',
+				"utf-8",
 			);
 			expect(posixResult.logWarnMock).not.toHaveBeenCalledWith(
 				expect.stringContaining(posixResult.expectedLegacyPath),
 			);
 
-			const windowsResult = await runWithCodexHome(String.raw`C:\Users\test\.codex-home`);
+			const windowsResult = await runWithCodexHome(
+				String.raw`C:\Users\test\.codex-home`,
+			);
 			expect(windowsResult.isWindowsStyle).toBe(true);
 			expect(windowsResult.config.codexMode).toBe(true);
 			expect(windowsResult.readFileSyncMock).toHaveBeenCalledWith(
 				expect.stringMatching(/multi-auth[\\/]config\.json$/),
-				'utf-8',
+				"utf-8",
 			);
 			expect(windowsResult.logWarnMock).not.toHaveBeenCalledWith(
 				expect.stringContaining(windowsResult.expectedLegacyPath),
 			);
 		});
 
-		it('should merge user config with defaults', () => {
+		it("should merge user config with defaults", () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue(JSON.stringify({}));
 
@@ -444,15 +499,15 @@ describe('Plugin Configuration', () => {
 			expect(config).toEqual({
 				codexMode: true,
 				codexTuiV2: true,
-				codexTuiColorProfile: 'truecolor',
-				codexTuiGlyphMode: 'ascii',
+				codexTuiColorProfile: "truecolor",
+				codexTuiGlyphMode: "ascii",
 				fastSession: false,
-				fastSessionStrategy: 'hybrid',
+				fastSessionStrategy: "hybrid",
 				fastSessionMaxInputItems: 30,
 				retryAllAccountsRateLimited: false,
 				retryAllAccountsMaxWaitMs: 0,
 				retryAllAccountsMaxRetries: 0,
-				unsupportedCodexPolicy: 'strict',
+				unsupportedCodexPolicy: "strict",
 				fallbackOnUnsupportedCodexModel: false,
 				fallbackToGpt52OnUnsupportedGpt53: true,
 				unsupportedCodexFallbackChain: {},
@@ -491,10 +546,11 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				routingMutex: "legacy",
 			});
 		});
 
-		it('should parse UTF-8 BOM-prefixed config files', () => {
+		it("should parse UTF-8 BOM-prefixed config files", () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue('\ufeff{"codexMode":false}');
 
@@ -503,46 +559,46 @@ describe('Plugin Configuration', () => {
 			expect(config.codexMode).toBe(false);
 		});
 
-	it('should handle invalid JSON gracefully', () => {
-		mockExistsSync.mockReturnValue(true);
-		mockReadFileSync.mockReturnValue('invalid json');
+		it("should handle invalid JSON gracefully", () => {
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockReturnValue("invalid json");
 
-		const mockLogWarn = vi.mocked(logger.logWarn);
-		mockLogWarn.mockClear();
-		const config = loadPluginConfig();
+			const mockLogWarn = vi.mocked(logger.logWarn);
+			mockLogWarn.mockClear();
+			const config = loadPluginConfig();
 
-	expect(config).toEqual({
-		codexMode: true,
-		codexTuiV2: true,
-		codexTuiColorProfile: 'truecolor',
-		codexTuiGlyphMode: 'ascii',
-		fastSession: false,
-		fastSessionStrategy: 'hybrid',
-		fastSessionMaxInputItems: 30,
-		retryAllAccountsRateLimited: false,
-		retryAllAccountsMaxWaitMs: 0,
-		retryAllAccountsMaxRetries: 0,
-		unsupportedCodexPolicy: 'strict',
-		fallbackOnUnsupportedCodexModel: false,
-		fallbackToGpt52OnUnsupportedGpt53: true,
-		unsupportedCodexFallbackChain: {},
-		tokenRefreshSkewMs: 60_000,
-		rateLimitToastDebounceMs: 60_000,
-		toastDurationMs: 5_000,
-		perProjectAccounts: true,
-		sessionRecovery: true,
-		autoResume: true,
-		parallelProbing: false,
-		parallelProbingMaxConcurrency: 2,
-		emptyResponseMaxRetries: 2,
-		emptyResponseRetryDelayMs: 1_000,
-		rateLimitDedupWindowMs: 2_000,
-		rateLimitStateResetMs: 120_000,
-		rateLimitMaxBackoffMs: 60_000,
-		rateLimitShortRetryThresholdMs: 5_000,
-		pidOffsetEnabled: false,
-		fetchTimeoutMs: 60_000,
-		streamStallTimeoutMs: 45_000,
+			expect(config).toEqual({
+				codexMode: true,
+				codexTuiV2: true,
+				codexTuiColorProfile: "truecolor",
+				codexTuiGlyphMode: "ascii",
+				fastSession: false,
+				fastSessionStrategy: "hybrid",
+				fastSessionMaxInputItems: 30,
+				retryAllAccountsRateLimited: false,
+				retryAllAccountsMaxWaitMs: 0,
+				retryAllAccountsMaxRetries: 0,
+				unsupportedCodexPolicy: "strict",
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+				unsupportedCodexFallbackChain: {},
+				tokenRefreshSkewMs: 60_000,
+				rateLimitToastDebounceMs: 60_000,
+				toastDurationMs: 5_000,
+				perProjectAccounts: true,
+				sessionRecovery: true,
+				autoResume: true,
+				parallelProbing: false,
+				parallelProbingMaxConcurrency: 2,
+				emptyResponseMaxRetries: 2,
+				emptyResponseRetryDelayMs: 1_000,
+				rateLimitDedupWindowMs: 2_000,
+				rateLimitStateResetMs: 120_000,
+				rateLimitMaxBackoffMs: 60_000,
+				rateLimitShortRetryThresholdMs: 5_000,
+				pidOffsetEnabled: false,
+				fetchTimeoutMs: 60_000,
+				streamStallTimeoutMs: 45_000,
 				liveAccountSync: true,
 				liveAccountSyncDebounceMs: 250,
 				liveAccountSyncPollMs: 2_000,
@@ -561,52 +617,53 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
-	});
-		expect(mockLogWarn).toHaveBeenCalled();
-	});
-
-		it('should handle file read errors gracefully', () => {
-		mockExistsSync.mockReturnValue(true);
-		mockReadFileSync.mockImplementation(() => {
-			throw new Error('Permission denied');
+				routingMutex: "legacy",
+			});
+			expect(mockLogWarn).toHaveBeenCalled();
 		});
 
-		const mockLogWarn = vi.mocked(logger.logWarn);
-		mockLogWarn.mockClear();
-		const config = loadPluginConfig();
+		it("should handle file read errors gracefully", () => {
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockImplementation(() => {
+				throw new Error("Permission denied");
+			});
 
-		expect(config).toEqual({
-			codexMode: true,
-			codexTuiV2: true,
-			codexTuiColorProfile: 'truecolor',
-			codexTuiGlyphMode: 'ascii',
-			fastSession: false,
-			fastSessionStrategy: 'hybrid',
-			fastSessionMaxInputItems: 30,
-			retryAllAccountsRateLimited: false,
-			retryAllAccountsMaxWaitMs: 0,
-			retryAllAccountsMaxRetries: 0,
-			unsupportedCodexPolicy: 'strict',
-			fallbackOnUnsupportedCodexModel: false,
-			fallbackToGpt52OnUnsupportedGpt53: true,
-			unsupportedCodexFallbackChain: {},
-			tokenRefreshSkewMs: 60_000,
-			rateLimitToastDebounceMs: 60_000,
-			toastDurationMs: 5_000,
-			perProjectAccounts: true,
-			sessionRecovery: true,
-			autoResume: true,
-			parallelProbing: false,
-			parallelProbingMaxConcurrency: 2,
-			emptyResponseMaxRetries: 2,
-			emptyResponseRetryDelayMs: 1_000,
-			rateLimitDedupWindowMs: 2_000,
-			rateLimitStateResetMs: 120_000,
-			rateLimitMaxBackoffMs: 60_000,
-			rateLimitShortRetryThresholdMs: 5_000,
-			pidOffsetEnabled: false,
-			fetchTimeoutMs: 60_000,
-			streamStallTimeoutMs: 45_000,
+			const mockLogWarn = vi.mocked(logger.logWarn);
+			mockLogWarn.mockClear();
+			const config = loadPluginConfig();
+
+			expect(config).toEqual({
+				codexMode: true,
+				codexTuiV2: true,
+				codexTuiColorProfile: "truecolor",
+				codexTuiGlyphMode: "ascii",
+				fastSession: false,
+				fastSessionStrategy: "hybrid",
+				fastSessionMaxInputItems: 30,
+				retryAllAccountsRateLimited: false,
+				retryAllAccountsMaxWaitMs: 0,
+				retryAllAccountsMaxRetries: 0,
+				unsupportedCodexPolicy: "strict",
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+				unsupportedCodexFallbackChain: {},
+				tokenRefreshSkewMs: 60_000,
+				rateLimitToastDebounceMs: 60_000,
+				toastDurationMs: 5_000,
+				perProjectAccounts: true,
+				sessionRecovery: true,
+				autoResume: true,
+				parallelProbing: false,
+				parallelProbingMaxConcurrency: 2,
+				emptyResponseMaxRetries: 2,
+				emptyResponseRetryDelayMs: 1_000,
+				rateLimitDedupWindowMs: 2_000,
+				rateLimitStateResetMs: 120_000,
+				rateLimitMaxBackoffMs: 60_000,
+				rateLimitShortRetryThresholdMs: 5_000,
+				pidOffsetEnabled: false,
+				fetchTimeoutMs: 60_000,
+				streamStallTimeoutMs: 45_000,
 				liveAccountSync: true,
 				liveAccountSyncDebounceMs: 250,
 				liveAccountSyncPollMs: 2_000,
@@ -625,18 +682,19 @@ describe('Plugin Configuration', () => {
 				preemptiveQuotaRemainingPercent5h: 5,
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
+				routingMutex: "legacy",
+			});
+			expect(mockLogWarn).toHaveBeenCalled();
 		});
-		expect(mockLogWarn).toHaveBeenCalled();
-	});
 
-		it('should deduplicate repeated validation warnings across multiple loads', () => {
+		it("should deduplicate repeated validation warnings across multiple loads", () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue(
 				JSON.stringify({
 					unsupportedCodexFallbackChain: {
-						'gpt-5.3-codex-spark': 'gpt-5-codex',
+						"gpt-5.3-codex-spark": "gpt-5-codex",
 					},
-				})
+				}),
 			);
 
 			const mockLogWarn = vi.mocked(logger.logWarn);
@@ -646,14 +704,14 @@ describe('Plugin Configuration', () => {
 			loadPluginConfig();
 
 			const validationWarnings = mockLogWarn.mock.calls.filter(([message]) =>
-				String(message).includes('Plugin config validation warnings:')
+				String(message).includes("Plugin config validation warnings:"),
 			);
 			expect(validationWarnings).toHaveLength(1);
 		});
 	});
 
-	describe('getCodexMode', () => {
-		it('should return true by default', () => {
+	describe("getCodexMode", () => {
+		it("should return true by default", () => {
 			delete process.env.CODEX_MODE;
 			const config: PluginConfig = {};
 
@@ -662,7 +720,7 @@ describe('Plugin Configuration', () => {
 			expect(result).toBe(true);
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_MODE;
 			const config: PluginConfig = { codexMode: false };
 
@@ -671,8 +729,8 @@ describe('Plugin Configuration', () => {
 			expect(result).toBe(false);
 		});
 
-		it('should prioritize env var CODEX_MODE=1 over config', () => {
-			process.env.CODEX_MODE = '1';
+		it("should prioritize env var CODEX_MODE=1 over config", () => {
+			process.env.CODEX_MODE = "1";
 			const config: PluginConfig = { codexMode: false };
 
 			const result = getCodexMode(config);
@@ -680,8 +738,8 @@ describe('Plugin Configuration', () => {
 			expect(result).toBe(true);
 		});
 
-		it('should prioritize env var CODEX_MODE=0 over config', () => {
-			process.env.CODEX_MODE = '0';
+		it("should prioritize env var CODEX_MODE=0 over config", () => {
+			process.env.CODEX_MODE = "0";
 			const config: PluginConfig = { codexMode: true };
 
 			const result = getCodexMode(config);
@@ -689,8 +747,8 @@ describe('Plugin Configuration', () => {
 			expect(result).toBe(false);
 		});
 
-		it('should ignore invalid env values and fall back to config/default', () => {
-			process.env.CODEX_MODE = 'maybe';
+		it("should ignore invalid env values and fall back to config/default", () => {
+			process.env.CODEX_MODE = "maybe";
 			const config: PluginConfig = { codexMode: false };
 
 			const result = getCodexMode(config);
@@ -698,7 +756,7 @@ describe('Plugin Configuration', () => {
 			expect(result).toBe(false);
 		});
 
-		it('should use config codexMode=true when explicitly set', () => {
+		it("should use config codexMode=true when explicitly set", () => {
 			delete process.env.CODEX_MODE;
 			const config: PluginConfig = { codexMode: true };
 
@@ -708,135 +766,151 @@ describe('Plugin Configuration', () => {
 		});
 	});
 
-	describe('getResponseContinuation', () => {
-		it('should default to false', () => {
+	describe("getResponseContinuation", () => {
+		it("should default to false", () => {
 			delete process.env.CODEX_AUTH_RESPONSE_CONTINUATION;
 			expect(getResponseContinuation({})).toBe(false);
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_AUTH_RESPONSE_CONTINUATION;
-			expect(getResponseContinuation({ responseContinuation: true })).toBe(true);
+			expect(getResponseContinuation({ responseContinuation: true })).toBe(
+				true,
+			);
 		});
 
-		it('should prioritize env override', () => {
-			process.env.CODEX_AUTH_RESPONSE_CONTINUATION = '1';
-			expect(getResponseContinuation({ responseContinuation: false })).toBe(true);
-			process.env.CODEX_AUTH_RESPONSE_CONTINUATION = '0';
-			expect(getResponseContinuation({ responseContinuation: true })).toBe(false);
+		it("should prioritize env override", () => {
+			process.env.CODEX_AUTH_RESPONSE_CONTINUATION = "1";
+			expect(getResponseContinuation({ responseContinuation: false })).toBe(
+				true,
+			);
+			process.env.CODEX_AUTH_RESPONSE_CONTINUATION = "0";
+			expect(getResponseContinuation({ responseContinuation: true })).toBe(
+				false,
+			);
 		});
 	});
 
-	describe('getBackgroundResponses', () => {
-		it('should default to false', () => {
+	describe("getBackgroundResponses", () => {
+		it("should default to false", () => {
 			delete process.env.CODEX_AUTH_BACKGROUND_RESPONSES;
 			expect(getBackgroundResponses({})).toBe(false);
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_AUTH_BACKGROUND_RESPONSES;
 			expect(getBackgroundResponses({ backgroundResponses: true })).toBe(true);
 		});
 
-		it('should prioritize env override', () => {
-			process.env.CODEX_AUTH_BACKGROUND_RESPONSES = '1';
+		it("should prioritize env override", () => {
+			process.env.CODEX_AUTH_BACKGROUND_RESPONSES = "1";
 			expect(getBackgroundResponses({ backgroundResponses: false })).toBe(true);
-			process.env.CODEX_AUTH_BACKGROUND_RESPONSES = '0';
+			process.env.CODEX_AUTH_BACKGROUND_RESPONSES = "0";
 			expect(getBackgroundResponses({ backgroundResponses: true })).toBe(false);
 		});
 	});
 
-	describe('getCodexTuiV2', () => {
-		it('should default to true', () => {
+	describe("getCodexTuiV2", () => {
+		it("should default to true", () => {
 			delete process.env.CODEX_TUI_V2;
 			expect(getCodexTuiV2({})).toBe(true);
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_TUI_V2;
 			expect(getCodexTuiV2({ codexTuiV2: false })).toBe(false);
 		});
 
-		it('should prioritize env value over config', () => {
-			process.env.CODEX_TUI_V2 = '0';
+		it("should prioritize env value over config", () => {
+			process.env.CODEX_TUI_V2 = "0";
 			expect(getCodexTuiV2({ codexTuiV2: true })).toBe(false);
-			process.env.CODEX_TUI_V2 = '1';
+			process.env.CODEX_TUI_V2 = "1";
 			expect(getCodexTuiV2({ codexTuiV2: false })).toBe(true);
 		});
 	});
 
-	describe('getCodexTuiColorProfile', () => {
-		it('should default to truecolor', () => {
+	describe("getCodexTuiColorProfile", () => {
+		it("should default to truecolor", () => {
 			delete process.env.CODEX_TUI_COLOR_PROFILE;
-			expect(getCodexTuiColorProfile({})).toBe('truecolor');
+			expect(getCodexTuiColorProfile({})).toBe("truecolor");
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_TUI_COLOR_PROFILE;
-			expect(getCodexTuiColorProfile({ codexTuiColorProfile: 'ansi16' })).toBe('ansi16');
+			expect(getCodexTuiColorProfile({ codexTuiColorProfile: "ansi16" })).toBe(
+				"ansi16",
+			);
 		});
 
-		it('should prioritize valid env value over config', () => {
-			process.env.CODEX_TUI_COLOR_PROFILE = 'ansi256';
-			expect(getCodexTuiColorProfile({ codexTuiColorProfile: 'ansi16' })).toBe('ansi256');
+		it("should prioritize valid env value over config", () => {
+			process.env.CODEX_TUI_COLOR_PROFILE = "ansi256";
+			expect(getCodexTuiColorProfile({ codexTuiColorProfile: "ansi16" })).toBe(
+				"ansi256",
+			);
 		});
 
-		it('should ignore invalid env value and fallback to config/default', () => {
-			process.env.CODEX_TUI_COLOR_PROFILE = 'invalid-profile';
-			expect(getCodexTuiColorProfile({ codexTuiColorProfile: 'ansi16' })).toBe('ansi16');
-			expect(getCodexTuiColorProfile({})).toBe('truecolor');
+		it("should ignore invalid env value and fallback to config/default", () => {
+			process.env.CODEX_TUI_COLOR_PROFILE = "invalid-profile";
+			expect(getCodexTuiColorProfile({ codexTuiColorProfile: "ansi16" })).toBe(
+				"ansi16",
+			);
+			expect(getCodexTuiColorProfile({})).toBe("truecolor");
 		});
 	});
 
-	describe('getCodexTuiGlyphMode', () => {
-		it('should default to ascii', () => {
+	describe("getCodexTuiGlyphMode", () => {
+		it("should default to ascii", () => {
 			delete process.env.CODEX_TUI_GLYPHS;
-			expect(getCodexTuiGlyphMode({})).toBe('ascii');
+			expect(getCodexTuiGlyphMode({})).toBe("ascii");
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_TUI_GLYPHS;
-			expect(getCodexTuiGlyphMode({ codexTuiGlyphMode: 'unicode' })).toBe('unicode');
+			expect(getCodexTuiGlyphMode({ codexTuiGlyphMode: "unicode" })).toBe(
+				"unicode",
+			);
 		});
 
-		it('should prioritize valid env value over config', () => {
-			process.env.CODEX_TUI_GLYPHS = 'auto';
-			expect(getCodexTuiGlyphMode({ codexTuiGlyphMode: 'ascii' })).toBe('auto');
+		it("should prioritize valid env value over config", () => {
+			process.env.CODEX_TUI_GLYPHS = "auto";
+			expect(getCodexTuiGlyphMode({ codexTuiGlyphMode: "ascii" })).toBe("auto");
 		});
 
-		it('should ignore invalid env value and fallback to config/default', () => {
-			process.env.CODEX_TUI_GLYPHS = 'invalid';
-			expect(getCodexTuiGlyphMode({ codexTuiGlyphMode: 'unicode' })).toBe('unicode');
-			expect(getCodexTuiGlyphMode({})).toBe('ascii');
+		it("should ignore invalid env value and fallback to config/default", () => {
+			process.env.CODEX_TUI_GLYPHS = "invalid";
+			expect(getCodexTuiGlyphMode({ codexTuiGlyphMode: "unicode" })).toBe(
+				"unicode",
+			);
+			expect(getCodexTuiGlyphMode({})).toBe("ascii");
 		});
 	});
 
-	describe('getFastSession', () => {
-		it('should default to false', () => {
+	describe("getFastSession", () => {
+		it("should default to false", () => {
 			delete process.env.CODEX_AUTH_FAST_SESSION;
 			expect(getFastSession({})).toBe(false);
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_AUTH_FAST_SESSION;
 			expect(getFastSession({ fastSession: true })).toBe(true);
 		});
 
-		it('should prioritize env var over config', () => {
-			process.env.CODEX_AUTH_FAST_SESSION = '0';
+		it("should prioritize env var over config", () => {
+			process.env.CODEX_AUTH_FAST_SESSION = "0";
 			expect(getFastSession({ fastSession: true })).toBe(false);
-			process.env.CODEX_AUTH_FAST_SESSION = '1';
+			process.env.CODEX_AUTH_FAST_SESSION = "1";
 			expect(getFastSession({ fastSession: false })).toBe(true);
 		});
 	});
 
-	describe('getFallbackToGpt52OnUnsupportedGpt53', () => {
-		it('should default to true', () => {
+	describe("getFallbackToGpt52OnUnsupportedGpt53", () => {
+		it("should default to true", () => {
 			delete process.env.CODEX_AUTH_FALLBACK_GPT53_TO_GPT52;
 			expect(getFallbackToGpt52OnUnsupportedGpt53({})).toBe(true);
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_AUTH_FALLBACK_GPT53_TO_GPT52;
 			expect(
 				getFallbackToGpt52OnUnsupportedGpt53({
@@ -845,14 +919,14 @@ describe('Plugin Configuration', () => {
 			).toBe(true);
 		});
 
-		it('should prioritize env var over config', () => {
-			process.env.CODEX_AUTH_FALLBACK_GPT53_TO_GPT52 = '0';
+		it("should prioritize env var over config", () => {
+			process.env.CODEX_AUTH_FALLBACK_GPT53_TO_GPT52 = "0";
 			expect(
 				getFallbackToGpt52OnUnsupportedGpt53({
 					fallbackToGpt52OnUnsupportedGpt53: true,
 				}),
 			).toBe(false);
-			process.env.CODEX_AUTH_FALLBACK_GPT53_TO_GPT52 = '1';
+			process.env.CODEX_AUTH_FALLBACK_GPT53_TO_GPT52 = "1";
 			expect(
 				getFallbackToGpt52OnUnsupportedGpt53({
 					fallbackToGpt52OnUnsupportedGpt53: false,
@@ -861,136 +935,168 @@ describe('Plugin Configuration', () => {
 		});
 	});
 
-	describe('getUnsupportedCodexPolicy', () => {
-		it('should default to strict', () => {
+	describe("getUnsupportedCodexPolicy", () => {
+		it("should default to strict", () => {
 			delete process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY;
 			delete process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL;
-			expect(getUnsupportedCodexPolicy({})).toBe('strict');
+			expect(getUnsupportedCodexPolicy({})).toBe("strict");
 		});
 
-		it('should use config policy when set', () => {
+		it("should use config policy when set", () => {
 			delete process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY;
-			expect(getUnsupportedCodexPolicy({ unsupportedCodexPolicy: 'fallback' })).toBe('fallback');
+			expect(
+				getUnsupportedCodexPolicy({ unsupportedCodexPolicy: "fallback" }),
+			).toBe("fallback");
 		});
 
-		it('should prioritize env policy over config', () => {
-			process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY = 'strict';
-			expect(getUnsupportedCodexPolicy({ unsupportedCodexPolicy: 'fallback' })).toBe('strict');
-			process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY = 'fallback';
-			expect(getUnsupportedCodexPolicy({ unsupportedCodexPolicy: 'strict' })).toBe('fallback');
+		it("should prioritize env policy over config", () => {
+			process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY = "strict";
+			expect(
+				getUnsupportedCodexPolicy({ unsupportedCodexPolicy: "fallback" }),
+			).toBe("strict");
+			process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY = "fallback";
+			expect(
+				getUnsupportedCodexPolicy({ unsupportedCodexPolicy: "strict" }),
+			).toBe("fallback");
 		});
 
-		it('should map legacy fallback flag to fallback policy when policy key missing', () => {
+		it("should map legacy fallback flag to fallback policy when policy key missing", () => {
 			delete process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY;
-			expect(getUnsupportedCodexPolicy({ fallbackOnUnsupportedCodexModel: true })).toBe('fallback');
+			expect(
+				getUnsupportedCodexPolicy({ fallbackOnUnsupportedCodexModel: true }),
+			).toBe("fallback");
 		});
 
-		it('should map legacy env fallback toggle when policy env is unset', () => {
+		it("should map legacy env fallback toggle when policy env is unset", () => {
 			delete process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY;
-			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = '1';
-			expect(getUnsupportedCodexPolicy({})).toBe('fallback');
-			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = '0';
-			expect(getUnsupportedCodexPolicy({})).toBe('strict');
+			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = "1";
+			expect(getUnsupportedCodexPolicy({})).toBe("fallback");
+			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = "0";
+			expect(getUnsupportedCodexPolicy({})).toBe("strict");
 		});
 	});
 
-	describe('getFallbackOnUnsupportedCodexModel', () => {
-		it('should default to false (strict policy)', () => {
+	describe("getFallbackOnUnsupportedCodexModel", () => {
+		it("should default to false (strict policy)", () => {
 			delete process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL;
 			delete process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY;
 			expect(getFallbackOnUnsupportedCodexModel({})).toBe(false);
 		});
 
-		it('should use explicit policy when set', () => {
+		it("should use explicit policy when set", () => {
 			delete process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY;
 			delete process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL;
-			expect(getFallbackOnUnsupportedCodexModel({ unsupportedCodexPolicy: 'fallback' })).toBe(true);
-			expect(getFallbackOnUnsupportedCodexModel({ unsupportedCodexPolicy: 'strict' })).toBe(false);
+			expect(
+				getFallbackOnUnsupportedCodexModel({
+					unsupportedCodexPolicy: "fallback",
+				}),
+			).toBe(true);
+			expect(
+				getFallbackOnUnsupportedCodexModel({
+					unsupportedCodexPolicy: "strict",
+				}),
+			).toBe(false);
 		});
 
-		it('should still support legacy env toggle', () => {
-			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = '0';
+		it("should still support legacy env toggle", () => {
+			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = "0";
 			delete process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY;
 			expect(getFallbackOnUnsupportedCodexModel({})).toBe(false);
-			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = '1';
+			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = "1";
 			expect(getFallbackOnUnsupportedCodexModel({})).toBe(true);
 		});
 
-		it('policy env overrides legacy toggles', () => {
-			process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY = 'strict';
-			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = '1';
-			expect(getFallbackOnUnsupportedCodexModel({ unsupportedCodexPolicy: 'fallback' })).toBe(false);
-			process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY = 'fallback';
-			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = '0';
-			expect(getFallbackOnUnsupportedCodexModel({ unsupportedCodexPolicy: 'strict' })).toBe(true);
+		it("policy env overrides legacy toggles", () => {
+			process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY = "strict";
+			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = "1";
+			expect(
+				getFallbackOnUnsupportedCodexModel({
+					unsupportedCodexPolicy: "fallback",
+				}),
+			).toBe(false);
+			process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY = "fallback";
+			process.env.CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL = "0";
+			expect(
+				getFallbackOnUnsupportedCodexModel({
+					unsupportedCodexPolicy: "strict",
+				}),
+			).toBe(true);
 		});
 	});
 
-	describe('getUnsupportedCodexFallbackChain', () => {
-		it('returns normalized fallback chain entries', () => {
+	describe("getUnsupportedCodexFallbackChain", () => {
+		it("returns normalized fallback chain entries", () => {
 			const result = getUnsupportedCodexFallbackChain({
 				unsupportedCodexFallbackChain: {
-					'OpenAI/GPT-5.3-CODEX-SPARK': [' gpt-5.3-codex ', 'gpt-5.2-codex'],
+					"OpenAI/GPT-5.3-CODEX-SPARK": [" gpt-5.3-codex ", "gpt-5.2-codex"],
 				},
 			});
 
 			expect(result).toEqual({
-				'gpt-5.3-codex-spark': ['gpt-5.3-codex', 'gpt-5.2-codex'],
+				"gpt-5.3-codex-spark": ["gpt-5.3-codex", "gpt-5.2-codex"],
 			});
 		});
 
-		it('returns empty object for missing/invalid chain', () => {
+		it("returns empty object for missing/invalid chain", () => {
 			expect(getUnsupportedCodexFallbackChain({})).toEqual({});
 			expect(
 				getUnsupportedCodexFallbackChain({
 					unsupportedCodexFallbackChain: {
-						'': ['   '],
+						"": ["   "],
 					},
 				}),
 			).toEqual({});
 		});
 	});
 
-	describe('getFastSessionMaxInputItems', () => {
-		it('should default to 30', () => {
+	describe("getFastSessionMaxInputItems", () => {
+		it("should default to 30", () => {
 			delete process.env.CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS;
 			expect(getFastSessionMaxInputItems({})).toBe(30);
 		});
 
-		it('should use config value when env var not set', () => {
+		it("should use config value when env var not set", () => {
 			delete process.env.CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS;
-			expect(getFastSessionMaxInputItems({ fastSessionMaxInputItems: 18 })).toBe(18);
+			expect(
+				getFastSessionMaxInputItems({ fastSessionMaxInputItems: 18 }),
+			).toBe(18);
 		});
 
-		it('should clamp to minimum 8', () => {
-			process.env.CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS = '2';
+		it("should clamp to minimum 8", () => {
+			process.env.CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS = "2";
 			expect(getFastSessionMaxInputItems({})).toBe(8);
 		});
 	});
 
-	describe('getFastSessionStrategy', () => {
-		it('should default to hybrid', () => {
+	describe("getFastSessionStrategy", () => {
+		it("should default to hybrid", () => {
 			delete process.env.CODEX_AUTH_FAST_SESSION_STRATEGY;
-			expect(getFastSessionStrategy({})).toBe('hybrid');
+			expect(getFastSessionStrategy({})).toBe("hybrid");
 		});
 
-		it('should use config value', () => {
+		it("should use config value", () => {
 			delete process.env.CODEX_AUTH_FAST_SESSION_STRATEGY;
-			expect(getFastSessionStrategy({ fastSessionStrategy: 'always' })).toBe('always');
+			expect(getFastSessionStrategy({ fastSessionStrategy: "always" })).toBe(
+				"always",
+			);
 		});
 
-		it('should prioritize env value', () => {
-			process.env.CODEX_AUTH_FAST_SESSION_STRATEGY = 'always';
-			expect(getFastSessionStrategy({ fastSessionStrategy: 'hybrid' })).toBe('always');
-			process.env.CODEX_AUTH_FAST_SESSION_STRATEGY = 'hybrid';
-			expect(getFastSessionStrategy({ fastSessionStrategy: 'always' })).toBe('hybrid');
+		it("should prioritize env value", () => {
+			process.env.CODEX_AUTH_FAST_SESSION_STRATEGY = "always";
+			expect(getFastSessionStrategy({ fastSessionStrategy: "hybrid" })).toBe(
+				"always",
+			);
+			process.env.CODEX_AUTH_FAST_SESSION_STRATEGY = "hybrid";
+			expect(getFastSessionStrategy({ fastSessionStrategy: "always" })).toBe(
+				"hybrid",
+			);
 		});
 	});
 
-	describe('Priority order', () => {
-		it('should follow priority: env var > config file > default', () => {
+	describe("Priority order", () => {
+		it("should follow priority: env var > config file > default", () => {
 			// Test 1: env var overrides config
-			process.env.CODEX_MODE = '0';
+			process.env.CODEX_MODE = "0";
 			expect(getCodexMode({ codexMode: true })).toBe(false);
 
 			// Test 2: config overrides default
@@ -1002,31 +1108,35 @@ describe('Plugin Configuration', () => {
 		});
 	});
 
-	describe('Schema validation warnings', () => {
-		it('should log warning when config has invalid properties', () => {
+	describe("Schema validation warnings", () => {
+		it("should log warning when config has invalid properties", () => {
 			mockExistsSync.mockReturnValue(true);
-			mockReadFileSync.mockReturnValue(JSON.stringify({ 
-				codexMode: 'not-a-boolean',
-				unknownProperty: 'value'
-			}));
+			mockReadFileSync.mockReturnValue(
+				JSON.stringify({
+					codexMode: "not-a-boolean",
+					unknownProperty: "value",
+				}),
+			);
 
 			const mockLogWarn = vi.mocked(logger.logWarn);
 			mockLogWarn.mockClear();
 			loadPluginConfig();
 
 			expect(mockLogWarn).toHaveBeenCalledWith(
-				expect.stringContaining('Plugin config validation warnings')
+				expect.stringContaining("Plugin config validation warnings"),
 			);
 		});
 
-		it('drops invalid persisted values while keeping valid config keys', () => {
+		it("drops invalid persisted values while keeping valid config keys", () => {
 			mockExistsSync.mockReturnValue(true);
-			mockReadFileSync.mockReturnValue(JSON.stringify({
-				codexMode: 'not-a-boolean',
-				fetchTimeoutMs: 'oops',
-				streamStallTimeoutMs: 30000,
-				backgroundResponses: true,
-			}));
+			mockReadFileSync.mockReturnValue(
+				JSON.stringify({
+					codexMode: "not-a-boolean",
+					fetchTimeoutMs: "oops",
+					streamStallTimeoutMs: 30000,
+					backgroundResponses: true,
+				}),
+			);
 
 			const config = loadPluginConfig();
 
@@ -1037,16 +1147,16 @@ describe('Plugin Configuration', () => {
 		});
 	});
 
-	describe('resolveNumberSetting without min option', () => {
-		it('should return candidate without min constraint via getRetryAllAccountsMaxRetries', () => {
+	describe("resolveNumberSetting without min option", () => {
+		it("should return candidate without min constraint via getRetryAllAccountsMaxRetries", () => {
 			delete process.env.CODEX_AUTH_RETRY_ALL_MAX_RETRIES;
 			const config: PluginConfig = { retryAllAccountsMaxRetries: 5 };
 			const result = getRetryAllAccountsMaxRetries(config);
 			expect(result).toBe(5);
 		});
 
-		it('should return env value without min constraint', () => {
-			process.env.CODEX_AUTH_TOKEN_REFRESH_SKEW_MS = '30000';
+		it("should return env value without min constraint", () => {
+			process.env.CODEX_AUTH_TOKEN_REFRESH_SKEW_MS = "30000";
 			const config: PluginConfig = { tokenRefreshSkewMs: 60000 };
 			const result = getTokenRefreshSkewMs(config);
 			expect(result).toBe(30000);
@@ -1054,43 +1164,53 @@ describe('Plugin Configuration', () => {
 		});
 	});
 
-	describe('timeout settings', () => {
-		it('should read fetch timeout from config', () => {
+	describe("timeout settings", () => {
+		it("should read fetch timeout from config", () => {
 			const config: PluginConfig = { fetchTimeoutMs: 120000 };
 			expect(getFetchTimeoutMs(config)).toBe(120000);
 		});
 
-		it('should ignore empty numeric env values and fall back to config/default', () => {
-			process.env.CODEX_AUTH_FETCH_TIMEOUT_MS = '';
+		it("should ignore empty numeric env values and fall back to config/default", () => {
+			process.env.CODEX_AUTH_FETCH_TIMEOUT_MS = "";
 			expect(getFetchTimeoutMs({ fetchTimeoutMs: 90000 })).toBe(90000);
 			delete process.env.CODEX_AUTH_FETCH_TIMEOUT_MS;
 			expect(getFetchTimeoutMs({})).toBe(60000);
 		});
 
-		it('should read stream stall timeout from env', () => {
-			process.env.CODEX_AUTH_STREAM_STALL_TIMEOUT_MS = '30000';
+		it("should read stream stall timeout from env", () => {
+			process.env.CODEX_AUTH_STREAM_STALL_TIMEOUT_MS = "30000";
 			expect(getStreamStallTimeoutMs({})).toBe(30000);
 			delete process.env.CODEX_AUTH_STREAM_STALL_TIMEOUT_MS;
 		});
 	});
 
-	describe('rate-limit backoff settings', () => {
-		it('uses defaults when no overrides are provided', () => {
+	describe("rate-limit backoff settings", () => {
+		it("uses defaults when no overrides are provided", () => {
 			expect(getRateLimitDedupWindowMs({})).toBe(2_000);
 			expect(getRateLimitStateResetMs({})).toBe(120_000);
 			expect(getRateLimitMaxBackoffMs({})).toBe(60_000);
 			expect(getRateLimitShortRetryThresholdMs({})).toBe(5_000);
 		});
 
-		it('prioritizes environment overrides for backoff settings', () => {
-			process.env.CODEX_AUTH_RATE_LIMIT_DEDUP_WINDOW_MS = '3000';
-			process.env.CODEX_AUTH_RATE_LIMIT_STATE_RESET_MS = '180000';
-			process.env.CODEX_AUTH_RATE_LIMIT_MAX_BACKOFF_MS = '90000';
-			process.env.CODEX_AUTH_RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS = '7000';
-			expect(getRateLimitDedupWindowMs({ rateLimitDedupWindowMs: 1_000 })).toBe(3_000);
-			expect(getRateLimitStateResetMs({ rateLimitStateResetMs: 60_000 })).toBe(180_000);
-			expect(getRateLimitMaxBackoffMs({ rateLimitMaxBackoffMs: 30_000 })).toBe(90_000);
-			expect(getRateLimitShortRetryThresholdMs({ rateLimitShortRetryThresholdMs: 2_000 })).toBe(7_000);
+		it("prioritizes environment overrides for backoff settings", () => {
+			process.env.CODEX_AUTH_RATE_LIMIT_DEDUP_WINDOW_MS = "3000";
+			process.env.CODEX_AUTH_RATE_LIMIT_STATE_RESET_MS = "180000";
+			process.env.CODEX_AUTH_RATE_LIMIT_MAX_BACKOFF_MS = "90000";
+			process.env.CODEX_AUTH_RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS = "7000";
+			expect(getRateLimitDedupWindowMs({ rateLimitDedupWindowMs: 1_000 })).toBe(
+				3_000,
+			);
+			expect(getRateLimitStateResetMs({ rateLimitStateResetMs: 60_000 })).toBe(
+				180_000,
+			);
+			expect(getRateLimitMaxBackoffMs({ rateLimitMaxBackoffMs: 30_000 })).toBe(
+				90_000,
+			);
+			expect(
+				getRateLimitShortRetryThresholdMs({
+					rateLimitShortRetryThresholdMs: 2_000,
+				}),
+			).toBe(7_000);
 			delete process.env.CODEX_AUTH_RATE_LIMIT_DEDUP_WINDOW_MS;
 			delete process.env.CODEX_AUTH_RATE_LIMIT_STATE_RESET_MS;
 			delete process.env.CODEX_AUTH_RATE_LIMIT_MAX_BACKOFF_MS;
@@ -1098,24 +1218,37 @@ describe('Plugin Configuration', () => {
 		});
 	});
 
-	describe('preemptive quota settings', () => {
-		it('should use default thresholds', () => {
+	describe("preemptive quota settings", () => {
+		it("should use default thresholds", () => {
 			expect(getPreemptiveQuotaEnabled({})).toBe(true);
 			expect(getPreemptiveQuotaRemainingPercent5h({})).toBe(5);
 			expect(getPreemptiveQuotaRemainingPercent7d({})).toBe(5);
 			expect(getPreemptiveQuotaMaxDeferralMs({})).toBe(2 * 60 * 60_000);
 		});
 
-		it('should prioritize environment overrides', () => {
-			process.env.CODEX_AUTH_PREEMPTIVE_QUOTA_ENABLED = '0';
-			process.env.CODEX_AUTH_PREEMPTIVE_QUOTA_5H_REMAINING_PCT = '9';
-			process.env.CODEX_AUTH_PREEMPTIVE_QUOTA_7D_REMAINING_PCT = '11';
-			process.env.CODEX_AUTH_PREEMPTIVE_QUOTA_MAX_DEFERRAL_MS = '123000';
-			expect(getPreemptiveQuotaEnabled({ preemptiveQuotaEnabled: true })).toBe(false);
-			expect(getPreemptiveQuotaRemainingPercent5h({ preemptiveQuotaRemainingPercent5h: 1 })).toBe(9);
-			expect(getPreemptiveQuotaRemainingPercent7d({ preemptiveQuotaRemainingPercent7d: 2 })).toBe(11);
-			expect(getPreemptiveQuotaMaxDeferralMs({ preemptiveQuotaMaxDeferralMs: 2_000 })).toBe(123000);
+		it("should prioritize environment overrides", () => {
+			process.env.CODEX_AUTH_PREEMPTIVE_QUOTA_ENABLED = "0";
+			process.env.CODEX_AUTH_PREEMPTIVE_QUOTA_5H_REMAINING_PCT = "9";
+			process.env.CODEX_AUTH_PREEMPTIVE_QUOTA_7D_REMAINING_PCT = "11";
+			process.env.CODEX_AUTH_PREEMPTIVE_QUOTA_MAX_DEFERRAL_MS = "123000";
+			expect(getPreemptiveQuotaEnabled({ preemptiveQuotaEnabled: true })).toBe(
+				false,
+			);
+			expect(
+				getPreemptiveQuotaRemainingPercent5h({
+					preemptiveQuotaRemainingPercent5h: 1,
+				}),
+			).toBe(9);
+			expect(
+				getPreemptiveQuotaRemainingPercent7d({
+					preemptiveQuotaRemainingPercent7d: 2,
+				}),
+			).toBe(11);
+			expect(
+				getPreemptiveQuotaMaxDeferralMs({
+					preemptiveQuotaMaxDeferralMs: 2_000,
+				}),
+			).toBe(123000);
 		});
 	});
 });
-

--- a/test/property/rotation-concurrency.property.test.ts
+++ b/test/property/rotation-concurrency.property.test.ts
@@ -38,6 +38,13 @@ interface PoolState {
 	activeIndex: number;
 	coolingDownUntil: Record<number, number>;
 	history: SelectionResult[];
+	/**
+	 * External concurrency observer — counts how many tasks are currently
+	 * INSIDE the critical section. Under a working mutex this must never
+	 * exceed 1. A broken mutex (or legacy mode) will let it reach 2+.
+	 */
+	concurrentCallers: number;
+	maxConcurrentCallers: number;
 }
 
 function createPoolState(accounts: number): PoolState {
@@ -46,6 +53,8 @@ function createPoolState(accounts: number): PoolState {
 		activeIndex: 0,
 		coolingDownUntil: {},
 		history: [],
+		concurrentCallers: 0,
+		maxConcurrentCallers: 0,
 	};
 }
 
@@ -57,7 +66,14 @@ function createPoolState(accounts: number): PoolState {
  *   - commit the new activeIndex
  *
  * The yield (setImmediate) between read and write is what exposes the race
- * when no mutex guards the region.
+ * when no mutex guards the region. The concurrentCallers counter is the
+ * external observer that proves the mutex actually serializes access — a
+ * broken mutex would let the counter exceed 1 during the yield.
+ *
+ * Returns the result, plus pushes it to history OUTSIDE the critical
+ * section so the invariant that `history` chains linearizably is observable
+ * from outside the mutex (a broken mutex cannot fake chained history when
+ * push happens post-release).
  */
 async function rotateOnce(
 	state: PoolState,
@@ -65,38 +81,50 @@ async function rotateOnce(
 	cooldownWindowMs: number,
 	nowMs: number,
 ): Promise<SelectionResult> {
-	return withRoutingMutex(mode, async () => {
-		const prior = state.activeIndex;
-		// Simulate decision latency so the interleaving race window is real.
-		await new Promise((r) => setImmediate(r));
-
-		// Policy: skip cooling-down accounts. In real code this is the
-		// `isAvailable` filter inside selectHybridAccount. If every account is
-		// cooling we fall back to the prior account (LRU) to match the
-		// selection fallback behaviour.
-		let next = prior;
-		for (let offset = 1; offset <= state.accounts; offset += 1) {
-			const candidate = (prior + offset) % state.accounts;
-			if ((state.coolingDownUntil[candidate] ?? 0) <= nowMs) {
-				next = candidate;
-				break;
-			}
+	const result = await withRoutingMutex(mode, async () => {
+		state.concurrentCallers += 1;
+		if (state.concurrentCallers > state.maxConcurrentCallers) {
+			state.maxConcurrentCallers = state.concurrentCallers;
 		}
+		try {
+			const prior = state.activeIndex;
+			// Simulate decision latency so the interleaving race window is real.
+			await new Promise((r) => setImmediate(r));
 
-		const wasDoubleInsideCooldown =
-			next !== prior && (state.coolingDownUntil[next] ?? 0) > nowMs;
+			// Policy: skip cooling-down accounts. In real code this is the
+			// `isAvailable` filter inside selectHybridAccount. If every account is
+			// cooling we fall back to the prior account (LRU) to match the
+			// selection fallback behaviour.
+			let next = prior;
+			for (let offset = 1; offset <= state.accounts; offset += 1) {
+				const candidate = (prior + offset) % state.accounts;
+				if ((state.coolingDownUntil[candidate] ?? 0) <= nowMs) {
+					next = candidate;
+					break;
+				}
+			}
 
-		state.coolingDownUntil[prior] = nowMs + cooldownWindowMs;
-		state.activeIndex = next;
+			const wasDoubleInsideCooldown =
+				next !== prior && (state.coolingDownUntil[next] ?? 0) > nowMs;
 
-		const result: SelectionResult = {
-			chosenIndex: next,
-			priorActiveIndex: prior,
-			wasDoubleInsideCooldown,
-		};
-		state.history.push(result);
-		return result;
+			state.coolingDownUntil[prior] = nowMs + cooldownWindowMs;
+			state.activeIndex = next;
+
+			return {
+				chosenIndex: next,
+				priorActiveIndex: prior,
+				wasDoubleInsideCooldown,
+			} satisfies SelectionResult;
+		} finally {
+			state.concurrentCallers -= 1;
+		}
 	});
+	// Push to history OUTSIDE the critical section so history chaining is
+	// observable post-release. Under a broken mutex the chain invariant
+	// (cur.priorActiveIndex === prev.chosenIndex) would be violated because
+	// two tasks could read the same `prior` before either wrote.
+	state.history.push(result);
+	return result;
 }
 
 describe("routing mutex concurrency property tests", () => {
@@ -120,6 +148,9 @@ describe("routing mutex concurrency property tests", () => {
 					// Invariant 2: no double-selection inside cooldown window.
 					const offenders = results.filter((r) => r.wasDoubleInsideCooldown);
 					expect(offenders).toEqual([]);
+					// Invariant 4: external observer proves mutual exclusion — a broken
+					// mutex would let two+ tasks enter the critical section concurrently.
+					expect(state.maxConcurrentCallers).toBeLessThanOrEqual(1);
 				},
 			),
 			{ numRuns: 100 },
@@ -149,6 +180,9 @@ describe("routing mutex concurrency property tests", () => {
 						const cur = state.history[i];
 						expect(cur?.priorActiveIndex).toBe(prev?.chosenIndex);
 					}
+					// Invariant 4: external observer proves mutual exclusion — a broken
+					// mutex would let two+ tasks enter the critical section concurrently.
+					expect(state.maxConcurrentCallers).toBeLessThanOrEqual(1);
 				},
 			),
 			{ numRuns: 100 },
@@ -159,6 +193,12 @@ describe("routing mutex concurrency property tests", () => {
 		// We do not assert absence of races here — legacy mode is the
 		// unprotected baseline. We only assert that the system does not
 		// crash and that history length matches the number of issued tasks.
+		//
+		// Note: `state.maxConcurrentCallers` is EXPECTED to be > 1 under legacy
+		// mode because the no-op mutex allows overlapping execution of the
+		// critical section — that is precisely the race window PR-N closes.
+		// No assertion is made here; this test is intentionally a
+		// documentation-only baseline for the pre-PR-N behaviour.
 		await fc.assert(
 			fc.asyncProperty(
 				fc.integer({ min: 3, max: 5 }),

--- a/test/property/rotation-concurrency.property.test.ts
+++ b/test/property/rotation-concurrency.property.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fc from "fast-check";
+import {
+	createAsyncMutex,
+	withRoutingMutex,
+	__resetRoutingMutexForTests,
+	type RoutingMutexMode,
+} from "../../lib/routing-mutex.js";
+
+/**
+ * PR-N / R4 concurrency property tests.
+ *
+ * Simulates N concurrent requests touching a shared `activeIndex` cursor and
+ * an in-memory cooldown map to expose the TOCTOU race the routing mutex is
+ * meant to close.
+ *
+ * Invariants under `"enabled"` mode:
+ *   1. No lost updates: every attempted selection must either appear in the
+ *      final history or be observed as superseded, never silently dropped.
+ *   2. No double-selection inside a single cooldown window: if an account is
+ *      marked cooling at time T, no concurrent selection may also mark the
+ *      same account at time T without observing the cooldown.
+ *   3. Cursor monotonicity w.r.t. the serialization order: reads observed
+ *      inside the critical section are not stale.
+ *
+ * Under `"legacy"` mode the same scenarios may exhibit lost updates — those
+ * runs are kept as a baseline to document the pre-PR-N behaviour.
+ */
+
+type SelectionResult = {
+	chosenIndex: number;
+	priorActiveIndex: number;
+	wasDoubleInsideCooldown: boolean;
+};
+
+interface PoolState {
+	accounts: number;
+	activeIndex: number;
+	coolingDownUntil: Record<number, number>;
+	history: SelectionResult[];
+}
+
+function createPoolState(accounts: number): PoolState {
+	return {
+		accounts,
+		activeIndex: 0,
+		coolingDownUntil: {},
+		history: [],
+	};
+}
+
+/**
+ * Simulated rotation critical section:
+ *   - read activeIndex
+ *   - pick the next unused account
+ *   - mark the previous account cooling down for `cooldownWindowMs`
+ *   - commit the new activeIndex
+ *
+ * The yield (setImmediate) between read and write is what exposes the race
+ * when no mutex guards the region.
+ */
+async function rotateOnce(
+	state: PoolState,
+	mode: RoutingMutexMode,
+	cooldownWindowMs: number,
+	nowMs: number,
+): Promise<SelectionResult> {
+	return withRoutingMutex(mode, async () => {
+		const prior = state.activeIndex;
+		// Simulate decision latency so the interleaving race window is real.
+		await new Promise((r) => setImmediate(r));
+
+		// Policy: skip cooling-down accounts. In real code this is the
+		// `isAvailable` filter inside selectHybridAccount. If every account is
+		// cooling we fall back to the prior account (LRU) to match the
+		// selection fallback behaviour.
+		let next = prior;
+		for (let offset = 1; offset <= state.accounts; offset += 1) {
+			const candidate = (prior + offset) % state.accounts;
+			if ((state.coolingDownUntil[candidate] ?? 0) <= nowMs) {
+				next = candidate;
+				break;
+			}
+		}
+
+		const wasDoubleInsideCooldown =
+			next !== prior && (state.coolingDownUntil[next] ?? 0) > nowMs;
+
+		state.coolingDownUntil[prior] = nowMs + cooldownWindowMs;
+		state.activeIndex = next;
+
+		const result: SelectionResult = {
+			chosenIndex: next,
+			priorActiveIndex: prior,
+			wasDoubleInsideCooldown,
+		};
+		state.history.push(result);
+		return result;
+	});
+}
+
+describe("routing mutex concurrency property tests", () => {
+	afterEach(() => __resetRoutingMutexForTests());
+
+	it("mutex-enabled: no double-selection inside cooldown window", async () => {
+		await fc.assert(
+			fc.asyncProperty(
+				fc.integer({ min: 2, max: 6 }),
+				fc.integer({ min: 2, max: 12 }),
+				async (accountCount, concurrentRequests) => {
+					const state = createPoolState(accountCount);
+					const nowMs = 1_000_000;
+					const cooldownWindowMs = 10_000;
+					const tasks = Array.from({ length: concurrentRequests }, () =>
+						rotateOnce(state, "enabled", cooldownWindowMs, nowMs),
+					);
+					const results = await Promise.all(tasks);
+					// Invariant 1: history length equals issued requests (no lost updates).
+					expect(state.history.length).toBe(concurrentRequests);
+					// Invariant 2: no double-selection inside cooldown window.
+					const offenders = results.filter((r) => r.wasDoubleInsideCooldown);
+					expect(offenders).toEqual([]);
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("mutex-enabled: history chains linearizably under serialization order", async () => {
+		await fc.assert(
+			fc.asyncProperty(
+				fc.integer({ min: 3, max: 5 }),
+				fc.integer({ min: 4, max: 10 }),
+				async (accountCount, concurrentRequests) => {
+					const state = createPoolState(accountCount);
+					const nowMs = 1_000_000;
+					// Small window so not every rotation gets blocked by cooldown.
+					const cooldownWindowMs = 1_000;
+					const tasks = Array.from({ length: concurrentRequests }, () =>
+						rotateOnce(state, "enabled", cooldownWindowMs, nowMs),
+					);
+					await Promise.all(tasks);
+
+					// Invariant 3: each history entry's prior must equal the previous
+					// entry's chosen (strict chaining proves linearizability — no
+					// interleaving between the read-and-write of activeIndex).
+					for (let i = 1; i < state.history.length; i += 1) {
+						const prev = state.history[i - 1];
+						const cur = state.history[i];
+						expect(cur?.priorActiveIndex).toBe(prev?.chosenIndex);
+					}
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("legacy baseline: documents race windows without mutex", async () => {
+		// We do not assert absence of races here — legacy mode is the
+		// unprotected baseline. We only assert that the system does not
+		// crash and that history length matches the number of issued tasks.
+		await fc.assert(
+			fc.asyncProperty(
+				fc.integer({ min: 3, max: 5 }),
+				fc.integer({ min: 6, max: 10 }),
+				async (accountCount, concurrentRequests) => {
+					const state = createPoolState(accountCount);
+					const nowMs = 1_000_000;
+					const cooldownWindowMs = 10_000;
+					const tasks = Array.from({ length: concurrentRequests }, () =>
+						rotateOnce(state, "legacy", cooldownWindowMs, nowMs),
+					);
+					const results = await Promise.all(tasks);
+					expect(results).toHaveLength(concurrentRequests);
+					expect(state.history.length).toBe(concurrentRequests);
+				},
+			),
+			{ numRuns: 100 },
+		);
+	});
+});
+
+describe("routing mutex regression: two simultaneous requests on same account", () => {
+	afterEach(() => __resetRoutingMutexForTests());
+
+	it("mutex serializes markSwitched + cooldown on identical account", async () => {
+		const mutex = createAsyncMutex();
+		const account = {
+			lastSwitchReason: "initial" as string,
+			coolingDownUntil: 0,
+		};
+		const nowMs = 2_000_000;
+
+		const observedInsideCritical: string[] = [];
+
+		const first = mutex.runExclusive(async () => {
+			observedInsideCritical.push("first:enter");
+			// Emulate the gap between read and write.
+			await new Promise((r) => setImmediate(r));
+			account.lastSwitchReason = "rotation";
+			account.coolingDownUntil = nowMs + 5_000;
+			observedInsideCritical.push("first:exit");
+		});
+
+		const second = mutex.runExclusive(async () => {
+			observedInsideCritical.push("second:enter");
+			// Second observer must see first's committed state.
+			expect(account.lastSwitchReason).toBe("rotation");
+			expect(account.coolingDownUntil).toBe(nowMs + 5_000);
+			account.lastSwitchReason = "rate-limit";
+			observedInsideCritical.push("second:exit");
+		});
+
+		await Promise.all([first, second]);
+		expect(observedInsideCritical).toEqual([
+			"first:enter",
+			"first:exit",
+			"second:enter",
+			"second:exit",
+		]);
+		expect(account.lastSwitchReason).toBe("rate-limit");
+	});
+});

--- a/test/routing-mutex-config.test.ts
+++ b/test/routing-mutex-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { DEFAULT_PLUGIN_CONFIG, getRoutingMutexMode } from "../lib/config.js";
+import type { PluginConfig } from "../lib/types.js";
+
+describe("routingMutex config flag", () => {
+	const ORIGINAL_ENV = process.env.CODEX_AUTH_ROUTING_MUTEX;
+
+	beforeEach(() => {
+		delete process.env.CODEX_AUTH_ROUTING_MUTEX;
+	});
+
+	afterEach(() => {
+		if (ORIGINAL_ENV === undefined) {
+			delete process.env.CODEX_AUTH_ROUTING_MUTEX;
+		} else {
+			process.env.CODEX_AUTH_ROUTING_MUTEX = ORIGINAL_ENV;
+		}
+	});
+
+	it("defaults to legacy in DEFAULT_PLUGIN_CONFIG", () => {
+		expect(DEFAULT_PLUGIN_CONFIG.routingMutex).toBe("legacy");
+	});
+
+	it("getRoutingMutexMode returns legacy when config is undefined", () => {
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			routingMutex: undefined,
+		};
+		expect(getRoutingMutexMode(cfg)).toBe("legacy");
+	});
+
+	it("getRoutingMutexMode respects explicit enabled in config", () => {
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			routingMutex: "enabled",
+		};
+		expect(getRoutingMutexMode(cfg)).toBe("enabled");
+	});
+
+	it("env var CODEX_AUTH_ROUTING_MUTEX=enabled overrides config", () => {
+		process.env.CODEX_AUTH_ROUTING_MUTEX = "enabled";
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			routingMutex: "legacy",
+		};
+		expect(getRoutingMutexMode(cfg)).toBe("enabled");
+	});
+
+	it("env var CODEX_AUTH_ROUTING_MUTEX=legacy overrides config", () => {
+		process.env.CODEX_AUTH_ROUTING_MUTEX = "legacy";
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			routingMutex: "enabled",
+		};
+		expect(getRoutingMutexMode(cfg)).toBe("legacy");
+	});
+
+	it("rejects unknown env values and falls back to config", () => {
+		process.env.CODEX_AUTH_ROUTING_MUTEX = "bogus-mode";
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			routingMutex: "enabled",
+		};
+		expect(getRoutingMutexMode(cfg)).toBe("enabled");
+	});
+});

--- a/test/routing-mutex.test.ts
+++ b/test/routing-mutex.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+	createAsyncMutex,
+	getRoutingMutex,
+	withRoutingMutex,
+	__resetRoutingMutexForTests,
+	type SelectionRecord,
+} from "../lib/routing-mutex.js";
+
+describe("createAsyncMutex", () => {
+	it("runExclusive serializes concurrent tasks", async () => {
+		const mutex = createAsyncMutex();
+		const events: string[] = [];
+
+		const makeTask = (name: string, delayMs: number) =>
+			mutex.runExclusive(async () => {
+				events.push(`${name}:start`);
+				await new Promise((r) => setTimeout(r, delayMs));
+				events.push(`${name}:end`);
+				return name;
+			});
+
+		const [a, b, c] = await Promise.all([
+			makeTask("A", 10),
+			makeTask("B", 5),
+			makeTask("C", 1),
+		]);
+
+		// Execution must be strictly serialized: A finishes before B starts, etc.
+		expect(events).toEqual([
+			"A:start",
+			"A:end",
+			"B:start",
+			"B:end",
+			"C:start",
+			"C:end",
+		]);
+		expect([a, b, c]).toEqual(["A", "B", "C"]);
+	});
+
+	it("propagates errors but keeps chain alive", async () => {
+		const mutex = createAsyncMutex();
+
+		const failing = mutex.runExclusive(async () => {
+			throw new Error("boom");
+		});
+
+		await expect(failing).rejects.toThrow("boom");
+
+		const recovered = await mutex.runExclusive(async () => "ok");
+		expect(recovered).toBe("ok");
+		expect(mutex.isLocked()).toBe(false);
+		expect(mutex.queueLength()).toBe(0);
+	});
+
+	it("releases lock when task throws synchronously", async () => {
+		const mutex = createAsyncMutex();
+
+		const failing = mutex.runExclusive((): number => {
+			throw new Error("sync-boom");
+		});
+
+		await expect(failing).rejects.toThrow("sync-boom");
+		expect(mutex.isLocked()).toBe(false);
+
+		const next = await mutex.runExclusive(() => 42);
+		expect(next).toBe(42);
+	});
+
+	it("reports queue length while tasks are waiting", async () => {
+		const mutex = createAsyncMutex();
+		let release: (() => void) | undefined;
+		const first = mutex.runExclusive(
+			() =>
+				new Promise<void>((resolve) => {
+					release = resolve;
+				}),
+		);
+
+		const waiting1 = mutex.runExclusive(async () => "two");
+		const waiting2 = mutex.runExclusive(async () => "three");
+
+		// Give the chain a tick to start the first task.
+		await new Promise((r) => setImmediate(r));
+		expect(mutex.isLocked()).toBe(true);
+		expect(mutex.queueLength()).toBeGreaterThanOrEqual(2);
+
+		release?.();
+		await first;
+		expect(await waiting1).toBe("two");
+		expect(await waiting2).toBe("three");
+		expect(mutex.isLocked()).toBe(false);
+	});
+});
+
+describe("withRoutingMutex flag gating", () => {
+	afterEach(() => __resetRoutingMutexForTests());
+
+	it("legacy mode runs inline without entering the mutex", async () => {
+		let observedLocked = false;
+		const result = await withRoutingMutex("legacy", () => {
+			observedLocked = getRoutingMutex().isLocked();
+			return "legacy-result";
+		});
+		expect(result).toBe("legacy-result");
+		// Inline execution must not flip the shared mutex lock state.
+		expect(observedLocked).toBe(false);
+	});
+
+	it("enabled mode routes through the shared mutex", async () => {
+		let observedLocked = false;
+		const result = await withRoutingMutex("enabled", () => {
+			observedLocked = getRoutingMutex().isLocked();
+			return "enabled-result";
+		});
+		expect(result).toBe("enabled-result");
+		// While the task is running the mutex must be locked.
+		expect(observedLocked).toBe(true);
+	});
+
+	it("enabled mode serializes concurrent callers", async () => {
+		const order: string[] = [];
+		const tasks = ["a", "b", "c", "d"].map((name) =>
+			withRoutingMutex("enabled", async () => {
+				order.push(`${name}:in`);
+				await new Promise((r) => setTimeout(r, 1));
+				order.push(`${name}:out`);
+			}),
+		);
+		await Promise.all(tasks);
+		// No interleaving: every in/out pair must be contiguous.
+		for (let i = 0; i < order.length; i += 2) {
+			const label = order[i]?.split(":")[0];
+			expect(order[i + 1]).toBe(`${label}:out`);
+		}
+	});
+});
+
+describe("SelectionRecord shape", () => {
+	it("accepts the minimum required fields", () => {
+		const record: SelectionRecord = {
+			accountIndex: 2,
+			accountId: "acct_123",
+			reason: "rotation",
+			timestamp: Date.now(),
+		};
+		expect(record.accountIndex).toBe(2);
+		expect(record.reason).toBe("rotation");
+	});
+
+	it("accepts the full decision payload", () => {
+		const record: SelectionRecord = {
+			accountIndex: 0,
+			accountId: "acct_0",
+			reason: "best",
+			timestamp: 1_700_000_000_000,
+			trackerKeyQuota: "codex:gpt-5-codex",
+			health: 93,
+			tokens: 48,
+			score: 512,
+		};
+		expect(record.trackerKeyQuota).toBe("codex:gpt-5-codex");
+		expect(record.score).toBe(512);
+	});
+});


### PR DESCRIPTION
Implements PR-N from Phase 1 roadmap (docs/audits/MASTER_AUDIT.md §14).

## Summary

Introduces a feature-flagged routing mutex and `SelectionRecord` type to close TOCTOU races in the account selection / cursor-mutation path. **Default is legacy (off)** for one release cycle — zero behavior change for existing users on this PR.

## Why

- **D-02**: current cursor / mutation path has a TOCTOU window under concurrent requests (two simultaneous requests can both read the same `activeIndex`, both mark the same account, lose one update)
- **D-09**: the rotation decision + cursor update are not atomic. A concurrent request can slip through between selection and mutation.

## Design

- New `lib/routing-mutex.ts` with a small inline promise-based async mutex (no new deps)
- New `SelectionRecord` type in `lib/rotation.ts`: `{ accountIndex, accountId, reason, timestamp, trackerKeyQuota?, health?, tokens?, score? }`
- New async mutex-locked twins in `lib/accounts.ts` (e.g. `markSwitchedLocked`) — existing synchronous `markSwitched` / `markAccountCoolingDown` / `setActiveIndex` are UNTOUCHED for backward compat
- Gating via `withRoutingMutex(mode, fn)` helper — `"legacy"` runs callback inline (no mutex allocation, no wait); `"enabled"` routes through the singleton `getRoutingMutex()`. O(1) check per call.

## Feature Flag

- `PluginConfig.routingMutex: "enabled" | "legacy"` (Zod-validated in `lib/schemas.ts`)
- Default: `"legacy"` in `DEFAULT_PLUGIN_CONFIG`
- Env override: `CODEX_AUTH_ROUTING_MUTEX=enabled|legacy`
- Resolver: `getRoutingMutexMode(config)` in `lib/config.ts`

## Tests

- `test/routing-mutex.test.ts` — 9 unit tests (runExclusive serializes, error propagation, release-on-throw)
- `test/routing-mutex-config.test.ts` — 6 config-plumbing tests
- `test/accounts-routing-mutex.test.ts` — 7 integration tests (mutex-locked twins preserve semantics)
- `test/property/rotation-concurrency.property.test.ts` — 4 fast-check property tests, **100 runs each (400 generated cases)**:
  - `mutex-enabled: no double-selection inside cooldown window` — 100 runs, 0 counterexamples
  - `mutex-enabled: history chains linearizably under serialization order` — 100 runs, strict `cur.priorActiveIndex === prev.chosenIndex` invariant holds
  - `legacy baseline: documents race windows without mutex` — 100 runs, no crashes
  - `mutex serializes markSwitched + cooldown on identical account` — strict ordering `first:enter → first:exit → second:enter → second:exit` with second observer seeing first's committed state
- Plugin config snapshot tests (`test/plugin-config.test.ts`): +5 updates for new flag
- Full suite: 229 files / **3444 tests green** (+26 from baseline 3418)
- `npm run typecheck`, `npm run lint`: clean

## Changelog

Entry added under Unreleased announcing flag + one-release-cycle rollout plan.

## Dependencies Satisfied

- PR-C (AUTH_REDIRECT SSOT) landed
- PR-L (Zod storage boundaries) landed in PR #409
- PR-P (why-selected + verify --paths) landed in PR #410 — `selectHybridAccountTraced` intentionally untouched by this PR

## Closes

- D-02, D-09
- Improves H2 / H3 base substrate

See docs/audits/MASTER_AUDIT.md §14 PR-N.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr lays the routing-mutex infrastructure (pr-n / r4): a promise-chain async mutex, a `SelectionRecord` type, and mutex-locked twins of the three cursor-mutation helpers in `AccountManager`. the flag defaults to `"legacy"` so existing users see zero behaviour change. the implementation is clean, well-tested (property tests + integration), and the flag/env plumbing is correct.

- the locked helpers (`markSwitchedLocked`, etc.) are infrastructure only — the fetch loop in `index.ts` still calls the unlocked synchronous variants, so enabling the flag today has no runtime effect. this is noted in the previous thread; the concern here is that the wiring follow-up pr should be explicitly tracked before the default flips to `"enabled"`.
- `setActiveIndexLocked` wraps `setActiveIndex`, which fires `void this.syncCodexCliActiveSelectionForIndex(...)` — the cli sync starts inside the mutex callback but is never awaited, so it completes outside the mutex scope. future callers wrapping the full select→write path in a single `withRoutingMutex` block should be aware this side-effect is not serialized.

<h3>Confidence Score: 4/5</h3>

safe to merge as infrastructure-only — no behaviour change for existing users; two P2 findings worth addressing before the follow-up wiring PR lands

all findings are P2. the flag defaults to `"legacy"` so there is zero runtime change. the mutex implementation and property tests are solid. score is 4 rather than 5 because the `isLocked` transient false-negative and the fire-and-forget cli-sync inside the mutex callback are real concurrency footguns for whoever writes the follow-up wiring pr.

lib/accounts.ts (setActiveIndexLocked unawaited side-effect), lib/routing-mutex.ts (isLocked transient state documentation)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/routing-mutex.ts | new module — promise-chain async mutex, `SelectionRecord` type, `withRoutingMutex` flag helper, and singleton accessor. implementation is correct; minor: `release` typed `| undefined` due to ts flow-analysis limitation but guaranteed non-null at callsite. |
| lib/accounts.ts | adds `routingMutexMode` field and three locked helpers. `setActiveIndexLocked` wraps sync `setActiveIndex` which fires an unawaited async cli-sync side-effect outside the mutex scope — consistent with the sync variant but worth noting for future wiring. |
| lib/config.ts | adds `getRoutingMutexMode` resolver using existing `resolveStringSetting` pattern with `CODEX_AUTH_ROUTING_MUTEX` env override. clean and consistent with other flag resolvers. |
| test/accounts-routing-mutex.test.ts | 7 integration tests verify locked helpers preserve semantics, mode toggle, and out-of-range guards. no gaps found. |
| test/property/rotation-concurrency.property.test.ts | 4 property tests (100 runs each) verify no double-selection, linearizable history, mutual exclusion, and legacy baseline. uses `concurrentCallers` counter as external proof of mutex exclusivity. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frouting-mutex%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frouting-mutex%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Faccounts.ts%3A928-932%0A**%60setActiveIndexLocked%60%20fires%20an%20unawaited%20async%20side-effect%20inside%20the%20mutex%20callback**%0A%0A%60setActiveIndex%60%20calls%20%60void%20this.syncCodexCliActiveSelectionForIndex%28...%29%60%20%E2%80%94%20the%20cli-sync%20task%20starts%20executing%20synchronously%20inside%20the%20mutex%20callback%20but%20the%20i%2Fo%20completes%20after%20the%20callback%20returns%20and%20the%20lock%20is%20already%20released.%20this%20means%20the%20cli-sync%20side-effect%20is%20not%20serialized%20by%20the%20mutex.%0A%0Afor%20this%20release%20%28infrastructure%20only%29%20it%20is%20consistent%20with%20the%20sync%20%60setActiveIndex%60%20semantics%20and%20harmless.%20but%20when%20the%20follow-up%20pr%20wires%20the%20fetch%20loop%20to%20call%20%60withRoutingMutex%60%20around%20the%20full%20select%E2%86%92write%20path%2C%20callers%20should%20be%20aware%20that%20the%20%60syncCodexCliActiveSelectionForIndex%60%20leg%20will%20interleave%20with%20the%20next%20task's%20critical%20section.%20worth%20a%20short%20comment%20here%20to%20warn%20future%20callers%3A%0A%0A%60%60%60typescript%0Aasync%20setActiveIndexLocked%28index%3A%20number%29%3A%20Promise%3CManagedAccount%20%7C%20null%3E%20%7B%0A%20%20%20%20return%20withRoutingMutex%28this.routingMutexMode%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Note%3A%20setActiveIndex%20fires%20syncCodexCliActiveSelectionForIndex%20as%20a%0A%20%20%20%20%20%20%20%20%2F%2F%20void%2Ffire-and-forget.%20That%20async%20I%2FO%20completes%20outside%20the%20mutex%0A%20%20%20%20%20%20%20%20%2F%2F%20scope%20and%20is%20intentionally%20not%20serialized.%0A%20%20%20%20%20%20%20%20return%20this.setActiveIndex%28index%29%3B%0A%20%20%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Frouting-mutex.ts%3A96-116%0A**%60isLocked%28%29%60%20has%20a%20transient%20false-negative%20between%20task%20release%20and%20next-task%20start**%0A%0Aafter%20the%20current%20task's%20%60finally%60%20runs%20%28%60running%20-%3D%201%60%20then%20%60release%3F.%28%29%60%29%2C%20%60isLocked%28%29%60%20returns%20%60false%60%20and%20%60queueLength%28%29%60%20still%20shows%20the%20waiting%20task%20%E2%80%94%20because%20the%20microtask%20that%20decrements%20%60queued%60%20and%20increments%20%60running%60%20hasn't%20executed%20yet.%20callers%20that%20poll%20%60isLocked%28%29%60%20to%20know%20whether%20the%20mutex%20is%20%22idle%22%20%28e.g.%20a%20flush-before-shutdown%20helper%20in%20a%20future%20pr%29%20may%20read%20a%20false%20negative%20here.%0A%0Athis%20is%20diagnostic-only%20for%20now%2C%20but%20worth%20a%20short%20comment%20near%20%60isLocked%60%3A%0A%0A%60%60%60typescript%0A%2F**%0A%20*%20Returns%20true%20while%20some%20critical%20section%20is%20executing.%0A%20*%20Note%3A%20there%20is%20a%20brief%20microtask%20gap%20between%20when%20a%20task%20releases%20the%0A%20*%20lock%20and%20when%20the%20next%20queued%20task%20increments%20%60running%60.%20During%20that%0A%20*%20window%20isLocked%28%29%20returns%20false%20even%20though%20a%20task%20is%20about%20to%20start.%0A%20*%20Use%20queueLength%28%29%20%2B%20isLocked%28%29%20together%20for%20a%20complete%20picture.%0A%20*%2F%0AisLocked%3A%20%28%29%20%3D%3E%20running%20%3E%200%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Faccounts-routing-mutex.test.ts%3A83-96%0A**missing%20cooldown%20expiry%20bound%20on%20windows%20paths**%0A%0A%60account.coolingDownUntil%60%20is%20checked%20as%20%60toBeGreaterThan%28Date.now%28%29%29%60%20%E2%80%94%20on%20a%20heavily%20loaded%20windows%20runner%20the%20%60nowMs%28%29%60%20inside%20%60markAccountCoolingDownLocked%60%20and%20%60Date.now%28%29%60%20in%20the%20assertion%20could%20be%20the%20same%20millisecond%2C%20making%20the%20test%20flaky.%20%60toBeGreaterThanOrEqual%28Date.now%28%29%29%60%20avoids%20the%20off-by-one%3A%0A%0A%60%60%60suggestion%0A%09%09expect%28account.coolingDownUntil%29.toBeGreaterThanOrEqual%28Date.now%28%29%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/accounts.ts
Line: 928-932

Comment:
**`setActiveIndexLocked` fires an unawaited async side-effect inside the mutex callback**

`setActiveIndex` calls `void this.syncCodexCliActiveSelectionForIndex(...)` — the cli-sync task starts executing synchronously inside the mutex callback but the i/o completes after the callback returns and the lock is already released. this means the cli-sync side-effect is not serialized by the mutex.

for this release (infrastructure only) it is consistent with the sync `setActiveIndex` semantics and harmless. but when the follow-up pr wires the fetch loop to call `withRoutingMutex` around the full select→write path, callers should be aware that the `syncCodexCliActiveSelectionForIndex` leg will interleave with the next task's critical section. worth a short comment here to warn future callers:

```typescript
async setActiveIndexLocked(index: number): Promise<ManagedAccount | null> {
    return withRoutingMutex(this.routingMutexMode, () => {
        // Note: setActiveIndex fires syncCodexCliActiveSelectionForIndex as a
        // void/fire-and-forget. That async I/O completes outside the mutex
        // scope and is intentionally not serialized.
        return this.setActiveIndex(index);
    });
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/routing-mutex.ts
Line: 96-116

Comment:
**`isLocked()` has a transient false-negative between task release and next-task start**

after the current task's `finally` runs (`running -= 1` then `release?.()`), `isLocked()` returns `false` and `queueLength()` still shows the waiting task — because the microtask that decrements `queued` and increments `running` hasn't executed yet. callers that poll `isLocked()` to know whether the mutex is "idle" (e.g. a flush-before-shutdown helper in a future pr) may read a false negative here.

this is diagnostic-only for now, but worth a short comment near `isLocked`:

```typescript
/**
 * Returns true while some critical section is executing.
 * Note: there is a brief microtask gap between when a task releases the
 * lock and when the next queued task increments `running`. During that
 * window isLocked() returns false even though a task is about to start.
 * Use queueLength() + isLocked() together for a complete picture.
 */
isLocked: () => running > 0,
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/accounts-routing-mutex.test.ts
Line: 83-96

Comment:
**missing cooldown expiry bound on windows paths**

`account.coolingDownUntil` is checked as `toBeGreaterThan(Date.now())` — on a heavily loaded windows runner the `nowMs()` inside `markAccountCoolingDownLocked` and `Date.now()` in the assertion could be the same millisecond, making the test flaky. `toBeGreaterThanOrEqual(Date.now())` avoids the off-by-one:

```suggestion
		expect(account.coolingDownUntil).toBeGreaterThanOrEqual(Date.now());
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(routing-mutex): strengthen property..."](https://github.com/ndycode/codex-multi-auth/commit/21c466aa7e0de0e40311ae50cb75bab175427a81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28728326)</sub>

<!-- /greptile_comment -->