### PR TITLE
fix(auth): redact opaque tokens from free-form log messages (LIB-HIGH-001)

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -66,6 +66,82 @@ function getOAuthResponseLogMetadata(
 	return { responseType: typeof rawResponse };
 }
 
+const OAUTH_SENSITIVE_BODY_KEYS = [
+	"refresh_token",
+	"refreshToken",
+	"access_token",
+	"accessToken",
+	"id_token",
+	"idToken",
+	"token",
+	"code",
+	"code_verifier",
+] as const;
+
+function redactSensitiveFields(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map((item) => redactSensitiveFields(item));
+	}
+	if (value !== null && typeof value === "object") {
+		const out: Record<string, unknown> = {};
+		const sensitiveSet = new Set<string>(OAUTH_SENSITIVE_BODY_KEYS);
+		for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+			if (sensitiveSet.has(k)) {
+				out[k] = "***REDACTED***";
+			} else {
+				out[k] = redactSensitiveFields(v);
+			}
+		}
+		return out;
+	}
+	return value;
+}
+
+/**
+ * Scrub opaque tokens from a raw OAuth token-endpoint response body before
+ * interpolating it into a log message.
+ *
+ * Error and success responses from `/oauth/token` may contain `refresh_token`,
+ * `access_token`, or `id_token` values. ChatGPT refresh tokens are opaque
+ * high-entropy strings that do NOT match the logger's `TOKEN_PATTERNS`
+ * (JWT, long hex, `sk-*`, `Bearer <x>`), so they would be written verbatim
+ * to disk log files when a status-body string is concatenated into a
+ * `logError` message.
+ *
+ * Strategy:
+ *   1. If the body parses as JSON, walk it and mask sensitive keys.
+ *   2. Otherwise fall back to a targeted regex scrub of `"key":"value"` and
+ *      `key=value` patterns for the known sensitive keys.
+ *
+ * The returned string is safe to interpolate into log messages.
+ */
+export function sanitizeOAuthResponseBodyForLog(rawBody: string): string {
+	if (!rawBody) return rawBody;
+	const trimmed = rawBody.trim();
+	if (trimmed.length === 0) return rawBody;
+
+	if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+		try {
+			const parsed = JSON.parse(trimmed) as unknown;
+			const redacted = redactSensitiveFields(parsed);
+			return JSON.stringify(redacted);
+		} catch {
+			// Fall through to regex scrub for malformed JSON.
+		}
+	}
+
+	let scrubbed = rawBody;
+	for (const key of OAUTH_SENSITIVE_BODY_KEYS) {
+		// "key":"value" style (JSON-like text)
+		const jsonPattern = new RegExp(`("${key}"\\s*:\\s*)"[^"]*"`, "g");
+		scrubbed = scrubbed.replace(jsonPattern, `$1"***REDACTED***"`);
+		// key=value style (urlencoded / query-string)
+		const urlPattern = new RegExp(`(${key}=)[^&\\s]+`, "g");
+		scrubbed = scrubbed.replace(urlPattern, `$1***REDACTED***`);
+	}
+	return scrubbed;
+}
+
 /**
  * Redacts sensitive OAuth query parameters for safe logging.
  * Returns the original string when parsing fails.
@@ -160,12 +236,13 @@ export async function exchangeAuthorizationCode(
 	});
 	if (!res.ok) {
 		const text = await res.text().catch(() => "");
-		logError(`code->token failed: ${res.status} ${text}`);
+		const safeText = sanitizeOAuthResponseBodyForLog(text);
+		logError(`code->token failed: ${res.status} ${safeText}`);
 		return {
 			type: "failed",
 			reason: "http_error",
 			statusCode: res.status,
-			message: text || undefined,
+			message: safeText || undefined,
 		};
 	}
 	const rawJson = (await res.json()) as unknown;
@@ -252,12 +329,13 @@ export async function refreshAccessToken(
 
 		if (!response.ok) {
 			const text = await response.text().catch(() => "");
-			logError(`Token refresh failed: ${response.status} ${text}`);
+			const safeText = sanitizeOAuthResponseBodyForLog(text);
+			logError(`Token refresh failed: ${response.status} ${safeText}`);
 			return {
 				type: "failed",
 				reason: "http_error",
 				statusCode: response.status,
-				message: text || undefined,
+				message: safeText || undefined,
 			};
 		}
 

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -73,10 +73,23 @@ const OAUTH_SENSITIVE_BODY_KEYS = [
 	"accessToken",
 	"id_token",
 	"idToken",
+	"codeVerifier",
 	"token",
 	"code",
 	"code_verifier",
 ] as const;
+
+function scrubTokenLikeSubstrings(value: string): string {
+	let scrubbed = value.replace(
+		/(\b(?:refresh|access|id)[_-]?token\s*[:=]\s*)([^\s,;"'}]{8,})/gi,
+		(_match, prefix) => `${prefix}***REDACTED***`,
+	);
+	scrubbed = scrubbed.replace(
+		/\b(?:RT|AT)_ch_[A-Za-z0-9_-]{20,}\b/g,
+		"***REDACTED***",
+	);
+	return scrubbed;
+}
 
 function redactSensitiveFields(value: unknown): unknown {
 	if (Array.isArray(value)) {
@@ -93,6 +106,9 @@ function redactSensitiveFields(value: unknown): unknown {
 			}
 		}
 		return out;
+	}
+	if (typeof value === "string") {
+		return scrubTokenLikeSubstrings(value);
 	}
 	return value;
 }

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -136,8 +136,8 @@ export function sanitizeOAuthResponseBodyForLog(rawBody: string): string {
 		const jsonPattern = new RegExp(`("${key}"\\s*:\\s*)"[^"]*"`, "g");
 		scrubbed = scrubbed.replace(jsonPattern, `$1"***REDACTED***"`);
 		// key=value style (urlencoded / query-string)
-		const urlPattern = new RegExp(`(${key}=)[^&\\s]+`, "g");
-		scrubbed = scrubbed.replace(urlPattern, `$1***REDACTED***`);
+		const urlPattern = new RegExp(`(^|[?&\\s])(${key}=)[^&\\s]+`, "g");
+		scrubbed = scrubbed.replace(urlPattern, `$1$2***REDACTED***`);
 	}
 	return scrubbed;
 }

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -7,6 +7,7 @@ import {
 	redactOAuthUrlForLog,
 	refreshAccessToken,
 	exchangeAuthorizationCode,
+	sanitizeOAuthResponseBodyForLog,
 	CLIENT_ID,
 	AUTHORIZE_URL,
 	REDIRECT_URI,
@@ -741,6 +742,190 @@ describe("Auth Module", () => {
 			} finally {
 				globalThis.fetch = originalFetch;
 				vi.restoreAllMocks();
+			}
+		});
+	});
+
+	describe("sanitizeOAuthResponseBodyForLog (LIB-HIGH-001 regression)", () => {
+		const OPAQUE_REFRESH =
+			"RT_ch_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP0123456789";
+		const OPAQUE_ACCESS =
+			"AT_ch_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+
+		it("masks refresh_token and access_token in JSON error body", () => {
+			const body = JSON.stringify({
+				error: "invalid_grant",
+				error_description: "bad refresh",
+				refresh_token: OPAQUE_REFRESH,
+				access_token: OPAQUE_ACCESS,
+				id_token: "some.id.token",
+			});
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			expect(out).not.toContain(OPAQUE_REFRESH);
+			expect(out).not.toContain(OPAQUE_ACCESS);
+			expect(out).toContain("***REDACTED***");
+			expect(out).toContain("invalid_grant");
+		});
+
+		it("masks nested sensitive fields in JSON body", () => {
+			const body = JSON.stringify({
+				error: "invalid_grant",
+				debug: { refresh_token: OPAQUE_REFRESH, reason: "x" },
+			});
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			expect(out).not.toContain(OPAQUE_REFRESH);
+			expect(out).toContain("invalid_grant");
+			expect(out).toContain("x");
+		});
+
+		it("masks urlencoded refresh_token=value form", () => {
+			const body = `error=invalid_grant&refresh_token=${OPAQUE_REFRESH}&other=safe`;
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			expect(out).not.toContain(OPAQUE_REFRESH);
+			expect(out).toContain("refresh_token=***REDACTED***");
+			expect(out).toContain("other=safe");
+		});
+
+		it("masks refresh_token in malformed JSON via regex fallback", () => {
+			const body = `{"error":"invalid_grant","refresh_token":"${OPAQUE_REFRESH}",`;
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			expect(out).not.toContain(OPAQUE_REFRESH);
+			expect(out).toContain('"refresh_token":"***REDACTED***"');
+		});
+
+		it("returns non-token plain text unchanged", () => {
+			expect(sanitizeOAuthResponseBodyForLog("Bad Request")).toBe(
+				"Bad Request",
+			);
+			expect(sanitizeOAuthResponseBodyForLog("")).toBe("");
+		});
+
+		it("preserves structure and non-sensitive JSON fields", () => {
+			const body = JSON.stringify({
+				error: "invalid_grant",
+				status: 400,
+				refresh_token: OPAQUE_REFRESH,
+			});
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			const parsed = JSON.parse(out) as Record<string, unknown>;
+			expect(parsed.error).toBe("invalid_grant");
+			expect(parsed.status).toBe(400);
+			expect(parsed.refresh_token).toBe("***REDACTED***");
+		});
+
+		it("masks camelCase variants (refreshToken / accessToken)", () => {
+			const body = JSON.stringify({
+				refreshToken: OPAQUE_REFRESH,
+				accessToken: OPAQUE_ACCESS,
+			});
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			expect(out).not.toContain(OPAQUE_REFRESH);
+			expect(out).not.toContain(OPAQUE_ACCESS);
+		});
+	});
+
+	describe("refreshAccessToken does not leak tokens into log message (LIB-HIGH-001)", () => {
+		const OPAQUE_REFRESH =
+			"RT_ch_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP0123456789";
+		const OPAQUE_NEW_REFRESH =
+			"RT_ch_NEW_nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn";
+
+		it("scrubs refresh_token from logError when refresh fails with JSON body", async () => {
+			const logErrorSpy = vi
+				.spyOn(loggerModule, "logError")
+				.mockImplementation(() => {});
+			const originalFetch = globalThis.fetch;
+			const errorBody = JSON.stringify({
+				error: "invalid_grant",
+				error_description: "refresh_token expired",
+				refresh_token: OPAQUE_NEW_REFRESH,
+			});
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(errorBody, {
+						status: 400,
+					}),
+			) as never;
+
+			try {
+				const result = await refreshAccessToken(OPAQUE_REFRESH);
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.statusCode).toBe(400);
+					expect(result.message).toBeDefined();
+					expect(result.message).not.toContain(OPAQUE_NEW_REFRESH);
+				}
+				const loggedArgs = logErrorSpy.mock.calls.flat().map(String);
+				for (const entry of loggedArgs) {
+					expect(entry).not.toContain(OPAQUE_NEW_REFRESH);
+				}
+			} finally {
+				globalThis.fetch = originalFetch;
+				logErrorSpy.mockRestore();
+			}
+		});
+
+		it("scrubs access_token from logError when code->token exchange fails with JSON body", async () => {
+			const logErrorSpy = vi
+				.spyOn(loggerModule, "logError")
+				.mockImplementation(() => {});
+			const OPAQUE_ACCESS =
+				"AT_ch_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+			const originalFetch = globalThis.fetch;
+			const errorBody = JSON.stringify({
+				error: "server_error",
+				access_token: OPAQUE_ACCESS,
+			});
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(errorBody, {
+						status: 500,
+					}),
+			) as never;
+
+			try {
+				const result = await exchangeAuthorizationCode("code", "verifier");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.statusCode).toBe(500);
+					expect(result.message).toBeDefined();
+					expect(result.message).not.toContain(OPAQUE_ACCESS);
+				}
+				const loggedArgs = logErrorSpy.mock.calls.flat().map(String);
+				for (const entry of loggedArgs) {
+					expect(entry).not.toContain(OPAQUE_ACCESS);
+				}
+			} finally {
+				globalThis.fetch = originalFetch;
+				logErrorSpy.mockRestore();
+			}
+		});
+
+		it("preserves non-sensitive body content in log message", async () => {
+			const logErrorSpy = vi
+				.spyOn(loggerModule, "logError")
+				.mockImplementation(() => {});
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							error: "invalid_grant",
+							error_description: "token expired",
+						}),
+						{ status: 400 },
+					),
+			) as never;
+
+			try {
+				await refreshAccessToken("some-token");
+				const loggedArgs = logErrorSpy.mock.calls.flat().map(String);
+				const joined = loggedArgs.join(" ");
+				expect(joined).toContain("invalid_grant");
+				expect(joined).toContain("token expired");
+			} finally {
+				globalThis.fetch = originalFetch;
+				logErrorSpy.mockRestore();
 			}
 		});
 	});

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -830,6 +830,26 @@ describe("Auth Module", () => {
 			expect(out).not.toContain(OPAQUE_REFRESH);
 			expect(out).not.toContain(OPAQUE_ACCESS);
 		});
+
+		it("masks codeVerifier camelCase variant", () => {
+			const body = JSON.stringify({
+				codeVerifier: OPAQUE_REFRESH,
+				status: 400,
+			});
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			expect(out).not.toContain(OPAQUE_REFRESH);
+			expect(out).toContain("***REDACTED***");
+			expect(out).toContain("400");
+		});
+
+		it("scrubs token-like substrings inside parsed JSON string values", () => {
+			const body = JSON.stringify({
+				error_description: `refresh failed for token ${OPAQUE_REFRESH}`,
+			});
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			expect(out).not.toContain(OPAQUE_REFRESH);
+			expect(out).toContain("***REDACTED***");
+		});
 	});
 
 	describe("refreshAccessToken does not leak tokens into log message (LIB-HIGH-001)", () => {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -786,6 +786,14 @@ describe("Auth Module", () => {
 			expect(out).toContain("other=safe");
 		});
 
+		it("does not over-redact longer parameter names ending in _code", () => {
+			const body = `error=invalid_grant&device_code=device-safe&refresh_token=${OPAQUE_REFRESH}&other=safe`;
+			const out = sanitizeOAuthResponseBodyForLog(body);
+			expect(out).toContain("device_code=device-safe");
+			expect(out).toContain("refresh_token=***REDACTED***");
+			expect(out).toContain("other=safe");
+		});
+
 		it("masks refresh_token in malformed JSON via regex fallback", () => {
 			const body = `{"error":"invalid_grant","refresh_token":"${OPAQUE_REFRESH}",`;
 			const out = sanitizeOAuthResponseBodyForLog(body);


### PR DESCRIPTION
## Summary

Addresses deep-audit finding **LIB-HIGH-001**: opaque refresh / access tokens could leak into free-form log messages when the OAuth `/oauth/token` endpoint returned a non-OK status.

PR #395 previously redacted sensitive query params in OAuth URLs, but response bodies were still concatenated into `logError` messages verbatim. The central logger's `TOKEN_PATTERNS` only matches JWT / long-hex / `sk-*` / `Bearer <x>` strings — ChatGPT refresh tokens are opaque and do **not** match any of those, so they would be written verbatim to disk logs (`~/.codex/multi-auth/logs/codex-plugin/`, mode 0o600 but persistent) when `ENABLE_PLUGIN_REQUEST_LOGGING=1`.

## Leak sites identified

- `lib/auth/auth.ts` — `exchangeAuthorizationCode`: `logError(\`code->token failed: ${res.status} ${text}\`)` where `text` is the raw body of a failed token-exchange response.
- `lib/auth/auth.ts` — `refreshAccessToken`: `logError(\`Token refresh failed: ${response.status} ${text}\`)` same pattern.
- Both sites also returned the raw `text` as `TokenResult.message`, which downstream `codex-manager.ts` paths (`Refresh failed: ${tokenResult.message ...}`, `normalizeFailureDetail(result.message, ...)`) also forwarded into user-facing output and `logError`.

## Fix strategy — targeted, not a logger hot-path change

Added `sanitizeOAuthResponseBodyForLog(rawBody: string): string` in `lib/auth/auth.ts`:

1. If the body parses as JSON, walk it and mask `refresh_token`, `access_token`, `id_token` (plus camelCase variants, `token`, `code`, `code_verifier`).
2. Otherwise fall back to regex scrubs for `"key":"value"` and `key=value` forms.
3. Preserves all non-sensitive fields (error code, description, status, etc.) so log messages remain actionable.

Both leak sites now route the body through the helper before it reaches `logError` and before it is stored in the returned `TokenResult.message`.

## Regression tests

Added `sanitizeOAuthResponseBodyForLog` unit tests and two end-to-end assertions in `test/auth.test.ts` covering:

- JSON body with nested sensitive fields is masked.
- urlencoded `refresh_token=…` form is masked.
- Malformed JSON falls back to regex scrub.
- camelCase `refreshToken` / `accessToken` variants are masked.
- Plain-text non-token bodies (`"Bad Request"`) are unchanged.
- `refreshAccessToken` and `exchangeAuthorizationCode` never pass the opaque token value into `logError.mock.calls` and never return it in `TokenResult.message`.
- Non-sensitive body content (error code, error_description) still reaches the log message.

## Verification

- `npm run typecheck`: clean.
- `npm run lint`: clean.
- `npm test`: 232 files / 3539 tests pass.

## Constraints honored

- No `as any`, no `@ts-ignore`, no `@ts-expect-error`.
- No changes to the logger hot path.
- Fix is localized to `lib/auth/auth.ts` plus test file.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR fixes LIB-HIGH-001 by routing raw oauth response bodies through `sanitizeOAuthResponseBodyForLog` before they reach `logError` or `TokenResult.message` in both `exchangeAuthorizationCode` and `refreshAccessToken`. the previous thread concern about URL-encoded regex over-redacting `device_code` was addressed in commit f474aa2 with `(^|[?&\\s])` anchoring.

one remaining asymmetry: the JSON parse path applies `scrubTokenLikeSubstrings` to all string values (including non-sensitive fields like `error_description`), but the regex fallback path does not — so an opaque token embedded in a description field inside malformed JSON would survive the scrub on the fallback path.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are P2; no token leaks on the primary well-formed JSON path, and the URL-encoded anchoring concern from the previous thread is resolved

all remaining findings are P2: an asymmetry in the regex fallback path, a minor Set allocation inside a recursive function, and missing test coverage for a few key variants — none block the fix from achieving its goal on the common paths

lib/auth/auth.ts lines 149–158 — the regex fallback return value should be passed through scrubTokenLikeSubstrings before returning

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/auth/auth.ts | adds sanitizeOAuthResponseBodyForLog with JSON and regex fallback paths; JSON path correctly applies scrubTokenLikeSubstrings to all string values but fallback path does not, creating an asymmetry for malformed JSON bodies; new Set recreated on each recursive call |
| test/auth.test.ts | comprehensive regression tests for LIB-HIGH-001; missing coverage for token and code_verifier snake_case in URL-encoded path and for the regex fallback when tokens are embedded in non-sensitive field values |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[raw response body] --> B{empty or whitespace?}
    B -- yes --> C[return as-is]
    B -- no --> D{starts with brace or bracket?}
    D -- yes --> E[JSON.parse]
    E -- success --> F[redactSensitiveFields recursive walk]
    F --> G{node type}
    G -- object --> H[mask sensitive keys, recurse values]
    G -- array --> I[recurse each item]
    G -- string --> J[scrubTokenLikeSubstrings applied]
    H & I & J --> K[JSON.stringify and return]
    E -- parse error --> L[regex fallback loop]
    D -- no --> L
    L --> M[jsonPattern and urlPattern per sensitive key]
    M --> N[return scrubbed string — no token-substring scrub on free text]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Ftoken-log-redaction%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftoken-log-redaction%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fauth%2Fauth.ts%3A149-158%0A**Regex%20fallback%20skips%20%60scrubTokenLikeSubstrings%60**%0A%0Athe%20JSON%20path%20applies%20%60scrubTokenLikeSubstrings%60%20to%20every%20string%20value%20in%20the%20parsed%20tree%2C%20including%20non-sensitive%20fields%20like%20%60error_description%60.%20the%20regex%20fallback%20path%20only%20loops%20over%20%60OAUTH_SENSITIVE_BODY_KEYS%60%20and%20does%20not%20apply%20the%20same%20scrub%20to%20the%20rest%20of%20the%20text.%20a%20malformed%20JSON%20body%20like%20%60%7B%22error%22%3A%22invalid%22%2C%22error_description%22%3A%22token%20expired%22%2C%22refresh_token%22%3A%22...%22%2C%60%20would%20have%20%60refresh_token%60%20redacted%20but%20an%20opaque%20token%20embedded%20in%20%60error_description%60%20would%20survive%20%E2%80%94%20contradicting%20the%20JSON%20path's%20behavior%20for%20the%20same%20logical%20content.%0A%0Afix%3A%20apply%20%60scrubTokenLikeSubstrings%60%20to%20the%20output%20of%20the%20regex%20pass%20before%20returning.%0A%0A%60%60%60suggestion%0A%09return%20scrubTokenLikeSubstrings%28scrubbed%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fauth%2Fauth.ts%3A100%0A**%60new%20Set%60%20recreated%20on%20every%20recursive%20call**%0A%0A%60sensitiveSet%60%20is%20rebuilt%20from%20%60OAUTH_SENSITIVE_BODY_KEYS%60%20for%20every%20nested%20object%20node%20visited%20by%20%60redactSensitiveFields%60.%20hoist%20to%20module%20scope%20so%20it%20is%20allocated%20once.%0A%0A%60%60%60suggestion%0A%09%09const%20sensitiveSet%20%3D%20OAUTH_SENSITIVE_BODY_KEYS_SET%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fauth.test.ts%3A797-853%0A**missing%20vitest%20coverage%20for%20several%20fallback%20branches**%0A%0Athree%20gaps%20worth%20adding%3A%0A%0A1.%20the%20%60%22token%22%60%20key%20in%20URL-encoded%20form%20%E2%80%94%20no%20test%20verifies%20it%20is%20redacted%20by%20the%20regex%20path.%0A2.%20the%20%60%22code_verifier%22%60%20snake_case%20key%20in%20URL-encoded%20form%20%E2%80%94%20only%20the%20camelCase%20%60codeVerifier%60%20variant%20is%20covered.%0A3.%20the%20regex%20fallback%20path%20where%20an%20opaque%20token%20appears%20inside%20a%20non-sensitive%20field%20value%20in%20a%20malformed%20JSON%20body%20%E2%80%94%20a%20failing%20test%20here%20would%20make%20the%20gap%20on%20lines%20149%E2%80%93158%20of%20%60auth.ts%60%20concrete.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/auth/auth.ts
Line: 149-158

Comment:
**Regex fallback skips `scrubTokenLikeSubstrings`**

the JSON path applies `scrubTokenLikeSubstrings` to every string value in the parsed tree, including non-sensitive fields like `error_description`. the regex fallback path only loops over `OAUTH_SENSITIVE_BODY_KEYS` and does not apply the same scrub to the rest of the text. a malformed JSON body like `{"error":"invalid","error_description":"token expired","refresh_token":"...",` would have `refresh_token` redacted but an opaque token embedded in `error_description` would survive — contradicting the JSON path's behavior for the same logical content.

fix: apply `scrubTokenLikeSubstrings` to the output of the regex pass before returning.

```suggestion
	return scrubTokenLikeSubstrings(scrubbed);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/auth/auth.ts
Line: 100

Comment:
**`new Set` recreated on every recursive call**

`sensitiveSet` is rebuilt from `OAUTH_SENSITIVE_BODY_KEYS` for every nested object node visited by `redactSensitiveFields`. hoist to module scope so it is allocated once.

```suggestion
		const sensitiveSet = OAUTH_SENSITIVE_BODY_KEYS_SET;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/auth.test.ts
Line: 797-853

Comment:
**missing vitest coverage for several fallback branches**

three gaps worth adding:

1. the `"token"` key in URL-encoded form — no test verifies it is redacted by the regex path.
2. the `"code_verifier"` snake_case key in URL-encoded form — only the camelCase `codeVerifier` variant is covered.
3. the regex fallback path where an opaque token appears inside a non-sensitive field value in a malformed JSON body — a failing test here would make the gap on lines 149–158 of `auth.ts` concrete.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(auth): scrub codeVerifier and token-..."](https://github.com/ndycode/codex-multi-auth/commit/a7bea8b15937b4b0f4b6c1855f5d29a212b5df30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28833995)</sub>

<!-- /greptile_comment -->