### PR TITLE
fix(settings): retry section writes against latest disk state (R-LOGIC-01)

### DIFF
--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -25,7 +25,6 @@ let settingsWriteQueue: Promise<void> = Promise.resolve();
 type SettingsReadResult = {
 	record: JsonRecord | null;
 	usedBackup: boolean;
-	mtimeMs?: number | null;
 };
 
 function isRetryableFsError(error: unknown): boolean {
@@ -91,33 +90,13 @@ function readSettingsRecordSyncFromPath(filePath: string): JsonRecord | null {
 async function readSettingsRecordAsyncFromPath(
 	filePath: string,
 ): Promise<JsonRecord | null> {
-	const result = await readSettingsRecordAsyncFromPathWithMetadata(filePath);
-	return result?.record ?? null;
-}
-
-async function readSettingsRecordAsyncFromPathWithMetadata(
-	filePath: string,
-): Promise<{ record: JsonRecord; mtimeMs: number | null } | null> {
-	let handle: Awaited<ReturnType<typeof fs.open>> | null = null;
 	try {
-		handle = await fs.open(filePath, "r");
-		const [content, stats] = await Promise.all([
-			handle.readFile({ encoding: "utf8" }),
-			handle.stat(),
-		]);
-		return {
-			record: parseSettingsRecord(content),
-			mtimeMs: stats.mtimeMs,
-		};
+		return parseSettingsRecord(await fs.readFile(filePath, "utf8"));
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
 			return null;
 		}
 		throw error;
-	} finally {
-		await handle?.close().catch(() => {
-			// Best-effort cleanup for read handles.
-		});
 	}
 }
 
@@ -288,11 +267,11 @@ function readSettingsRecordSync(): JsonRecord | null {
 async function readSettingsRecordAsyncInternal(): Promise<SettingsReadResult> {
 	const primaryExists = existsSync(UNIFIED_SETTINGS_PATH);
 	try {
-		const primaryRead = await readSettingsRecordAsyncFromPathWithMetadata(
+		const primaryRecord = await readSettingsRecordAsyncFromPath(
 			UNIFIED_SETTINGS_PATH,
 		);
-		if (primaryRead) {
-			return { record: primaryRead.record, usedBackup: false, mtimeMs: primaryRead.mtimeMs };
+		if (primaryRecord) {
+			return { record: primaryRecord, usedBackup: false };
 		}
 	} catch (error) {
 		if (!shouldFallbackToSettingsBackup(primaryExists, error)) {
@@ -300,15 +279,15 @@ async function readSettingsRecordAsyncInternal(): Promise<SettingsReadResult> {
 		}
 		const backupRecord = await readSettingsBackupAsync();
 		if (backupRecord) {
-			return { record: backupRecord, usedBackup: true, mtimeMs: null };
+			return { record: backupRecord, usedBackup: true };
 		}
 		if (isInvalidSettingsRecordError(error)) {
-			return { record: null, usedBackup: false, mtimeMs: null };
+			return { record: null, usedBackup: false };
 		}
 		throw error;
 	}
 
-	return { record: null, usedBackup: false, mtimeMs: null };
+	return { record: null, usedBackup: false };
 }
 
 async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
@@ -543,7 +522,8 @@ export function saveUnifiedPluginConfigSync(pluginConfig: JsonRecord): void {
  */
 export async function saveUnifiedPluginConfig(pluginConfig: JsonRecord): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		let { record, usedBackup, mtimeMs: expectedMtimeMs } = await readSettingsRecordAsyncInternal();
+		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
+		let expectedMtimeMs = await getUnifiedSettingsMtimeMs();
 		for (let attempt = 0; attempt < 3; attempt += 1) {
 			const nextRecord = record ?? {};
 			nextRecord.pluginConfig = { ...pluginConfig };
@@ -557,7 +537,8 @@ export async function saveUnifiedPluginConfig(pluginConfig: JsonRecord): Promise
 				if ((error as NodeJS.ErrnoException).code !== "ESTALE" || attempt >= 2) {
 					throw error;
 				}
-				({ record, usedBackup, mtimeMs: expectedMtimeMs } = await readSettingsRecordAsyncInternal());
+				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
+				expectedMtimeMs = await getUnifiedSettingsMtimeMs();
 			}
 		}
 	});
@@ -600,7 +581,8 @@ export async function saveUnifiedDashboardSettings(
 	dashboardDisplaySettings: JsonRecord,
 ): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		let { record, usedBackup, mtimeMs: expectedMtimeMs } = await readSettingsRecordAsyncInternal();
+		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
+		let expectedMtimeMs = await getUnifiedSettingsMtimeMs();
 		for (let attempt = 0; attempt < 3; attempt += 1) {
 			const nextRecord = record ?? {};
 			nextRecord.dashboardDisplaySettings = { ...dashboardDisplaySettings };
@@ -614,7 +596,8 @@ export async function saveUnifiedDashboardSettings(
 				if ((error as NodeJS.ErrnoException).code !== "ESTALE" || attempt >= 2) {
 					throw error;
 				}
-				({ record, usedBackup, mtimeMs: expectedMtimeMs } = await readSettingsRecordAsyncInternal());
+				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
+				expectedMtimeMs = await getUnifiedSettingsMtimeMs();
 			}
 		}
 	});

--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -385,7 +385,7 @@ function writeSettingsRecordSync(
  */
 async function writeSettingsRecordAsync(
 	record: JsonRecord,
-	options?: { skipBackupSnapshot?: boolean },
+	options?: { skipBackupSnapshot?: boolean; expectedMtimeMs?: number | null },
 ): Promise<void> {
 	await fs.mkdir(getCodexMultiAuthDir(), { recursive: true });
 	const payload = normalizeForWrite(record);
@@ -397,6 +397,24 @@ async function writeSettingsRecordAsync(
 	await fs.writeFile(tempPath, data, "utf8");
 	let moved = false;
 	try {
+		if (options && "expectedMtimeMs" in options) {
+			let currentMtimeMs: number | null = null;
+			try {
+				currentMtimeMs = (await fs.stat(UNIFIED_SETTINGS_PATH)).mtimeMs;
+			} catch (error) {
+				const code = (error as NodeJS.ErrnoException).code;
+				if (code !== "ENOENT") {
+					throw error;
+				}
+			}
+			if (currentMtimeMs !== options.expectedMtimeMs) {
+				const staleError = new Error(
+					"Unified settings changed on disk during save; retrying with latest state.",
+				) as NodeJS.ErrnoException;
+				staleError.code = "ESTALE";
+				throw staleError;
+			}
+		}
 		for (let attempt = 0; attempt < 5; attempt += 1) {
 			try {
 				await fs.rename(tempPath, UNIFIED_SETTINGS_PATH);
@@ -417,6 +435,18 @@ async function writeSettingsRecordAsync(
 				// Best-effort temp cleanup.
 			}
 		}
+	}
+}
+
+async function getUnifiedSettingsMtimeMs(): Promise<number | null> {
+	try {
+		return (await fs.stat(UNIFIED_SETTINGS_PATH)).mtimeMs;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") {
+			return null;
+		}
+		throw error;
 	}
 }
 
@@ -492,12 +522,25 @@ export function saveUnifiedPluginConfigSync(pluginConfig: JsonRecord): void {
  */
 export async function saveUnifiedPluginConfig(pluginConfig: JsonRecord): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		const { record, usedBackup } = await readSettingsRecordAsyncInternal();
-		const nextRecord = record ?? {};
-		nextRecord.pluginConfig = { ...pluginConfig };
-		await writeSettingsRecordAsync(nextRecord, {
-			skipBackupSnapshot: usedBackup,
-		});
+		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
+		let expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const nextRecord = record ?? {};
+			nextRecord.pluginConfig = { ...pluginConfig };
+			try {
+				await writeSettingsRecordAsync(nextRecord, {
+					skipBackupSnapshot: usedBackup,
+					expectedMtimeMs,
+				});
+				return;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ESTALE" || attempt >= 2) {
+					throw error;
+				}
+				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
+				expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+			}
+		}
 	});
 }
 
@@ -538,11 +581,24 @@ export async function saveUnifiedDashboardSettings(
 	dashboardDisplaySettings: JsonRecord,
 ): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		const { record, usedBackup } = await readSettingsRecordAsyncInternal();
-		const nextRecord = record ?? {};
-		nextRecord.dashboardDisplaySettings = { ...dashboardDisplaySettings };
-		await writeSettingsRecordAsync(nextRecord, {
-			skipBackupSnapshot: usedBackup,
-		});
+		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
+		let expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const nextRecord = record ?? {};
+			nextRecord.dashboardDisplaySettings = { ...dashboardDisplaySettings };
+			try {
+				await writeSettingsRecordAsync(nextRecord, {
+					skipBackupSnapshot: usedBackup,
+					expectedMtimeMs,
+				});
+				return;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ESTALE" || attempt >= 2) {
+					throw error;
+				}
+				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
+				expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+			}
+		}
 	});
 }

--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -25,6 +25,7 @@ let settingsWriteQueue: Promise<void> = Promise.resolve();
 type SettingsReadResult = {
 	record: JsonRecord | null;
 	usedBackup: boolean;
+	mtimeMs?: number | null;
 };
 
 function isRetryableFsError(error: unknown): boolean {
@@ -90,13 +91,33 @@ function readSettingsRecordSyncFromPath(filePath: string): JsonRecord | null {
 async function readSettingsRecordAsyncFromPath(
 	filePath: string,
 ): Promise<JsonRecord | null> {
+	const result = await readSettingsRecordAsyncFromPathWithMetadata(filePath);
+	return result?.record ?? null;
+}
+
+async function readSettingsRecordAsyncFromPathWithMetadata(
+	filePath: string,
+): Promise<{ record: JsonRecord; mtimeMs: number | null } | null> {
+	let handle: Awaited<ReturnType<typeof fs.open>> | null = null;
 	try {
-		return parseSettingsRecord(await fs.readFile(filePath, "utf8"));
+		handle = await fs.open(filePath, "r");
+		const [content, stats] = await Promise.all([
+			handle.readFile({ encoding: "utf8" }),
+			handle.stat(),
+		]);
+		return {
+			record: parseSettingsRecord(content),
+			mtimeMs: stats.mtimeMs,
+		};
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
 			return null;
 		}
 		throw error;
+	} finally {
+		await handle?.close().catch(() => {
+			// Best-effort cleanup for read handles.
+		});
 	}
 }
 
@@ -267,11 +288,11 @@ function readSettingsRecordSync(): JsonRecord | null {
 async function readSettingsRecordAsyncInternal(): Promise<SettingsReadResult> {
 	const primaryExists = existsSync(UNIFIED_SETTINGS_PATH);
 	try {
-		const primaryRecord = await readSettingsRecordAsyncFromPath(
+		const primaryRead = await readSettingsRecordAsyncFromPathWithMetadata(
 			UNIFIED_SETTINGS_PATH,
 		);
-		if (primaryRecord) {
-			return { record: primaryRecord, usedBackup: false };
+		if (primaryRead) {
+			return { record: primaryRead.record, usedBackup: false, mtimeMs: primaryRead.mtimeMs };
 		}
 	} catch (error) {
 		if (!shouldFallbackToSettingsBackup(primaryExists, error)) {
@@ -279,15 +300,15 @@ async function readSettingsRecordAsyncInternal(): Promise<SettingsReadResult> {
 		}
 		const backupRecord = await readSettingsBackupAsync();
 		if (backupRecord) {
-			return { record: backupRecord, usedBackup: true };
+			return { record: backupRecord, usedBackup: true, mtimeMs: null };
 		}
 		if (isInvalidSettingsRecordError(error)) {
-			return { record: null, usedBackup: false };
+			return { record: null, usedBackup: false, mtimeMs: null };
 		}
 		throw error;
 	}
 
-	return { record: null, usedBackup: false };
+	return { record: null, usedBackup: false, mtimeMs: null };
 }
 
 async function readSettingsRecordAsync(): Promise<JsonRecord | null> {
@@ -522,8 +543,7 @@ export function saveUnifiedPluginConfigSync(pluginConfig: JsonRecord): void {
  */
 export async function saveUnifiedPluginConfig(pluginConfig: JsonRecord): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
-		let expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+		let { record, usedBackup, mtimeMs: expectedMtimeMs } = await readSettingsRecordAsyncInternal();
 		for (let attempt = 0; attempt < 3; attempt += 1) {
 			const nextRecord = record ?? {};
 			nextRecord.pluginConfig = { ...pluginConfig };
@@ -537,8 +557,7 @@ export async function saveUnifiedPluginConfig(pluginConfig: JsonRecord): Promise
 				if ((error as NodeJS.ErrnoException).code !== "ESTALE" || attempt >= 2) {
 					throw error;
 				}
-				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
-				expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+				({ record, usedBackup, mtimeMs: expectedMtimeMs } = await readSettingsRecordAsyncInternal());
 			}
 		}
 	});
@@ -581,8 +600,7 @@ export async function saveUnifiedDashboardSettings(
 	dashboardDisplaySettings: JsonRecord,
 ): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
-		let expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+		let { record, usedBackup, mtimeMs: expectedMtimeMs } = await readSettingsRecordAsyncInternal();
 		for (let attempt = 0; attempt < 3; attempt += 1) {
 			const nextRecord = record ?? {};
 			nextRecord.dashboardDisplaySettings = { ...dashboardDisplaySettings };
@@ -596,8 +614,7 @@ export async function saveUnifiedDashboardSettings(
 				if ((error as NodeJS.ErrnoException).code !== "ESTALE" || attempt >= 2) {
 					throw error;
 				}
-				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
-				expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+				({ record, usedBackup, mtimeMs: expectedMtimeMs } = await readSettingsRecordAsyncInternal());
 			}
 		}
 	});

--- a/lib/unified-settings.ts
+++ b/lib/unified-settings.ts
@@ -522,8 +522,8 @@ export function saveUnifiedPluginConfigSync(pluginConfig: JsonRecord): void {
  */
 export async function saveUnifiedPluginConfig(pluginConfig: JsonRecord): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
 		let expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
 		for (let attempt = 0; attempt < 3; attempt += 1) {
 			const nextRecord = record ?? {};
 			nextRecord.pluginConfig = { ...pluginConfig };
@@ -537,8 +537,8 @@ export async function saveUnifiedPluginConfig(pluginConfig: JsonRecord): Promise
 				if ((error as NodeJS.ErrnoException).code !== "ESTALE" || attempt >= 2) {
 					throw error;
 				}
-				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
 				expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
 			}
 		}
 	});
@@ -581,8 +581,8 @@ export async function saveUnifiedDashboardSettings(
 	dashboardDisplaySettings: JsonRecord,
 ): Promise<void> {
 	await enqueueSettingsWrite(async () => {
-		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
 		let expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+		let { record, usedBackup } = await readSettingsRecordAsyncInternal();
 		for (let attempt = 0; attempt < 3; attempt += 1) {
 			const nextRecord = record ?? {};
 			nextRecord.dashboardDisplaySettings = { ...dashboardDisplaySettings };
@@ -596,8 +596,8 @@ export async function saveUnifiedDashboardSettings(
 				if ((error as NodeJS.ErrnoException).code !== "ESTALE" || attempt >= 2) {
 					throw error;
 				}
-				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
 				expectedMtimeMs = await getUnifiedSettingsMtimeMs();
+				({ record, usedBackup } = await readSettingsRecordAsyncInternal());
 			}
 		}
 	});

--- a/test/unified-settings.test.ts
+++ b/test/unified-settings.test.ts
@@ -736,6 +736,93 @@ describe("unified settings", () => {
 		});
 	});
 
+	it("retries plugin section write against newer on-disk record to avoid stale overwrite", async () => {
+		const {
+			getUnifiedSettingsPath,
+			saveUnifiedPluginConfig,
+		} = await import("../lib/unified-settings.js");
+
+		await fs.writeFile(
+			getUnifiedSettingsPath(),
+			JSON.stringify(
+				{
+					version: 1,
+					pluginConfig: { codexMode: false, retries: 9 },
+					dashboardDisplaySettings: {
+						menuShowLastUsed: true,
+						uiThemePreset: "green",
+					},
+					experimentalDraft: {
+						enabled: false,
+						panels: ["future"],
+					},
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+
+		const originalWriteFile = fs.writeFile;
+		const writeSpy = vi.spyOn(fs, "writeFile");
+		let injectedConcurrentWrite = false;
+		writeSpy.mockImplementation(async (...args: Parameters<typeof fs.writeFile>) => {
+			const [filePath, data] = args;
+			const result = await originalWriteFile(...args);
+			if (!injectedConcurrentWrite && String(filePath).includes(".tmp")) {
+				injectedConcurrentWrite = true;
+				await originalWriteFile(
+					getUnifiedSettingsPath(),
+					`${JSON.stringify(
+						{
+							version: 1,
+							pluginConfig: { codexMode: false, retries: 9 },
+							dashboardDisplaySettings: {
+								menuShowLastUsed: false,
+								uiThemePreset: "purple",
+							},
+							experimentalDraft: {
+								enabled: true,
+								panels: ["fresh"],
+							},
+						},
+						null,
+						2,
+					)}\n`,
+					"utf8",
+				);
+			}
+			return result;
+		});
+
+		try {
+			await saveUnifiedPluginConfig({ codexMode: true, fetchTimeoutMs: 45_000 });
+		} finally {
+			writeSpy.mockRestore();
+		}
+
+		expect(injectedConcurrentWrite).toBe(true);
+		const parsed = JSON.parse(
+			await fs.readFile(getUnifiedSettingsPath(), "utf8"),
+		) as {
+			pluginConfig?: Record<string, unknown>;
+			dashboardDisplaySettings?: Record<string, unknown>;
+			experimentalDraft?: Record<string, unknown>;
+		};
+		expect(parsed.pluginConfig).toEqual({
+			codexMode: true,
+			fetchTimeoutMs: 45_000,
+		});
+		expect(parsed.dashboardDisplaySettings).toEqual({
+			menuShowLastUsed: false,
+			uiThemePreset: "purple",
+		});
+		expect(parsed.experimentalDraft).toEqual({
+			enabled: true,
+			panels: ["fresh"],
+		});
+	});
+
 	it("falls back to backup when the primary settings file is unreadable", async () => {
 		const {
 			saveUnifiedPluginConfig,


### PR DESCRIPTION
Addresses R-LOGIC-01 and R-TEST-01 from the deep runtime audit.

The async unified-settings save paths (`saveUnifiedPluginConfig`, `saveUnifiedDashboardSettings`) used a read-modify-write flow with only an in-process queue. If another process wrote a newer `settings.json` after the read but before the rename, the stale in-memory record would overwrite unrelated sections.

This PR adds an optimistic mtime check:
- capture the observed settings mtime after read
- check the current mtime immediately before rename
- on mismatch (`ESTALE`), re-read the latest record and re-apply the section-scoped mutation
- retry up to 3 times

Includes a regression test that injects an external write between temp-file creation and rename, and verifies the external writer's unrelated sections are preserved.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr patches the async read-modify-write paths in `saveUnifiedPluginConfig` and `saveUnifiedDashboardSettings` with an optimistic mtime check: capture mtime before the read, re-stat immediately before rename, and retry up to 3 times on mismatch (`ESTALE`). the mtime-before-read ordering is correct in both the initial path and the retry path, addressing the toctou concern raised previously. all remaining findings are p2.

<h3>Confidence Score: 5/5</h3>

safe to merge; prior toctou concern is resolved, remaining findings are p2 style/coverage gaps

the mtime-before-read ordering is correct in both initial and retry paths; estale sentinel is synthetic so no windows compat issue; only open items are a missing dashboard test and a fat32 mtime granularity edge case, both p2

test/unified-settings.test.ts — missing symmetric regression test for saveUnifiedDashboardSettings

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/unified-settings.ts | adds optimistic mtime check before rename and 3-attempt retry loop to both async save paths; mtime-then-read order is correct; mtime granularity on fat32/network mounts is a latent windows risk |
| test/unified-settings.test.ts | adds regression test for saveUnifiedPluginConfig stale-overwrite scenario; saveUnifiedDashboardSettings has no symmetric test despite identical retry logic |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant saveUnifiedPluginConfig
    participant fs

    Caller->>saveUnifiedPluginConfig: saveUnifiedPluginConfig(pluginConfig)
    saveUnifiedPluginConfig->>fs: stat(settings.json) → T1
    saveUnifiedPluginConfig->>fs: readFile(settings.json) → record
    loop attempt 0..2
        saveUnifiedPluginConfig->>saveUnifiedPluginConfig: merge pluginConfig into record
        saveUnifiedPluginConfig->>fs: writeFile(temp.tmp, merged)
        Note over fs: external process may write settings.json here (mtime → T2)
        saveUnifiedPluginConfig->>fs: stat(settings.json) → currentMtime
        alt currentMtime ≠ expectedMtime (ESTALE)
            saveUnifiedPluginConfig->>fs: unlink(temp.tmp)
            saveUnifiedPluginConfig->>fs: stat(settings.json) → T2
            saveUnifiedPluginConfig->>fs: readFile(settings.json) → fresh record
        else mtime matches
            saveUnifiedPluginConfig->>fs: rename(temp.tmp → settings.json)
            saveUnifiedPluginConfig-->>Caller: done
        end
    end
    saveUnifiedPluginConfig-->>Caller: throw ESTALE (after 3 failed attempts)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Funified-settings-stale-overwrite%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Funified-settings-stale-overwrite%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Funified-settings.test.ts%3A739-824%0A**missing%20regression%20test%20for%20%60saveUnifiedDashboardSettings%60**%0A%0A%60saveUnifiedDashboardSettings%60%20received%20the%20same%20optimistic-retry%20block%20%28lines%20583%E2%80%93603%20of%20%60lib%2Funified-settings.ts%60%29%2C%20but%20there%20is%20no%20corresponding%20regression%20test%20that%20injects%20a%20concurrent%20write%20and%20verifies%20unrelated%20sections%20are%20preserved.%20the%20existing%20test%20only%20exercises%20%60saveUnifiedPluginConfig%60.%20adding%20a%20symmetric%20test%20%28same%20spy%20pattern%2C%20asserting%20%60pluginConfig%60%20is%20untouched%20after%20an%20external%20write%20between%20temp%20creation%20and%20rename%29%20would%20complete%20R-TEST-01%20coverage%20for%20both%20save%20paths.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Funified-settings.ts%3A400-416%0A**mtime%20granularity%20silently%20bypasses%20conflict%20detection%20on%20low-res%20filesystems**%0A%0A%60mtimeMs%60%20precision%20depends%20on%20the%20underlying%20filesystem.%20fat32%20rounds%20mtime%20to%202-second%20boundaries%3B%20some%20smb%2Fnfs%20mounts%20round%20to%201%20second.%20if%20an%20external%20process%20writes%20%60settings.json%60%20within%20the%20same%20granularity%20window%20as%20the%20captured%20%60expectedMtimeMs%60%2C%20%60currentMtimeMs%20%3D%3D%3D%20options.expectedMtimeMs%60%20holds%20and%20the%20stale-overwrite%20detection%20silently%20passes%20%E2%80%94%20exactly%20the%20lost-update%20this%20check%20is%20meant%20to%20prevent.%20this%20is%20a%20real%20windows%20filesystem%20risk%20%28fat32%20on%20removable%20drives%2C%20some%20mapped%20network%20drives%29.%20consider%20also%20comparing%20file%20size%20or%20a%20content%20hash%20as%20a%20secondary%20check%2C%20or%20documenting%20the%20known%20limitation%20in%20the%20function%20jsdoc.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/unified-settings.test.ts
Line: 739-824

Comment:
**missing regression test for `saveUnifiedDashboardSettings`**

`saveUnifiedDashboardSettings` received the same optimistic-retry block (lines 583–603 of `lib/unified-settings.ts`), but there is no corresponding regression test that injects a concurrent write and verifies unrelated sections are preserved. the existing test only exercises `saveUnifiedPluginConfig`. adding a symmetric test (same spy pattern, asserting `pluginConfig` is untouched after an external write between temp creation and rename) would complete R-TEST-01 coverage for both save paths.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/unified-settings.ts
Line: 400-416

Comment:
**mtime granularity silently bypasses conflict detection on low-res filesystems**

`mtimeMs` precision depends on the underlying filesystem. fat32 rounds mtime to 2-second boundaries; some smb/nfs mounts round to 1 second. if an external process writes `settings.json` within the same granularity window as the captured `expectedMtimeMs`, `currentMtimeMs === options.expectedMtimeMs` holds and the stale-overwrite detection silently passes — exactly the lost-update this check is meant to prevent. this is a real windows filesystem risk (fat32 on removable drives, some mapped network drives). consider also comparing file size or a content hash as a secondary check, or documenting the known limitation in the function jsdoc.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(settings): snapshot mtime before asy..."](https://github.com/ndycode/codex-multi-auth/commit/e6de13d3b58642df37e68c0b727373d55c046d0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28852960)</sub>

<!-- /greptile_comment -->