### PR TITLE
fix(request): linear SSE buffering with pre-append size check

### DIFF
--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -789,14 +789,15 @@ export async function convertSseToJson(
 			);
 			if (done) break;
 			const decoded = decoder.decode(value, { stream: true });
+			const decodedBytes = Buffer.byteLength(decoded, "utf8");
 			// Pre-append size check: reject before allocating/retaining the chunk
 			// alongside the accumulated buffer. This bounds peak memory to the
 			// cap rather than cap + chunk.
-			if (totalSize + decoded.length > MAX_SSE_SIZE) {
+			if (totalSize + decodedBytes > MAX_SSE_SIZE) {
 				throw new Error(`SSE response exceeds ${MAX_SSE_SIZE} bytes limit`);
 			}
 			chunks.push(decoded);
-			totalSize += decoded.length;
+			totalSize += decodedBytes;
 		}
 
 		const fullText = chunks.join("");

--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -766,7 +766,13 @@ export async function convertSseToJson(
 	}
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();
-	let fullText = "";
+	// REQ-HIGH-03: Accumulate decoded chunks in an array instead of concatenating
+	// into a growing string. Repeated `fullText += chunk` is O(n) per append,
+	// producing O(n^2) total work on V8 for large streams. The array-then-join()
+	// pattern is O(n) total. The size check runs BEFORE appending so we never
+	// allocate a chunk that would exceed MAX_SSE_SIZE.
+	const chunks: string[] = [];
+	let totalSize = 0;
 	const streamStallTimeoutMs = Math.max(
 		1_000,
 		Math.floor(
@@ -782,11 +788,18 @@ export async function convertSseToJson(
 				streamStallTimeoutMs,
 			);
 			if (done) break;
-			fullText += decoder.decode(value, { stream: true });
-			if (fullText.length > MAX_SSE_SIZE) {
+			const decoded = decoder.decode(value, { stream: true });
+			// Pre-append size check: reject before allocating/retaining the chunk
+			// alongside the accumulated buffer. This bounds peak memory to the
+			// cap rather than cap + chunk.
+			if (totalSize + decoded.length > MAX_SSE_SIZE) {
 				throw new Error(`SSE response exceeds ${MAX_SSE_SIZE} bytes limit`);
 			}
+			chunks.push(decoded);
+			totalSize += decoded.length;
 		}
+
+		const fullText = chunks.join("");
 
 		if (LOGGING_ENABLED) {
 			logRequest("stream-full", { fullContent: fullText });

--- a/test/response-handler-sse-buffer.test.ts
+++ b/test/response-handler-sse-buffer.test.ts
@@ -112,4 +112,31 @@ describe("convertSseToJson: REQ-HIGH-03 linear buffering with pre-append cap", (
 		expect(reader.read).toHaveBeenCalledTimes(1);
 		expect(reader.cancel).toHaveBeenCalled();
 	});
+
+	it("counts utf-8 bytes rather than utf-16 code units in the pre-append guard", async () => {
+		// 😀 is 2 UTF-16 code units but 4 UTF-8 bytes. The guard must count bytes
+		// or it underestimates multi-byte chunks and can exceed the 10MB budget.
+		const emoji = "😀";
+		const repeats = Math.ceil((MAX_SSE_SIZE_FOR_TEST + 16) / 4);
+		const filler = emoji.repeat(repeats);
+		const sse =
+			'data: {"type":"response.started"}\n' +
+			`data: {"type":"response.done","response":{"id":"resp_emoji","output":${JSON.stringify(filler)}}}\n`;
+		const bytes = new TextEncoder().encode(sse);
+		// Sanity check: real bytes exceed cap even though string length alone would
+		// underestimate the size.
+		const decodedLengthEstimate = sse.length;
+		const byteLength = bytes.byteLength;
+		if (!(byteLength > MAX_SSE_SIZE_FOR_TEST && decodedLengthEstimate < byteLength)) {
+			throw new Error("test setup invalid: expected utf-8 bytes > utf-16 length");
+		}
+
+		const { response, reader } = buildChunkedReader([bytes]);
+		await expect(convertSseToJson(response, new Headers())).rejects.toThrow(
+			/exceeds.*bytes limit/,
+		);
+		// One read only; the first chunk is rejected based on byte length.
+		expect(reader.read).toHaveBeenCalledTimes(1);
+		expect(reader.cancel).toHaveBeenCalled();
+	});
 });

--- a/test/response-handler-sse-buffer.test.ts
+++ b/test/response-handler-sse-buffer.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest";
+import { convertSseToJson } from "../lib/request/response-handler.js";
+
+// REQ-HIGH-03: Linear SSE buffering with pre-append size check.
+//
+// Previous implementation of convertSseToJson used
+//   fullText += decoder.decode(value, { stream: true })
+// which is O(n) per append on V8 (string rope materialization), producing
+// O(n^2) total work on large SSE streams. It also checked MAX_SSE_SIZE
+// AFTER appending, so peak memory transiently held chunk_size + 10MB
+// before throwing.
+//
+// Fix accumulates decoded chunks in a string[] and joins once at the end,
+// and enforces the MAX_SSE_SIZE cap BEFORE appending each chunk, so memory
+// is bounded to the cap and the throw cannot allocate a cap+chunk buffer.
+//
+// These tests live in a dedicated file to isolate the regression scenarios
+// from the much larger response-handler.test.ts suite.
+
+describe("convertSseToJson: REQ-HIGH-03 linear buffering with pre-append cap", () => {
+	// MAX_SSE_SIZE is an internal constant in lib/request/response-handler.ts.
+	// Mirror it here so tests read the same numeric cap the implementation
+	// enforces. Drift is caught by the "just under cap" test.
+	const MAX_SSE_SIZE_FOR_TEST = 10 * 1024 * 1024; // 10MB, must match lib constant
+
+	// Build a multi-chunk SSE stream reader that emits ASCII bytes. Using
+	// ASCII guarantees decoder.decode(value, { stream: true }) returns a
+	// string of the same length as the byte buffer, so totalSize tracking
+	// is deterministic relative to MAX_SSE_SIZE (10MB).
+	const buildChunkedReader = (chunks: Uint8Array[]) => {
+		let i = 0;
+		const reader = {
+			read: vi.fn(async () => {
+				if (i >= chunks.length) return { done: true, value: undefined };
+				const value = chunks[i++];
+				return { done: false, value };
+			}),
+			cancel: vi.fn(async () => undefined),
+			releaseLock: vi.fn(),
+		};
+		const response = {
+			body: { getReader: () => reader },
+			status: 200,
+			statusText: "OK",
+		} as unknown as Response;
+		return { response, reader };
+	};
+
+	it("accumulates many chunks totaling just under the 10MB cap without throwing on append", async () => {
+		// Build a valid SSE response whose payload is large (~9MB of filler
+		// inside a JSON string field plus a terminal done event), split
+		// across many ~128KB chunks. The sum stays below the 10MB cap so
+		// the pre-append check must not trigger, and all chunks accumulate
+		// and parse correctly.
+		const filler = "x".repeat(9 * 1024 * 1024);
+		const sse =
+			'data: {"type":"response.started"}\n' +
+			`data: {"type":"response.done","response":{"id":"resp_big","output":${JSON.stringify(filler)}}}\n`;
+		const bytes = new TextEncoder().encode(sse);
+		expect(bytes.byteLength).toBeLessThan(MAX_SSE_SIZE_FOR_TEST);
+
+		const chunkSize = 128 * 1024;
+		const chunks: Uint8Array[] = [];
+		for (let off = 0; off < bytes.byteLength; off += chunkSize) {
+			chunks.push(
+				bytes.slice(off, Math.min(off + chunkSize, bytes.byteLength)),
+			);
+		}
+		expect(chunks.length).toBeGreaterThan(1);
+
+		const { response, reader } = buildChunkedReader(chunks);
+
+		const result = await convertSseToJson(response, new Headers());
+		const body = (await result.json()) as { id: string; output: string };
+		expect(body.id).toBe("resp_big");
+		expect(body.output.length).toBe(filler.length);
+		// One read per chunk plus the final done=true read.
+		expect(reader.read).toHaveBeenCalledTimes(chunks.length + 1);
+	});
+
+	it("throws on the FIRST chunk that would exceed the cap (pre-append, not post-append)", async () => {
+		// Chunk 1: stays safely under the cap.
+		// Chunk 2: small on its own, but pushes totalSize past MAX_SSE_SIZE.
+		// The old implementation would append first then throw after the
+		// accumulated string had already grown past the cap. The fix must
+		// throw BEFORE appending chunk 2, so the reader is only called for
+		// the two chunks and the second chunk is never retained alongside
+		// the accumulated buffer.
+		const nearCap = new Uint8Array(MAX_SSE_SIZE_FOR_TEST - 16).fill(0x61); // 'a'
+		const overflow = new Uint8Array(64).fill(0x62); // 'b'
+		const { response, reader } = buildChunkedReader([nearCap, overflow]);
+
+		await expect(convertSseToJson(response, new Headers())).rejects.toThrow(
+			/exceeds.*bytes limit/,
+		);
+
+		// Two reads: first chunk accepted, second chunk checked pre-append
+		// and rejected. No further reads after throw.
+		expect(reader.read).toHaveBeenCalledTimes(2);
+		expect(reader.cancel).toHaveBeenCalled();
+	});
+
+	it("throws on the very first chunk when it alone exceeds the cap", async () => {
+		// Single chunk that blows the cap by itself. Fix must reject before
+		// attempting to push/retain it alongside an empty buffer.
+		const tooBig = new Uint8Array(MAX_SSE_SIZE_FOR_TEST + 1).fill(0x63); // 'c'
+		const { response, reader } = buildChunkedReader([tooBig]);
+
+		await expect(convertSseToJson(response, new Headers())).rejects.toThrow(
+			/exceeds.*bytes limit/,
+		);
+		expect(reader.read).toHaveBeenCalledTimes(1);
+		expect(reader.cancel).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Addresses deep-audit finding `REQ-HIGH-03`: `convertSseToJson` in `lib/request/response-handler.ts` buffered the entire SSE stream via repeated `fullText += decoder.decode(...)`. That is O(n) per append on V8, producing O(n^2) total work for large streams, and the `MAX_SSE_SIZE` (10 MB) cap was enforced AFTER the append, so peak memory briefly held `chunk + 10 MB` before throwing.

## Fix

- Accumulate decoded chunks in a `string[]` and `join('')` once at the end (linear total work).
- Track a running `totalSize` counter.
- Check `totalSize + decoded.length > MAX_SSE_SIZE` BEFORE appending each chunk, so the cap is enforced pre-allocation and peak memory is bounded to the cap rather than `cap + chunk`.

## Tests

New dedicated regression file `test/response-handler-sse-buffer.test.ts` (3 tests), isolated from the existing 860-line `response-handler.test.ts` to avoid whole-file reformatting noise in the diff:

- Accumulates many ~128 KB chunks summing just under the 10 MB cap and parses successfully (exercises the multi-chunk accumulation path).
- Asserts the throw fires on the FIRST chunk that would push past the cap (pre-append), and that no further reads happen after the throw.
- Asserts a single oversize first chunk is rejected before it is retained in any buffer.

## Verification

- `npm test -- response-handler` — 56 passed (was 53; +3 regression tests)
- `npm run typecheck` — clean
- `npm run lint` — clean

## Constraints observed

- No `as any`, `@ts-ignore`, or `@ts-expect-error`.
- Changes are confined to `lib/request/response-handler.ts` and a new co-located `response-handler`-scoped test file.
- No amend, no force-push.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

the pr correctly replaces O(n²) string concatenation with an array-then-join pattern and enforces the 10 MB cap before each append. the follow-up commit (`afd1fff`) also switched from `decoded.length` (utf-16 code units) to `Buffer.byteLength(decoded, "utf8")`, addressing the prior review comment — though `value.byteLength` would be simpler, avoids re-encoding, and is slightly tighter at multi-byte chunk boundaries.

<h3>Confidence Score: 5/5</h3>

safe to merge; both remaining findings are P2 style suggestions with no correctness impact

the core fix is correct — linear accumulation, pre-append guard, and proper utf-8 byte counting all work. the `Buffer.byteLength` vs `value.byteLength` difference is a minor efficiency/elegance nit, not a bug; totals are equivalent over the full stream. four targeted regression tests cover all three original scenarios plus the utf-8 edge case. no security, data-loss, or concurrency issues.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/response-handler.ts | linear accumulation and pre-append size guard are correct; `Buffer.byteLength(decoded, "utf8")` re-encodes needlessly — `value.byteLength` is simpler and tighter at chunk boundaries |
| test/response-handler-sse-buffer.test.ts | 4 targeted regression tests covering accumulation, pre-append throw, single-oversized-chunk, and utf-8 byte counting; the ascii-rationale comment in `buildChunkedReader` is stale after the utf-8 fix |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[reader.read] --> B{done?}
    B -- yes --> G[chunks.join]
    B -- no --> C[decoder.decode value stream:true]
    C --> D[decodedBytes = Buffer.byteLength decoded utf8]
    D --> E{totalSize + decodedBytes > MAX_SSE_SIZE?}
    E -- yes --> F[throw + reader.cancel]
    E -- no --> H[chunks.push decoded\ntotalSize += decodedBytes]
    H --> A
    G --> I[parseSseStream fullText]
    I --> J{finalResponse?}
    J -- no --> K[return plain text Response]
    J -- yes --> L[return JSON Response]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fsse-buffer-linear%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsse-buffer-linear%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Frequest%2Fresponse-handler.ts%3A792-800%0A**unnecessary%20re-encode%3B%20use%20%60value.byteLength%60%20directly**%0A%0A%60Buffer.byteLength%28decoded%2C%20%22utf8%22%29%60%20re-encodes%20the%20already-decoded%20string%20back%20to%20UTF-8%20just%20to%20count%20bytes.%20%60value%60%20is%20a%20%60Uint8Array%60%20whose%20%60.byteLength%60%20is%20exactly%20the%20raw%20wire-byte%20count%20%E2%80%94%20no%20extra%20allocation%20or%20encoding%20pass%20needed.%20additionally%2C%20when%20%60TextDecoder%60%20running%20in%20streaming%20mode%20buffers%201%E2%80%933%20trailing%20bytes%20of%20a%20split%20multi-byte%20sequence%2C%20%60Buffer.byteLength%28decoded%2C%20%22utf8%22%29%60%20excludes%20those%20bytes%20from%20the%20current%20chunk%20%28they%20appear%20in%20the%20next%20%60decoded%60%20call%20instead%29%3B%20%60value.byteLength%60%20counts%20them%20immediately%2C%20making%20the%20guard%20slightly%20tighter%20at%20chunk%20boundaries.%0A%0A%60%60%60suggestion%0A%09%09%09const%20decodedBytes%20%3D%20value.byteLength%3B%0A%09%09%09%2F%2F%20Pre-append%20size%20check%3A%20reject%20before%20allocating%2Fretaining%20the%20chunk%0A%09%09%09%2F%2F%20alongside%20the%20accumulated%20buffer.%20This%20bounds%20peak%20memory%20to%20the%0A%09%09%09%2F%2F%20cap%20rather%20than%20cap%20%2B%20chunk.%0A%09%09%09if%20%28totalSize%20%2B%20decodedBytes%20%3E%20MAX_SSE_SIZE%29%20%7B%0A%09%09%09%09throw%20new%20Error%28%60SSE%20response%20exceeds%20%24%7BMAX_SSE_SIZE%7D%20bytes%20limit%60%29%3B%0A%09%09%09%7D%0A%09%09%09chunks.push%28decoded%29%3B%0A%09%09%09totalSize%20%2B%3D%20decodedBytes%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fresponse-handler-sse-buffer.test.ts%3A28-30%0A**stale%20comment%20rationale%20after%20switching%20to%20%60Buffer.byteLength%60**%0A%0Athe%20comment%20says%20ascii%20is%20chosen%20because%20%60decoder.decode%28%29%60%20returns%20a%20string%20of%20the%20same%20length%20as%20the%20byte%20buffer%20%E2%80%94%20that%20was%20relevant%20when%20tracking%20%60decoded.length%60.%20now%20that%20the%20implementation%20uses%20%60Buffer.byteLength%28decoded%2C%20%22utf8%22%29%60%20%28or%20ideally%20%60value.byteLength%60%29%2C%20the%20byte%20count%20is%20exact%20for%20all%20inputs%2C%20so%20ascii%20is%20no%20longer%20required%20for%20determinism.%20the%204th%20test%20in%20this%20file%20already%20uses%20emoji.%20the%20comment%20is%20now%20misleading%3B%20consider%20trimming%20or%20updating%20it%20to%20match%20the%20actual%20accounting.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/request/response-handler.ts
Line: 792-800

Comment:
**unnecessary re-encode; use `value.byteLength` directly**

`Buffer.byteLength(decoded, "utf8")` re-encodes the already-decoded string back to UTF-8 just to count bytes. `value` is a `Uint8Array` whose `.byteLength` is exactly the raw wire-byte count — no extra allocation or encoding pass needed. additionally, when `TextDecoder` running in streaming mode buffers 1–3 trailing bytes of a split multi-byte sequence, `Buffer.byteLength(decoded, "utf8")` excludes those bytes from the current chunk (they appear in the next `decoded` call instead); `value.byteLength` counts them immediately, making the guard slightly tighter at chunk boundaries.

```suggestion
			const decodedBytes = value.byteLength;
			// Pre-append size check: reject before allocating/retaining the chunk
			// alongside the accumulated buffer. This bounds peak memory to the
			// cap rather than cap + chunk.
			if (totalSize + decodedBytes > MAX_SSE_SIZE) {
				throw new Error(`SSE response exceeds ${MAX_SSE_SIZE} bytes limit`);
			}
			chunks.push(decoded);
			totalSize += decodedBytes;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/response-handler-sse-buffer.test.ts
Line: 28-30

Comment:
**stale comment rationale after switching to `Buffer.byteLength`**

the comment says ascii is chosen because `decoder.decode()` returns a string of the same length as the byte buffer — that was relevant when tracking `decoded.length`. now that the implementation uses `Buffer.byteLength(decoded, "utf8")` (or ideally `value.byteLength`), the byte count is exact for all inputs, so ascii is no longer required for determinism. the 4th test in this file already uses emoji. the comment is now misleading; consider trimming or updating it to match the actual accounting.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(request): count utf-8 bytes in SSE s..."](https://github.com/ndycode/codex-multi-auth/commit/afd1fffb2f91baf25b8693fe57838b19908ee2f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28834148)</sub>

<!-- /greptile_comment -->