### PR TITLE
test(rotation): update hybrid selector coverage to null contract (HI-05)

### DIFF
--- a/test/property/hybrid-selector-concurrency.property.test.ts
+++ b/test/property/hybrid-selector-concurrency.property.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fc from "fast-check";
+import {
+	HealthScoreTracker,
+	TokenBucketTracker,
+	selectHybridAccount,
+	type AccountWithMetrics,
+} from "../../lib/rotation.js";
+import {
+	withRoutingMutex,
+	__resetRoutingMutexForTests,
+	type RoutingMutexMode,
+} from "../../lib/routing-mutex.js";
+
+/**
+ * HI-05 concurrency coverage for `selectHybridAccount`.
+ *
+ * The companion `rotation-concurrency.property.test.ts` exercises the routing
+ * mutex against a simulated cursor / cooldown map. That file documents the
+ * critical-section invariants the rotation pipeline relies on, but it does
+ * not call `selectHybridAccount` directly. This file fills that gap: it
+ * spawns N parallel `selectHybridAccount` calls that each mutate the shared
+ * `HealthScoreTracker` / `TokenBucketTracker` / per-account `isAvailable`
+ * state inside the critical section, and asserts that under
+ * `routingMutex === "enabled"` the selector never hands the same slot to two
+ * concurrent callers when only one slot is available.
+ *
+ * Rationale:
+ *   `selectHybridAccount` itself is pure w.r.t. its inputs, but real callers
+ *   interleave selection with mutation of the trackers and the pool's
+ *   `isAvailable` view (drain tokens, record rate-limit, flip availability).
+ *   Without serialization, two concurrent callers can observe the same
+ *   "last remaining available" slot and both pick it — the exact TOCTOU the
+ *   routing mutex is meant to close.
+ */
+
+type SelectionObservation = {
+	/** Index returned by selectHybridAccount inside the critical section. */
+	chosenIndex: number | null;
+	/**
+	 * `true` when this caller entered the critical section and observed the
+	 * pool state written by a previous caller (post-release visibility).
+	 */
+	sawPredecessorWrite: boolean;
+};
+
+interface MutablePool {
+	accounts: AccountWithMetrics[];
+	healthTracker: HealthScoreTracker;
+	tokenTracker: TokenBucketTracker;
+	/** Serialization observer — must stay <= 1 under enabled mode. */
+	concurrentCallers: number;
+	maxConcurrentCallers: number;
+	/** Ordered record of what each critical section chose. */
+	history: SelectionObservation[];
+}
+
+function createMutablePool(accountCount: number): MutablePool {
+	const now = Date.now();
+	const accounts: AccountWithMetrics[] = Array.from(
+		{ length: accountCount },
+		(_, index) => ({
+			index,
+			isAvailable: true,
+			lastUsed: now - (accountCount - index),
+		}),
+	);
+	return {
+		accounts,
+		healthTracker: new HealthScoreTracker(),
+		tokenTracker: new TokenBucketTracker(),
+		concurrentCallers: 0,
+		maxConcurrentCallers: 0,
+		history: [],
+	};
+}
+
+/**
+ * One caller's unit of work: take the mutex, read pool, call the real
+ * `selectHybridAccount`, then mutate the same shared state the next caller
+ * will see (flip isAvailable on the winner, drain its tokens, bump lastUsed).
+ *
+ * The `setImmediate` yield between read and write is what exposes the race
+ * when no mutex is present — two concurrent tasks see the same `isAvailable`
+ * view and both claim the same last-remaining slot.
+ */
+async function selectAndConsumeOnce(
+	pool: MutablePool,
+	mode: RoutingMutexMode,
+): Promise<SelectionObservation> {
+	const observation = await withRoutingMutex(mode, async () => {
+		pool.concurrentCallers += 1;
+		if (pool.concurrentCallers > pool.maxConcurrentCallers) {
+			pool.maxConcurrentCallers = pool.concurrentCallers;
+		}
+		try {
+			const preAvailable = pool.accounts.filter((a) => a.isAvailable).length;
+			const selected = selectHybridAccount(
+				pool.accounts,
+				pool.healthTracker,
+				pool.tokenTracker,
+			);
+			// Simulate decision latency between read and write so interleaving
+			// races would manifest if the mutex were absent or broken.
+			await new Promise((r) => setImmediate(r));
+
+			let chosenIndex: number | null = null;
+			if (selected) {
+				chosenIndex = selected.index;
+				// Critical-section write: flip availability + mutate trackers.
+				// The next caller through this section must observe these writes.
+				const target = pool.accounts[selected.index];
+				if (target) {
+					target.isAvailable = false;
+					target.lastUsed = Date.now();
+				}
+				pool.tokenTracker.drain(selected.index, undefined, 100);
+				pool.healthTracker.recordRateLimit(selected.index);
+			}
+
+			// Post-release visibility check: a new caller after at least one
+			// predecessor should see strictly fewer available slots than the
+			// first caller did (monotone non-increasing under mutex).
+			const sawPredecessorWrite =
+				pool.history.length > 0 && preAvailable < pool.accounts.length;
+
+			return {
+				chosenIndex,
+				sawPredecessorWrite,
+			} satisfies SelectionObservation;
+		} finally {
+			pool.concurrentCallers -= 1;
+		}
+	});
+	pool.history.push(observation);
+	return observation;
+}
+
+describe("selectHybridAccount concurrency (HI-05)", () => {
+	afterEach(() => __resetRoutingMutexForTests());
+
+	it("mutex-enabled: no double-selection of the same slot across parallel callers", async () => {
+		await fc.assert(
+			fc.asyncProperty(
+				fc.integer({ min: 2, max: 6 }),
+				fc.integer({ min: 2, max: 10 }),
+				async (accountCount, concurrentRequests) => {
+					const pool = createMutablePool(accountCount);
+					const tasks = Array.from({ length: concurrentRequests }, () =>
+						selectAndConsumeOnce(pool, "enabled"),
+					);
+					const results = await Promise.all(tasks);
+
+					// Invariant 1: every caller produced an observation (no lost updates).
+					expect(pool.history).toHaveLength(concurrentRequests);
+
+					// Invariant 2: no two winning callers returned the same index.
+					// Once a caller wins a slot it marks the slot unavailable inside
+					// the critical section; under a working mutex the next caller
+					// must see that write and either pick a different slot or null.
+					const winners = results
+						.map((r) => r.chosenIndex)
+						.filter((i): i is number => i !== null);
+					const unique = new Set(winners);
+					expect(unique.size).toBe(winners.length);
+
+					// Invariant 3: winner count is bounded by account count. With
+					// each caller consuming one slot, at most `accountCount` callers
+					// can succeed; the rest must observe an exhausted pool and
+					// return null.
+					expect(winners.length).toBeLessThanOrEqual(accountCount);
+
+					// Invariant 4: external observer proves mutual exclusion — a
+					// broken mutex would let two+ tasks enter the critical section
+					// concurrently and both see the same `isAvailable` view.
+					expect(pool.maxConcurrentCallers).toBeLessThanOrEqual(1);
+				},
+			),
+			{ numRuns: 50 },
+		);
+	});
+
+	it("mutex-enabled: single-slot pool under N parallel callers yields exactly one winner", async () => {
+		await fc.assert(
+			fc.asyncProperty(
+				fc.integer({ min: 2, max: 12 }),
+				async (concurrentRequests) => {
+					const pool = createMutablePool(1);
+					const tasks = Array.from({ length: concurrentRequests }, () =>
+						selectAndConsumeOnce(pool, "enabled"),
+					);
+					const results = await Promise.all(tasks);
+
+					// Exactly one caller may claim the single slot; every other
+					// caller must observe it as unavailable and receive null.
+					// `selectHybridAccount` returns `null` when the pool is
+					// either empty or entirely unavailable (AUDIT-H2 contract).
+					const winners = results.filter((r) => r.chosenIndex !== null);
+					expect(winners).toHaveLength(1);
+					expect(winners[0]?.chosenIndex).toBe(0);
+
+					const losers = results.filter((r) => r.chosenIndex === null);
+					expect(losers).toHaveLength(concurrentRequests - 1);
+
+					expect(pool.maxConcurrentCallers).toBeLessThanOrEqual(1);
+				},
+			),
+			{ numRuns: 50 },
+		);
+	});
+
+	it("mutex-enabled: saturates an N-slot pool across more than N parallel callers without double-selection", async () => {
+		const accountCount = 3;
+		const concurrentRequests = 8;
+		const pool = createMutablePool(accountCount);
+
+		const tasks = Array.from({ length: concurrentRequests }, () =>
+			selectAndConsumeOnce(pool, "enabled"),
+		);
+		const results = await Promise.all(tasks);
+
+		const winners = results
+			.map((r) => r.chosenIndex)
+			.filter((i): i is number => i !== null);
+
+		// Every slot must be claimed exactly once, overflow callers see null.
+		expect(winners).toHaveLength(accountCount);
+		expect(new Set(winners).size).toBe(accountCount);
+		expect(new Set(winners)).toEqual(new Set([0, 1, 2]));
+
+		expect(pool.maxConcurrentCallers).toBeLessThanOrEqual(1);
+	});
+});

--- a/test/property/hybrid-selector-concurrency.property.test.ts
+++ b/test/property/hybrid-selector-concurrency.property.test.ts
@@ -174,6 +174,14 @@ describe("selectHybridAccount concurrency (HI-05)", () => {
 					// broken mutex would let two+ tasks enter the critical section
 					// concurrently and both see the same `isAvailable` view.
 					expect(pool.maxConcurrentCallers).toBeLessThanOrEqual(1);
+
+					// Invariant 5: once more than one parallel caller runs, at least
+					// one later observation must report seeing a predecessor's write.
+					// This makes the `sawPredecessorWrite` field meaningful instead
+					// of dead bookkeeping.
+					expect(results.slice(1).some((r) => r.sawPredecessorWrite)).toBe(
+						true,
+					);
 				},
 			),
 			{ numRuns: 50 },
@@ -203,6 +211,9 @@ describe("selectHybridAccount concurrency (HI-05)", () => {
 					expect(losers).toHaveLength(concurrentRequests - 1);
 
 					expect(pool.maxConcurrentCallers).toBeLessThanOrEqual(1);
+					expect(results.slice(1).some((r) => r.sawPredecessorWrite)).toBe(
+						true,
+					);
 				},
 			),
 			{ numRuns: 50 },
@@ -226,8 +237,11 @@ describe("selectHybridAccount concurrency (HI-05)", () => {
 		// Every slot must be claimed exactly once, overflow callers see null.
 		expect(winners).toHaveLength(accountCount);
 		expect(new Set(winners).size).toBe(accountCount);
-		expect(new Set(winners)).toEqual(new Set([0, 1, 2]));
+				expect(new Set(winners)).toEqual(new Set([0, 1, 2]));
 
-		expect(pool.maxConcurrentCallers).toBeLessThanOrEqual(1);
-	});
+				expect(pool.maxConcurrentCallers).toBeLessThanOrEqual(1);
+				expect(results.slice(1).some((r) => r.sawPredecessorWrite)).toBe(
+					true,
+				);
+			});
 });


### PR DESCRIPTION
Addresses HI-05 from the deep accounts-rotation audit.

Current main had already changed `selectHybridAccount` to return `null` when all accounts are unavailable, but test coverage was stale in two places:
- `test/rotation.test.ts` still asserted the old LRU fallback behavior
- `test/property/rotation.property.test.ts` also asserted the old fallback

This PR updates both tests to the current AUDIT-H2 null contract.

No production code changes.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds a new property test file (`test/property/hybrid-selector-concurrency.property.test.ts`) covering `selectHybridAccount` concurrency under the routing mutex, implementing the AUDIT-H2 null contract. the `sawPredecessorWrite` field flagged in the prior review now has a proper invariant 5 assertion across all three test cases.

- the file lacks a `\"legacy\"` mode negative test (the companion `rotation-concurrency.property.test.ts` has one at line 192); without it, no test demonstrates that double-selection actually occurs without the mutex, leaving the key audit claim unverified.
- the third test case uses hard-coded `accountCount = 3, concurrentRequests = 8` rather than `fc.asyncProperty`, and its inner `expect` calls have inconsistent indentation (two extra levels vs. the rest of the file).

<h3>Confidence Score: 4/5</h3>

safe to merge as test-only coverage but the missing legacy-mode negative test leaves the core audit claim unverified

no production code changed; all three enabled-mode invariants are structurally sound and the sawPredecessorWrite assertion gap from the previous review is now closed. score is 4 rather than 5 because the absence of a legacy-mode negative test means the test suite cannot demonstrate that double-selection actually occurs without the mutex — the companion rotation-concurrency file sets that precedent explicitly and this audit-tagged file should match it

test/property/hybrid-selector-concurrency.property.test.ts — missing legacy-mode baseline and third test is non-property-based with indentation issues

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/property/hybrid-selector-concurrency.property.test.ts | new property test file with three concurrency invariants for selectHybridAccount under the routing mutex; missing a "legacy" mode negative test (the companion rotation-concurrency file has one) and the third test case uses fixed inputs with inconsistent indentation |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T1 as Caller 1
    participant T2 as Caller 2
    participant M as RoutingMutex
    participant P as MutablePool

    T1->>M: withRoutingMutex("enabled", fn)
    M-->>T1: acquire (immediate)
    T1->>P: read isAvailable (all available)
    T1->>P: selectHybridAccount → account[0]
    Note over T1: setImmediate yield
    T1->>P: mark account[0] unavailable
    T1->>M: release
    Note over T1: pool.history.push(obs1)

    T2->>M: withRoutingMutex("enabled", fn)
    M-->>T2: acquire (after T1 releases)
    T2->>P: read isAvailable (account[0] unavailable)
    T2->>P: selectHybridAccount → account[1] or null
    Note over T2: setImmediate yield
    T2->>P: mark account[1] unavailable (if selected)
    T2->>M: release
    Note over T2: pool.history.push(obs2)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fhybrid-selector-test-coverage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhybrid-selector-test-coverage%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fproperty%2Fhybrid-selector-concurrency.property.test.ts%3A142-189%0A**missing%20%60%22legacy%22%60%20mode%20negative%20test**%0A%0Athe%20companion%20file%20%60rotation-concurrency.property.test.ts%60%20%28line%20192%29%20has%20an%20explicit%20%60%22legacy%20baseline%22%60%20case%20that%20confirms%20double-selection%20%2F%20%60maxConcurrentCallers%20%3E%201%60%20does%20materialize%20without%20the%20mutex.%20this%20file%20has%20no%20equivalent.%20without%20it%2C%20a%20reviewer%20can't%20distinguish%20%22mutex%20works%20correctly%22%20from%20%22the%20%60setImmediate%60%20yield%20doesn't%20create%20a%20real%20race%20window%20at%20all%22%20%E2%80%94%20all%20three%20tests%20would%20pass%20even%20if%20%60withRoutingMutex%28%22enabled%22%2C%20fn%29%60%20was%20silently%20equivalent%20to%20a%20no-op.%0A%0A%60%60%60ts%0Ait%28%22legacy-mode%20baseline%3A%20race%20window%20produces%20maxConcurrentCallers%20%3E%201%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20await%20fc.assert%28%0A%20%20%20%20fc.asyncProperty%28%0A%20%20%20%20%20%20fc.integer%28%7B%20min%3A%203%2C%20max%3A%206%20%7D%29%2C%0A%20%20%20%20%20%20fc.integer%28%7B%20min%3A%206%2C%20max%3A%2010%20%7D%29%2C%0A%20%20%20%20%20%20async%20%28accountCount%2C%20concurrentRequests%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20const%20pool%20%3D%20createMutablePool%28accountCount%29%3B%0A%20%20%20%20%20%20%20%20const%20tasks%20%3D%20Array.from%28%7B%20length%3A%20concurrentRequests%20%7D%2C%20%28%29%20%3D%3E%0A%20%20%20%20%20%20%20%20%20%20selectAndConsumeOnce%28pool%2C%20%22legacy%22%29%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20await%20Promise.all%28tasks%29%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Under%20legacy%20mode%20the%20setImmediate%20yield%20exposes%20a%20real%20TOCTOU%0A%20%20%20%20%20%20%20%20%2F%2F%20window%3B%20concurrent%20callers%20overlap%20and%20maxConcurrentCallers%20%3E%201.%0A%20%20%20%20%20%20%20%20expect%28pool.maxConcurrentCallers%29.toBeGreaterThan%281%29%3B%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%29%2C%0A%20%20%20%20%7B%20numRuns%3A%2030%20%7D%2C%0A%20%20%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fproperty%2Fhybrid-selector-concurrency.property.test.ts%3A223-246%0A**third%20test%3A%20fixed%20inputs%20%2B%20indentation%20drift**%0A%0Aunlike%20the%20first%20two%20cases%20this%20test%20uses%20hard-coded%20%60accountCount%20%3D%203%2C%20concurrentRequests%20%3D%208%60%20instead%20of%20%60fc.asyncProperty%60.%20edge%20cases%20like%20%60concurrentRequests%20%3D%3D%3D%20accountCount%60%20%28exactly%20saturated%29%20or%20%60concurrentRequests%20%3D%3D%3D%20accountCount%20%2B%201%60%20%28exactly%20one%20overflow%20caller%29%20are%20never%20exercised.%20additionally%20the%20%60expect%60%20calls%20from%20line%20240%20onward%20are%20indented%20two%20extra%20levels%20relative%20to%20the%20enclosing%20%60it%60%20body%2C%20inconsistent%20with%20the%20rest%20of%20the%20file.%0A%0A%60%60%60ts%0Ait%28%22mutex-enabled%3A%20saturates%20an%20N-slot%20pool%20across%20more%20than%20N%20parallel%20callers%20without%20double-selection%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20await%20fc.assert%28%0A%20%20%20%20fc.asyncProperty%28%0A%20%20%20%20%20%20fc.integer%28%7B%20min%3A%201%2C%20max%3A%204%20%7D%29%2C%0A%20%20%20%20%20%20fc.integer%28%7B%20min%3A%201%2C%20max%3A%204%20%7D%29%2C%0A%20%20%20%20%20%20async%20%28accountCount%2C%20overflow%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20const%20concurrentRequests%20%3D%20accountCount%20%2B%20overflow%3B%0A%20%20%20%20%20%20%20%20const%20pool%20%3D%20createMutablePool%28accountCount%29%3B%0A%20%20%20%20%20%20%20%20const%20tasks%20%3D%20Array.from%28%7B%20length%3A%20concurrentRequests%20%7D%2C%20%28%29%20%3D%3E%0A%20%20%20%20%20%20%20%20%20%20selectAndConsumeOnce%28pool%2C%20%22enabled%22%29%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20const%20results%20%3D%20await%20Promise.all%28tasks%29%3B%0A%20%20%20%20%20%20%20%20const%20winners%20%3D%20results%0A%20%20%20%20%20%20%20%20%20%20.map%28%28r%29%20%3D%3E%20r.chosenIndex%29%0A%20%20%20%20%20%20%20%20%20%20.filter%28%28i%29%3A%20i%20is%20number%20%3D%3E%20i%20!%3D%3D%20null%29%3B%0A%0A%20%20%20%20%20%20%20%20expect%28winners%29.toHaveLength%28accountCount%29%3B%0A%20%20%20%20%20%20%20%20expect%28new%20Set%28winners%29.size%29.toBe%28accountCount%29%3B%0A%20%20%20%20%20%20%20%20expect%28pool.maxConcurrentCallers%29.toBeLessThanOrEqual%281%29%3B%0A%20%20%20%20%20%20%20%20expect%28results.slice%281%29.some%28%28r%29%20%3D%3E%20r.sawPredecessorWrite%29%29.toBe%28true%29%3B%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%29%2C%0A%20%20%20%20%7B%20numRuns%3A%2050%20%7D%2C%0A%20%20%29%3B%0A%7D%29%3B%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/property/hybrid-selector-concurrency.property.test.ts
Line: 142-189

Comment:
**missing `"legacy"` mode negative test**

the companion file `rotation-concurrency.property.test.ts` (line 192) has an explicit `"legacy baseline"` case that confirms double-selection / `maxConcurrentCallers > 1` does materialize without the mutex. this file has no equivalent. without it, a reviewer can't distinguish "mutex works correctly" from "the `setImmediate` yield doesn't create a real race window at all" — all three tests would pass even if `withRoutingMutex("enabled", fn)` was silently equivalent to a no-op.

```ts
it("legacy-mode baseline: race window produces maxConcurrentCallers > 1", async () => {
  await fc.assert(
    fc.asyncProperty(
      fc.integer({ min: 3, max: 6 }),
      fc.integer({ min: 6, max: 10 }),
      async (accountCount, concurrentRequests) => {
        const pool = createMutablePool(accountCount);
        const tasks = Array.from({ length: concurrentRequests }, () =>
          selectAndConsumeOnce(pool, "legacy"),
        );
        await Promise.all(tasks);
        // Under legacy mode the setImmediate yield exposes a real TOCTOU
        // window; concurrent callers overlap and maxConcurrentCallers > 1.
        expect(pool.maxConcurrentCallers).toBeGreaterThan(1);
      },
    ),
    { numRuns: 30 },
  );
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/property/hybrid-selector-concurrency.property.test.ts
Line: 223-246

Comment:
**third test: fixed inputs + indentation drift**

unlike the first two cases this test uses hard-coded `accountCount = 3, concurrentRequests = 8` instead of `fc.asyncProperty`. edge cases like `concurrentRequests === accountCount` (exactly saturated) or `concurrentRequests === accountCount + 1` (exactly one overflow caller) are never exercised. additionally the `expect` calls from line 240 onward are indented two extra levels relative to the enclosing `it` body, inconsistent with the rest of the file.

```ts
it("mutex-enabled: saturates an N-slot pool across more than N parallel callers without double-selection", async () => {
  await fc.assert(
    fc.asyncProperty(
      fc.integer({ min: 1, max: 4 }),
      fc.integer({ min: 1, max: 4 }),
      async (accountCount, overflow) => {
        const concurrentRequests = accountCount + overflow;
        const pool = createMutablePool(accountCount);
        const tasks = Array.from({ length: concurrentRequests }, () =>
          selectAndConsumeOnce(pool, "enabled"),
        );
        const results = await Promise.all(tasks);
        const winners = results
          .map((r) => r.chosenIndex)
          .filter((i): i is number => i !== null);

        expect(winners).toHaveLength(accountCount);
        expect(new Set(winners).size).toBe(accountCount);
        expect(pool.maxConcurrentCallers).toBeLessThanOrEqual(1);
        expect(results.slice(1).some((r) => r.sawPredecessorWrite)).toBe(true);
      },
    ),
    { numRuns: 50 },
  );
});

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(rotation): assert sawPredecessorWri..."](https://github.com/ndycode/codex-multi-auth/commit/69315269b131e687ca307f8a3b99ce212a58bd59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28849558)</sub>

<!-- /greptile_comment -->