### PR TITLE
fix(settings): remove Atomics.wait from sync retry loops (LIB-HIGH-002)

### DIFF
--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -189,7 +189,6 @@ function trySnapshotUnifiedSettingsBackupSync(options?: {
 			if (!isRetryableFsError(error) || attempt >= 4) {
 				return;
 			}
-			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10 * 2 ** attempt);
 		}
 	}
 }
@@ -349,7 +348,6 @@ function writeSettingsRecordSync(
 				if (!isRetryableFsError(error) || attempt >= 4) {
 					throw error;
 				}
-				Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10 * 2 ** attempt);
 			}
 		}
 	} finally {

--- a/test/unified-settings.test.ts
+++ b/test/unified-settings.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { removeWithRetry } from "./helpers/remove-with-retry.js";
 

--- a/test/unified-settings.test.ts
+++ b/test/unified-settings.test.ts
@@ -495,6 +495,71 @@ describe("unified settings", () => {
 		}
 	});
 
+	it("retries sync rename on retryable fs errors without Atomics.wait", async () => {
+		const atomicsWaitSpy = vi.spyOn(Atomics, "wait");
+		vi.resetModules();
+		vi.doMock("node:fs", async () => {
+			const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+			let first = true;
+			return {
+				...actual,
+				renameSync: (...args: Parameters<typeof actual.renameSync>) => {
+					if (first) {
+						first = false;
+						const error = new Error("busy") as NodeJS.ErrnoException;
+						error.code = "EBUSY";
+						throw error;
+					}
+					return actual.renameSync(...args);
+				},
+			};
+		});
+		try {
+			const { saveUnifiedPluginConfigSync, loadUnifiedPluginConfigSync } =
+				await import("../lib/unified-settings.js");
+			saveUnifiedPluginConfigSync({ codexMode: true, retries: 9 });
+			expect(atomicsWaitSpy).not.toHaveBeenCalled();
+			expect(loadUnifiedPluginConfigSync()).toEqual({
+				codexMode: true,
+				retries: 9,
+			});
+		} finally {
+			vi.doUnmock("node:fs");
+			vi.resetModules();
+			atomicsWaitSpy.mockRestore();
+		}
+	});
+
+	it("retries sync backup snapshot copy on retryable fs errors without Atomics.wait", async () => {
+		const atomicsWaitSpy = vi.spyOn(Atomics, "wait");
+		vi.resetModules();
+		vi.doMock("node:fs", async () => {
+			const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+			let first = true;
+			return {
+				...actual,
+				copyFileSync: (...args: Parameters<typeof actual.copyFileSync>) => {
+					if (first) {
+						first = false;
+						const error = new Error("perm") as NodeJS.ErrnoException;
+						error.code = "EPERM";
+						throw error;
+					}
+					return actual.copyFileSync(...args);
+				},
+			};
+		});
+		try {
+			const { saveUnifiedPluginConfigSync } = await import("../lib/unified-settings.js");
+			saveUnifiedPluginConfigSync({ codexMode: true, retries: 1 });
+			expect(atomicsWaitSpy).not.toHaveBeenCalled();
+		} finally {
+			vi.doUnmock("node:fs");
+			vi.resetModules();
+			atomicsWaitSpy.mockRestore();
+		}
+	});
+
 	it("cleans async temp file when rename fails with non-retryable code", async () => {
 		const { saveUnifiedPluginConfig, getUnifiedSettingsPath } = await import(
 			"../lib/unified-settings.js"

--- a/test/unified-settings.test.ts
+++ b/test/unified-settings.test.ts
@@ -531,6 +531,15 @@ describe("unified settings", () => {
 	});
 
 	it("retries sync backup snapshot copy on retryable fs errors without Atomics.wait", async () => {
+		const { getUnifiedSettingsPath } = await import("../lib/unified-settings.js");
+		const settingsPath = getUnifiedSettingsPath();
+		await fs.mkdir(dirname(settingsPath), { recursive: true });
+		await fs.writeFile(
+			settingsPath,
+			JSON.stringify({ version: 1, pluginConfig: { codexMode: true } }, null, 2),
+			"utf8",
+		);
+
 		const atomicsWaitSpy = vi.spyOn(Atomics, "wait");
 		vi.resetModules();
 		vi.doMock("node:fs", async () => {


### PR DESCRIPTION
Addresses LIB-HIGH-002 from the deep top-level lib audit.

`lib/unified-settings.ts` used `Atomics.wait(new SharedArrayBuffer(...))` as a synchronous sleep in two retry loops, blocking the event loop under retryable filesystem errors.

Per user decision, this PR keeps the sync API and drops the blocking sleep instead of refactoring the sync path to async. The sync retry loops now retry immediately; the async path still uses `await sleep(...)`.

Includes regression tests verifying:
- sync rename retries succeed without calling `Atomics.wait`
- sync backup snapshot copy retries succeed without calling `Atomics.wait`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

removes `Atomics.wait` from two sync retry loops in `lib/unified-settings.ts` that were blocking the event loop on retryable filesystem errors (EBUSY/EPERM). the async path retains its `await sleep` exponential backoff; the sync path now retries immediately, which is an intentional trade-off documented in the PR description. two regression tests verify both sync retry paths work without invoking `Atomics.wait`.

<h3>Confidence Score: 5/5</h3>

safe to merge — the fix is correct and targeted; remaining findings are P2 style suggestions about missing code comments.

no P0 or P1 issues. the event-loop-blocking Atomics.wait calls are cleanly removed. the async path retains backoff. the two regression tests are structurally sound with proper temp-dir isolation and module mock teardown. the only callout is the undocumented intentional spin-retry behavior on windows, which the PR description already justifies.

no files require special attention; optional code comments on both retry loops in lib/unified-settings.ts would help future windows-safety audits.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/unified-settings.ts | removes two Atomics.wait blocking sleeps from sync retry loops; async path retains await sleep backoff. change is correct but leaves undocumented intentional spin-retry behavior on windows. |
| test/unified-settings.test.ts | adds two regression tests for sync retry paths (renameSync EBUSY, copyFileSync EPERM) verifying Atomics.wait is not called; tests correctly use vi.doMock + vi.resetModules with temp-dir isolation from outer afterEach. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[saveUnifiedPluginConfigSync] --> B[trySnapshotUnifiedSettingsBackupSync]
    B --> C{existsSync?}
    C -- no --> D[return early]
    C -- yes --> E[copyFileSync loop\nattempt 0..4]
    E --> F{EBUSY/EPERM?}
    F -- retryable + attempt < 4 --> G[immediate retry\nno sleep — LIB-HIGH-002]
    G --> E
    F -- non-retryable or attempt >= 4 --> H[return silently]
    F -- success --> I[return]
    A --> J[writeFileSync tempPath]
    J --> K[renameSync loop\nattempt 0..4]
    K --> L{EBUSY/EPERM?}
    L -- retryable + attempt < 4 --> M[immediate retry\nno sleep — LIB-HIGH-002]
    M --> K
    L -- non-retryable or attempt >= 4 --> N[throw error\nunlink tempPath]
    L -- success --> O[moved=true, return]

    style G fill:#ffe0b2
    style M fill:#ffe0b2
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Funified-settings-sync-sleep%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Funified-settings-sync-sleep%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Funified-settings.ts%3A184-193%0A**No%20backoff%20in%20sync%20retry%20%E2%80%94%20Windows%20AV%20risk**%0A%0Aremoving%20%60Atomics.wait%60%20is%20correct%2C%20but%20the%20loop%20now%20retries%20immediately%20with%20zero%20delay.%20on%20windows%2C%20defender%2Fav%20can%20hold%20an%20exclusive%20lock%20on%20settings.json%20for%2010%E2%80%9350%20ms.%20with%205%20rapid%20retries%20completing%20in%20%3C%201%20ms%2C%20all%20attempts%20can%20exhaust%20before%20the%20lock%20is%20released%2C%20effectively%20reducing%20the%20sync%20retry%20path%20to%20a%20single%20attempt%20on%20locked%20windows%20filesystems.%0A%0Athe%20async%20counterpart%20%28%60trySnapshotUnifiedSettingsBackupAsync%60%29%20still%20has%20%60await%20sleep%2810%20*%202%20**%20attempt%29%60%20so%20this%20divergence%20is%20intentional%20per%20the%20PR%2C%20but%20a%20short%20comment%20here%20would%20help%20future%20maintainers%20understand%20why%20there's%20no%20sleep%3A%0A%0A%60%60%60suggestion%0A%09for%20%28let%20attempt%20%3D%200%3B%20attempt%20%3C%205%3B%20attempt%20%2B%3D%201%29%20%7B%0A%09%09try%20%7B%0A%09%09%09copyFileSync%28UNIFIED_SETTINGS_PATH%2C%20UNIFIED_SETTINGS_BACKUP_PATH%29%3B%0A%09%09%09return%3B%0A%09%09%7D%20catch%20%28error%29%20%7B%0A%09%09%09if%20%28!isRetryableFsError%28error%29%20%7C%7C%20attempt%20%3E%3D%204%29%20%7B%0A%09%09%09%09return%3B%0A%09%09%09%7D%0A%09%09%09%2F%2F%20No%20sleep%3A%20blocking%20the%20event%20loop%20with%20Atomics.wait%20was%20removed%20%28LIB-HIGH-002%29.%0A%09%09%09%2F%2F%20Sync%20callers%20accept%20immediate%20retry%3B%20prefer%20the%20async%20path%20for%20backoff.%0A%09%09%7D%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Funified-settings.ts%3A342-352%0A**Same%20immediate-retry%20spin%20on%20rename%20%E2%80%94%20same%20Windows%20caveat**%0A%0Asame%20zero-delay%20spin%20applies%20here%20for%20%60renameSync%60.%20on%20windows%2C%20%60EBUSY%60%20from%20av%20file%20scanning%20can%20persist%20for%20tens%20of%20ms%3B%205%20immediate%20retries%20may%20all%20fail%20within%201%20ms.%20same%20intentional%20trade-off%20applies%2C%20and%20the%20same%20short%20comment%20would%20clarify%20this%20for%20future%20readers%3A%0A%0A%60%60%60suggestion%0A%09%09%09for%20%28let%20attempt%20%3D%200%3B%20attempt%20%3C%205%3B%20attempt%20%2B%3D%201%29%20%7B%0A%09%09%09%09try%20%7B%0A%09%09%09%09%09renameSync%28tempPath%2C%20UNIFIED_SETTINGS_PATH%29%3B%0A%09%09%09%09%09moved%20%3D%20true%3B%0A%09%09%09%09%09return%3B%0A%09%09%09%09%7D%20catch%20%28error%29%20%7B%0A%09%09%09%09%09if%20%28!isRetryableFsError%28error%29%20%7C%7C%20attempt%20%3E%3D%204%29%20%7B%0A%09%09%09%09%09%09throw%20error%3B%0A%09%09%09%09%09%7D%0A%09%09%09%09%09%2F%2F%20No%20sleep%3A%20blocking%20the%20event%20loop%20with%20Atomics.wait%20was%20removed%20%28LIB-HIGH-002%29.%0A%09%09%09%09%09%2F%2F%20Sync%20callers%20accept%20immediate%20retry%3B%20prefer%20the%20async%20path%20for%20backoff.%0A%09%09%09%09%7D%0A%09%09%09%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/unified-settings.ts
Line: 184-193

Comment:
**No backoff in sync retry — Windows AV risk**

removing `Atomics.wait` is correct, but the loop now retries immediately with zero delay. on windows, defender/av can hold an exclusive lock on settings.json for 10–50 ms. with 5 rapid retries completing in < 1 ms, all attempts can exhaust before the lock is released, effectively reducing the sync retry path to a single attempt on locked windows filesystems.

the async counterpart (`trySnapshotUnifiedSettingsBackupAsync`) still has `await sleep(10 * 2 ** attempt)` so this divergence is intentional per the PR, but a short comment here would help future maintainers understand why there's no sleep:

```suggestion
	for (let attempt = 0; attempt < 5; attempt += 1) {
		try {
			copyFileSync(UNIFIED_SETTINGS_PATH, UNIFIED_SETTINGS_BACKUP_PATH);
			return;
		} catch (error) {
			if (!isRetryableFsError(error) || attempt >= 4) {
				return;
			}
			// No sleep: blocking the event loop with Atomics.wait was removed (LIB-HIGH-002).
			// Sync callers accept immediate retry; prefer the async path for backoff.
		}
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/unified-settings.ts
Line: 342-352

Comment:
**Same immediate-retry spin on rename — same Windows caveat**

same zero-delay spin applies here for `renameSync`. on windows, `EBUSY` from av file scanning can persist for tens of ms; 5 immediate retries may all fail within 1 ms. same intentional trade-off applies, and the same short comment would clarify this for future readers:

```suggestion
			for (let attempt = 0; attempt < 5; attempt += 1) {
				try {
					renameSync(tempPath, UNIFIED_SETTINGS_PATH);
					moved = true;
					return;
				} catch (error) {
					if (!isRetryableFsError(error) || attempt >= 4) {
						throw error;
					}
					// No sleep: blocking the event loop with Atomics.wait was removed (LIB-HIGH-002).
					// Sync callers accept immediate retry; prefer the async path for backoff.
				}
			}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(settings): import dirname in sync b..."](https://github.com/ndycode/codex-multi-auth/commit/81824d742f3256b8cb245c0940b71aa18d640760) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28852567)</sub>

<!-- /greptile_comment -->