### PR TITLE
fix(storage): consult WAL on newer-mtime even when primary parses (STORAGE-001)

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1454,6 +1454,74 @@ async function loadAccountsFromJournal(
 	}
 }
 
+/**
+ * STORAGE-001 helper: return replayed WAL storage when the WAL journal is
+ * strictly newer than the primary file and its checksum validates.
+ *
+ * saveAccountsToDisk writes the WAL journal before the temp file and before
+ * renaming temp -> primary. If a crash (or a rename that exhausts its retry
+ * budget) occurs after the WAL write but before cleanupWal runs, the primary
+ * still holds stale content while the WAL holds the intended new content.
+ * Consulting the WAL only inside the catch branch of loadAccountsInternal
+ * silently discards committed-to-WAL saves. Resolve that durability gap by
+ * checking mtime when the primary parses successfully.
+ *
+ * Returns null when:
+ *   - the WAL file does not exist
+ *   - the primary does not exist (caller goes through existing catch branch)
+ *   - the WAL mtime is not strictly newer than the primary mtime
+ *   - loadAccountsFromJournal rejects the WAL (invalid checksum, schema,
+ *     reset marker, etc.)
+ *
+ * Any stat failure other than ENOENT is treated as "no replay" and the
+ * primary content is returned by the caller unchanged.
+ */
+async function replayWalIfNewerThanPrimary(
+	path: string,
+): Promise<AccountStorageV3 | null> {
+	const walPath = getAccountsWalPath(path);
+	let primaryStat: { mtimeMs: number };
+	let walStat: { mtimeMs: number };
+	try {
+		primaryStat = await fs.stat(path);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT") {
+			log.warn("Failed to stat primary account storage for WAL freshness", {
+				path,
+				error: String(error),
+			});
+		}
+		return null;
+	}
+	try {
+		walStat = await fs.stat(walPath);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT") {
+			log.warn("Failed to stat WAL journal for WAL freshness", {
+				path: walPath,
+				error: String(error),
+			});
+		}
+		return null;
+	}
+	if (!(walStat.mtimeMs > primaryStat.mtimeMs)) {
+		return null;
+	}
+	const replayed = await loadAccountsFromJournal(path, { silent: true });
+	if (!replayed) {
+		return null;
+	}
+	log.warn("Replayed WAL journal newer than primary account storage", {
+		path,
+		walPath,
+		primaryMtimeMs: primaryStat.mtimeMs,
+		walMtimeMs: walStat.mtimeMs,
+	});
+	return replayed;
+}
+
 async function loadAccountsInternal(
 	persistMigration: ((storage: AccountStorageV3) => Promise<void>) | null,
 ): Promise<AccountStorageV3 | null> {
@@ -1493,6 +1561,36 @@ async function loadAccountsInternal(
 
 		if (existsSync(resetMarkerPath)) {
 			return createEmptyStorageWithMetadata(false, "intentional-reset");
+		}
+
+		// STORAGE-001: saveAccountsToDisk writes WAL first, then the temp
+		// file, then renames temp into place. If a crash or a failed rename
+		// occurs AFTER the WAL write but BEFORE cleanupWal runs, the primary
+		// file holds stale content while the WAL holds the intended new
+		// content. The try-branch below returns the stale primary unless we
+		// explicitly consult the WAL. Replay the WAL when its mtime is
+		// strictly newer than the primary and its checksum validates.
+		if (normalized) {
+			const walReplay = await replayWalIfNewerThanPrimary(path);
+			if (walReplay) {
+				if (existsSync(resetMarkerPath)) {
+					return createEmptyStorageWithMetadata(false, "intentional-reset");
+				}
+				if (persistMigration) {
+					try {
+						await persistMigration(walReplay);
+					} catch (persistError) {
+						log.warn("Failed to persist WAL-newer storage replay", {
+							path,
+							error: String(persistError),
+						});
+					}
+				}
+				if (walReplay.accounts.length === 0) {
+					return withRestoreMetadata(walReplay, true, "empty-storage");
+				}
+				return walReplay;
+			}
 		}
 
 		if (normalized && normalized.accounts.length === 0) {

--- a/test/storage-recovery-paths.test.ts
+++ b/test/storage-recovery-paths.test.ts
@@ -15,12 +15,24 @@ import {
 	getRestoreAssessment,
 } from "../lib/storage.js";
 
-function getRestoreEligibility(value: unknown): { restoreEligible?: boolean; restoreReason?: string } {
+function getRestoreEligibility(value: unknown): {
+	restoreEligible?: boolean;
+	restoreReason?: string;
+} {
 	if (value && typeof value === "object" && "restoreEligible" in value) {
-		const candidate = value as { restoreEligible?: unknown; restoreReason?: unknown };
+		const candidate = value as {
+			restoreEligible?: unknown;
+			restoreReason?: unknown;
+		};
 		return {
-			restoreEligible: typeof candidate.restoreEligible === "boolean" ? candidate.restoreEligible : undefined,
-			restoreReason: typeof candidate.restoreReason === "string" ? candidate.restoreReason : undefined,
+			restoreEligible:
+				typeof candidate.restoreEligible === "boolean"
+					? candidate.restoreEligible
+					: undefined,
+			restoreReason:
+				typeof candidate.restoreReason === "string"
+					? candidate.restoreReason
+					: undefined,
 		};
 	}
 	return {};
@@ -35,7 +47,10 @@ describe("storage recovery paths", () => {
 	let storagePath = "";
 
 	beforeEach(async () => {
-		workDir = join(tmpdir(), `codex-storage-recovery-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		workDir = join(
+			tmpdir(),
+			`codex-storage-recovery-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
 		storagePath = join(workDir, "openai-codex-accounts.json");
 		await fs.mkdir(workDir, { recursive: true });
 		setStoragePathDirect(storagePath);
@@ -46,6 +61,146 @@ describe("storage recovery paths", () => {
 		setStoragePathDirect(null);
 		setStorageBackupEnabled(true);
 		await removeWithRetry(workDir, { recursive: true, force: true });
+	});
+
+	it("prefers WAL journal when primary parses but WAL mtime is newer (STORAGE-001)", async () => {
+		// Regression guard for STORAGE-001: saveAccountsToDisk writes the WAL
+		// journal before the temp file is renamed into place. If the process
+		// crashes (or the rename retry budget is exhausted) between the WAL
+		// write and cleanupWal, the primary still holds OLD content while the
+		// WAL holds the intended NEW content. Before the fix, loadAccounts
+		// only consulted the WAL in the catch branch (primary read throws),
+		// so a valid-but-stale primary silently shadowed a valid newer WAL.
+		const stalePrimaryPayload = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "stale-primary-refresh",
+					accountId: "stale-primary",
+					addedAt: 1,
+					lastUsed: 1,
+				},
+			],
+		};
+		await fs.writeFile(
+			storagePath,
+			JSON.stringify(stalePrimaryPayload),
+			"utf-8",
+		);
+
+		// Ensure a real mtime gap so the WAL-newer test cannot be flaky on
+		// filesystems with coarse (~1s) mtime granularity (e.g. FAT, some NFS).
+		await new Promise((resolve) => setTimeout(resolve, 1100));
+
+		const walPayload = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "newer-wal-refresh",
+					accountId: "newer-wal",
+					addedAt: 2,
+					lastUsed: 2,
+				},
+			],
+		};
+		const walContent = JSON.stringify(walPayload);
+		const walEntry = {
+			version: 1,
+			createdAt: Date.now(),
+			path: storagePath,
+			checksum: sha256(walContent),
+			content: walContent,
+		};
+		await fs.writeFile(`${storagePath}.wal`, JSON.stringify(walEntry), "utf-8");
+
+		const primaryStat = await fs.stat(storagePath);
+		const walStat = await fs.stat(`${storagePath}.wal`);
+		expect(walStat.mtimeMs).toBeGreaterThan(primaryStat.mtimeMs);
+
+		const recovered = await loadAccounts();
+		expect(recovered?.accounts).toHaveLength(1);
+		expect(recovered?.accounts[0]?.accountId).toBe("newer-wal");
+
+		const persisted = JSON.parse(await fs.readFile(storagePath, "utf-8")) as {
+			accounts?: Array<{ accountId?: string }>;
+		};
+		expect(persisted.accounts?.[0]?.accountId).toBe("newer-wal");
+	});
+
+	it("keeps primary content when WAL mtime is older than primary (STORAGE-001 guard)", async () => {
+		// Control scenario for STORAGE-001: an older WAL must not overwrite a
+		// newer primary. Verifies the mtime comparison is strict and does not
+		// regress the common post-save state where cleanupWal was interrupted
+		// yet the WAL is already stale relative to a later successful save.
+		const walPayload = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "older-wal-refresh",
+					accountId: "older-wal",
+					addedAt: 1,
+					lastUsed: 1,
+				},
+			],
+		};
+		const walContent = JSON.stringify(walPayload);
+		const walEntry = {
+			version: 1,
+			createdAt: Date.now(),
+			path: storagePath,
+			checksum: sha256(walContent),
+			content: walContent,
+		};
+		await fs.writeFile(`${storagePath}.wal`, JSON.stringify(walEntry), "utf-8");
+
+		await new Promise((resolve) => setTimeout(resolve, 1100));
+
+		const primaryPayload = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "fresh-primary-refresh",
+					accountId: "fresh-primary",
+					addedAt: 2,
+					lastUsed: 2,
+				},
+			],
+		};
+		await fs.writeFile(storagePath, JSON.stringify(primaryPayload), "utf-8");
+
+		const primaryStat = await fs.stat(storagePath);
+		const walStat = await fs.stat(`${storagePath}.wal`);
+		expect(primaryStat.mtimeMs).toBeGreaterThan(walStat.mtimeMs);
+
+		const recovered = await loadAccounts();
+		expect(recovered?.accounts).toHaveLength(1);
+		expect(recovered?.accounts[0]?.accountId).toBe("fresh-primary");
+	});
+
+	it("keeps primary content when no WAL exists (STORAGE-001 guard)", async () => {
+		// Baseline: no WAL file at all -> normal primary load, no mtime lookup
+		// falls over.
+		const primaryPayload = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "plain-primary-refresh",
+					accountId: "plain-primary",
+					addedAt: 3,
+					lastUsed: 3,
+				},
+			],
+		};
+		await fs.writeFile(storagePath, JSON.stringify(primaryPayload), "utf-8");
+
+		const recovered = await loadAccounts();
+		expect(recovered?.accounts).toHaveLength(1);
+		expect(recovered?.accounts[0]?.accountId).toBe("plain-primary");
 	});
 
 	it("recovers from WAL journal when primary storage is unreadable", async () => {
@@ -98,7 +253,11 @@ describe("storage recovery paths", () => {
 				},
 			],
 		};
-		await fs.writeFile(`${storagePath}.bak`, JSON.stringify(backupPayload), "utf-8");
+		await fs.writeFile(
+			`${storagePath}.bak`,
+			JSON.stringify(backupPayload),
+			"utf-8",
+		);
 
 		const recovered = await loadAccounts();
 		expect(recovered?.accounts).toHaveLength(1);
@@ -192,14 +351,16 @@ describe("storage recovery paths", () => {
 
 		const originalReadFile = fs.readFile.bind(fs);
 		const originalWriteFile = fs.writeFile.bind(fs);
-		const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
-			const [targetPath] = args;
-			const result = await originalReadFile(...args);
-			if (targetPath === backupPath) {
-				await originalWriteFile(resetMarkerPath, "reset", "utf-8");
-			}
-			return result;
-		});
+		const readSpy = vi
+			.spyOn(fs, "readFile")
+			.mockImplementation(async (...args) => {
+				const [targetPath] = args;
+				const result = await originalReadFile(...args);
+				if (targetPath === backupPath) {
+					await originalWriteFile(resetMarkerPath, "reset", "utf-8");
+				}
+				return result;
+			});
 
 		try {
 			const recovered = await loadFlaggedAccounts();
@@ -225,7 +386,11 @@ describe("storage recovery paths", () => {
 				},
 			],
 		};
-		await fs.writeFile(`${storagePath}.bak.1`, JSON.stringify(historicalBackupPayload), "utf-8");
+		await fs.writeFile(
+			`${storagePath}.bak.1`,
+			JSON.stringify(historicalBackupPayload),
+			"utf-8",
+		);
 
 		const recovered = await loadAccounts();
 		expect(recovered?.accounts).toHaveLength(1);
@@ -254,7 +419,11 @@ describe("storage recovery paths", () => {
 				},
 			],
 		};
-		await fs.writeFile(`${storagePath}.bak.2`, JSON.stringify(oldestBackupPayload), "utf-8");
+		await fs.writeFile(
+			`${storagePath}.bak.2`,
+			JSON.stringify(oldestBackupPayload),
+			"utf-8",
+		);
 
 		const recovered = await loadAccounts();
 		expect(recovered?.accounts).toHaveLength(1);
@@ -515,14 +684,20 @@ describe("storage recovery paths", () => {
 				},
 			],
 		};
-		await fs.writeFile(`${storagePath}.bak`, JSON.stringify(backupPayload), "utf-8");
+		await fs.writeFile(
+			`${storagePath}.bak`,
+			JSON.stringify(backupPayload),
+			"utf-8",
+		);
 
 		const assessment = await getRestoreAssessment();
 
 		expect(assessment.restoreEligible).toBe(true);
 		expect(assessment.restoreReason).toBe("missing-storage");
 		expect(assessment.latestSnapshot?.path).toBe(`${storagePath}.bak`);
-		expect(assessment.backupMetadata.accounts.latestValidPath).toBe(`${storagePath}.bak`);
+		expect(assessment.backupMetadata.accounts.latestValidPath).toBe(
+			`${storagePath}.bak`,
+		);
 	});
 
 	it("ignores Codex CLI mirror files during restore assessment", async () => {
@@ -573,7 +748,9 @@ describe("storage recovery paths", () => {
 		expect(assessment.backupMetadata.accounts.latestValidPath).toBeUndefined();
 		expect(
 			assessment.backupMetadata.accounts.snapshots.some(
-				(snapshot) => snapshot.path === codexCliAccountsPath || snapshot.path === codexCliAuthPath,
+				(snapshot) =>
+					snapshot.path === codexCliAccountsPath ||
+					snapshot.path === codexCliAuthPath,
 			),
 		).toBe(false);
 	});
@@ -651,7 +828,9 @@ describe("storage recovery paths", () => {
 
 		const reloaded = await loadAccounts();
 		expect(reloaded?.accounts).toHaveLength(0);
-		expect(getRestoreEligibility(reloaded).restoreReason).toBe("intentional-reset");
+		expect(getRestoreEligibility(reloaded).restoreReason).toBe(
+			"intentional-reset",
+		);
 	});
 
 	it("suppresses WAL recovery when a reset marker appears while the WAL is being read", async () => {
@@ -680,22 +859,26 @@ describe("storage recovery paths", () => {
 
 		const originalReadFile = fs.readFile.bind(fs);
 		const originalWriteFile = fs.writeFile.bind(fs);
-		const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
-			const [targetPath] = args;
-			if (targetPath === `${storagePath}.wal`) {
-				await originalWriteFile(
-					`${storagePath}.reset-intent`,
-					JSON.stringify({ version: 1, createdAt: Date.now() }),
-					"utf-8",
-				);
-			}
-			return originalReadFile(...args);
-		});
+		const readSpy = vi
+			.spyOn(fs, "readFile")
+			.mockImplementation(async (...args) => {
+				const [targetPath] = args;
+				if (targetPath === `${storagePath}.wal`) {
+					await originalWriteFile(
+						`${storagePath}.reset-intent`,
+						JSON.stringify({ version: 1, createdAt: Date.now() }),
+						"utf-8",
+					);
+				}
+				return originalReadFile(...args);
+			});
 
 		try {
 			const reloaded = await loadAccounts();
 			expect(reloaded?.accounts).toHaveLength(0);
-			expect(getRestoreEligibility(reloaded).restoreReason).toBe("intentional-reset");
+			expect(getRestoreEligibility(reloaded).restoreReason).toBe(
+				"intentional-reset",
+			);
 		} finally {
 			readSpy.mockRestore();
 		}
@@ -731,7 +914,14 @@ describe("storage recovery paths", () => {
 			JSON.stringify({
 				version: 3,
 				activeIndex: 0,
-				accounts: [{ refreshToken: "primary-refresh", accountId: "primary", addedAt: 6, lastUsed: 6 }],
+				accounts: [
+					{
+						refreshToken: "primary-refresh",
+						accountId: "primary",
+						addedAt: 6,
+						lastUsed: 6,
+					},
+				],
 			}),
 			"utf-8",
 		);
@@ -767,7 +957,14 @@ describe("storage recovery paths", () => {
 			JSON.stringify({
 				version: 3,
 				activeIndex: 0,
-				accounts: [{ refreshToken: "backup-refresh", accountId: "disabled-backup", addedAt: 3, lastUsed: 3 }],
+				accounts: [
+					{
+						refreshToken: "backup-refresh",
+						accountId: "disabled-backup",
+						addedAt: 3,
+						lastUsed: 3,
+					},
+				],
 			}),
 			"utf-8",
 		);
@@ -838,10 +1035,16 @@ describe("storage recovery paths", () => {
 
 		const metadata = await getBackupMetadata();
 		const accountSnapshots = metadata.accounts.snapshots;
-		const cacheEntries = accountSnapshots.filter((snapshot) => snapshot.path.endsWith(".cache"));
+		const cacheEntries = accountSnapshots.filter((snapshot) =>
+			snapshot.path.endsWith(".cache"),
+		);
 		expect(cacheEntries).toHaveLength(0);
-		expect(metadata.accounts.latestValidPath).toBe(`${storagePath}.manual-meta-checkpoint`);
-		const discovered = accountSnapshots.find((snapshot) => snapshot.path.endsWith("manual-meta-checkpoint"));
+		expect(metadata.accounts.latestValidPath).toBe(
+			`${storagePath}.manual-meta-checkpoint`,
+		);
+		const discovered = accountSnapshots.find((snapshot) =>
+			snapshot.path.endsWith("manual-meta-checkpoint"),
+		);
 		expect(discovered?.kind).toBe("accounts-discovered-backup");
 		expect(discovered?.valid).toBe(true);
 		expect(discovered?.accountCount).toBe(1);
@@ -857,7 +1060,14 @@ describe("storage recovery paths", () => {
 			JSON.stringify({
 				version: 3,
 				activeIndex: 0,
-				accounts: [{ refreshToken: "older-refresh", accountId: "older", addedAt: 1, lastUsed: 1 }],
+				accounts: [
+					{
+						refreshToken: "older-refresh",
+						accountId: "older",
+						addedAt: 1,
+						lastUsed: 1,
+					},
+				],
 			}),
 			"utf-8",
 		);
@@ -867,7 +1077,14 @@ describe("storage recovery paths", () => {
 			JSON.stringify({
 				version: 3,
 				activeIndex: 0,
-				accounts: [{ refreshToken: "newer-refresh", accountId: "newer", addedAt: 2, lastUsed: 2 }],
+				accounts: [
+					{
+						refreshToken: "newer-refresh",
+						accountId: "newer",
+						addedAt: 2,
+						lastUsed: 2,
+					},
+				],
 			}),
 			"utf-8",
 		);
@@ -876,4 +1093,3 @@ describe("storage recovery paths", () => {
 		expect(metadata.accounts.latestValidPath).toBe(newerManualPath);
 	});
 });
-

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -956,11 +956,20 @@ describe("storage", () => {
 					),
 				).toBe(true);
 
+				// STORAGE-001: the failed rollback still wrote its intended
+				// pre-transaction payload to the WAL journal before the rename
+				// exhausted its retry budget. Because the rollback WAL is
+				// strictly newer than the primary (which was renamed during
+				// attempt 1 with the 2-account forward state), loadAccounts
+				// now replays the WAL and surfaces the rolled-back single
+				// account. The AggregateError above still reports the double
+				// failure to the caller; the durable on-disk state no longer
+				// silently discards a committed-to-WAL rollback.
 				const loadedAccounts = await isolatedStorageModule.loadAccounts();
-				expect(loadedAccounts?.accounts).toHaveLength(2);
+				expect(loadedAccounts?.accounts).toHaveLength(1);
 				expect(
 					loadedAccounts?.accounts.map((account) => account.refreshToken),
-				).toEqual(["refresh-existing", "refresh-restored"]);
+				).toEqual(["refresh-existing"]);
 
 				const loadedFlagged = await isolatedStorageModule.loadFlaggedAccounts();
 				expect(loadedFlagged.accounts).toHaveLength(1);


### PR DESCRIPTION
## Summary

Fix deep-audit finding **STORAGE-001** (see `.sisyphus/notepads/deep-audit/reports/storage.json`): committed-to-WAL saves were silently lost on the next load when the primary file was stale but still parsed cleanly.

## Root cause

`saveAccountsToDisk` (`lib/storage/account-save.ts`) writes in this order:

1. WAL journal (`writeJournal`)
2. Temp file (`writeTemp`)
3. `renameTempToPath` (temp -> primary)
4. `cleanupResetMarker` / `cleanupWal`

If the process crashes, or the inline rename retry budget in `saveAccountsUnlocked` (`lib/storage.ts:1689-1706`) is exhausted, **after** the WAL write but **before** the rename succeeds, the primary still holds old content while the WAL holds the intended new content.

On next startup, `loadAccountsInternal` read the primary, parsed it (it's valid — just old), and returned. `loadAccountsFromJournal` was only invoked from the catch branch (primary read/parse throws). Result: a valid-but-stale primary silently shadowed a valid newer WAL — a write-durability regression.

## Fix

In `loadAccountsInternal`, after the primary parses successfully, check whether `.wal` exists with `mtimeMs > primary.mtimeMs`. If yes, reuse the existing `loadAccountsFromJournal` helper (checksum + schema validation) and prefer the replayed WAL content. Persist it back through the existing `persistMigration` path so subsequent loads are clean. If the WAL is missing, stale (older mtime), or fails checksum/schema, fall through unchanged.

Scope: `lib/storage.ts` only. `lib/storage/account-save.ts` write order unchanged. WAL format and checksum algorithm unchanged.

## Verification

Three scenarios now tested in `test/storage-recovery-paths.test.ts`:

1. **Clean primary, no WAL** -> loads primary (unchanged).
2. **Clean primary, stale WAL** (older mtime) -> loads primary (unchanged).
3. **Clean primary, NEWER valid WAL** -> loads WAL (new behavior, the STORAGE-001 durability guarantee).

Existing catch-branch paths (primary throws -> WAL -> backups) are preserved unchanged.

One existing test in `test/storage.test.ts` (`surfaces rollback failure when flagged persistence and account rollback both fail`) was updated: it encoded the pre-fix behavior where a committed rollback WAL was silently discarded. Under the fix, the rollback WAL now wins on next load — the durable on-disk state correctly reflects the intended rollback, and the caller still receives the `AggregateError` describing the double failure.

## Tests

- `npm run typecheck`: pass
- `npm run lint`: pass
- `npm test`: 232 files / 3532 tests pass
- Storage suites (storage.test.ts + storage-async.test.ts + storage-recovery-paths.test.ts): 208/208 pass
- Net new tests: +3 in `storage-recovery-paths.test.ts`. One updated assertion in `storage.test.ts`.

## Must-not checks

- [x] No `as any`, `@ts-ignore`, `@ts-expect-error`
- [x] Changes limited to `lib/storage.ts`, `test/storage-recovery-paths.test.ts`, `test/storage.test.ts`
- [x] WAL format + checksum algorithm unchanged
- [x] No `--amend`, no force-push

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr fixes STORAGE-001 by adding a mtime-based WAL consultation in the try-branch of `loadAccountsInternal`. previously, a valid-but-stale primary silently shadowed a newer WAL when the save cycle crashed after the WAL write but before the rename committed. the fix is sound for v3 storage and the three new vitest scenarios cover the happy path, older-WAL guard, and no-WAL baseline.

two edge cases in the new path deserve attention before merge:
- the v1→v3 migration `persistMigration` call (lines 1546-1558) runs a full save cycle *before* `replayWalIfNewerThanPrimary` executes, which clears the WAL and resets the primary mtime — silently discarding the intended WAL content for the (rare) v1-format-with-newer-WAL scenario
- `replayWalIfNewerThanPrimary` performs three sequential async ops (stat primary, stat WAL, read WAL) without holding the storage lock; an interleaved `saveAccounts` can cause a stale WAL to appear newer than the freshly-renamed primary

<h3>Confidence Score: 4/5</h3>

safe to merge for v3 storage (the overwhelming majority of users); two P2 edge cases in the v1-migration ordering and the unlocked stat/stat/read sequence should be addressed before the next release

all four findings are P2 — no data corruption risk for v3 format users and the fix correctly solves STORAGE-001 for the common case. the v1→v3 migration ordering issue silently defeats the fix for an already-rare scenario, and the concurrency TOCTOU is a pre-existing pattern in the storage layer; neither is a regression in the happy path. bumping to 4 rather than 5 because the migration-ordering issue is a correctness gap in the new code path that is straightforward to fix before merge.

lib/storage.ts lines 1546-1593: version-migration persist order vs WAL replay check, and the three-op unlocked stat/stat/read sequence in replayWalIfNewerThanPrimary

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/storage.ts | adds replayWalIfNewerThanPrimary helper + wires it into the try-branch of loadAccountsInternal; v1→v3 migration persist call preceding the WAL replay check defeats the fix for the rare v1+newer-WAL scenario; TOCTOU race in unlocked stat/stat/read sequence |
| test/storage-recovery-paths.test.ts | adds three STORAGE-001 scenarios; 1100ms sleep is insufficient for FAT32 (2s write-time granularity) and the WAL-newer-invalid-checksum + WAL-replay-0-accounts paths are not covered |
| test/storage.test.ts | updates one assertion to reflect the corrected durability contract: rollback WAL now wins on next load instead of being silently discarded |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[loadAccountsInternal] --> B[loadAccountsFromPath - parse primary]
    B --> C{parse succeeds?}
    C -- no --> CATCH[catch branch]
    CATCH --> D[loadAccountsFromJournal - WAL recovery]
    D --> E{WAL valid?}
    E -- yes --> F[persistMigration WAL]
    E -- no --> G[try backup files]
    C -- yes --> H{resetMarker exists?}
    H -- yes --> EMPTY1[return empty intentional-reset]
    H -- no --> VER{v1->v3 migration?}
    VER -- yes --> MPER[persistMigration normalized - FULL SAVE CYCLE clears WAL!]
    MPER --> WAL_CHECK
    VER -- no --> WAL_CHECK
    WAL_CHECK[replayWalIfNewerThanPrimary] --> STAT1[stat primary]
    STAT1 --> STAT2[stat WAL]
    STAT2 --> MTIME{WAL mtime > primary mtime?}
    MTIME -- no --> PRIMARY[return normalized primary]
    MTIME -- yes --> JLOAD[loadAccountsFromJournal silent]
    JLOAD --> VALID{WAL valid checksum + schema?}
    VALID -- no --> PRIMARY
    VALID -- yes --> RM2{resetMarker exists?}
    RM2 -- yes --> EMPTY2[return empty intentional-reset]
    RM2 -- no --> WPER[persistMigration walReplay]
    WPER --> WALRET{walReplay.accounts empty?}
    WALRET -- yes --> EMPTY3[return withRestoreMetadata empty-storage]
    WALRET -- no --> WALWIN[return walReplay - STORAGE-001 fix]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/storage.ts`, line 1546-1560 ([link](https://github.com/ndycode/codex-multi-auth/blob/2212d955290ff345b7d68d645773d11d1eb5bc5a/lib/storage.ts#L1546-L1560)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **v1→v3 migration persist clears the WAL before the mtime check runs**

   when `storedVersion !== normalized.version` (v1→v3), `persistMigration(normalized)` triggers a full `saveAccounts` cycle: WAL write → rename → `cleanupWal`. by the time `replayWalIfNewerThanPrimary` executes a few lines later, the original WAL is gone and the primary carries a fresh mtime — so the intended WAL content is silently discarded for the rare but valid v1-format-with-newer-WAL scenario.

   swapping the order (mtime check first, version-migration persist after, skipped if WAL wins) would close the gap:

   ```typescript
   // resolve STORAGE-001 before version-migration persist so the
   // version-migration write doesn't clobber the WAL or reset the mtime.
   if (normalized) {
       const walReplay = await replayWalIfNewerThanPrimary(path);
       if (walReplay) {
           if (existsSync(resetMarkerPath)) {
               return createEmptyStorageWithMetadata(false, "intentional-reset");
           }
           if (persistMigration) {
               try { await persistMigration(walReplay); } catch (e) { /* ... */ }
           }
           if (walReplay.accounts.length === 0) {
               return withRestoreMetadata(walReplay, true, "empty-storage");
           }
           return walReplay;
       }
   }

   // version-migration persist only when WAL did not win
   if (normalized && storedVersion !== normalized.version) { ... }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/storage.ts
   Line: 1546-1560

   Comment:
   **v1→v3 migration persist clears the WAL before the mtime check runs**

   when `storedVersion !== normalized.version` (v1→v3), `persistMigration(normalized)` triggers a full `saveAccounts` cycle: WAL write → rename → `cleanupWal`. by the time `replayWalIfNewerThanPrimary` executes a few lines later, the original WAL is gone and the primary carries a fresh mtime — so the intended WAL content is silently discarded for the rare but valid v1-format-with-newer-WAL scenario.

   swapping the order (mtime check first, version-migration persist after, skipped if WAL wins) would close the gap:

   ```typescript
   // resolve STORAGE-001 before version-migration persist so the
   // version-migration write doesn't clobber the WAL or reset the mtime.
   if (normalized) {
       const walReplay = await replayWalIfNewerThanPrimary(path);
       if (walReplay) {
           if (existsSync(resetMarkerPath)) {
               return createEmptyStorageWithMetadata(false, "intentional-reset");
           }
           if (persistMigration) {
               try { await persistMigration(walReplay); } catch (e) { /* ... */ }
           }
           if (walReplay.accounts.length === 0) {
               return withRestoreMetadata(walReplay, true, "empty-storage");
           }
           return walReplay;
       }
   }

   // version-migration persist only when WAL did not win
   if (normalized && storedVersion !== normalized.version) { ... }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fwal-stale-primary-replay%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwal-stale-primary-replay%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fstorage.ts%0ALine%3A%201546-1560%0A%0AComment%3A%0A**v1%E2%86%92v3%20migration%20persist%20clears%20the%20WAL%20before%20the%20mtime%20check%20runs**%0A%0Awhen%20%60storedVersion%20!%3D%3D%20normalized.version%60%20%28v1%E2%86%92v3%29%2C%20%60persistMigration%28normalized%29%60%20triggers%20a%20full%20%60saveAccounts%60%20cycle%3A%20WAL%20write%20%E2%86%92%20rename%20%E2%86%92%20%60cleanupWal%60.%20by%20the%20time%20%60replayWalIfNewerThanPrimary%60%20executes%20a%20few%20lines%20later%2C%20the%20original%20WAL%20is%20gone%20and%20the%20primary%20carries%20a%20fresh%20mtime%20%E2%80%94%20so%20the%20intended%20WAL%20content%20is%20silently%20discarded%20for%20the%20rare%20but%20valid%20v1-format-with-newer-WAL%20scenario.%0A%0Aswapping%20the%20order%20%28mtime%20check%20first%2C%20version-migration%20persist%20after%2C%20skipped%20if%20WAL%20wins%29%20would%20close%20the%20gap%3A%0A%0A%60%60%60typescript%0A%2F%2F%20resolve%20STORAGE-001%20before%20version-migration%20persist%20so%20the%0A%2F%2F%20version-migration%20write%20doesn't%20clobber%20the%20WAL%20or%20reset%20the%20mtime.%0Aif%20%28normalized%29%20%7B%0A%20%20%20%20const%20walReplay%20%3D%20await%20replayWalIfNewerThanPrimary%28path%29%3B%0A%20%20%20%20if%20%28walReplay%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28existsSync%28resetMarkerPath%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20createEmptyStorageWithMetadata%28false%2C%20%22intentional-reset%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20%28persistMigration%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20try%20%7B%20await%20persistMigration%28walReplay%29%3B%20%7D%20catch%20%28e%29%20%7B%20%2F*%20...%20*%2F%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20%28walReplay.accounts.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20withRestoreMetadata%28walReplay%2C%20true%2C%20%22empty-storage%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20walReplay%3B%0A%20%20%20%20%7D%0A%7D%0A%0A%2F%2F%20version-migration%20persist%20only%20when%20WAL%20did%20not%20win%0Aif%20%28normalized%20%26%26%20storedVersion%20!%3D%3D%20normalized.version%29%20%7B%20...%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fwal-stale-primary-replay%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwal-stale-primary-replay%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Fstorage.ts%3A1546-1560%0A**v1%E2%86%92v3%20migration%20persist%20clears%20the%20WAL%20before%20the%20mtime%20check%20runs**%0A%0Awhen%20%60storedVersion%20!%3D%3D%20normalized.version%60%20%28v1%E2%86%92v3%29%2C%20%60persistMigration%28normalized%29%60%20triggers%20a%20full%20%60saveAccounts%60%20cycle%3A%20WAL%20write%20%E2%86%92%20rename%20%E2%86%92%20%60cleanupWal%60.%20by%20the%20time%20%60replayWalIfNewerThanPrimary%60%20executes%20a%20few%20lines%20later%2C%20the%20original%20WAL%20is%20gone%20and%20the%20primary%20carries%20a%20fresh%20mtime%20%E2%80%94%20so%20the%20intended%20WAL%20content%20is%20silently%20discarded%20for%20the%20rare%20but%20valid%20v1-format-with-newer-WAL%20scenario.%0A%0Aswapping%20the%20order%20%28mtime%20check%20first%2C%20version-migration%20persist%20after%2C%20skipped%20if%20WAL%20wins%29%20would%20close%20the%20gap%3A%0A%0A%60%60%60typescript%0A%2F%2F%20resolve%20STORAGE-001%20before%20version-migration%20persist%20so%20the%0A%2F%2F%20version-migration%20write%20doesn't%20clobber%20the%20WAL%20or%20reset%20the%20mtime.%0Aif%20%28normalized%29%20%7B%0A%20%20%20%20const%20walReplay%20%3D%20await%20replayWalIfNewerThanPrimary%28path%29%3B%0A%20%20%20%20if%20%28walReplay%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28existsSync%28resetMarkerPath%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20createEmptyStorageWithMetadata%28false%2C%20%22intentional-reset%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20%28persistMigration%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20try%20%7B%20await%20persistMigration%28walReplay%29%3B%20%7D%20catch%20%28e%29%20%7B%20%2F*%20...%20*%2F%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20%28walReplay.accounts.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20withRestoreMetadata%28walReplay%2C%20true%2C%20%22empty-storage%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20walReplay%3B%0A%20%20%20%20%7D%0A%7D%0A%0A%2F%2F%20version-migration%20persist%20only%20when%20WAL%20did%20not%20win%0Aif%20%28normalized%20%26%26%20storedVersion%20!%3D%3D%20normalized.version%29%20%7B%20...%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fstorage.ts%3A1479-1523%0A**concurrency%3A%20three%20unlocked%20async%20ops%20between%20stat%28primary%29%20and%20readFile%28WAL%29**%0A%0A%60replayWalIfNewerThanPrimary%60%20calls%20%60fs.stat%28path%29%60%2C%20%60fs.stat%28walPath%29%60%2C%20then%20%60loadAccountsFromJournal%60%20%28readFile%29%20in%20sequence%20without%20holding%20the%20storage%20lock.%20a%20concurrent%20%60saveAccounts%60%20can%20land%20between%20any%20two%20of%20those%20calls%3A%0A%0A1.%20stat%28primary%29%20%E2%86%92%20returns%20%60T_old%60%0A2.%20%E2%86%B3%20concurrent%20save%20completes%3A%20rename%20gives%20primary%20mtime%20%60T_new%60%2C%20%60cleanupWal%60%20removes%20WAL%2C%20new%20WAL%20written%20at%20%60T_wal%60%0A3.%20stat%28WAL%29%20%E2%86%92%20returns%20%60T_wal%60%20where%20%60T_wal%20%3E%20T_new%20%3E%20T_old%60%0A4.%20WAL%20appears%20newer%20%E2%86%92%20%60loadAccountsFromJournal%60%20reads%20the%20**new-cycle**%20WAL%0A5.%20WAL%20replay%20persists%20that%20content%2C%20overwriting%20the%20primary%20that%20the%20concurrent%20save%20just%20committed%0A%0Anet%20effect%20is%20an%20extra%20unnecessary%20write%3B%20content%20is%20consistent%20only%20if%20the%20concurrent%20save%20wrote%20the%20same%20payload%20%E2%80%94%20not%20guaranteed%20in%20a%20multi-writer%20context.%20calling%20out%20per%20project%20conventions%3A%20concurrency%20issues%20in%20the%20storage%20layer%20are%20always%20worth%20an%20explicit%20note.%0A%0A%23%23%23%20Issue%203%20of%204%0Atest%2Fstorage-recovery-paths.test.ts%3A94%0A**FAT32%20mtime%20granularity%3A%201100ms%20sleep%20is%20insufficient**%0A%0Athe%20comment%20says%20%22coarse%20%28~1s%29%20mtime%20granularity%20%28e.g.%20FAT%2C%20some%20NFS%29%22%20but%20FAT32%20stores%20write-time%20in%202-second%20resolution.%20a%201100ms%20gap%20still%20falls%20within%20the%20same%202-second%20bucket%2C%20so%20%60walStat.mtimeMs%20%3D%3D%3D%20primaryStat.mtimeMs%60%20is%20possible%20on%20a%20FAT32%20windows%20volume%20and%20the%20test%20would%20fail%20with%20a%20correct%20%60%3E%60%20assertion%20at%20line%20120.%0A%0Abumping%20to%20%602100%60%20would%20cover%20both%20the%20~1s%20%28NFS%2Fext3%29%20and%202s%20%28FAT32%29%20cases.%20on%20windows%20NTFS%20%28100ns%20resolution%29%20and%20linux%20ext4%2Fbtrfs%20%28ns%20resolution%29%20the%20extra%201%20second%20costs%20nothing%20meaningful%20in%20CI.%0A%0A%60%60%60suggestion%0A%09%09await%20new%20Promise%28%28resolve%29%20%3D%3E%20setTimeout%28resolve%2C%202100%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Alib%2Fstorage.ts%3A1573-1593%0A**missing%20vitest%20coverage%20for%20two%20new%20branches**%0A%0Atwo%20code%20paths%20in%20the%20WAL%20replay%20block%20are%20not%20exercised%20by%20the%20new%20tests%3A%0A%0A1.%20**WAL%20is%20newer%20but%20checksum%20is%20invalid**%20%28or%20schema%20validation%20fails%20inside%20%60loadAccountsFromJournal%60%29%20%E2%86%92%20%60replayWalIfNewerThanPrimary%60%20returns%20%60null%60%20and%20execution%20should%20fall%20through%20to%20primary%20content.%20no%20test%20verifies%20this%20guard%3B%20if%20the%20condition%20were%20accidentally%20inverted%2C%20stale-primary%20would%20silently%20win%20and%20the%20only%20signal%20would%20be%20the%20silent%20%60%7Bsilent%3Atrue%7D%60%20call%20%E2%80%94%20no%20log%20emitted.%0A%0A2.%20**WAL%20replay%20returns%200%20accounts**%20%28lines%201589-1591%3A%20%60withRestoreMetadata%28walReplay%2C%20true%2C%20%22empty-storage%22%29%60%29.%20the%20%60restoreEligible%3Dtrue%60%20%2B%20%60restoreReason%3Dempty-storage%60%20branch%20for%20a%20WAL-replayed%20empty%20pool%20is%20untested.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/storage.ts
Line: 1546-1560

Comment:
**v1→v3 migration persist clears the WAL before the mtime check runs**

when `storedVersion !== normalized.version` (v1→v3), `persistMigration(normalized)` triggers a full `saveAccounts` cycle: WAL write → rename → `cleanupWal`. by the time `replayWalIfNewerThanPrimary` executes a few lines later, the original WAL is gone and the primary carries a fresh mtime — so the intended WAL content is silently discarded for the rare but valid v1-format-with-newer-WAL scenario.

swapping the order (mtime check first, version-migration persist after, skipped if WAL wins) would close the gap:

```typescript
// resolve STORAGE-001 before version-migration persist so the
// version-migration write doesn't clobber the WAL or reset the mtime.
if (normalized) {
    const walReplay = await replayWalIfNewerThanPrimary(path);
    if (walReplay) {
        if (existsSync(resetMarkerPath)) {
            return createEmptyStorageWithMetadata(false, "intentional-reset");
        }
        if (persistMigration) {
            try { await persistMigration(walReplay); } catch (e) { /* ... */ }
        }
        if (walReplay.accounts.length === 0) {
            return withRestoreMetadata(walReplay, true, "empty-storage");
        }
        return walReplay;
    }
}

// version-migration persist only when WAL did not win
if (normalized && storedVersion !== normalized.version) { ... }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/storage.ts
Line: 1479-1523

Comment:
**concurrency: three unlocked async ops between stat(primary) and readFile(WAL)**

`replayWalIfNewerThanPrimary` calls `fs.stat(path)`, `fs.stat(walPath)`, then `loadAccountsFromJournal` (readFile) in sequence without holding the storage lock. a concurrent `saveAccounts` can land between any two of those calls:

1. stat(primary) → returns `T_old`
2. ↳ concurrent save completes: rename gives primary mtime `T_new`, `cleanupWal` removes WAL, new WAL written at `T_wal`
3. stat(WAL) → returns `T_wal` where `T_wal > T_new > T_old`
4. WAL appears newer → `loadAccountsFromJournal` reads the **new-cycle** WAL
5. WAL replay persists that content, overwriting the primary that the concurrent save just committed

net effect is an extra unnecessary write; content is consistent only if the concurrent save wrote the same payload — not guaranteed in a multi-writer context. calling out per project conventions: concurrency issues in the storage layer are always worth an explicit note.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/storage-recovery-paths.test.ts
Line: 94

Comment:
**FAT32 mtime granularity: 1100ms sleep is insufficient**

the comment says "coarse (~1s) mtime granularity (e.g. FAT, some NFS)" but FAT32 stores write-time in 2-second resolution. a 1100ms gap still falls within the same 2-second bucket, so `walStat.mtimeMs === primaryStat.mtimeMs` is possible on a FAT32 windows volume and the test would fail with a correct `>` assertion at line 120.

bumping to `2100` would cover both the ~1s (NFS/ext3) and 2s (FAT32) cases. on windows NTFS (100ns resolution) and linux ext4/btrfs (ns resolution) the extra 1 second costs nothing meaningful in CI.

```suggestion
		await new Promise((resolve) => setTimeout(resolve, 2100));
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/storage.ts
Line: 1573-1593

Comment:
**missing vitest coverage for two new branches**

two code paths in the WAL replay block are not exercised by the new tests:

1. **WAL is newer but checksum is invalid** (or schema validation fails inside `loadAccountsFromJournal`) → `replayWalIfNewerThanPrimary` returns `null` and execution should fall through to primary content. no test verifies this guard; if the condition were accidentally inverted, stale-primary would silently win and the only signal would be the silent `{silent:true}` call — no log emitted.

2. **WAL replay returns 0 accounts** (lines 1589-1591: `withRestoreMetadata(walReplay, true, "empty-storage")`). the `restoreEligible=true` + `restoreReason=empty-storage` branch for a WAL-replayed empty pool is untested.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(storage): consult WAL on newer-mtime..."](https://github.com/ndycode/codex-multi-auth/commit/2212d955290ff345b7d68d645773d11d1eb5bc5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28831858)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->