### PR TITLE
fix(auth): enforce expectedState in OAuth server waitForCode (AUTH-HIGH-2)

### DIFF
--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -66,7 +66,10 @@ export function startLocalOAuthServer({
 				"default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; script-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
 			);
 			res.end(successHtml);
-			const trackedServer = server as http.Server & { _lastCode?: string };
+			const trackedServer = server as http.Server & {
+				_lastCode?: string;
+				_lastState?: string;
+			};
 			if (trackedServer._lastCode) {
 				logWarn(
 					"Duplicate OAuth callback received; preserving first authorization code",
@@ -74,6 +77,7 @@ export function startLocalOAuthServer({
 				return;
 			}
 			trackedServer._lastCode = code;
+			trackedServer._lastState = state;
 		} catch (err) {
 			logError(
 				`Request handler error: ${(err as Error)?.message ?? String(err)}`,
@@ -95,7 +99,7 @@ export function startLocalOAuthServer({
 						pollAborted = true;
 						server.close();
 					},
-					waitForCode: async () => {
+					waitForCode: async (expectedState: string) => {
 						const POLL_INTERVAL_MS = 100;
 						const TIMEOUT_MS = 5 * 60 * 1000;
 						const maxIterations = Math.floor(TIMEOUT_MS / POLL_INTERVAL_MS);
@@ -103,9 +107,20 @@ export function startLocalOAuthServer({
 							new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
 						for (let i = 0; i < maxIterations; i++) {
 							if (pollAborted) return null;
-							const lastCode = (server as http.Server & { _lastCode?: string })
-								._lastCode;
-							if (lastCode) return { code: lastCode };
+							const trackedServer = server as http.Server & {
+								_lastCode?: string;
+								_lastState?: string;
+							};
+							const lastCode = trackedServer._lastCode;
+							if (lastCode) {
+								if (trackedServer._lastState !== expectedState) {
+									logWarn(
+										"Discarding OAuth callback due to state mismatch in waitForCode",
+									);
+									return null;
+								}
+								return { code: lastCode };
+							}
 							await poll();
 						}
 						logWarn("OAuth poll timeout after 5 minutes");
@@ -130,7 +145,7 @@ export function startLocalOAuthServer({
 							);
 						}
 					},
-					waitForCode: () => Promise.resolve(null),
+					waitForCode: (_expectedState: string) => Promise.resolve(null),
 				});
 			});
 	});

--- a/test/server.unit.test.ts
+++ b/test/server.unit.test.ts
@@ -300,6 +300,27 @@ describe('OAuth Server Unit Tests', () => {
 			expect(code).toEqual({ code: 'the-code' });
 		});
 
+		it('returns null when stored callback state does not match expectedState', async () => {
+			(mockServer.listen as ReturnType<typeof vi.fn>).mockImplementation(
+				(_port: number, _host: string, callback: () => void) => {
+					callback();
+					return mockServer;
+				}
+			);
+			(mockServer.on as ReturnType<typeof vi.fn>).mockReturnValue(mockServer);
+
+			const result = await startLocalOAuthServer({ state: 'test-state' });
+
+			mockServer._lastCode = 'the-code';
+			mockServer._lastState = 'other-state';
+
+			const code = await result.waitForCode('test-state');
+			expect(code).toBeNull();
+			expect(logWarn).toHaveBeenCalledWith(
+				'Discarding OAuth callback due to state mismatch in waitForCode',
+			);
+		});
+
 		it('should return null after 5 minute timeout', async () => {
 			vi.useFakeTimers();
 			


### PR DESCRIPTION
Addresses the second auth HIGH finding from the deep auth audit.

`OAuthServerInfo.waitForCode(state)` accepted an expected-state parameter in the public contract (`lib/types.ts`) and all callers/tests passed it, but the implementation in `lib/auth/server.ts` ignored the argument entirely and returned the first captured code.

The HTTP callback path already validated `state` before storing `_lastCode`, but `waitForCode()` itself provided no defense-in-depth re-check. This PR stores `_lastState` alongside `_lastCode` and returns `null` if the stored callback state does not match the `expectedState` passed by the caller.

Includes a unit test covering the mismatch path, while existing integration tests continue to pass.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr correctly adds `_lastState` storage alongside `_lastCode` and wires in a defense-in-depth state check inside `waitForCode`, closing the gap where the public contract accepted `expectedState` but the implementation ignored it.

- the pre-existing `waitForCode` positive test (\"should return code when available\") is broken: it sets `mockServer._lastCode` but not `mockServer._lastState`, so the new mismatch guard fires and returns `null` — the test will fail as written.

<h3>Confidence Score: 4/5</h3>

not safe to merge until the broken positive test is fixed — it will fail in CI as-is

the implementation in server.ts is correct; the P1 issue is in the test file where the positive path test omits `_lastState`, meaning the test suite will fail on the changed file. one-line fix required before merge.

test/server.unit.test.ts — "should return code when available" test needs `mockServer._lastState = 'test-state'` and the type declaration needs `_lastState?: string`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/auth/server.ts | adds `_lastState` tracking and defense-in-depth check in `waitForCode`; logic is correct but stores closure `state` rather than the URL param (functionally equivalent, minor clarity nit) |
| test/server.unit.test.ts | new mismatch test is correct, but the pre-existing positive path test ("should return code when available") omits `mockServer._lastState`, causing `waitForCode` to hit the new mismatch branch and return `null` — test will fail; also `_lastState` missing from mock type declaration |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant Server as OAuthServer (port 1455)
    participant Caller

    Caller->>Server: startLocalOAuthServer({ state })
    Server-->>Caller: OAuthServerInfo (port, ready, close, waitForCode)

    Caller->>Server: waitForCode(expectedState)
    activate Server
    Note over Server: poll loop starts

    Browser->>Server: GET /auth/callback?code=X&state=S
    alt state !== closure state
        Server-->>Browser: 400 State Mismatch
    else state === closure state
        Server->>Server: _lastCode = code
        Server->>Server: _lastState = state
        Server-->>Browser: 200 Success HTML
    end

    Note over Server: next poll iteration
    Server->>Server: check _lastCode (truthy)
    alt _lastState !== expectedState
        Server-->>Caller: null + logWarn (mismatch)
    else _lastState === expectedState
        Server-->>Caller: { code }
    end
    deactivate Server
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `test/server.unit.test.ts`, line 286-301 ([link](https://github.com/ndycode/codex-multi-auth/blob/eb5408d4530b7fe25e832d3d8b424e5cee8e283b/test/server.unit.test.ts#L286-L301)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **positive path test broken by new state check**

   `mockServer._lastState` is never set here, so it stays `undefined`. `waitForCode` now evaluates `trackedServer._lastState !== expectedState` → `undefined !== 'test-state'` → `true`, hits the mismatch branch, logs a warning, and returns `null` — but the test asserts `{ code: 'the-code' }`. this will fail.

   fix: add `mockServer._lastState = 'test-state'` alongside `_lastCode`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/server.unit.test.ts
   Line: 286-301

   Comment:
   **positive path test broken by new state check**

   `mockServer._lastState` is never set here, so it stays `undefined`. `waitForCode` now evaluates `trackedServer._lastState !== expectedState` → `undefined !== 'test-state'` → `true`, hits the mismatch branch, logs a warning, and returns `null` — but the test asserts `{ code: 'the-code' }`. this will fail.

   fix: add `mockServer._lastState = 'test-state'` alongside `_lastCode`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Foauth-server-waitforcode-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Foauth-server-waitforcode-state%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fserver.unit.test.ts%0ALine%3A%20286-301%0A%0AComment%3A%0A**positive%20path%20test%20broken%20by%20new%20state%20check**%0A%0A%60mockServer._lastState%60%20is%20never%20set%20here%2C%20so%20it%20stays%20%60undefined%60.%20%60waitForCode%60%20now%20evaluates%20%60trackedServer._lastState%20!%3D%3D%20expectedState%60%20%E2%86%92%20%60undefined%20!%3D%3D%20'test-state'%60%20%E2%86%92%20%60true%60%2C%20hits%20the%20mismatch%20branch%2C%20logs%20a%20warning%2C%20and%20returns%20%60null%60%20%E2%80%94%20but%20the%20test%20asserts%20%60%7B%20code%3A%20'the-code'%20%7D%60.%20this%20will%20fail.%0A%0Afix%3A%20add%20%60mockServer._lastState%20%3D%20'test-state'%60%20alongside%20%60_lastCode%60.%0A%0A%60%60%60suggestion%0A%09%09%09mockServer._lastCode%20%3D%20'the-code'%3B%0A%09%09%09mockServer._lastState%20%3D%20'test-state'%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>


2. `test/server.unit.test.ts`, line 46-49 ([link](https://github.com/ndycode/codex-multi-auth/blob/eb5408d4530b7fe25e832d3d8b424e5cee8e283b/test/server.unit.test.ts#L46-L49)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`_lastState` missing from mock type**

   the declared type for `mockServer` doesn't include `_lastState?: string`. assigning `mockServer._lastState = 'other-state'` on line 315 is a TypeScript error (`tsc`/`typecheck` will reject it). also the initial mock object at line 11–17 only declares `_lastCode`, so `_lastState` is silently missing from the inferred shape.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/server.unit.test.ts
   Line: 46-49

   Comment:
   **`_lastState` missing from mock type**

   the declared type for `mockServer` doesn't include `_lastState?: string`. assigning `mockServer._lastState = 'other-state'` on line 315 is a TypeScript error (`tsc`/`typecheck` will reject it). also the initial mock object at line 11–17 only declares `_lastCode`, so `_lastState` is silently missing from the inferred shape.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Foauth-server-waitforcode-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Foauth-server-waitforcode-state%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fserver.unit.test.ts%0ALine%3A%2046-49%0A%0AComment%3A%0A**%60_lastState%60%20missing%20from%20mock%20type**%0A%0Athe%20declared%20type%20for%20%60mockServer%60%20doesn't%20include%20%60_lastState%3F%3A%20string%60.%20assigning%20%60mockServer._lastState%20%3D%20'other-state'%60%20on%20line%20315%20is%20a%20TypeScript%20error%20%28%60tsc%60%2F%60typecheck%60%20will%20reject%20it%29.%20also%20the%20initial%20mock%20object%20at%20line%2011%E2%80%9317%20only%20declares%20%60_lastCode%60%2C%20so%20%60_lastState%60%20is%20silently%20missing%20from%20the%20inferred%20shape.%0A%0A%60%60%60suggestion%0A%09let%20mockServer%3A%20ReturnType%3Ctypeof%20http.createServer%3E%20%26%20%7B%0A%09%09_handler%3F%3A%20%28req%3A%20IncomingMessage%2C%20res%3A%20ServerResponse%29%20%3D%3E%20void%3B%0A%09%09_lastCode%3F%3A%20string%3B%0A%09%09_lastState%3F%3A%20string%3B%0A%09%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Foauth-server-waitforcode-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Foauth-server-waitforcode-state%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atest%2Fserver.unit.test.ts%3A286-301%0A**positive%20path%20test%20broken%20by%20new%20state%20check**%0A%0A%60mockServer._lastState%60%20is%20never%20set%20here%2C%20so%20it%20stays%20%60undefined%60.%20%60waitForCode%60%20now%20evaluates%20%60trackedServer._lastState%20!%3D%3D%20expectedState%60%20%E2%86%92%20%60undefined%20!%3D%3D%20'test-state'%60%20%E2%86%92%20%60true%60%2C%20hits%20the%20mismatch%20branch%2C%20logs%20a%20warning%2C%20and%20returns%20%60null%60%20%E2%80%94%20but%20the%20test%20asserts%20%60%7B%20code%3A%20'the-code'%20%7D%60.%20this%20will%20fail.%0A%0Afix%3A%20add%20%60mockServer._lastState%20%3D%20'test-state'%60%20alongside%20%60_lastCode%60.%0A%0A%60%60%60suggestion%0A%09%09%09mockServer._lastCode%20%3D%20'the-code'%3B%0A%09%09%09mockServer._lastState%20%3D%20'test-state'%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fserver.unit.test.ts%3A46-49%0A**%60_lastState%60%20missing%20from%20mock%20type**%0A%0Athe%20declared%20type%20for%20%60mockServer%60%20doesn't%20include%20%60_lastState%3F%3A%20string%60.%20assigning%20%60mockServer._lastState%20%3D%20'other-state'%60%20on%20line%20315%20is%20a%20TypeScript%20error%20%28%60tsc%60%2F%60typecheck%60%20will%20reject%20it%29.%20also%20the%20initial%20mock%20object%20at%20line%2011%E2%80%9317%20only%20declares%20%60_lastCode%60%2C%20so%20%60_lastState%60%20is%20silently%20missing%20from%20the%20inferred%20shape.%0A%0A%60%60%60suggestion%0A%09let%20mockServer%3A%20ReturnType%3Ctypeof%20http.createServer%3E%20%26%20%7B%0A%09%09_handler%3F%3A%20%28req%3A%20IncomingMessage%2C%20res%3A%20ServerResponse%29%20%3D%3E%20void%3B%0A%09%09_lastCode%3F%3A%20string%3B%0A%09%09_lastState%3F%3A%20string%3B%0A%09%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fauth%2Fserver.ts%3A79-80%0A**stores%20closure%20%60state%60%20instead%20of%20URL%20param**%0A%0A%60trackedServer._lastState%20%3D%20state%60%20stores%20the%20closure%20variable%2C%20not%20%60url.searchParams.get%28%22state%22%29%60.%20they're%20equivalent%20here%20because%20the%20handler%20already%20rejected%20mismatching%20requests%20on%20line%2049%20%E2%80%94%20but%20storing%20the%20URL%20param%20directly%20would%20make%20the%20intent%20clearer%20and%20be%20less%20surprising%20to%20future%20readers.%20minor%20nit%20since%20there's%20no%20functional%20difference.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/server.unit.test.ts
Line: 286-301

Comment:
**positive path test broken by new state check**

`mockServer._lastState` is never set here, so it stays `undefined`. `waitForCode` now evaluates `trackedServer._lastState !== expectedState` → `undefined !== 'test-state'` → `true`, hits the mismatch branch, logs a warning, and returns `null` — but the test asserts `{ code: 'the-code' }`. this will fail.

fix: add `mockServer._lastState = 'test-state'` alongside `_lastCode`.

```suggestion
			mockServer._lastCode = 'the-code';
			mockServer._lastState = 'test-state';
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/server.unit.test.ts
Line: 46-49

Comment:
**`_lastState` missing from mock type**

the declared type for `mockServer` doesn't include `_lastState?: string`. assigning `mockServer._lastState = 'other-state'` on line 315 is a TypeScript error (`tsc`/`typecheck` will reject it). also the initial mock object at line 11–17 only declares `_lastCode`, so `_lastState` is silently missing from the inferred shape.

```suggestion
	let mockServer: ReturnType<typeof http.createServer> & {
		_handler?: (req: IncomingMessage, res: ServerResponse) => void;
		_lastCode?: string;
		_lastState?: string;
	};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/auth/server.ts
Line: 79-80

Comment:
**stores closure `state` instead of URL param**

`trackedServer._lastState = state` stores the closure variable, not `url.searchParams.get("state")`. they're equivalent here because the handler already rejected mismatching requests on line 49 — but storing the URL param directly would make the intent clearer and be less surprising to future readers. minor nit since there's no functional difference.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): enforce expectedState in wait..."](https://github.com/ndycode/codex-multi-auth/commit/eb5408d4530b7fe25e832d3d8b424e5cee8e283b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28852865)</sub>

<!-- /greptile_comment -->