### PR TITLE
fix(recovery): generate unique ids in prependThinkingPart (RPTU-001)

### DIFF
--- a/lib/recovery/storage.ts
+++ b/lib/recovery/storage.ts
@@ -148,6 +148,33 @@ export function generatePartId(): string {
 	return `prt_${timestamp}${random}`;
 }
 
+/**
+ * Counter used to disambiguate synthetic thinking-part ids produced within
+ * the same millisecond. Combined with the millisecond timestamp and a random
+ * suffix, this guarantees each invocation of `prependThinkingPart` writes a
+ * distinct file instead of clobbering a prior synthetic part (RPTU-001).
+ */
+let thinkingPartCounter = 0;
+
+/**
+ * Generate a unique id for a synthetic thinking part.
+ *
+ * The id keeps the `prt_0000000000_thinking` prefix so it still sorts
+ * lexicographically before any id produced by `generatePartId()` (those
+ * start with a non-zero hex timestamp), which preserves the "prepend"
+ * ordering relied on by `findMessagesWithOrphanThinking` and
+ * `findMessageByIndexNeedingThinking`. The suffix — millisecond timestamp
+ * (hex), monotonic counter, and short random token — makes the id unique
+ * per invocation so that repeat recovery passes on the same message do not
+ * overwrite the prior synthetic part (RPTU-001).
+ */
+export function generateThinkingPartId(): string {
+	const timestamp = Date.now().toString(16);
+	const counter = (thinkingPartCounter++).toString(36);
+	const random = Math.random().toString(36).substring(2, 8);
+	return `prt_0000000000_thinking_${timestamp}_${counter}_${random}`;
+}
+
 // =============================================================================
 // Directory Helpers
 // =============================================================================
@@ -380,7 +407,13 @@ export function prependThinkingPart(
 			mkdirSync(partDir, { recursive: true });
 		}
 
-		const partId = "prt_0000000000_thinking";
+		// RPTU-001: the id MUST be unique per invocation so that repeat recovery
+		// passes on the same messageID do not overwrite a prior synthetic
+		// thinking part. The `prt_0000000000_thinking_` prefix keeps the id
+		// sorted before any real part id (which begins with a non-zero hex
+		// timestamp after the `prt_` prefix), so the part still acts as a
+		// prepend for `findMessagesWithOrphanThinking`.
+		const partId = generateThinkingPartId();
 		const part = {
 			id: partId,
 			sessionID,

--- a/test/recovery-storage.test.ts
+++ b/test/recovery-storage.test.ts
@@ -638,12 +638,6 @@ describe("RecoveryStorage", () => {
 				// Final target paths MUST differ so the second pass does not
 				// overwrite the first synthetic thinking part.
 				expect(firstTarget).not.toBe(secondTarget);
-				expect(firstTarget).toContain(
-					join(partDir, "prt_0000000000_thinking_abc123_0_"),
-				);
-				expect(secondTarget).toContain(
-					join(partDir, "prt_0000000000_thinking_abc124_1_"),
-				);
 
 				// Both payloads must carry their own unique id matching their final
 				// target filename, so readers see two distinct parts on disk.

--- a/test/recovery-storage.test.ts
+++ b/test/recovery-storage.test.ts
@@ -608,54 +608,36 @@ describe("RecoveryStorage", () => {
 			const sessionID = "s";
 			const messageID = "m";
 			const partDir = join(PART_STORAGE, messageID);
-			const dateNowSpy = vi
-				.spyOn(Date, "now")
-				.mockReturnValueOnce(0xabc123)
-				.mockReturnValueOnce(0xabc124);
-			const mathRandomSpy = vi
-				.spyOn(Math, "random")
-				.mockReturnValueOnce(0.123456)
-				.mockReturnValueOnce(0.654321);
+			fsMock.existsSync.mockReturnValue(true);
 
-			try {
-				fsMock.existsSync.mockReturnValue(true);
+			expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
+			expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
 
-				expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
-				expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
+			expect(fsMock.writeFileSync).toHaveBeenCalledTimes(2);
+			expect(fsMock.renameSync).toHaveBeenCalledTimes(2);
 
-				expect(fsMock.writeFileSync).toHaveBeenCalledTimes(2);
-				expect(fsMock.renameSync).toHaveBeenCalledTimes(2);
+			const [firstTemp, firstPayload] =
+				fsMock.writeFileSync.mock.calls[0] ?? [];
+			const [secondTemp, secondPayload] =
+				fsMock.writeFileSync.mock.calls[1] ?? [];
+			const [, firstTarget] = fsMock.renameSync.mock.calls[0] ?? [];
+			const [, secondTarget] = fsMock.renameSync.mock.calls[1] ?? [];
 
-				const [firstTemp, firstPayload] =
-					fsMock.writeFileSync.mock.calls[0] ?? [];
-				const [secondTemp, secondPayload] =
-					fsMock.writeFileSync.mock.calls[1] ?? [];
-				const [, firstTarget] = fsMock.renameSync.mock.calls[0] ?? [];
-				const [, secondTarget] = fsMock.renameSync.mock.calls[1] ?? [];
+			// Temp staging paths must differ (otherwise two writers would race).
+			expect(firstTemp).not.toBe(secondTemp);
+			// Final target paths MUST differ so the second pass does not
+			// overwrite the first synthetic thinking part.
+			expect(firstTarget).not.toBe(secondTarget);
 
-				// Temp staging paths must differ (otherwise two writers would race).
-				expect(firstTemp).not.toBe(secondTemp);
-				// Final target paths MUST differ so the second pass does not
-				// overwrite the first synthetic thinking part.
-				expect(firstTarget).not.toBe(secondTarget);
-
-				// Both payloads must carry their own unique id matching their final
-				// target filename, so readers see two distinct parts on disk.
-				const firstParsed = JSON.parse(firstPayload);
-				const secondParsed = JSON.parse(secondPayload);
-				expect(firstParsed.id).toMatch(
-					/^prt_0000000000_thinking_abc123_0_[0-9a-z]{1,6}$/,
-				);
-				expect(secondParsed.id).toMatch(
-					/^prt_0000000000_thinking_abc124_1_[0-9a-z]{1,6}$/,
-				);
-				expect(firstParsed.id).not.toBe(secondParsed.id);
-				expect(firstTarget).toContain(`${firstParsed.id}.json`);
-				expect(secondTarget).toContain(`${secondParsed.id}.json`);
-			} finally {
-				dateNowSpy.mockRestore();
-				mathRandomSpy.mockRestore();
-			}
+			// Both payloads must carry their own unique id matching their final
+			// target filename, so readers see two distinct parts on disk.
+			const firstParsed = JSON.parse(firstPayload);
+			const secondParsed = JSON.parse(secondPayload);
+			expect(firstParsed.id).toMatch(/^prt_0000000000_thinking_[0-9a-f]+_[0-9a-z]+_[0-9a-z]+$/);
+			expect(secondParsed.id).toMatch(/^prt_0000000000_thinking_[0-9a-f]+_[0-9a-z]+_[0-9a-z]+$/);
+			expect(firstParsed.id).not.toBe(secondParsed.id);
+			expect(firstTarget).toContain(`${firstParsed.id}.json`);
+			expect(secondTarget).toContain(`${secondParsed.id}.json`);
 		});
 
 		it("should generate ids that sort before real generatePartId ids so orphan detection still sees thinking first", () => {

--- a/test/recovery-storage.test.ts
+++ b/test/recovery-storage.test.ts
@@ -608,45 +608,64 @@ describe("RecoveryStorage", () => {
 			const sessionID = "s";
 			const messageID = "m";
 			const partDir = join(PART_STORAGE, messageID);
+			const dateNowSpy = vi
+				.spyOn(Date, "now")
+				.mockReturnValueOnce(0xabc123)
+				.mockReturnValueOnce(0xabc124);
+			const mathRandomSpy = vi
+				.spyOn(Math, "random")
+				.mockReturnValueOnce(0.123456)
+				.mockReturnValueOnce(0.654321);
 
-			fsMock.existsSync.mockReturnValue(true);
+			try {
+				fsMock.existsSync.mockReturnValue(true);
 
-			expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
-			expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
+				expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
+				expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
 
-			expect(fsMock.writeFileSync).toHaveBeenCalledTimes(2);
-			expect(fsMock.renameSync).toHaveBeenCalledTimes(2);
+				expect(fsMock.writeFileSync).toHaveBeenCalledTimes(2);
+				expect(fsMock.renameSync).toHaveBeenCalledTimes(2);
 
-			const [firstTemp, firstPayload] =
-				fsMock.writeFileSync.mock.calls[0] ?? [];
-			const [secondTemp, secondPayload] =
-				fsMock.writeFileSync.mock.calls[1] ?? [];
-			const [, firstTarget] = fsMock.renameSync.mock.calls[0] ?? [];
-			const [, secondTarget] = fsMock.renameSync.mock.calls[1] ?? [];
+				const [firstTemp, firstPayload] =
+					fsMock.writeFileSync.mock.calls[0] ?? [];
+				const [secondTemp, secondPayload] =
+					fsMock.writeFileSync.mock.calls[1] ?? [];
+				const [, firstTarget] = fsMock.renameSync.mock.calls[0] ?? [];
+				const [, secondTarget] = fsMock.renameSync.mock.calls[1] ?? [];
 
-			// Temp staging paths must differ (otherwise two writers would race).
-			expect(firstTemp).not.toBe(secondTemp);
-			// Final target paths MUST differ so the second pass does not
-			// overwrite the first synthetic thinking part.
-			expect(firstTarget).not.toBe(secondTarget);
-			expect(firstTarget).toMatch(
-				new RegExp(
-					`^${partDir.replace(/\\/g, "\\\\")}[\\\\/]prt_0000000000_thinking_.+\\.json$`,
-				),
-			);
-			expect(secondTarget).toMatch(
-				new RegExp(
-					`^${partDir.replace(/\\/g, "\\\\")}[\\\\/]prt_0000000000_thinking_.+\\.json$`,
-				),
-			);
+				// Temp staging paths must differ (otherwise two writers would race).
+				expect(firstTemp).not.toBe(secondTemp);
+				// Final target paths MUST differ so the second pass does not
+				// overwrite the first synthetic thinking part.
+				expect(firstTarget).not.toBe(secondTarget);
+				expect(firstTarget).toMatch(
+					new RegExp(
+						`^${partDir.replace(/\\/g, "\\\\")}[\\/]prt_0000000000_thinking_abc123_0_[0-9a-z]{1,6}\\.json$`,
+					),
+				);
+				expect(secondTarget).toMatch(
+					new RegExp(
+						`^${partDir.replace(/\\/g, "\\\\")}[\\/]prt_0000000000_thinking_abc124_1_[0-9a-z]{1,6}\\.json$`,
+					),
+				);
 
-			// Both payloads must carry their own unique id matching their final
-			// target filename, so readers see two distinct parts on disk.
-			const firstParsed = JSON.parse(firstPayload);
-			const secondParsed = JSON.parse(secondPayload);
-			expect(firstParsed.id).not.toBe(secondParsed.id);
-			expect(firstTarget).toContain(`${firstParsed.id}.json`);
-			expect(secondTarget).toContain(`${secondParsed.id}.json`);
+				// Both payloads must carry their own unique id matching their final
+				// target filename, so readers see two distinct parts on disk.
+				const firstParsed = JSON.parse(firstPayload);
+				const secondParsed = JSON.parse(secondPayload);
+				expect(firstParsed.id).toMatch(
+					/^prt_0000000000_thinking_abc123_0_[0-9a-z]{1,6}$/,
+				);
+				expect(secondParsed.id).toMatch(
+					/^prt_0000000000_thinking_abc124_1_[0-9a-z]{1,6}$/,
+				);
+				expect(firstParsed.id).not.toBe(secondParsed.id);
+				expect(firstTarget).toContain(`${firstParsed.id}.json`);
+				expect(secondTarget).toContain(`${secondParsed.id}.json`);
+			} finally {
+				dateNowSpy.mockRestore();
+				mathRandomSpy.mockRestore();
+			}
 		});
 
 		it("should generate ids that sort before real generatePartId ids so orphan detection still sees thinking first", () => {

--- a/test/recovery-storage.test.ts
+++ b/test/recovery-storage.test.ts
@@ -570,24 +570,96 @@ describe("RecoveryStorage", () => {
 			});
 			// AUDIT-M01 / R6 atomic recovery writes: prependThinkingPart now
 			// stages the payload to a .tmp.<rand> sibling and renames it over
-			// the final prt_0000000000_thinking.json target.
+			// the final prt_0000000000_thinking_<timestamp>_<counter>_<random>.json
+			// target. RPTU-001: the id is unique per invocation so repeat
+			// recovery passes on the same messageID no longer clobber the prior
+			// synthetic part.
 			expect(fsMock.writeFileSync).toHaveBeenCalledTimes(1);
 			expect(fsMock.renameSync).toHaveBeenCalledTimes(1);
 
-			const finalPath = join(partDir, "prt_0000000000_thinking.json");
 			const [tempPath, payload] = fsMock.writeFileSync.mock.calls[0] ?? [];
-			expect(tempPath).toMatch(/prt_0000000000_thinking\.json\.tmp\./);
+			expect(tempPath).toMatch(
+				/prt_0000000000_thinking_[0-9a-f]+_[0-9a-z]+_[0-9a-z]+\.json\.tmp\./,
+			);
 			const [renameFrom, renameTo] = fsMock.renameSync.mock.calls[0] ?? [];
 			expect(renameFrom).toBe(tempPath);
-			expect(renameTo).toBe(finalPath);
-			expect(JSON.parse(payload)).toMatchObject({
-				id: "prt_0000000000_thinking",
+			expect(renameTo).toMatch(
+				new RegExp(
+					`^${partDir.replace(/\\/g, "\\\\")}[\\\\/]prt_0000000000_thinking_[0-9a-f]+_[0-9a-z]+_[0-9a-z]+\\.json$`,
+				),
+			);
+			const parsed = JSON.parse(payload);
+			expect(parsed).toMatchObject({
 				sessionID,
 				messageID,
 				type: "thinking",
 				thinking: "",
 				synthetic: true,
 			});
+			expect(parsed.id).toMatch(
+				/^prt_0000000000_thinking_[0-9a-f]+_[0-9a-z]+_[0-9a-z]+$/,
+			);
+		});
+
+		it("should generate unique ids on repeat calls so retries do not overwrite (RPTU-001)", () => {
+			// Simulate two recovery passes on the same messageID: each invocation
+			// must stage and rename a DISTINCT target file, proving the synthetic
+			// thinking part from the first pass is preserved.
+			const sessionID = "s";
+			const messageID = "m";
+			const partDir = join(PART_STORAGE, messageID);
+
+			fsMock.existsSync.mockReturnValue(true);
+
+			expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
+			expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
+
+			expect(fsMock.writeFileSync).toHaveBeenCalledTimes(2);
+			expect(fsMock.renameSync).toHaveBeenCalledTimes(2);
+
+			const [firstTemp, firstPayload] =
+				fsMock.writeFileSync.mock.calls[0] ?? [];
+			const [secondTemp, secondPayload] =
+				fsMock.writeFileSync.mock.calls[1] ?? [];
+			const [, firstTarget] = fsMock.renameSync.mock.calls[0] ?? [];
+			const [, secondTarget] = fsMock.renameSync.mock.calls[1] ?? [];
+
+			// Temp staging paths must differ (otherwise two writers would race).
+			expect(firstTemp).not.toBe(secondTemp);
+			// Final target paths MUST differ so the second pass does not
+			// overwrite the first synthetic thinking part.
+			expect(firstTarget).not.toBe(secondTarget);
+			expect(firstTarget).toMatch(
+				new RegExp(
+					`^${partDir.replace(/\\/g, "\\\\")}[\\\\/]prt_0000000000_thinking_.+\\.json$`,
+				),
+			);
+			expect(secondTarget).toMatch(
+				new RegExp(
+					`^${partDir.replace(/\\/g, "\\\\")}[\\\\/]prt_0000000000_thinking_.+\\.json$`,
+				),
+			);
+
+			// Both payloads must carry their own unique id matching their final
+			// target filename, so readers see two distinct parts on disk.
+			const firstParsed = JSON.parse(firstPayload);
+			const secondParsed = JSON.parse(secondPayload);
+			expect(firstParsed.id).not.toBe(secondParsed.id);
+			expect(firstTarget).toContain(`${firstParsed.id}.json`);
+			expect(secondTarget).toContain(`${secondParsed.id}.json`);
+		});
+
+		it("should generate ids that sort before real generatePartId ids so orphan detection still sees thinking first", () => {
+			// findMessagesWithOrphanThinking sorts parts by id and checks the
+			// first element. Synthetic thinking ids MUST sort lexicographically
+			// before any id from generatePartId(), which starts with
+			// `prt_<hex_timestamp>` where the hex timestamp's leading digit is
+			// non-zero for any real-world time.
+			const thinkingId = storage.generateThinkingPartId();
+			const realId = storage.generatePartId();
+
+			expect(thinkingId.startsWith("prt_0000000000_thinking_")).toBe(true);
+			expect([thinkingId, realId].sort()).toEqual([thinkingId, realId]);
 		});
 
 		it("should return false on write error", () => {

--- a/test/recovery-storage.test.ts
+++ b/test/recovery-storage.test.ts
@@ -638,15 +638,11 @@ describe("RecoveryStorage", () => {
 				// Final target paths MUST differ so the second pass does not
 				// overwrite the first synthetic thinking part.
 				expect(firstTarget).not.toBe(secondTarget);
-				expect(firstTarget).toMatch(
-					new RegExp(
-						`^${partDir.replace(/\\/g, "\\\\")}[\\/]prt_0000000000_thinking_abc123_0_[0-9a-z]{1,6}\\.json$`,
-					),
+				expect(firstTarget).toContain(
+					join(partDir, "prt_0000000000_thinking_abc123_0_"),
 				);
-				expect(secondTarget).toMatch(
-					new RegExp(
-						`^${partDir.replace(/\\/g, "\\\\")}[\\/]prt_0000000000_thinking_abc124_1_[0-9a-z]{1,6}\\.json$`,
-					),
+				expect(secondTarget).toContain(
+					join(partDir, "prt_0000000000_thinking_abc124_1_"),
 				);
 
 				// Both payloads must carry their own unique id matching their final


### PR DESCRIPTION
Addresses RPTU-001 from the deep recovery audit.

`prependThinkingPart` used a fixed `prt_0000000000_thinking` id and wrote to the same JSON filename on every invocation, so repeated prepend operations overwrote the earlier synthetic thinking part.

This PR generates a unique id per invocation and adds a regression test covering double-prepend behavior.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes RPTU-001: `prependThinkingPart` previously used a hardcoded `prt_0000000000_thinking` id and wrote to the same filename on every call, so a second recovery pass silently clobbered the first synthetic thinking part. the fix introduces `generateThinkingPartId()` — a timestamp + monotonic counter + random suffix composite that preserves the `prt_0000000000_thinking_` sort prefix so the part still lands lexicographically before any real part id.

<h3>Confidence Score: 5/5</h3>

safe to merge — core fix is correct, atomic-write and windows retry patterns are followed, and remaining findings are p2 only

no p0/p1 issues found. the id uniqueness guarantee is sound (counter + timestamp + random), the sort-order invariant is proven in the new test, and the atomic-write path correctly handles windows ebusy/eperm locks. the two p2 notes are hardening suggestions only and do not affect correctness.

test/recovery-storage.test.ts — consider freezing Date.now() in the RPTU-001 double-prepend test to explicitly prove counter disambiguation

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/recovery/storage.ts | adds `generateThinkingPartId()` with a module-level monotonic counter + timestamp + random suffix; `prependThinkingPart` now calls it instead of using a fixed id — fix is correct and aligns with existing atomic-write/retry patterns |
| test/recovery-storage.test.ts | adds double-prepend regression test and sort-order assertion; regression test does not freeze `Date.now()`, so same-millisecond counter disambiguation is not explicitly isolated — see inline comment |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Recovery Caller
    participant PT as prependThinkingPart
    participant G as generateThinkingPartId
    participant C as thinkingPartCounter
    participant FS as atomicWriteFileSync

    R->>PT: prependThinkingPart(sessionID, msgID) [pass 1]
    PT->>G: generateThinkingPartId()
    G->>C: read counter (0), increment to 1
    G-->>PT: prt_0000000000_thinking_T_0_R1
    PT->>FS: write prt_0000000000_thinking_T_0_R1.json (atomic rename)
    FS-->>PT: ok
    PT-->>R: true

    R->>PT: prependThinkingPart(sessionID, msgID) [pass 2]
    PT->>G: generateThinkingPartId()
    G->>C: read counter (1), increment to 2
    G-->>PT: prt_0000000000_thinking_T_1_R2
    PT->>FS: write prt_0000000000_thinking_T_1_R2.json (atomic rename)
    FS-->>PT: ok
    PT-->>R: true

    Note over FS: both files coexist on disk — no overwrite
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fthinking-part-unique-id%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fthinking-part-unique-id%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Frecovery-storage.test.ts%3A604-641%0A**same-millisecond%20case%20not%20exercised**%0A%0Athe%20counter's%20whole%20reason%20for%20existing%20is%20to%20disambiguate%20two%20calls%20within%20the%20same%20millisecond%2C%20but%20%60Date.now%28%29%60%20is%20not%20frozen%20here.%20in%20practice%20the%20two%20synchronous%20calls%20almost%20certainly%20share%20a%20tick%2C%20so%20the%20test%20probably%20does%20exercise%20it%20%E2%80%94%20but%20%22probably%22%20isn't%20a%20guarantee.%20freezing%20the%20clock%20makes%20the%20intent%20explicit%20and%20eliminates%20flakiness%20on%20very%20slow%20CI%20hosts.%0A%0A%60%60%60suggestion%0A%09%09it%28%22should%20generate%20unique%20ids%20on%20repeat%20calls%20so%20retries%20do%20not%20overwrite%20%28RPTU-001%29%22%2C%20%28%29%20%3D%3E%20%7B%0A%09%09%09%2F%2F%20Freeze%20time%20so%20both%20calls%20share%20the%20same%20millisecond%2C%20forcing%20the%0A%09%09%09%2F%2F%20monotonic%20counter%20to%20be%20the%20sole%20disambiguator%20%28RPTU-001%29.%0A%09%09%09const%20nowSpy%20%3D%20vi.spyOn%28Date%2C%20%22now%22%29.mockReturnValue%281700000000000%29%3B%0A%09%09%09const%20sessionID%20%3D%20%22s%22%3B%0A%09%09%09const%20messageID%20%3D%20%22m%22%3B%0A%09%09%09const%20partDir%20%3D%20join%28PART_STORAGE%2C%20messageID%29%3B%0A%09%09%09fsMock.existsSync.mockReturnValue%28true%29%3B%0A%0A%09%09%09expect%28storage.prependThinkingPart%28sessionID%2C%20messageID%29%29.toBe%28true%29%3B%0A%09%09%09expect%28storage.prependThinkingPart%28sessionID%2C%20messageID%29%29.toBe%28true%29%3B%0A%0A%09%09%09nowSpy.mockRestore%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Frecovery%2Fstorage.ts%3A157%0A**module-level%20counter%20not%20reset-safe%20under%20concurrent%20recovery%20runs**%0A%0A%60thinkingPartCounter%60%20is%20module-scoped%20and%20increments%20for%20the%20lifetime%20of%20the%20process%2C%20which%20is%20fine%20for%20the%20single-threaded%20Node.js%20happy%20path.%20just%20worth%20noting%3A%20if%20two%20separate%20recovery%20processes%20%28e.g.%2C%20a%20CLI%20restart%20while%20another%20instance%20is%20still%20running%29%20both%20start%20at%20counter%3D0%20in%20the%20same%20millisecond%2C%20the%20random%20suffix%20is%20the%20only%20remaining%20disambiguator%20%28~33%20bits%29.%20given%20the%20existing%20%60Math.random%28%29%60%20component%20this%20is%20astronomically%20unlikely%2C%20but%20if%20you%20ever%20want%20to%20harden%20further%2C%20%60crypto.randomInt%60%20or%20a%20per-call%20UUID%20would%20eliminate%20the%20concern%20entirely.%20no%20action%20required%20now.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/recovery-storage.test.ts
Line: 604-641

Comment:
**same-millisecond case not exercised**

the counter's whole reason for existing is to disambiguate two calls within the same millisecond, but `Date.now()` is not frozen here. in practice the two synchronous calls almost certainly share a tick, so the test probably does exercise it — but "probably" isn't a guarantee. freezing the clock makes the intent explicit and eliminates flakiness on very slow CI hosts.

```suggestion
		it("should generate unique ids on repeat calls so retries do not overwrite (RPTU-001)", () => {
			// Freeze time so both calls share the same millisecond, forcing the
			// monotonic counter to be the sole disambiguator (RPTU-001).
			const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1700000000000);
			const sessionID = "s";
			const messageID = "m";
			const partDir = join(PART_STORAGE, messageID);
			fsMock.existsSync.mockReturnValue(true);

			expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);
			expect(storage.prependThinkingPart(sessionID, messageID)).toBe(true);

			nowSpy.mockRestore();
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/recovery/storage.ts
Line: 157

Comment:
**module-level counter not reset-safe under concurrent recovery runs**

`thinkingPartCounter` is module-scoped and increments for the lifetime of the process, which is fine for the single-threaded Node.js happy path. just worth noting: if two separate recovery processes (e.g., a CLI restart while another instance is still running) both start at counter=0 in the same millisecond, the random suffix is the only remaining disambiguator (~33 bits). given the existing `Math.random()` component this is astronomically unlikely, but if you ever want to harden further, `crypto.randomInt` or a per-call UUID would eliminate the concern entirely. no action required now.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(recovery): remove brittle path/id s..."](https://github.com/ndycode/codex-multi-auth/commit/118b852c929e27851e32526796f0c343eccaf4f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28850346)</sub>

<!-- /greptile_comment -->