### PR TITLE
fix(ui): honor Q hotkey consistently in select/confirm (RPTU-003)

### DIFF
--- a/lib/ui/select.ts
+++ b/lib/ui/select.ts
@@ -498,8 +498,12 @@ export async function select<T>(items: MenuItem<T>[], options: SelectOptions<T>)
 					}
 					return;
 				default:
+					const hotkey = decodeHotkeyInput(data);
+					if (hotkey && hotkey.toLowerCase() === "q") {
+						finish(null);
+						return;
+					}
 					if (options.onInput) {
-						const hotkey = decodeHotkeyInput(data);
 						if (hotkey) {
 							rerenderRequested = false;
 							const result = options.onInput(hotkey, {

--- a/test/select.test.ts
+++ b/test/select.test.ts
@@ -98,4 +98,33 @@ describe("ui select", () => {
 		expect(process.listenerCount("SIGINT")).toBe(initialSigintCount);
 		clearIntervalSpy.mockRestore();
 	});
+
+	it("treats q hotkey as back/cancel", async () => {
+		const { select } = await import("../lib/ui/select.js");
+		const selectPromise = select(
+			[
+				{ label: "A", value: "a" },
+				{ label: "B", value: "b" },
+			],
+			{
+				message: "Pick",
+			},
+		);
+
+		await vi.advanceTimersByTimeAsync(130);
+		stdin.emit("data", Buffer.from("q", "utf8"));
+
+		const result = await selectPromise;
+		expect(result).toBeNull();
+	});
+
+	it("confirm returns false when q hotkey cancels", async () => {
+		const { confirm } = await import("../lib/ui/confirm.js");
+		const confirmPromise = confirm("Are you sure?");
+
+		await vi.advanceTimersByTimeAsync(130);
+		stdin.emit("data", Buffer.from("q", "utf8"));
+
+		await expect(confirmPromise).resolves.toBe(false);
+	});
 });


### PR DESCRIPTION
Addresses RPTU-003 from the deep recovery/UI audit.

The help text in `lib/ui/copy.ts` and `lib/ui/select.ts` advertises `Q Back`, but `select()` only handled arrows, enter, and escape. `q`/`Q` only worked when callers manually implemented `onInput`, and `confirm()` therefore silently ignored q.

This PR makes `q`/`Q` a default cancel/back hotkey in `select()` itself and adds focused regression tests for both `select()` and `confirm()`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

moves `q`/`Q` cancellation from caller-side `onInput` conventions into `select()` itself, resolving RPTU-003. the change is behavioral but backward-compatible — all callers already gate on `!result` or `!action`, so the shift from a typed back-value to `null` produces identical outcomes.

- the 120 ms input-guard window suppresses `enter` and `escape` but not the new `q` handler, creating an asymmetry: pressing `q` in the first 120 ms still cancels the prompt while the same escape press would be swallowed.
- existing `q` branches in six `onInput` callbacks across `auth-menu.ts`, `settings-hub-prompt.ts`, `backend-category-prompt.ts`, and `experimental-settings-*` are now unreachable dead code and should be removed in a follow-up.
- uppercase `Q` path has no test coverage.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are P2; no behavioral regression for existing callers

the core change is correct and all existing callers handle null properly. remaining feedback (input-guard gap, dead onInput branches, missing Q test) are style/cleanup concerns that don't block merge.

no files require special attention for merge; dead q branches in auth-menu.ts and settings-hub-prompt.ts should be cleaned up in a follow-up

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/ui/select.ts | adds built-in q/Q cancel before onInput dispatch; input-guard window inconsistency and dead code in callers are left unaddressed |
| test/select.test.ts | adds regression tests for q cancel in select() and confirm(); uppercase Q path not covered |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[stdin data event] --> B{within 120ms\ninput guard?}
    B -- yes --> C{parseKey result}
    C -- enter / escape /\nescape-start --> D[return — suppressed]
    C -- other --> E[fall through to switch]
    B -- no --> E
    E --> F{switch parseKey}
    F -- up/down/home/end --> G[move cursor & render]
    F -- enter --> H[finish selected value]
    F -- escape --> I{allowEscape?}
    I -- yes --> J[finish null]
    I -- no --> K[ignore]
    F -- default --> L[decodeHotkeyInput]
    L --> M{hotkey.toLowerCase === 'q'?}
    M -- yes --> N[finish null — NEW]
    M -- no --> O{options.onInput?}
    O -- yes --> P[call onInput hotkey]
    P --> Q{result !== undefined?}
    Q -- yes --> R[finish result]
    Q -- no --> S[maybe rerender]
    O -- no --> T[return]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fui-q-hotkey%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fui-q-hotkey%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fui%2Fselect.ts%3A500-505%0A**Stale%20%60q%60%20handlers%20in%20%60onInput%60%20are%20now%20unreachable%20dead%20code**%0A%0Abecause%20%60q%60%2F%60Q%60%20is%20intercepted%20here%20before%20%60onInput%60%20is%20ever%20called%2C%20all%20existing%20callers%20that%20handled%20%60q%60%20in%20their%20%60onInput%60%20callbacks%20are%20now%20dead%20code.%20affected%20sites%3A%0A%0A-%20%60lib%2Fui%2Fauth-menu.ts%3A567%60%20%E2%80%94%20%60if%20%28lower%20%3D%3D%3D%20%22q%22%29%20return%20%7B%20type%3A%20%22cancel%22%20as%20const%20%7D%3B%60%0A-%20%60lib%2Fui%2Fauth-menu.ts%3A662%60%20%E2%80%94%20%60if%20%28lower%20%3D%3D%3D%20%22q%22%29%20return%20%22cancel%22%3B%60%0A-%20%60lib%2Fcodex-manager%2Fsettings-hub-prompt.ts%3A49%60%20%E2%80%94%20%60if%20%28lower%20%3D%3D%3D%20%22q%22%29%20return%20%7B%20type%3A%20%22back%22%20%7D%3B%60%0A-%20%60lib%2Fcodex-manager%2Fbackend-category-prompt.ts%3A240%60%20%E2%80%94%20%60if%20%28lower%20%3D%3D%3D%20%22q%22%29%20return%20%7B%20type%3A%20%22back%22%20as%20const%20%7D%3B%60%0A-%20%60lib%2Fcodex-manager%2Fexperimental-settings-schema.ts%3A40%2C48%60%20%E2%80%94%20both%20q-back%20branches%0A-%20%60lib%2Fcodex-manager%2Fexperimental-settings-prompt.ts%3A325%60%0A%0Athe%20callers%20all%20use%20%60!result%20%7C%7C%20result.type%20%3D%3D%3D%20%22back%22%60%20or%20%60if%20%28!action%29%60%20guards%2C%20so%20the%20behavioral%20outcome%20is%20unchanged%20%E2%80%94%20but%20these%20branches%20are%20now%20misleading.%20a%20follow-up%20cleanup%20PR%20should%20remove%20them%20to%20keep%20the%20%60onInput%60%20contract%20clear.%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fselect.test.ts%3A102-119%0A**Missing%20uppercase%20%60Q%60%20coverage**%0A%0Athe%20implementation%20does%20%60hotkey.toLowerCase%28%29%20%3D%3D%3D%20%22q%22%60%20so%20both%20%60q%60%20and%20%60Q%60%20cancel%2C%20but%20only%20lowercase%20is%20exercised%20here.%20worth%20adding%20a%20sibling%20test%20case%20emitting%20%60Buffer.from%28%22Q%22%2C%20%22utf8%22%29%60%20to%20confirm%20the%20uppercase%20path%20resolves%20to%20%60null%60.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fui%2Fselect.ts%3A501-505%0A**%60q%60%20not%20guarded%20during%20input-guard%20window**%0A%0A%60enter%60%20and%20%60escape%60%20are%20blocked%20within%20the%20120%20ms%20input-guard%20window%20%28lines%20451-455%29%2C%20but%20the%20new%20%60q%60%20cancel%20handler%20falls%20through%20the%20guard%20unconditionally.%20a%20user%20pressing%20%60q%60%20within%20the%20first%20120%20ms%20of%20the%20prompt%20opening%20will%20silently%20cancel%20it%2C%20while%20the%20same%20press%20of%20%60escape%60%20would%20have%20been%20suppressed.%20since%20%60q%60%20now%20carries%20the%20same%20cancel%20semantics%20as%20escape%2C%20it%20should%20be%20added%20to%20the%20guard's%20early-return%20condition%20alongside%20%60%22enter%22%60%2C%20%60%22escape%22%60%2C%20and%20%60%22escape-start%22%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/ui/select.ts
Line: 500-505

Comment:
**Stale `q` handlers in `onInput` are now unreachable dead code**

because `q`/`Q` is intercepted here before `onInput` is ever called, all existing callers that handled `q` in their `onInput` callbacks are now dead code. affected sites:

- `lib/ui/auth-menu.ts:567` — `if (lower === "q") return { type: "cancel" as const };`
- `lib/ui/auth-menu.ts:662` — `if (lower === "q") return "cancel";`
- `lib/codex-manager/settings-hub-prompt.ts:49` — `if (lower === "q") return { type: "back" };`
- `lib/codex-manager/backend-category-prompt.ts:240` — `if (lower === "q") return { type: "back" as const };`
- `lib/codex-manager/experimental-settings-schema.ts:40,48` — both q-back branches
- `lib/codex-manager/experimental-settings-prompt.ts:325`

the callers all use `!result || result.type === "back"` or `if (!action)` guards, so the behavioral outcome is unchanged — but these branches are now misleading. a follow-up cleanup PR should remove them to keep the `onInput` contract clear.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/select.test.ts
Line: 102-119

Comment:
**Missing uppercase `Q` coverage**

the implementation does `hotkey.toLowerCase() === "q"` so both `q` and `Q` cancel, but only lowercase is exercised here. worth adding a sibling test case emitting `Buffer.from("Q", "utf8")` to confirm the uppercase path resolves to `null`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/ui/select.ts
Line: 501-505

Comment:
**`q` not guarded during input-guard window**

`enter` and `escape` are blocked within the 120 ms input-guard window (lines 451-455), but the new `q` cancel handler falls through the guard unconditionally. a user pressing `q` within the first 120 ms of the prompt opening will silently cancel it, while the same press of `escape` would have been suppressed. since `q` now carries the same cancel semantics as escape, it should be added to the guard's early-return condition alongside `"enter"`, `"escape"`, and `"escape-start"`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): honor Q hotkey consistently in ..."](https://github.com/ndycode/codex-multi-auth/commit/aabb65299fbc23008cb5d4e11d006286e3315111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28852750)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->