### PR TITLE
fix(storage): cap import file size before readImportFile loads it (STORAGE-002)

### DIFF
--- a/lib/storage/import-export.ts
+++ b/lib/storage/import-export.ts
@@ -5,6 +5,7 @@ import type { AccountStorageV3 } from "../storage.js";
 
 const EXPORT_RENAME_MAX_ATTEMPTS = 4;
 const EXPORT_RENAME_BASE_DELAY_MS = 25;
+const MAX_IMPORT_BYTES = 4 * 1024 * 1024;
 
 async function renameExportFileWithRetry(
 	sourcePath: string,
@@ -87,6 +88,13 @@ export async function readImportFile(params: {
 }): Promise<AccountStorageV3> {
 	if (!existsSync(params.resolvedPath)) {
 		throw new Error(`Import file not found: ${params.resolvedPath}`);
+	}
+
+	const stats = await fs.stat(params.resolvedPath);
+	if (stats.size > MAX_IMPORT_BYTES) {
+		throw new Error(
+			`Import file exceeds maximum size of ${MAX_IMPORT_BYTES} bytes: ${params.resolvedPath}`,
+		);
 	}
 
 	const content = await fs.readFile(params.resolvedPath, "utf-8");

--- a/lib/storage/import-export.ts
+++ b/lib/storage/import-export.ts
@@ -90,14 +90,21 @@ export async function readImportFile(params: {
 		throw new Error(`Import file not found: ${params.resolvedPath}`);
 	}
 
-	const stats = await fs.stat(params.resolvedPath);
-	if (stats.size > MAX_IMPORT_BYTES) {
-		throw new Error(
-			`Import file exceeds maximum size of ${MAX_IMPORT_BYTES} bytes: ${params.resolvedPath}`,
-		);
+	const handle = await fs.open(params.resolvedPath, "r");
+	let content: string;
+	try {
+		const stats = await handle.stat();
+		if (stats.size > MAX_IMPORT_BYTES) {
+			throw new Error(
+				`Import file exceeds maximum size of ${MAX_IMPORT_BYTES} bytes: ${params.resolvedPath}`,
+			);
+		}
+		content = await handle.readFile({ encoding: "utf-8" });
+	} finally {
+		await handle.close().catch(() => {
+			// Best-effort cleanup for import file handles.
+		});
 	}
-
-	const content = await fs.readFile(params.resolvedPath, "utf-8");
 	// Try the strict Zod-guarded boundary first (fail-closed parse + schema).
 	// A successful parse hands Zod-validated data straight to the normalizer,
 	// making Zod authoritative for imports. On failure we distinguish

--- a/test/storage-import-export.test.ts
+++ b/test/storage-import-export.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const existsSyncMock = vi.fn();
+const statMock = vi.fn();
+const readFileMock = vi.fn();
+
+vi.mock("node:fs", () => ({
+	existsSync: existsSyncMock,
+	promises: {
+		stat: statMock,
+		readFile: readFileMock,
+		mkdir: vi.fn(),
+		writeFile: vi.fn(),
+		rename: vi.fn(),
+		unlink: vi.fn(),
+	},
+}));
+
+describe("storage import-export", () => {
+	beforeEach(() => {
+		existsSyncMock.mockReset();
+		statMock.mockReset();
+		readFileMock.mockReset();
+	});
+
+	it("rejects oversized import files before reading them", async () => {
+		existsSyncMock.mockReturnValue(true);
+		statMock.mockResolvedValue({ size: 4 * 1024 * 1024 + 1 });
+
+		const { readImportFile } = await import("../lib/storage/import-export.js");
+
+		await expect(
+			readImportFile({
+				resolvedPath: "/mock/import.json",
+				normalizeAccountStorage: vi.fn(),
+			}),
+		).rejects.toThrow(/exceeds maximum size/i);
+
+		expect(readFileMock).not.toHaveBeenCalled();
+	});
+
+	it("reads valid import files under the size limit", async () => {
+		existsSyncMock.mockReturnValue(true);
+		statMock.mockResolvedValue({ size: 256 });
+		readFileMock.mockResolvedValue('{"version":3,"accounts":[],"activeIndex":0}');
+
+		const normalizeAccountStorage = vi.fn().mockReturnValue({
+			version: 3,
+			accounts: [],
+			activeIndex: 0,
+		});
+
+		const { readImportFile } = await import("../lib/storage/import-export.js");
+
+		await expect(
+			readImportFile({
+				resolvedPath: "/mock/import.json",
+				normalizeAccountStorage,
+			}),
+		).resolves.toEqual({
+			version: 3,
+			accounts: [],
+			activeIndex: 0,
+		});
+
+		expect(readFileMock).toHaveBeenCalledWith("/mock/import.json", "utf-8");
+		expect(normalizeAccountStorage).toHaveBeenCalled();
+	});
+});

--- a/test/storage-import-export.test.ts
+++ b/test/storage-import-export.test.ts
@@ -3,12 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const existsSyncMock = vi.fn();
 const statMock = vi.fn();
 const readFileMock = vi.fn();
+const closeMock = vi.fn();
+const openMock = vi.fn();
 
 vi.mock("node:fs", () => ({
 	existsSync: existsSyncMock,
 	promises: {
 		stat: statMock,
 		readFile: readFileMock,
+		open: openMock,
 		mkdir: vi.fn(),
 		writeFile: vi.fn(),
 		rename: vi.fn(),
@@ -21,6 +24,14 @@ describe("storage import-export", () => {
 		existsSyncMock.mockReset();
 		statMock.mockReset();
 		readFileMock.mockReset();
+		closeMock.mockReset();
+		openMock.mockReset();
+		closeMock.mockResolvedValue(undefined);
+		openMock.mockResolvedValue({
+			stat: statMock,
+			readFile: readFileMock,
+			close: closeMock,
+		});
 	});
 
 	it("rejects oversized import files before reading them", async () => {
@@ -37,6 +48,35 @@ describe("storage import-export", () => {
 		).rejects.toThrow(/exceeds maximum size/i);
 
 		expect(readFileMock).not.toHaveBeenCalled();
+		expect(closeMock).toHaveBeenCalled();
+	});
+
+	it("accepts import files exactly at the size limit", async () => {
+		existsSyncMock.mockReturnValue(true);
+		statMock.mockResolvedValue({ size: 4 * 1024 * 1024 });
+		readFileMock.mockResolvedValue('{"version":3,"accounts":[],"activeIndex":0}');
+
+		const normalizeAccountStorage = vi.fn().mockReturnValue({
+			version: 3,
+			accounts: [],
+			activeIndex: 0,
+		});
+
+		const { readImportFile } = await import("../lib/storage/import-export.js");
+
+		await expect(
+			readImportFile({
+				resolvedPath: "/mock/import.json",
+				normalizeAccountStorage,
+			}),
+		).resolves.toEqual({
+			version: 3,
+			accounts: [],
+			activeIndex: 0,
+		});
+
+		expect(readFileMock).toHaveBeenCalled();
+		expect(closeMock).toHaveBeenCalled();
 	});
 
 	it("reads valid import files under the size limit", async () => {
@@ -63,7 +103,8 @@ describe("storage import-export", () => {
 			activeIndex: 0,
 		});
 
-		expect(readFileMock).toHaveBeenCalledWith("/mock/import.json", "utf-8");
+		expect(readFileMock).toHaveBeenCalledWith({ encoding: "utf-8" });
 		expect(normalizeAccountStorage).toHaveBeenCalled();
+		expect(closeMock).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Addresses STORAGE-002 from the deep storage audit.

`readImportFile()` previously went straight from `existsSync()` to `fs.readFile()` with no size check, allowing arbitrarily large JSON imports. This PR adds a 4 MiB `MAX_IMPORT_BYTES` guard via `fs.stat()` before reading, so oversized imports are rejected before allocating file contents.

Includes focused tests for:
- oversized import rejection (and confirms `readFile` is never called)
- successful import under the size limit

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

the pr upgrades `readImportFile` from a two-call `fs.stat(path)` + `fs.readFile(path)` pattern to a single `fs.open` → `handle.stat()` → `handle.readFile()` pipeline on one file descriptor. this correctly closes the TOCTOU gap raised in the previous thread: both the size check and the read operate on the same fd, so an on-disk replacement after open cannot bypass the 4 MiB guard. tests verify the oversized-reject path (including that `readFile` is never called) and the boundary/happy-path cases.

<h3>Confidence Score: 5/5</h3>

safe to merge — the core TOCTOU fix is correct and all remaining findings are P2 coverage gaps

the handle-based stat+read correctly eliminates the TOCTOU concern from the prior review thread; boundary conditions in tests are accurate; no P0/P1 issues found. only gap is missing vitest coverage for the existsSync=false and fs.open-failure paths, both P2

test/storage-import-export.test.ts — missing coverage for file-not-found and windows EPERM entry paths

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage/import-export.ts | replaces two-call fs.stat+fs.readFile with fs.open→handle.stat→handle.readFile on one fd, correctly closing the TOCTOU gap; size guard and finally-close are correct |
| test/storage-import-export.test.ts | covers oversized rejection, boundary accept, and under-limit happy path; missing coverage for existsSync=false (file not found) and fs.open EPERM failure (windows locked-file path) |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[readImportFile] --> B{existsSync?}
    B -- No --> C[throw: file not found]
    B -- Yes --> D[fs.open → FileHandle]
    D --> E[handle.stat]
    E --> F{size > 4 MiB?}
    F -- Yes --> G[throw: exceeds max size]
    G --> H[handle.close - finally]
    F -- No --> I[handle.readFile]
    I --> J[handle.close - finally]
    J --> K{safeParseJson succeeds?}
    K -- Yes --> L[normalizeAccountStorage]
    K -- No --> M[JSON.parse fallback]
    M --> N{SyntaxError?}
    N -- Yes --> O[throw: invalid JSON]
    N -- No --> L
    L --> P{normalized non-null?}
    P -- No --> Q[throw: invalid format]
    P -- Yes --> R[return AccountStorageV3]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fimport-size-limit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fimport-size-limit%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fstorage-import-export.test.ts%3A22%0A**missing%20coverage%20for%20error%20entry%20paths**%0A%0Atwo%20branches%20in%20%60readImportFile%60%20have%20no%20tests%3A%20the%20%60existsSync%20%E2%86%92%20false%60%20path%20%28file%20not%20found%29%20and%20%60fs.open%60%20throwing%20%28e.g.%20%60EPERM%60%20on%20windows%20when%20antivirus%20holds%20a%20lock%20between%20the%20sync%20exists%20check%20and%20the%20async%20open%29.%20the%20latter%20surfaces%20a%20raw%20node%20%60ErrnoException%60%20to%20callers%20rather%20than%20the%20friendly%20message%20from%20line%2090.%20worth%20adding%20both%20to%20this%20describe%20block.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/storage-import-export.test.ts
Line: 22

Comment:
**missing coverage for error entry paths**

two branches in `readImportFile` have no tests: the `existsSync → false` path (file not found) and `fs.open` throwing (e.g. `EPERM` on windows when antivirus holds a lock between the sync exists check and the async open). the latter surfaces a raw node `ErrnoException` to callers rather than the friendly message from line 90. worth adding both to this describe block.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(storage): use file handle stat/read ..."](https://github.com/ndycode/codex-multi-auth/commit/6f2c1ece3cf0c2972f719fc85678652b42b094a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28852402)</sub>

<!-- /greptile_comment -->