### PR TITLE
fix(request): remove double-exponential backoff in getRateLimitBackoffWithReason

### DIFF
--- a/lib/request/rate-limit-backoff.ts
+++ b/lib/request/rate-limit-backoff.ts
@@ -48,19 +48,28 @@ export function configureRateLimitBackoff(
 		typeof overrides.dedupWindowMs === "number" &&
 		Number.isFinite(overrides.dedupWindowMs)
 	) {
-		rateLimitBackoffConfig.dedupWindowMs = Math.max(0, Math.floor(overrides.dedupWindowMs));
+		rateLimitBackoffConfig.dedupWindowMs = Math.max(
+			0,
+			Math.floor(overrides.dedupWindowMs),
+		);
 	}
 	if (
 		typeof overrides.stateResetMs === "number" &&
 		Number.isFinite(overrides.stateResetMs)
 	) {
-		rateLimitBackoffConfig.stateResetMs = Math.max(1_000, Math.floor(overrides.stateResetMs));
+		rateLimitBackoffConfig.stateResetMs = Math.max(
+			1_000,
+			Math.floor(overrides.stateResetMs),
+		);
 	}
 	if (
 		typeof overrides.maxBackoffMs === "number" &&
 		Number.isFinite(overrides.maxBackoffMs)
 	) {
-		rateLimitBackoffConfig.maxBackoffMs = Math.max(1_000, Math.floor(overrides.maxBackoffMs));
+		rateLimitBackoffConfig.maxBackoffMs = Math.max(
+			1_000,
+			Math.floor(overrides.maxBackoffMs),
+		);
 	}
 	if (
 		typeof overrides.shortRetryThresholdMs === "number" &&
@@ -118,13 +127,18 @@ function resolveRateLimitStateKey(
 	return `${accountStateKey}:${quotaKey}`;
 }
 
-function normalizeDelayMs(value: number | null | undefined, fallback: number): number {
-	const candidate = typeof value === "number" && Number.isFinite(value) ? value : fallback;
+function normalizeDelayMs(
+	value: number | null | undefined,
+	fallback: number,
+): number {
+	const candidate =
+		typeof value === "number" && Number.isFinite(value) ? value : fallback;
 	return Math.max(0, Math.floor(candidate));
 }
 
 function addBackoffJitter(baseMs: number): number {
-	const jitter = baseMs * RATE_LIMIT_BACKOFF_JITTER_FACTOR * (Math.random() * 2 - 1);
+	const jitter =
+		baseMs * RATE_LIMIT_BACKOFF_JITTER_FACTOR * (Math.random() * 2 - 1);
 	return Math.max(0, Math.floor(baseMs + jitter));
 }
 
@@ -157,7 +171,10 @@ export function getRateLimitBackoff(
 
 	const baseDelay = normalizeDelayMs(serverRetryAfterMs, 1000);
 
-	if (previous && now - previous.lastAt < rateLimitBackoffConfig.dedupWindowMs) {
+	if (
+		previous &&
+		now - previous.lastAt < rateLimitBackoffConfig.dedupWindowMs
+	) {
 		return {
 			attempt: previous.consecutive429,
 			delayMs: previous.lastDelayMs,
@@ -213,15 +230,27 @@ const BACKOFF_MULTIPLIERS: Record<RateLimitReason, number> = {
 	unknown: 1.0,
 };
 
+/**
+ * Apply a reason-based multiplier to an already-exponential backoff delay.
+ *
+ * NOTE: `baseDelayMs` is expected to already incorporate any exponential
+ * progression and jitter (as produced by `getRateLimitBackoff`). This
+ * function intentionally does NOT re-apply `2^(attempt-1)`; doing so would
+ * double-apply the exponential when chained with `getRateLimitBackoff`,
+ * which previously caused delays to saturate at `maxBackoffMs` after just
+ * two consecutive 429s (see audit finding REQ-HIGH-01).
+ *
+ * The `attempt` parameter is retained for API compatibility and potential
+ * future use (e.g. reason-specific progression) but is not currently read.
+ */
 export function calculateBackoffMs(
 	baseDelayMs: number,
-	attempt: number,
+	_attempt: number,
 	reason: RateLimitReason = "unknown",
 ): number {
 	const multiplier = BACKOFF_MULTIPLIERS[reason] ?? 1.0;
-	const exponentialDelay = baseDelayMs * Math.pow(2, attempt - 1);
 	return Math.min(
-		Math.floor(exponentialDelay * multiplier),
+		Math.max(0, Math.floor(baseDelayMs * multiplier)),
 		rateLimitBackoffConfig.maxBackoffMs,
 	);
 }
@@ -272,8 +301,13 @@ export function getRateLimitBackoffWithReason(
 			"getRateLimitBackoffWithReason requires a non-negative integer accountIndex",
 		);
 	}
-	if (typeof resolvedQuotaKey !== "string" || resolvedQuotaKey.trim().length === 0) {
-		throw new TypeError("getRateLimitBackoffWithReason requires a non-empty quotaKey");
+	if (
+		typeof resolvedQuotaKey !== "string" ||
+		resolvedQuotaKey.trim().length === 0
+	) {
+		throw new TypeError(
+			"getRateLimitBackoffWithReason requires a non-empty quotaKey",
+		);
 	}
 	const normalizedQuotaKey = resolvedQuotaKey.trim();
 	const result = getRateLimitBackoff(
@@ -282,7 +316,17 @@ export function getRateLimitBackoffWithReason(
 		resolvedServerRetryAfterMs,
 		resolvedStableAccountKey,
 	);
-	const normalizedBaseDelay = normalizeDelayMs(resolvedServerRetryAfterMs, 1000);
+	const normalizedBaseDelay = normalizeDelayMs(
+		resolvedServerRetryAfterMs,
+		1000,
+	);
+	// For the first fresh attempt, pass the un-jittered normalized base so the
+	// deterministic portion of the reason multiplier is visible to callers.
+	// For subsequent attempts (or duplicate-window hits), `result.delayMs`
+	// already encodes the exponential progression + jitter from
+	// `getRateLimitBackoff`, and `calculateBackoffMs` intentionally applies
+	// only the reason multiplier so the exponential is NOT double-applied
+	// (see audit finding REQ-HIGH-01).
 	const adjustedDelay = calculateBackoffMs(
 		result.attempt === 1 && !result.isDuplicate
 			? normalizedBaseDelay

--- a/test/rate-limit-backoff.test.ts
+++ b/test/rate-limit-backoff.test.ts
@@ -132,9 +132,12 @@ describe("Rate limit backoff", () => {
 		);
 
 		expect(activeProfile).toBeDefined();
-		expect(calculateBackoffMs(1000, 20, "quota")).toBe(
-			activeProfile!.maxBackoffMs,
-		);
+		// calculateBackoffMs now applies only the reason multiplier (not an
+		// additional 2^(attempt-1)) so saturating maxBackoffMs requires a
+		// baseDelayMs well above the cap. See REQ-HIGH-01.
+		expect(
+			calculateBackoffMs(activeProfile!.maxBackoffMs * 10, 20, "quota"),
+		).toBe(activeProfile!.maxBackoffMs);
 
 		const first = getRateLimitBackoff(20, "concurrent", 1000);
 		expect(first.isDuplicate).toBe(false);
@@ -167,17 +170,24 @@ describe("Rate limit backoff", () => {
 			expect(result).toBe(1000);
 		});
 
-		it("applies exponential backoff on higher attempts", () => {
+		it("does not re-apply exponential on higher attempts (REQ-HIGH-01)", () => {
+			// calculateBackoffMs must not multiply by 2^(attempt-1) because its
+			// baseDelayMs argument is already exponential+jittered when chained
+			// with getRateLimitBackoff. Before the fix, this path caused a
+			// double-exponential that saturated maxBackoffMs after ~2 retries.
 			const attempt1 = calculateBackoffMs(1000, 1, "unknown");
 			const attempt2 = calculateBackoffMs(1000, 2, "unknown");
 			const attempt3 = calculateBackoffMs(1000, 3, "unknown");
 			expect(attempt1).toBe(1000);
-			expect(attempt2).toBe(2000);
-			expect(attempt3).toBe(4000);
+			expect(attempt2).toBe(1000);
+			expect(attempt3).toBe(1000);
 		});
 
 		it("caps at MAX_BACKOFF_MS", () => {
-			const result = calculateBackoffMs(1000, 20, "quota");
+			// Use a baseDelayMs large enough that the multiplier would exceed
+			// the default cap (5 min in this test's config context).
+			const huge = 10 * 60 * 1000;
+			const result = calculateBackoffMs(huge, 20, "quota");
 			expect(result).toBeLessThanOrEqual(5 * 60 * 1000);
 		});
 
@@ -188,12 +198,13 @@ describe("Rate limit backoff", () => {
 
 		it("uses fallback multiplier 1.0 when reason is not in map (line 111 coverage)", () => {
 			const result = calculateBackoffMs(1000, 1, "unknown-reason" as never);
-		expect(result).toBe(1000);
+			expect(result).toBe(1000);
 		});
 
 		it("uses configurable max backoff cap", () => {
 			configureRateLimitBackoff({ maxBackoffMs: 12_000 });
-			const result = calculateBackoffMs(1000, 20, "quota");
+			// baseDelayMs * quota multiplier (3.0) = 30_000, which clamps to 12_000.
+			const result = calculateBackoffMs(10_000, 20, "quota");
 			expect(result).toBe(12_000);
 		});
 	});
@@ -233,14 +244,24 @@ describe("Rate limit backoff", () => {
 
 	describe("getRateLimitBackoffWithReason", () => {
 		it("returns adjusted delay with quota reason", () => {
-			const result = getRateLimitBackoffWithReason(0, "test-quota", 1000, "quota");
+			const result = getRateLimitBackoffWithReason(
+				0,
+				"test-quota",
+				1000,
+				"quota",
+			);
 			expect(result.reason).toBe("quota");
 			expect(result.delayMs).toBe(3000);
 			expect(result.attempt).toBe(1);
 		});
 
 		it("returns adjusted delay with tokens reason", () => {
-			const result = getRateLimitBackoffWithReason(1, "test-tokens", 2000, "tokens");
+			const result = getRateLimitBackoffWithReason(
+				1,
+				"test-tokens",
+				2000,
+				"tokens",
+			);
 			expect(result.reason).toBe("tokens");
 			expect(result.delayMs).toBe(3000);
 		});
@@ -254,13 +275,27 @@ describe("Rate limit backoff", () => {
 		it("increments attempt on subsequent calls", () => {
 			getRateLimitBackoffWithReason(3, "test-increment", 1000, "quota");
 			vi.setSystemTime(new Date(2500));
-			const second = getRateLimitBackoffWithReason(3, "test-increment", 1000, "quota");
+			const second = getRateLimitBackoffWithReason(
+				3,
+				"test-increment",
+				1000,
+				"quota",
+			);
 			expect(second.attempt).toBe(2);
-			expect(second.delayMs).toBe(12000);
+			// getRateLimitBackoff gives 1000 * 2^1 = 2000 (attempt=2, zero jitter
+			// via Math.random mock). calculateBackoffMs applies only the quota
+			// multiplier (3.0): 2000 * 3.0 = 6000. Before REQ-HIGH-01 fix this
+			// double-applied the exponential and produced 12000.
+			expect(second.delayMs).toBe(6000);
 		});
 
 		it("supports named-parameter options form", () => {
-			const positional = getRateLimitBackoffWithReason(20, "named-quota", 1000, "tokens");
+			const positional = getRateLimitBackoffWithReason(
+				20,
+				"named-quota",
+				1000,
+				"tokens",
+			);
 			clearRateLimitBackoffState();
 			const named = getRateLimitBackoffWithReason({
 				accountIndex: 20,
@@ -301,9 +336,72 @@ describe("Rate limit backoff", () => {
 				}),
 			).toThrow();
 
-			const firstValid = getRateLimitBackoffWithReason(7, "state-safe", 1000, "unknown");
+			const firstValid = getRateLimitBackoffWithReason(
+				7,
+				"state-safe",
+				1000,
+				"unknown",
+			);
 			expect(firstValid.attempt).toBe(1);
 			expect(firstValid.isDuplicate).toBe(false);
+		});
+
+		// REQ-HIGH-01 regression: previously `getRateLimitBackoffWithReason`
+		// chained `getRateLimitBackoff` (which applies baseDelay * 2^(attempt-1)
+		// + jitter) and `calculateBackoffMs` (which ALSO applied 2^(attempt-1)).
+		// The double-exponential caused delays to saturate at `maxBackoffMs`
+		// after just ~2 consecutive 429s. See
+		// `.sisyphus/notepads/deep-audit/reports/request.json` for the audit.
+		it("does not double-apply exponential across chained attempts (REQ-HIGH-01)", () => {
+			const accountIndex = 42;
+			const quotaKey = "req-high-01-regression";
+			const baseDelayMs = 1000;
+
+			// attempt 1
+			const first = getRateLimitBackoffWithReason(
+				accountIndex,
+				quotaKey,
+				baseDelayMs,
+				"tokens",
+			);
+			expect(first.attempt).toBe(1);
+			// 1000 * 2^0 = 1000, jitter mocked to 0, then * tokens(1.5) = 1500.
+			expect(first.delayMs).toBe(1500);
+
+			// attempt 2 (step past default dedup window of 2000ms)
+			vi.setSystemTime(new Date(2_500));
+			const second = getRateLimitBackoffWithReason(
+				accountIndex,
+				quotaKey,
+				baseDelayMs,
+				"tokens",
+			);
+			expect(second.attempt).toBe(2);
+			// 1000 * 2^1 = 2000, then * tokens(1.5) = 3000.
+			expect(second.delayMs).toBe(3000);
+
+			// attempt 3
+			vi.setSystemTime(new Date(5_000));
+			const third = getRateLimitBackoffWithReason(
+				accountIndex,
+				quotaKey,
+				baseDelayMs,
+				"tokens",
+			);
+			expect(third.attempt).toBe(3);
+			// 1000 * 2^2 = 4000, then * tokens(1.5) = 6000.
+			// Before the fix this path evaluated to 4000 * 2^2 * 1.5 = 24000
+			// (still under the 60s cap for attempt=3 but rapidly saturating).
+			expect(third.delayMs).toBe(6000);
+
+			// Stays well under the default 60s cap.
+			expect(third.delayMs).toBeLessThan(60_000);
+
+			// Ratio attempt=1 -> attempt=3 must reflect a single exponential
+			// (2^2 = 4x), NOT a double exponential (2^4 = 16x or hitting cap).
+			const ratio = third.delayMs / first.delayMs;
+			expect(ratio).toBeCloseTo(4, 1);
+			expect(ratio).toBeLessThan(8);
 		});
 	});
 });


### PR DESCRIPTION
Addresses deep audit finding REQ-HIGH-01.

`getRateLimitBackoff()` already applies exponential + jitter. `getRateLimitBackoffWithReason()` was then calling `calculateBackoffMs()` which applied `2^(attempt-1)` a second time, causing delays to hit the 60s cap after ~2 consecutive 429s.

Fix: `calculateBackoffMs` now applies only the reason multiplier to the already-exponential `delayMs`.

Regression test added asserting attempt=3 delay stays under cap and ratio vs attempt=1 is ~4x (single exponential) not >16x (double exponential).

See `.sisyphus/notepads/deep-audit/reports/request.json` for the original finding.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR fixes the double-exponential backoff bug (REQ-HIGH-01): `calculateBackoffMs` was re-applying `2^(attempt-1)` on top of the already-exponential `delayMs` produced by `getRateLimitBackoff`, causing delays to saturate `maxBackoffMs` after ~2 consecutive 429s. the fix removes the exponential factor from `calculateBackoffMs` so it applies only the reason multiplier, and the regression test correctly pins the attempt=3/attempt=1 ratio at ~4x (single exponential). the change is self-contained and well-commented.

- `_attempt` is silently ignored in the public `calculateBackoffMs` signature — consumers reading the compiled `.d.ts` see `attempt: number` and will expect it to influence the result, but it is a no-op. the doc comment explains the intent but the parameter should carry a stronger `@deprecated` signal or be dropped from a future minor version.

<h3>Confidence Score: 5/5</h3>

safe to merge — core fix is correct, regression test is deterministic, no production callers of calculateBackoffMs outside getRateLimitBackoffWithReason

all findings are P2: the `_attempt` no-op in the public API and the zero-jitter-only regression test are style/coverage concerns, not present defects. the double-exponential is correctly removed, and the only internal caller (getRateLimitBackoffWithReason) is fully updated and covered.

lib/request/rate-limit-backoff.ts — `calculateBackoffMs` JSDoc should explicitly mark `_attempt` as ignored for external consumers

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/rate-limit-backoff.ts | core fix: removes `2^(attempt-1)` from `calculateBackoffMs`; `_attempt` is now a no-op in a publicly exported function, which is a silent API contract change for direct callers |
| test/rate-limit-backoff.test.ts | regression test added with deterministic jitter-mocked assertions; existing tests updated to match new semantics; no property-based coverage for non-zero jitter |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant GRLBWR as getRateLimitBackoffWithReason
    participant GRLB as getRateLimitBackoff
    participant State as rateLimitStateByAccountQuota
    participant CBM as calculateBackoffMs

    Caller->>GRLBWR: (accountIndex, quotaKey, serverRetryAfterMs, reason)
    GRLBWR->>GRLB: (accountIndex, quotaKey, serverRetryAfterMs)
    GRLB->>State: get previous state
    GRLB->>GRLB: baseDelay * 2^(attempt-1) + jitter
    GRLB->>State: store {attempt, jitteredDelayMs}
    GRLB-->>GRLBWR: {attempt, delayMs (exponential+jitter), isDuplicate}

    alt attempt === 1 && !isDuplicate
        GRLBWR->>CBM: (normalizedBaseDelay, _attempt, reason)
        Note over CBM: BEFORE: normalizedBaseDelay * 2^(attempt-1) * multiplier<br/>AFTER: normalizedBaseDelay * multiplier only
    else attempt > 1 OR isDuplicate
        GRLBWR->>CBM: (result.delayMs, _attempt, reason)
        Note over CBM: BEFORE: alreadyExponentialDelay * 2^(attempt-1) * multiplier double-exp<br/>AFTER: alreadyExponentialDelay * multiplier only
    end

    CBM-->>GRLBWR: min(baseDelayMs * multiplier, maxBackoffMs)
    GRLBWR-->>Caller: {attempt, delayMs (single-exponential + reason), isDuplicate, reason}
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Frate-limit-backoff-double-exponential%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frate-limit-backoff-double-exponential%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Frequest%2Frate-limit-backoff.ts%3A246-256%0A**%60_attempt%60%20silently%20ignored%20in%20exported%20public%20API**%0A%0A%60calculateBackoffMs%60%20is%20re-exported%20via%20%60lib%2Findex.ts%60%20as%20part%20of%20this%20package's%20public%20surface.%20the%20compiled%20%60.d.ts%60%20will%20still%20show%20%60_attempt%3A%20number%60%20%28TypeScript%20preserves%20the%20leading-underscore%20name%20in%20declarations%29%2C%20and%20any%20direct%20caller%20who%20passes%20%60attempt%20%3E%201%60%20expecting%20%60baseDelayMs%20*%202%5E%28attempt-1%29%20*%20multiplier%60%20now%20silently%20gets%20just%20%60baseDelayMs%20*%20multiplier%60.%20the%20JSDoc%20comment%20explains%20the%20reasoning%20well%2C%20but%20the%20parameter%20should%20carry%20a%20%60%40deprecated%60%2F%60%40unused%60%20annotation%20or%20a%20%60%40param%20_attempt%60%20note%20so%20consumers%20don't%20have%20to%20read%20the%20body%20to%20understand%20the%20no-op%3A%0A%0A%60%60%60typescript%0A%2F**%0A%20*%20...existing%20note...%0A%20*%0A%20*%20%40param%20_attempt%20-%20**ignored**%3B%20retained%20for%20call-site%20compatibility%20only.%0A%20*%20%20%20Do%20not%20rely%20on%20this%20parameter%20influencing%20the%20return%20value.%0A%20*%2F%0Aexport%20function%20calculateBackoffMs%28%0A%20%20%20%20baseDelayMs%3A%20number%2C%0A%20%20%20%20_attempt%3A%20number%2C%0A%20%20%20%20reason%3A%20RateLimitReason%20%3D%20%22unknown%22%2C%0A%29%3A%20number%20%7B%0A%60%60%60%0A%0Ano%20windows%2Ftoken-safety%20risk%20here%2C%20but%20worth%20noting%20for%20consumers%20who%20import%20this%20function%20directly.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Frate-limit-backoff.test.ts%3A355-405%0A**regression%20test%20exclusively%20uses%20zero-jitter%20mock%20%E2%80%94%20no%20property-based%20coverage**%0A%0Aall%20three%20attempt%20assertions%20use%20the%20%60beforeEach%60%20mock%20%60Math.random%20%3D%200.5%60%20which%20makes%20%60Math.random%28%29%20*%202%20-%201%20%3D%200%60%2C%20zeroing%20jitter%20entirely.%20the%20ratio%20guard%20%28%60ratio%20%3C%208%60%29%20is%20good%2C%20but%20it%20only%20fires%20in%20a%20degenerate%20case.%20under%20real%20jitter%20the%20ratio%20could%20still%20approach%2016x%20if%20positive%20jitter%20compounds%20across%20attempts%20without%20the%20fix%20%E2%80%94%20and%20the%20current%20test%20wouldn't%20catch%20a%20regression%20introduced%20per-attempt-jitter.%0A%0Athe%20project%20already%20has%20%60test%2Fproperty%2F%60%20for%20rotation%20invariants.%20a%20fast-check%20property-based%20test%20seeding%20%60Math.random%60%20with%20arbitrary%20values%20and%20asserting%20%60ratio%20%3C%208%60%20for%20any%20jitter%20scenario%20would%20make%20this%20the%20canonical%20proof.%20even%20a%20single%20extra%20%60it%60%20that%20tests%20with%20%60Math.random%20%3D%201%60%20%28max%20positive%20jitter%2C%20%2B20%25%29%20and%20%60Math.random%20%3D%200%60%20%28max%20negative%20jitter%29%20would%20add%20meaningful%20coverage%20without%20requiring%20fast-check.%0A%0Anot%20blocking%2C%20but%20flagging%20given%20the%2080%25%20coverage%20threshold%20and%20the%20existing%20property-test%20convention%20in%20this%20repo.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/request/rate-limit-backoff.ts
Line: 246-256

Comment:
**`_attempt` silently ignored in exported public API**

`calculateBackoffMs` is re-exported via `lib/index.ts` as part of this package's public surface. the compiled `.d.ts` will still show `_attempt: number` (TypeScript preserves the leading-underscore name in declarations), and any direct caller who passes `attempt > 1` expecting `baseDelayMs * 2^(attempt-1) * multiplier` now silently gets just `baseDelayMs * multiplier`. the JSDoc comment explains the reasoning well, but the parameter should carry a `@deprecated`/`@unused` annotation or a `@param _attempt` note so consumers don't have to read the body to understand the no-op:

```typescript
/**
 * ...existing note...
 *
 * @param _attempt - **ignored**; retained for call-site compatibility only.
 *   Do not rely on this parameter influencing the return value.
 */
export function calculateBackoffMs(
    baseDelayMs: number,
    _attempt: number,
    reason: RateLimitReason = "unknown",
): number {
```

no windows/token-safety risk here, but worth noting for consumers who import this function directly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/rate-limit-backoff.test.ts
Line: 355-405

Comment:
**regression test exclusively uses zero-jitter mock — no property-based coverage**

all three attempt assertions use the `beforeEach` mock `Math.random = 0.5` which makes `Math.random() * 2 - 1 = 0`, zeroing jitter entirely. the ratio guard (`ratio < 8`) is good, but it only fires in a degenerate case. under real jitter the ratio could still approach 16x if positive jitter compounds across attempts without the fix — and the current test wouldn't catch a regression introduced per-attempt-jitter.

the project already has `test/property/` for rotation invariants. a fast-check property-based test seeding `Math.random` with arbitrary values and asserting `ratio < 8` for any jitter scenario would make this the canonical proof. even a single extra `it` that tests with `Math.random = 1` (max positive jitter, +20%) and `Math.random = 0` (max negative jitter) would add meaningful coverage without requiring fast-check.

not blocking, but flagging given the 80% coverage threshold and the existing property-test convention in this repo.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(request): remove double-exponential ..."](https://github.com/ndycode/codex-multi-auth/commit/98ee7a2ff17e0fb72b85df0c4b2092f1a249c75c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28831830)</sub>

<!-- /greptile_comment -->