### PR TITLE
fix(accounts): signal removed-current instead of silent retarget (HI-04)

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1316,8 +1316,14 @@ export class AccountManager {
 
 		// Snapshot family pointers before splice so we can distinguish "was
 		// pointing at the removed account" from "was pointing past it".
-		const priorCursor: Record<ModelFamily, number> = {} as Record<ModelFamily, number>;
-		const priorActive: Record<ModelFamily, number> = {} as Record<ModelFamily, number>;
+		const priorCursor: Record<ModelFamily, number> = {} as Record<
+			ModelFamily,
+			number
+		>;
+		const priorActive: Record<ModelFamily, number> = {} as Record<
+			ModelFamily,
+			number
+		>;
 		for (const family of MODEL_FAMILIES) {
 			priorCursor[family] = this.cursorByFamily[family];
 			priorActive[family] = this.currentAccountIndexByFamily[family];
@@ -1335,6 +1341,14 @@ export class AccountManager {
 			}
 			return true;
 		}
+
+		// Track successor accounts that we explicitly retarget onto because the
+		// removed account was the caller's "current" for a given family. We
+		// stamp each such successor with lastSwitchReason="rotation" so the
+		// retarget is auditable instead of silently carrying whatever stale
+		// reason the successor already had (HI-04). De-duplicated across
+		// families because lastSwitchReason is per-account, not per-family.
+		const retargetedSuccessors = new Set<number>();
 
 		for (const family of MODEL_FAMILIES) {
 			// Cursor: shift down if it was past the removed index, then normalize
@@ -1358,11 +1372,14 @@ export class AccountManager {
 			// AT the removed slot (or is now dangling off the end after
 			// splice), advance to the next enabled account instead of
 			// defaulting to -1. Fall back to -1 only when every remaining
-			// account is disabled or the pool is empty.
+			// account is disabled or the pool is empty. When we retarget off
+			// the removed slot onto a different account, record the successor
+			// so we can explicitly signal the retarget via lastSwitchReason.
 			let active = priorActive[family];
+			const activeWasRemoved = active === idx;
 			if (active > idx) {
 				active -= 1;
-			} else if (active === idx) {
+			} else if (activeWasRemoved) {
 				// Same numeric position now hosts the successor account.
 				active = this.findNextEnabled(Math.min(idx, this.accounts.length - 1));
 			}
@@ -1370,6 +1387,22 @@ export class AccountManager {
 				active = this.findNextEnabled(0);
 			}
 			this.currentAccountIndexByFamily[family] = active;
+			if (activeWasRemoved && active >= 0 && active < this.accounts.length) {
+				retargetedSuccessors.add(active);
+			}
+		}
+
+		// Stamp retarget signal on each successor account that replaced a
+		// removed "current" pointer. This mirrors the existing rotation
+		// convention used by setActiveIndex / markSwitched, so downstream
+		// callers observing lastSwitchReason see a clear audit trail that the
+		// pool re-chose this account rather than the user selecting it
+		// themselves.
+		for (const successorIdx of retargetedSuccessors) {
+			const successor = this.accounts[successorIdx];
+			if (successor) {
+				successor.lastSwitchReason = "rotation";
+			}
 		}
 
 		return true;

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -2890,6 +2890,122 @@ describe("AccountManager", () => {
 			});
 		});
 
+		describe("removed-current retarget signal (HI-04)", () => {
+			// PR #413 hardened removeAccount() to avoid the pointer-dangle
+			// default-to-minus-one behavior, but it silently retargeted the
+			// current pointer onto a different account when the removed
+			// account WAS the current one. HI-04 flagged that silent
+			// retarget: callers observing getCurrentAccountForFamily()
+			// receive an account they never selected with no audit trail.
+			//
+			// The fix stamps lastSwitchReason="rotation" on the successor
+			// whenever removeAccount() retargets off the removed slot. This
+			// mirrors the convention already used by setActiveIndex() and
+			// markSwitched() for pool-driven selection events.
+
+			it("stamps lastSwitchReason='rotation' on successor when current is removed", () => {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 1,
+					activeIndexByFamily: { codex: 1 },
+					accounts: [
+						{ refreshToken: "token-1", addedAt: now, lastUsed: now, lastSwitchReason: "initial" as const },
+						{ refreshToken: "token-2", addedAt: now, lastUsed: now, lastSwitchReason: "initial" as const },
+						{ refreshToken: "token-3", addedAt: now, lastUsed: now, lastSwitchReason: "initial" as const },
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored as never);
+				const active = manager.getCurrentAccountForFamily("codex");
+				expect(active?.refreshToken).toBe("token-2");
+
+				// Remove the currently active (middle) account. The successor
+				// (token-3) shifts into index 1 and becomes the new current.
+				manager.removeAccount(active!);
+
+				const after = manager.getCurrentAccountForFamily("codex");
+				expect(after?.refreshToken).toBe("token-3");
+				// Successor must be explicitly stamped with the rotation
+				// reason so callers can tell the pool retargeted them rather
+				// than assuming they still hold the account they originally
+				// selected.
+				expect(after?.lastSwitchReason).toBe("rotation");
+
+				// The untouched account (token-1) retains its prior reason,
+				// proving we only stamp the successor the retarget landed on.
+				const untouched = manager.getAccountByIndex(0);
+				expect(untouched?.refreshToken).toBe("token-1");
+				expect(untouched?.lastSwitchReason).toBe("initial");
+			});
+
+			it("does not stamp a successor when every remaining account is disabled", () => {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 2,
+					activeIndexByFamily: { codex: 2 },
+					accounts: [
+						{ refreshToken: "token-1", addedAt: now, lastUsed: now, enabled: false, lastSwitchReason: "initial" as const },
+						{ refreshToken: "token-2", addedAt: now, lastUsed: now, enabled: false, lastSwitchReason: "initial" as const },
+						{ refreshToken: "token-3", addedAt: now, lastUsed: now, enabled: true, lastSwitchReason: "initial" as const },
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored as never);
+				const active = manager.getCurrentAccountForFamily("codex");
+				expect(active?.refreshToken).toBe("token-3");
+
+				// Remove the last enabled account; remaining pool is entirely
+				// disabled. Pointer must fall to -1 (no routable account).
+				manager.removeAccount(active!);
+
+				expect(manager.getCurrentAccountForFamily("codex")).toBeNull();
+				expect(manager.getActiveIndexForFamily("codex")).toBe(-1);
+
+				// Neither surviving (disabled) account may be silently
+				// promoted by having rotation stamped on them. Their stored
+				// reason must stay "initial".
+				for (let i = 0; i < manager.getAccountCount(); i++) {
+					const acc = manager.getAccountByIndex(i);
+					expect(acc?.lastSwitchReason).toBe("initial");
+				}
+			});
+
+			it("stamps the sole enabled successor when all other peers are disabled", () => {
+				const now = Date.now();
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					activeIndexByFamily: { codex: 0 },
+					accounts: [
+						{ refreshToken: "token-1", addedAt: now, lastUsed: now, enabled: true, lastSwitchReason: "initial" as const },
+						{ refreshToken: "token-2", addedAt: now, lastUsed: now, enabled: false, lastSwitchReason: "initial" as const },
+						{ refreshToken: "token-3", addedAt: now, lastUsed: now, enabled: true, lastSwitchReason: "initial" as const },
+					],
+				};
+
+				const manager = new AccountManager(undefined, stored as never);
+				const active = manager.getCurrentAccountForFamily("codex");
+				expect(active?.refreshToken).toBe("token-1");
+
+				// Remove the currently active account (token-1). token-2 is
+				// disabled, so findNextEnabled must skip it and land on
+				// token-3 (the single remaining enabled peer).
+				manager.removeAccount(active!);
+
+				const after = manager.getCurrentAccountForFamily("codex");
+				expect(after?.refreshToken).toBe("token-3");
+				expect(after?.lastSwitchReason).toBe("rotation");
+
+				// The disabled peer that was skipped during retarget must
+				// keep its original reason â€” we only stamp the account the
+				// pointer actually lands on.
+				const disabledPeer = manager.getAccountByIndex(0);
+				expect(disabledPeer?.refreshToken).toBe("token-2");
+				expect(disabledPeer?.lastSwitchReason).toBe("initial");
+			});
+		});
 	describe("flushPendingSave", () => {
 		it("flushes pending debounced save", async () => {
 			const { saveAccounts } = await import("../lib/storage.js");


### PR DESCRIPTION
## Summary

Closes the silent-retarget gap in `removeAccount()` flagged by HI-04 in
`.sisyphus/notepads/deep-audit/reports/accounts-rotation.json`.

PR #413 hardened pointer normalization so the active pointer no longer
defaults to `-1` when the current account is removed while other
accounts remain. It chose to retarget the pointer onto the successor
account at the post-splice slot. That fix closed the dangle, but the
retarget itself is silent: `getCurrentAccountForFamily()` now returns
an account the caller never selected, and the successor still carries
its prior `lastSwitchReason` (e.g. `"initial"`), so dashboards, audit
logs, and session-affinity consumers cannot tell that the pool re-chose
this account on their behalf.

This PR keeps PR #413's "stay routable" semantics intact and adds the
missing signal: when `removeAccount()` retargets the active pointer off
the removed slot onto a different successor, that successor account is
stamped with `lastSwitchReason = "rotation"` — the same convention
already used by `setActiveIndex()` and `markSwitched()` for pool-driven
selection events.

## Behavior change

| Scenario | Before this PR | After this PR |
| --- | --- | --- |
| Remove current; another enabled peer exists | Pointer lands on successor with stale `lastSwitchReason` | Pointer lands on successor; `lastSwitchReason="rotation"` stamped |
| Remove current; every remaining peer disabled | Pointer falls to `-1` | Pointer falls to `-1` (unchanged); no stamp written |
| Remove non-current account | Active pointer shifts down by 1 (unchanged) | Same — only retargets-off-removed-slot trigger the stamp |
| Remove last account in pool | Pointer = `-1` (unchanged) | Same |

`lastSwitchReason` is per-account, not per-family, so successors are
deduped via a `Set` to avoid stamping the same account multiple times
across families.

## Tests

Three new regression cases under
`AccountManager > removeAccount cursor adjustment > removed-current
retarget signal (HI-04)`:

1. `stamps lastSwitchReason='rotation' on successor when current is
   removed` — middle-slot removal, verifies the successor is stamped
   while the untouched peer keeps its prior reason.
2. `does not stamp a successor when every remaining account is disabled`
   — pointer correctly falls to `-1` and no disabled peer is silently
   promoted via a stamped reason.
3. `stamps the sole enabled successor when all other peers are
   disabled` — `findNextEnabled` skips a disabled peer and the lone
   enabled successor receives the rotation stamp.

The four existing PR #413 regression tests
(`active-account pointer dangle (audit HIGH-3)`) remain green, so this
change is layered on top of PR #413 without changing its routing
semantics.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — clean (TS + scripts)
- `npm test` — **3532 / 3532** tests passed across **232** files

## Source

`.sisyphus/notepads/deep-audit/reports/accounts-rotation.json` HI-04

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `lastSwitchReason = "rotation"` stamping in `removeAccount()` when the active pointer is silently retargeted onto a successor after the current account is removed. this closes the HI-04 observability gap layered on top of PR #413's pointer-dangle fix, using a `Set` to deduplicate successor stamps across families since `lastSwitchReason` is per-account.

<h3>Confidence Score: 5/5</h3>

safe to merge — implementation is correct, set deduplication is sound, and all three new regression cases pass; only gap is a missing non-current-removal test

all findings are P2 (missing test coverage); core stamp logic is correct, guard conditions are tight, and the change is purely additive over PR #413's routing semantics

test/accounts.test.ts — add a vitest case for non-current removal to complete coverage

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds `retargetedSuccessors` Set and post-loop stamp in `removeAccount()`; core logic is correct — condition guards `activeWasRemoved && active >= 0 && active < length` before adding to set, stamp loop has defensive `if (successor)` check |
| test/accounts.test.ts | adds three regression cases for HI-04 covering middle-slot removal, all-disabled pool, and sole-enabled successor; missing an explicit test for non-current removal to prove no spurious stamps are written |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[removeAccount called] --> B{account in pool?}
    B -- no --> Z[return false]
    B -- yes --> C[snapshot priorActive / priorCursor per family]
    C --> D[splice account out\nre-index remaining accounts]
    D --> E{pool empty?}
    E -- yes --> F[set all pointers to -1 / 0\nreturn true]
    E -- no --> G[init retargetedSuccessors Set]
    G --> H[for each MODEL_FAMILY]
    H --> I[adjust cursor]
    I --> J{activeWasRemoved?}
    J -- no, active > idx --> K[active -= 1]
    J -- yes --> L[findNextEnabled from splice point]
    K --> M{active >= length?}
    L --> M
    M -- yes --> N[findNextEnabled from 0]
    M -- no --> O[write currentAccountIndexByFamily]
    N --> O
    O --> P{activeWasRemoved AND\nactive in valid range?}
    P -- yes --> Q[retargetedSuccessors.add active]
    P -- no --> H
    Q --> H
    H -- all families done --> R[for each successorIdx in Set]
    R --> S[successor.lastSwitchReason = rotation]
    S --> T[return true]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fremove-account-retarget-semantics%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fremove-account-retarget-semantics%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Faccounts.test.ts%3A2906-2940%0A**missing%20%22remove%20non-current%20%E2%86%92%20no%20stamp%22%20regression%20case**%0A%0Athe%20PR%20description%20explicitly%20lists%20this%20scenario%20%28%22Remove%20non-current%20account%20%7C%20Same%20%E2%80%94%20only%20retargets-off-removed-slot%20trigger%20the%20stamp%22%29%2C%20but%20there's%20no%20vitest%20case%20that%20removes%20a%20non-current%20account%20and%20asserts%20%60lastSwitchReason%60%20on%20every%20remaining%20account%20is%20unchanged.%20without%20this%2C%20a%20regression%20that%20accidentally%20stamps%20on%20non-current%20removals%20would%20go%20undetected.%0A%0A%60%60%60typescript%0Ait%28%22does%20not%20stamp%20any%20account%20when%20a%20non-current%20account%20is%20removed%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20const%20now%20%3D%20Date.now%28%29%3B%0A%20%20const%20stored%20%3D%20%7B%0A%20%20%20%20version%3A%203%20as%20const%2C%0A%20%20%20%20activeIndex%3A%202%2C%0A%20%20%20%20activeIndexByFamily%3A%20%7B%20codex%3A%202%20%7D%2C%0A%20%20%20%20accounts%3A%20%5B%0A%20%20%20%20%20%20%7B%20refreshToken%3A%20%22token-1%22%2C%20addedAt%3A%20now%2C%20lastUsed%3A%20now%2C%20lastSwitchReason%3A%20%22initial%22%20as%20const%20%7D%2C%0A%20%20%20%20%20%20%7B%20refreshToken%3A%20%22token-2%22%2C%20addedAt%3A%20now%2C%20lastUsed%3A%20now%2C%20lastSwitchReason%3A%20%22rate-limit%22%20as%20const%20%7D%2C%0A%20%20%20%20%20%20%7B%20refreshToken%3A%20%22token-3%22%2C%20addedAt%3A%20now%2C%20lastUsed%3A%20now%2C%20lastSwitchReason%3A%20%22rotation%22%20as%20const%20%7D%2C%0A%20%20%20%20%5D%2C%0A%20%20%7D%3B%0A%20%20const%20manager%20%3D%20new%20AccountManager%28undefined%2C%20stored%20as%20never%29%3B%0A%20%20const%20nonCurrent%20%3D%20manager.getAccountByIndex%280%29!%3B%0A%20%20manager.removeAccount%28nonCurrent%29%3B%0A%0A%20%20%2F%2F%20pointer%20shifts%20from%202%20%E2%86%92%201%3B%20no%20stamp%20should%20be%20written%0A%20%20expect%28manager.getActiveIndexForFamily%28%22codex%22%29%29.toBe%281%29%3B%0A%20%20expect%28manager.getAccountByIndex%280%29%3F.lastSwitchReason%29.toBe%28%22rate-limit%22%29%3B%0A%20%20expect%28manager.getAccountByIndex%281%29%3F.lastSwitchReason%29.toBe%28%22rotation%22%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/accounts.test.ts
Line: 2906-2940

Comment:
**missing "remove non-current → no stamp" regression case**

the PR description explicitly lists this scenario ("Remove non-current account | Same — only retargets-off-removed-slot trigger the stamp"), but there's no vitest case that removes a non-current account and asserts `lastSwitchReason` on every remaining account is unchanged. without this, a regression that accidentally stamps on non-current removals would go undetected.

```typescript
it("does not stamp any account when a non-current account is removed", () => {
  const now = Date.now();
  const stored = {
    version: 3 as const,
    activeIndex: 2,
    activeIndexByFamily: { codex: 2 },
    accounts: [
      { refreshToken: "token-1", addedAt: now, lastUsed: now, lastSwitchReason: "initial" as const },
      { refreshToken: "token-2", addedAt: now, lastUsed: now, lastSwitchReason: "rate-limit" as const },
      { refreshToken: "token-3", addedAt: now, lastUsed: now, lastSwitchReason: "rotation" as const },
    ],
  };
  const manager = new AccountManager(undefined, stored as never);
  const nonCurrent = manager.getAccountByIndex(0)!;
  manager.removeAccount(nonCurrent);

  // pointer shifts from 2 → 1; no stamp should be written
  expect(manager.getActiveIndexForFamily("codex")).toBe(1);
  expect(manager.getAccountByIndex(0)?.lastSwitchReason).toBe("rate-limit");
  expect(manager.getAccountByIndex(1)?.lastSwitchReason).toBe("rotation");
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(accounts): signal removed-current in..."](https://github.com/ndycode/codex-multi-auth/commit/07c2032a577f5eb358f5d5a1d094ca11c71e3c46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28837833)</sub>

<!-- /greptile_comment -->