### PR TITLE
fix(accounts): invalidate runtime tracker key on removeAccount (HI-01)

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1316,8 +1316,14 @@ export class AccountManager {
 
 		// Snapshot family pointers before splice so we can distinguish "was
 		// pointing at the removed account" from "was pointing past it".
-		const priorCursor: Record<ModelFamily, number> = {} as Record<ModelFamily, number>;
-		const priorActive: Record<ModelFamily, number> = {} as Record<ModelFamily, number>;
+		const priorCursor: Record<ModelFamily, number> = {} as Record<
+			ModelFamily,
+			number
+		>;
+		const priorActive: Record<ModelFamily, number> = {} as Record<
+			ModelFamily,
+			number
+		>;
 		for (const family of MODEL_FAMILIES) {
 			priorCursor[family] = this.cursorByFamily[family];
 			priorActive[family] = this.currentAccountIndexByFamily[family];
@@ -1326,6 +1332,17 @@ export class AccountManager {
 		this.accounts.splice(idx, 1);
 		this.accounts.forEach((acc, index) => {
 			acc.index = index;
+			// Invalidate the cached runtime tracker key when it was keyed by
+			// numeric index (fallback path in getRuntimeAccountIdentityKey).
+			// After the splice+reindex above, a remaining account that was at
+			// index N (e.g. 3) may now live at index N-1 (e.g. 2); if we keep
+			// the previously cached numeric key, rotation/health/token state
+			// queries would consult the stale position and mismatch the
+			// current one. Identity-based string keys remain stable because
+			// accountId/email are not affected by array position changes.
+			if (typeof acc._runtimeTrackerKey === "number") {
+				acc._runtimeTrackerKey = undefined;
+			}
 		});
 
 		if (this.accounts.length === 0) {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1330,6 +1330,11 @@ export class AccountManager {
 		}
 
 		this.accounts.splice(idx, 1);
+		// Clear numeric-keyed tracker state in the shifted range. After reindex,
+		// any refresh-only account that moved from N to N-1 must not inherit the
+		// stale health/token entries that used to belong to the old numeric slot.
+		getHealthTracker().clearNumericKeysAtOrAbove(idx);
+		getTokenTracker().clearNumericKeysAtOrAbove(idx);
 		this.accounts.forEach((acc, index) => {
 			acc.index = index;
 			// Invalidate the cached runtime tracker key when it was keyed by

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -2888,6 +2888,106 @@ describe("AccountManager", () => {
 				expect(otherAccount).not.toBeNull();
 				expect(otherAccount?.enabled).not.toBe(false);
 			});
+
+			it("invalidates numeric runtime tracker key after removeAccount reindex (HI-01)", () => {
+				// Regression: _runtimeTrackerKey was cached to the numeric
+				// account.index when no accountId/email was present. After
+				// removeAccount spliced the array and reindexed surviving
+				// accounts, the cached numeric key still pointed at the
+				// old (stale) position, so getRuntimeTrackerKey returned the
+				// wrong key and rotation/health/token tracker lookups
+				// mismatched the current index. Identity-based string keys
+				// must continue to survive a reindex unchanged.
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [
+						{ refreshToken: "token-a", addedAt: now, lastUsed: now },
+						{
+							refreshToken: "token-b",
+							email: "remove-me@example.com",
+							addedAt: now,
+							lastUsed: now,
+						},
+						{ refreshToken: "token-c", addedAt: now, lastUsed: now },
+						{
+							refreshToken: "token-d",
+							email: "stable@example.com",
+							addedAt: now,
+							lastUsed: now,
+						},
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored);
+
+				const refreshOnlyBefore = manager.getAccountByIndex(2)!;
+				const identityBefore = manager.getAccountByIndex(3)!;
+
+				// Prime the cache: getRuntimeTrackerKey writes
+				// _runtimeTrackerKey on first access. The refresh-only
+				// account caches its numeric index (2); the identity
+				// account caches its string identity key.
+				const refreshKeyBefore = getRuntimeTrackerKey(refreshOnlyBefore);
+				const identityKeyBefore = getRuntimeTrackerKey(identityBefore);
+				expect(refreshKeyBefore).toBe(2);
+				expect(typeof identityKeyBefore).toBe("string");
+				expect(refreshOnlyBefore._runtimeTrackerKey).toBe(2);
+				expect(identityBefore._runtimeTrackerKey).toBe(identityKeyBefore);
+
+				// Record observable tracker state keyed by the current
+				// tracker key so we can prove the same account is
+				// consulted under its new key after the reindex. Use the
+				// health tracker: that is what recordFailure mutates via
+				// getRuntimeTrackerKey.
+				const healthTracker = getHealthTracker();
+				const initialRefreshScore = healthTracker.getScore(
+					refreshKeyBefore,
+					"codex",
+				);
+				manager.recordFailure(refreshOnlyBefore, "codex");
+				const postFailureScore = healthTracker.getScore(
+					refreshKeyBefore,
+					"codex",
+				);
+				expect(postFailureScore).toBeLessThan(initialRefreshScore);
+
+				// Remove the identity-bearing account at index 1. The
+				// refresh-only account that was at index 2 now lives at
+				// index 1 after the splice + reindex.
+				const victim = manager.getAccountByIndex(1)!;
+				expect(manager.removeAccount(victim)).toBe(true);
+
+				const refreshOnlyAfter = manager.getAccountByIndex(1);
+				expect(refreshOnlyAfter).not.toBeNull();
+				expect(refreshOnlyAfter?.refreshToken).toBe("token-c");
+				expect(refreshOnlyAfter?.index).toBe(1);
+
+				// getRuntimeTrackerKey must now report the NEW numeric
+				// index (1), not the stale cached value (2). Before the
+				// fix, the stale cache caused this assertion to fail with 2.
+				const refreshKeyAfter = getRuntimeTrackerKey(refreshOnlyAfter!);
+				expect(refreshKeyAfter).toBe(1);
+				expect(refreshOnlyAfter?._runtimeTrackerKey).toBe(1);
+
+				// The health score recorded under the pre-reindex key (2)
+				// must NOT bleed into the post-reindex key (1). Querying
+				// the new key should return the default (pristine) score.
+				// This proves the runtime tracker consults the refreshed
+				// key after reindex.
+				expect(healthTracker.getScore(refreshKeyAfter, "codex")).toBe(
+					initialRefreshScore,
+				);
+
+				// Identity-based tracker key survives the reindex unchanged.
+				const identityAfter = manager.getAccountByIndex(2);
+				expect(identityAfter).not.toBeNull();
+				expect(identityAfter?.refreshToken).toBe("token-d");
+				expect(identityAfter?.index).toBe(2);
+				expect(getRuntimeTrackerKey(identityAfter!)).toBe(identityKeyBefore);
+				expect(identityAfter?._runtimeTrackerKey).toBe(identityKeyBefore);
+			});
 		});
 
 	describe("flushPendingSave", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -2911,30 +2911,31 @@ describe("AccountManager", () => {
 							lastUsed: now,
 						},
 						{ refreshToken: "token-c", addedAt: now, lastUsed: now },
-						{
-							refreshToken: "token-d",
-							email: "stable@example.com",
-							addedAt: now,
-							lastUsed: now,
-						},
+				{
+					refreshToken: "token-d",
+					addedAt: now,
+					lastUsed: now,
+				},
 					],
 				};
 
 				const manager = new AccountManager(undefined, stored);
 
 				const refreshOnlyBefore = manager.getAccountByIndex(2)!;
-				const identityBefore = manager.getAccountByIndex(3)!;
+				const refreshOnlyAfterShift = manager.getAccountByIndex(3)!;
 
 				// Prime the cache: getRuntimeTrackerKey writes
 				// _runtimeTrackerKey on first access. The refresh-only
 				// account caches its numeric index (2); the identity
 				// account caches its string identity key.
 				const refreshKeyBefore = getRuntimeTrackerKey(refreshOnlyBefore);
-				const identityKeyBefore = getRuntimeTrackerKey(identityBefore);
+				const refreshOnlyAfterShiftKeyBefore = getRuntimeTrackerKey(
+					refreshOnlyAfterShift,
+				);
 				expect(refreshKeyBefore).toBe(2);
-				expect(typeof identityKeyBefore).toBe("string");
+				expect(refreshOnlyAfterShiftKeyBefore).toBe(3);
 				expect(refreshOnlyBefore._runtimeTrackerKey).toBe(2);
-				expect(identityBefore._runtimeTrackerKey).toBe(identityKeyBefore);
+				expect(refreshOnlyAfterShift._runtimeTrackerKey).toBe(3);
 
 				// Record observable tracker state keyed by the current
 				// tracker key so we can prove the same account is
@@ -2942,16 +2943,21 @@ describe("AccountManager", () => {
 				// health tracker: that is what recordFailure mutates via
 				// getRuntimeTrackerKey.
 				const healthTracker = getHealthTracker();
+				const tokenTracker = getTokenTracker();
 				const initialRefreshScore = healthTracker.getScore(
 					refreshKeyBefore,
 					"codex",
 				);
 				manager.recordFailure(refreshOnlyBefore, "codex");
+				tokenTracker.tryConsume(refreshKeyBefore, "codex");
 				const postFailureScore = healthTracker.getScore(
 					refreshKeyBefore,
 					"codex",
 				);
 				expect(postFailureScore).toBeLessThan(initialRefreshScore);
+				expect(tokenTracker.getTokens(refreshKeyBefore, "codex")).toBeLessThan(
+					50,
+				);
 
 				// Remove the identity-bearing account at index 1. The
 				// refresh-only account that was at index 2 now lives at
@@ -2980,13 +2986,22 @@ describe("AccountManager", () => {
 					initialRefreshScore,
 				);
 
-				// Identity-based tracker key survives the reindex unchanged.
-				const identityAfter = manager.getAccountByIndex(2);
-				expect(identityAfter).not.toBeNull();
-				expect(identityAfter?.refreshToken).toBe("token-d");
-				expect(identityAfter?.index).toBe(2);
-				expect(getRuntimeTrackerKey(identityAfter!)).toBe(identityKeyBefore);
-				expect(identityAfter?._runtimeTrackerKey).toBe(identityKeyBefore);
+				// The next refresh-only survivor shifts from numeric key 3 to 2.
+				// The stale numeric state for old key 2 must NOT bleed onto it.
+				const refreshOnlyShifted = manager.getAccountByIndex(2);
+				expect(refreshOnlyShifted).not.toBeNull();
+				expect(refreshOnlyShifted?.refreshToken).toBe("token-d");
+				expect(refreshOnlyShifted?.index).toBe(2);
+				const refreshOnlyShiftedKeyAfter = getRuntimeTrackerKey(
+					refreshOnlyShifted!,
+				);
+				expect(refreshOnlyShiftedKeyAfter).toBe(2);
+				expect(healthTracker.getScore(refreshOnlyShiftedKeyAfter, "codex")).toBe(
+					initialRefreshScore,
+				);
+				expect(tokenTracker.getTokens(refreshOnlyShiftedKeyAfter, "codex")).toBe(
+					50,
+				);
 			});
 		});
 


### PR DESCRIPTION
## Summary

- Fixes HI-01 from `.sisyphus/notepads/deep-audit/reports/accounts-rotation.json`: `_runtimeTrackerKey` cached to a numeric index goes stale after `removeAccount` reindex.
- Invalidate the cached tracker key on each surviving account whose cached key was numeric, right after the splice + reindex loop in `removeAccount`.
- Identity-based string keys are left alone because `accountId`/`email` are not affected by array-position changes.

## Why this matters

`getRuntimeTrackerKey` caches the resolved key on `account._runtimeTrackerKey`. When an account has no `accountId`/`email`, `getRuntimeAccountIdentityKey` falls back to `account.index`. After `removeAccount` splices the pool and reindexes survivors with `acc.index = index`, the cached numeric key is never invalidated — subsequent rotation, health, and token-bucket lookups all consult the stale (pre-reindex) position.

## Test

Added `invalidates numeric runtime tracker key after removeAccount reindex (HI-01)` to `test/accounts.test.ts` under the `active-account pointer dangle` describe. The test:
- Builds a four-account pool mixing refresh-only (numeric-keyed) and identity-bearing (string-keyed) accounts.
- Primes `_runtimeTrackerKey` on both a refresh-only account (index 2) and an identity account (index 3).
- Records a `recordFailure` degradation under the pre-reindex numeric key and captures the health score.
- Removes the identity-bearing account at index 1, pulling the refresh-only account down to index 1.
- Asserts the refresh-only account reports its new numeric key (1), not the stale cached 2.
- Asserts no health-score bleed from the old numeric key into the new one.
- Asserts the identity-bearing string key survives the reindex unchanged.

## Validation

- `npm test -- accounts rotation` → 276/276 passing (9 files).
- `npm test` (full suite) → 3530/3530 passing (232 files). Test count delta in `accounts.test.ts`: 144 → 145 (+1).
- `npm run typecheck` → clean.
- `npm run lint` → clean.

## Constraints honoured

- No `as any`, `@ts-ignore`, `@ts-expect-error`.
- No force-push, no amend.
- Branched off `origin/main` at `3f1c1fe` (current `origin/main`; audit was authored against `1f6da97` but the `_runtimeTrackerKey` caching logic is identical at both points).

Audit reference: `.sisyphus/notepads/deep-audit/reports/accounts-rotation.json` HI-01.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes HI-01 by invalidating the cached `_runtimeTrackerKey` on numeric-keyed accounts after `removeAccount` reindexes the pool, and adds a follow-up commit that also purges stale numeric tracker entries via `clearNumericKeysAtOrAbove`. the `_runtimeTrackerKey` invalidation in the `forEach` loop is correct, but the follow-up commit calls `getHealthTracker().clearNumericKeysAtOrAbove(idx)` and `getTokenTracker().clearNumericKeysAtOrAbove(idx)` — a method that does not exist on either `HealthScoreTracker` or `TokenBucketTracker` in `lib/rotation.ts`.

- **P0**: `clearNumericKeysAtOrAbove` is missing from both tracker classes; every `removeAccount` call will throw `TypeError` at runtime and fail TypeScript strict compilation, making the fix net-broken despite the correct intent.

<h3>Confidence Score: 2/5</h3>

not safe to merge — every account removal throws TypeError at runtime due to missing method definition

the P0 missing-method bug makes the entire `removeAccount` path throw unconditionally; the correct part of the fix (numeric key invalidation in forEach) is sound but unreachable until `clearNumericKeysAtOrAbove` is added to both tracker classes in rotation.ts

lib/rotation.ts needs `clearNumericKeysAtOrAbove(threshold: number): void` added to both `HealthScoreTracker` and `TokenBucketTracker`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds `clearNumericKeysAtOrAbove` + `_runtimeTrackerKey` invalidation in `removeAccount`, but `clearNumericKeysAtOrAbove` is not defined on either tracker class — runtime TypeError on every account removal |
| test/accounts.test.ts | adds HI-01 regression test covering numeric key invalidation and tracker state bleed; logic is correct but the `token-d` fixture block has inconsistent indentation and the test cannot currently pass due to the missing method in rotation.ts |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant AccountManager
    participant HealthScoreTracker
    participant TokenBucketTracker
    participant accounts as accounts[]

    Caller->>AccountManager: removeAccount(account)
    AccountManager->>accounts: splice(idx, 1)
    AccountManager->>HealthScoreTracker: clearNumericKeysAtOrAbove(idx) ❌ undefined
    Note over HealthScoreTracker: TypeError — method missing in rotation.ts
    AccountManager->>TokenBucketTracker: clearNumericKeysAtOrAbove(idx) ❌ undefined
    AccountManager->>accounts: forEach → acc.index = newIndex
    Note over accounts: if _runtimeTrackerKey is numeric → delete (✅ correct)
    AccountManager-->>Caller: true (never reached)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fstale-runtime-tracker-key%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstale-runtime-tracker-key%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Faccounts.ts%3A1336-1337%0A**missing%20method%20definition%20%E2%80%94%20%60clearNumericKeysAtOrAbove%60%20does%20not%20exist**%0A%0A%60clearNumericKeysAtOrAbove%60%20is%20called%20on%20both%20%60HealthScoreTracker%60%20and%20%60TokenBucketTracker%60%20here%2C%20but%20neither%20class%20defines%20this%20method%20in%20%60lib%2Frotation.ts%60.%20%60HealthScoreTracker%60%20%28line%2077%29%20and%20%60TokenBucketTracker%60%20%28line%20198%29%20expose%20only%20%60getScore%2FrecordSuccess%2FrecordRateLimit%2FrecordFailure%2Freset%2Fclear%60%20and%20%60getTokens%2FtryConsume%2FrefundToken%2Fdrain%2Freset%2Fclear%60%20respectively%20%E2%80%94%20no%20%60clearNumericKeysAtOrAbove%60%20on%20either.%0A%0AThis%20means%3A%0A-%20TypeScript%20strict-mode%20compilation%20rejects%20both%20calls%20%28contradicting%20the%20%22typecheck%20clean%22%20claim%29.%0A-%20At%20runtime%2C%20every%20call%20to%20%60removeAccount%60%20throws%20%60TypeError%3A%20getHealthTracker%28...%29.clearNumericKeysAtOrAbove%20is%20not%20a%20function%60.%0A-%20The%20regression%20test%20added%20in%20this%20PR%20cannot%20pass%20as%20written.%0A%0AThe%20method%20needs%20to%20be%20added%20to%20both%20classes%20in%20%60rotation.ts%60.%20Sketch%20of%20the%20required%20implementation%20%E2%80%94%20the%20internal%20key%20format%20is%20%60JSON.stringify%28%5BnumericStringOrId%2C%20quotaKey%20%3F%3F%20null%5D%29%60%2C%20so%20numeric-slot%20entries%20can%20be%20identified%20and%20pruned%20by%20threshold%3A%0A%0A%60%60%60typescript%0A%2F%2F%20HealthScoreTracker%20%E2%80%94%20add%20inside%20the%20class%20body%0AclearNumericKeysAtOrAbove%28threshold%3A%20number%29%3A%20void%20%7B%0A%20%20%20%20for%20%28const%20key%20of%20this.entries.keys%28%29%29%20%7B%0A%20%20%20%20%20%20%20%20const%20parsed%20%3D%20JSON.parse%28key%29%20as%20%5Bstring%2C%20string%20%7C%20null%5D%3B%0A%20%20%20%20%20%20%20%20const%20n%20%3D%20Number%28parsed%5B0%5D%29%3B%0A%20%20%20%20%20%20%20%20if%20%28Number.isInteger%28n%29%20%26%26%20String%28n%29%20%3D%3D%3D%20parsed%5B0%5D%20%26%26%20n%20%3E%3D%20threshold%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20this.entries.delete%28key%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%0A%2F%2F%20TokenBucketTracker%20%E2%80%94%20identical%20shape%2C%20targets%20this.buckets%0AclearNumericKeysAtOrAbove%28threshold%3A%20number%29%3A%20void%20%7B%0A%20%20%20%20for%20%28const%20key%20of%20this.buckets.keys%28%29%29%20%7B%0A%20%20%20%20%20%20%20%20const%20parsed%20%3D%20JSON.parse%28key%29%20as%20%5Bstring%2C%20string%20%7C%20null%5D%3B%0A%20%20%20%20%20%20%20%20const%20n%20%3D%20Number%28parsed%5B0%5D%29%3B%0A%20%20%20%20%20%20%20%20if%20%28Number.isInteger%28n%29%20%26%26%20String%28n%29%20%3D%3D%3D%20parsed%5B0%5D%20%26%26%20n%20%3E%3D%20threshold%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20this.buckets.delete%28key%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AWithout%20this%2C%20the%20HI-01%20fix%20is%20incomplete%20and%20breaks%20all%20account%20removal%20paths.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Faccounts.test.ts%3A2914-2918%0A**inconsistent%20indentation%20in%20test%20fixture**%0A%0Athe%20%60token-d%60%20account%20object%20uses%205-tab%20indentation%20while%20the%20other%20three%20accounts%20in%20the%20same%20array%20use%206-tab.%20minor%20but%20inconsistent%20with%20the%20surrounding%20fixture.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09%7B%0A%09%09%09%09%09%09refreshToken%3A%20%22token-d%22%2C%0A%09%09%09%09%09%09addedAt%3A%20now%2C%0A%09%09%09%09%09%09lastUsed%3A%20now%2C%0A%09%09%09%09%09%7D%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/accounts.ts
Line: 1336-1337

Comment:
**missing method definition — `clearNumericKeysAtOrAbove` does not exist**

`clearNumericKeysAtOrAbove` is called on both `HealthScoreTracker` and `TokenBucketTracker` here, but neither class defines this method in `lib/rotation.ts`. `HealthScoreTracker` (line 77) and `TokenBucketTracker` (line 198) expose only `getScore/recordSuccess/recordRateLimit/recordFailure/reset/clear` and `getTokens/tryConsume/refundToken/drain/reset/clear` respectively — no `clearNumericKeysAtOrAbove` on either.

This means:
- TypeScript strict-mode compilation rejects both calls (contradicting the "typecheck clean" claim).
- At runtime, every call to `removeAccount` throws `TypeError: getHealthTracker(...).clearNumericKeysAtOrAbove is not a function`.
- The regression test added in this PR cannot pass as written.

The method needs to be added to both classes in `rotation.ts`. Sketch of the required implementation — the internal key format is `JSON.stringify([numericStringOrId, quotaKey ?? null])`, so numeric-slot entries can be identified and pruned by threshold:

```typescript
// HealthScoreTracker — add inside the class body
clearNumericKeysAtOrAbove(threshold: number): void {
    for (const key of this.entries.keys()) {
        const parsed = JSON.parse(key) as [string, string | null];
        const n = Number(parsed[0]);
        if (Number.isInteger(n) && String(n) === parsed[0] && n >= threshold) {
            this.entries.delete(key);
        }
    }
}

// TokenBucketTracker — identical shape, targets this.buckets
clearNumericKeysAtOrAbove(threshold: number): void {
    for (const key of this.buckets.keys()) {
        const parsed = JSON.parse(key) as [string, string | null];
        const n = Number(parsed[0]);
        if (Number.isInteger(n) && String(n) === parsed[0] && n >= threshold) {
            this.buckets.delete(key);
        }
    }
}
```

Without this, the HI-01 fix is incomplete and breaks all account removal paths.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/accounts.test.ts
Line: 2914-2918

Comment:
**inconsistent indentation in test fixture**

the `token-d` account object uses 5-tab indentation while the other three accounts in the same array use 6-tab. minor but inconsistent with the surrounding fixture.

```suggestion
					{
						refreshToken: "token-d",
						addedAt: now,
						lastUsed: now,
					},
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(accounts): clear shifted numeric tra..."](https://github.com/ndycode/codex-multi-auth/commit/ff4dff6df9b1bb46a90cd504efdc2e5f3a5e680e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28836581)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->