### PR TITLE
fix(accounts): sync cursorByFamily in markSwitched (HI-02)

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -866,6 +866,16 @@ export class AccountManager {
 	): void {
 		account.lastSwitchReason = reason;
 		this.currentAccountIndexByFamily[family] = account.index;
+		// HI-02: keep cursorByFamily in lockstep so subsequent round-robin
+		// passes resume AFTER the just-switched account, matching the
+		// convention used in getCurrentOrNextForFamilyHybrid / the
+		// getCurrentOrNextForFamily inner loop. Without this, the cursor
+		// still points at the pre-switch position and the next selection
+		// can re-pick or skip the freshly marked account.
+		const count = this.accounts.length;
+		if (count > 0) {
+			this.cursorByFamily[family] = (account.index + 1) % count;
+		}
 	}
 
 	/**
@@ -900,6 +910,13 @@ export class AccountManager {
 		return withRoutingMutex(this.routingMutexMode, () => {
 			account.lastSwitchReason = reason;
 			this.currentAccountIndexByFamily[family] = account.index;
+			// HI-02: keep cursorByFamily in lockstep with the active-index
+			// mutation so the mutex-serialized variant preserves the same
+			// round-robin invariant as the legacy `markSwitched` path.
+			const count = this.accounts.length;
+			if (count > 0) {
+				this.cursorByFamily[family] = (account.index + 1) % count;
+			}
 			const trackerKey = getRuntimeTrackerKey(account);
 			const healthTracker = getHealthTracker();
 			const tokenTracker = getTokenTracker();
@@ -1316,8 +1333,14 @@ export class AccountManager {
 
 		// Snapshot family pointers before splice so we can distinguish "was
 		// pointing at the removed account" from "was pointing past it".
-		const priorCursor: Record<ModelFamily, number> = {} as Record<ModelFamily, number>;
-		const priorActive: Record<ModelFamily, number> = {} as Record<ModelFamily, number>;
+		const priorCursor: Record<ModelFamily, number> = {} as Record<
+			ModelFamily,
+			number
+		>;
+		const priorActive: Record<ModelFamily, number> = {} as Record<
+			ModelFamily,
+			number
+		>;
 		for (const family of MODEL_FAMILIES) {
 			priorCursor[family] = this.cursorByFamily[family];
 			priorActive[family] = this.currentAccountIndexByFamily[family];

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1953,6 +1953,37 @@ describe("AccountManager", () => {
 				"token-0",
 			);
 		});
+
+		it("syncs cursorByFamily in the mutex-serialized markSwitchedLocked path", async () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-0", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored, {
+				routingMutexMode: "enabled",
+			});
+
+			expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe(
+				"token-0",
+			);
+
+			const account2 = manager.getAccountByIndex(2)!;
+			await manager.markSwitchedLocked(account2, "rate-limit", "codex");
+
+			expect(manager.getCurrentAccountForFamily("codex")?.refreshToken).toBe(
+				"token-2",
+			);
+			expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe(
+				"token-0",
+			);
+		});
 	});
 
 	describe("saveToDisk", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1911,6 +1911,48 @@ describe("AccountManager", () => {
 			manager.markSwitched(account, "rate-limit", "codex");
 			expect(account.lastSwitchReason).toBe("rate-limit");
 		});
+
+		it("syncs cursorByFamily past the just-switched account (HI-02)", () => {
+			// Regression: markSwitched used to only update
+			// currentAccountIndexByFamily, leaving cursorByFamily pointing at
+			// the pre-switch position. The next round-robin pass would then
+			// start from the stale cursor instead of advancing past the
+			// freshly marked account.
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-0", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+
+			// Walk the cursor to a known non-zero position: first rotation
+			// returns index 0 and advances cursor to 1.
+			expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe(
+				"token-0",
+			);
+
+			const account2 = manager.getAccountByIndex(2)!;
+			manager.markSwitched(account2, "rate-limit", "codex");
+
+			// Active pointer moved to 2.
+			expect(manager.getCurrentAccountForFamily("codex")?.refreshToken).toBe(
+				"token-2",
+			);
+
+			// Cursor must advance to (2+1)%3 = 0 so the next rotation starts
+			// AFTER the just-switched account. Without the fix, cursor would
+			// still be at 1 and the next call would return token-1, skipping
+			// the round-robin intent of marking index 2.
+			expect(manager.getCurrentOrNextForFamily("codex")?.refreshToken).toBe(
+				"token-0",
+			);
+		});
 	});
 
 	describe("saveToDisk", () => {


### PR DESCRIPTION
Addresses HI-02 from the deep accounts-rotation audit.

`markSwitched` updated `currentAccountIndexByFamily` but not `cursorByFamily`, breaking the rotation invariant that the cursor advances past the just-selected account. This could cause the next family selection to start from stale state.

This PR keeps both pointers in sync and adds a regression test.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes HI-02: `markSwitched` and `markSwitchedLocked` now advance `cursorByFamily` to `(account.index + 1) % count` after updating `currentAccountIndexByFamily`, keeping both pointers in lockstep with the round-robin convention used in `getCurrentOrNextForFamily` and `getCurrentOrNextForFamilyHybrid`.

- the regression test for the `markSwitchedLocked` path (line 1969) passes a third constructor argument that `AccountManager` doesn't accept — `routingMutexMode` stays `\"legacy\"`, the mutex path is never engaged, and `npm run typecheck` will fail with `TS2554`.

<h3>Confidence Score: 4/5</h3>

core fix is correct and safe; one P1 test bug (invalid constructor arg) needs fixing before merge

the production fix in lib/accounts.ts is clean and correct. the test for markSwitchedLocked will break typecheck and doesn't actually exercise the mutex mode it claims to cover — needs a one-line fix (manager.setRoutingMutexMode("enabled")) before CI passes cleanly

test/accounts.test.ts line 1969

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | cursor sync fix in both markSwitched and markSwitchedLocked is correct and consistent with the (account.index+1)%count pattern used across the rest of the rotation pipeline |
| test/accounts.test.ts | HI-02 regression test for markSwitched is solid; markSwitchedLocked test passes an invalid 3rd constructor arg, leaving routingMutexMode as "legacy" and never exercising the mutex path it claims to cover — also a TS compile error |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant AccountManager
    participant RoutingMutex

    Note over AccountManager: markSwitched (legacy sync path)
    Caller->>AccountManager: markSwitched(account, reason, family)
    AccountManager->>AccountManager: currentAccountIndexByFamily[family] = account.index
    AccountManager->>AccountManager: cursorByFamily[family] = (account.index+1) % count ← HI-02 fix

    Note over AccountManager: markSwitchedLocked (mutex path)
    Caller->>AccountManager: markSwitchedLocked(account, reason, family)
    AccountManager->>RoutingMutex: withRoutingMutex(mode, fn)
    RoutingMutex->>AccountManager: fn() [exclusive]
    AccountManager->>AccountManager: currentAccountIndexByFamily[family] = account.index
    AccountManager->>AccountManager: cursorByFamily[family] = (account.index+1) % count ← HI-02 fix
    AccountManager-->>Caller: SelectionRecord

    Note over AccountManager: next rotation call
    Caller->>AccountManager: getCurrentOrNextForFamily(family)
    AccountManager->>AccountManager: cursor = cursorByFamily[family] → starts AFTER switched account
    AccountManager-->>Caller: next account in round-robin
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fmarksswitched-cursor-sync%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmarksswitched-cursor-sync%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Faccounts.test.ts%3A1969-1971%0A**constructor%20options%20arg%20doesn't%20exist%20%E2%80%94%20mutex%20mode%20never%20set%20to%20%22enabled%22**%0A%0A%60AccountManager%60's%20constructor%20only%20accepts%20two%20parameters%20%28%60authFallback%60%2C%20%60stored%60%29.%20the%20third%20argument%20%60%7B%20routingMutexMode%3A%20%22enabled%22%20%7D%60%20is%20silently%20dropped%20at%20runtime%20and%20%60routingMutexMode%60%20stays%20%60%22legacy%22%60%2C%20meaning%20%60markSwitchedLocked%60%20runs%20the%20callback%20inline%20via%20%60withRoutingMutex%28%22legacy%22%2C%20...%29%60%20%E2%80%94%20the%20mutex-serialized%20code%20path%20is%20never%20actually%20exercised.%20TypeScript%20will%20also%20reject%20this%20with%20%60TS2554%20Expected%200-2%20arguments%2C%20but%20got%203%60%2C%20breaking%20%60npm%20run%20typecheck%60.%0A%0Afix%3A%20construct%20with%202%20args%20and%20call%20%60setRoutingMutexMode%60%20explicitly%3A%0A%0A%60%60%60suggestion%0A%09%09%09const%20manager%20%3D%20new%20AccountManager%28undefined%2C%20stored%29%3B%0A%09%09%09manager.setRoutingMutexMode%28%22enabled%22%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/accounts.test.ts
Line: 1969-1971

Comment:
**constructor options arg doesn't exist — mutex mode never set to "enabled"**

`AccountManager`'s constructor only accepts two parameters (`authFallback`, `stored`). the third argument `{ routingMutexMode: "enabled" }` is silently dropped at runtime and `routingMutexMode` stays `"legacy"`, meaning `markSwitchedLocked` runs the callback inline via `withRoutingMutex("legacy", ...)` — the mutex-serialized code path is never actually exercised. TypeScript will also reject this with `TS2554 Expected 0-2 arguments, but got 3`, breaking `npm run typecheck`.

fix: construct with 2 args and call `setRoutingMutexMode` explicitly:

```suggestion
			const manager = new AccountManager(undefined, stored);
			manager.setRoutingMutexMode("enabled");
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(accounts): cover markSwitchedLocked..."](https://github.com/ndycode/codex-multi-auth/commit/33ec2c622ed31cc11af21cb17a29a1eb343e7ac4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28848739)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->