### PR TITLE
fix(shutdown): make runCleanup idempotent under concurrent calls (LIB-HIGH-003)

### DIFF
--- a/lib/shutdown.ts
+++ b/lib/shutdown.ts
@@ -2,6 +2,7 @@ type CleanupFn = () => void | Promise<void>;
 
 const cleanupFunctions: CleanupFn[] = [];
 let shutdownRegistered = false;
+let cleanupPromise: Promise<void> | null = null;
 
 export function registerCleanup(fn: CleanupFn): void {
 	cleanupFunctions.push(fn);
@@ -15,17 +16,27 @@ export function unregisterCleanup(fn: CleanupFn): void {
 	}
 }
 
-export async function runCleanup(): Promise<void> {
-	const fns = [...cleanupFunctions];
-	cleanupFunctions.length = 0;
-
-	for (const fn of fns) {
-		try {
-			await fn();
-		} catch {
-			// Ignore cleanup errors during shutdown
-		}
+export function runCleanup(): Promise<void> {
+	if (cleanupPromise) {
+		return cleanupPromise;
 	}
+
+	cleanupPromise = (async () => {
+		const fns = [...cleanupFunctions];
+		cleanupFunctions.length = 0;
+
+		for (const fn of fns) {
+			try {
+				await fn();
+			} catch {
+				// Ignore cleanup errors during shutdown
+			}
+		}
+	})().finally(() => {
+		cleanupPromise = null;
+	});
+
+	return cleanupPromise;
 }
 
 function ensureShutdownHandler(): void {

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -29,7 +29,7 @@ describe("Graceful shutdown", () => {
 		expect(fn).not.toHaveBeenCalled();
 	});
 
-	it("runs multiple cleanup functions in order", async () => {
+	it("runs multiple cleanup functions in registration order", async () => {
 		const order: number[] = [];
 		registerCleanup(() => { order.push(1); });
 		registerCleanup(() => { order.push(2); });
@@ -63,6 +63,26 @@ describe("Graceful shutdown", () => {
 		expect(getCleanupCount()).toBe(2);
 		await runCleanup();
 		expect(getCleanupCount()).toBe(0);
+	});
+
+	it("returns the same promise for concurrent runCleanup calls", async () => {
+		let release!: () => void;
+		const blocker = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const cleanupFn = vi.fn(async () => {
+			await blocker;
+		});
+		registerCleanup(cleanupFn);
+
+		const first = runCleanup();
+		const second = runCleanup();
+
+		expect(first).toBe(second);
+		expect(cleanupFn).toHaveBeenCalledTimes(1);
+
+		release();
+		await first;
 	});
 
 	it("unregister is no-op for non-registered function", () => {


### PR DESCRIPTION
Addresses the actionable concurrency part of LIB-HIGH-003 from the deep top-level lib audit.

The audit identified three shutdown concerns:
- cleanup ordering
- concurrent `runCleanup()` races
- signal / `beforeExit` semantics

This PR intentionally fixes the **smallest safe slice** only: overlapping `runCleanup()` calls now share one in-flight promise so cleanup handlers are not double-run.

It preserves the current FIFO cleanup order and current signal / `beforeExit` behavior to avoid a broader shutdown-contract change in the same PR.

Includes a regression test proving concurrent callers receive the same in-flight promise and the cleanup handler runs once.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

makes `runCleanup()` idempotent by tracking an in-flight `cleanupPromise` at module scope; concurrent callers receive the same promise and cleanup handlers run exactly once, with `.finally()` resetting the guard after all awaiters are notified. the implementation is correct — the `.finally()` reset fires before awaiting callers resume, so there are no hidden races in the node.js microtask ordering.

<h3>Confidence Score: 5/5</h3>

safe to merge — implementation is correct and the single P2 finding is a test coverage gap, not a production defect

the concurrency fix is sound: module-level promise guard deduplicates concurrent calls, `.finally()` reset fires in the correct microtask order before callers resume, and the existing test suite is green. the only gap is missing assertions for the post-completion reset path in the new regression test, which is a style/coverage issue, not a functional bug.

test/shutdown.test.ts — the new concurrent test lacks post-completion assertions for the .finally() reset branch

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/shutdown.ts | adds module-level `cleanupPromise` guard; concurrent calls return the same in-flight promise; `.finally()` reset is correctly ordered (fires before awaiters resume); logic is sound |
| test/shutdown.test.ts | adds concurrent-call regression test; proves in-flight deduplication and single handler invocation, but lacks post-completion reset assertions and has a test-isolation fragility if assertions fail before `release()` |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2
    participant RC as runCleanup()
    participant FN as cleanupFn

    C1->>RC: runCleanup()
    RC->>RC: cleanupPromise = null → create IIFE
    RC-->>C1: return cleanupPromise (P)
    C2->>RC: runCleanup()
    RC->>RC: cleanupPromise !== null → early return
    RC-->>C2: return same cleanupPromise (P)
    RC->>FN: await fn() [once]
    FN-->>RC: resolves
    RC->>RC: .finally() → cleanupPromise = null
    RC-->>C1: P resolves
    RC-->>C2: P resolves
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fshutdown-cleanup-ordering%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fshutdown-cleanup-ordering%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fshutdown.test.ts%3A68-86%0A**missing%20post-completion%20assertions**%0A%0Athe%20test%20proves%20in-flight%20deduplication%20but%20stops%20before%20checking%20the%20%60finally%60%20reset%20path.%20after%20%60await%20first%60%2C%20%60cleanupPromise%60%20should%20be%20%60null%60%20and%20a%20new%20%60runCleanup%28%29%60%20call%20should%20return%20a%20**different**%20promise.%20without%20asserting%20this%2C%20the%20%60.finally%28%28%29%20%3D%3E%20%7B%20cleanupPromise%20%3D%20null%3B%20%7D%29%60%20branch%20has%20no%20direct%20coverage.%0A%0Aadditionally%2C%20if%20any%20%60expect%60%20fails%20before%20%60release%28%29%60%20is%20called%2C%20the%20blocker%20never%20resolves%20and%20%60beforeEach%28async%20%28%29%20%3D%3E%20%7B%20await%20runCleanup%28%29%3B%20%7D%29%60%20in%20the%20next%20test%20will%20hang%20until%20vitest's%20per-test%20timeout%20fires.%20consider%20adding%20a%20cleanup%20via%20%60afterEach%60%20or%20using%20vitest's%20%60onTestFinished%60%3A%0A%0A%60%60%60typescript%0Arelease%28%29%3B%0Aawait%20first%3B%0A%0A%2F%2F%20verify%20reset%3A%20a%20post-cleanup%20call%20should%20be%20a%20fresh%20promise%0Aconst%20third%20%3D%20runCleanup%28%29%3B%0Aexpect%28third%29.not.toBe%28first%29%3B%0Aawait%20third%3B%20%2F%2F%20resolves%20instantly%20%28cleanupFunctions%20is%20empty%29%0A%0A%2F%2F%20cleanupFn%20should%20still%20have%20run%20exactly%20once%20total%0Aexpect%28cleanupFn%29.toHaveBeenCalledTimes%281%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/shutdown.test.ts
Line: 68-86

Comment:
**missing post-completion assertions**

the test proves in-flight deduplication but stops before checking the `finally` reset path. after `await first`, `cleanupPromise` should be `null` and a new `runCleanup()` call should return a **different** promise. without asserting this, the `.finally(() => { cleanupPromise = null; })` branch has no direct coverage.

additionally, if any `expect` fails before `release()` is called, the blocker never resolves and `beforeEach(async () => { await runCleanup(); })` in the next test will hang until vitest's per-test timeout fires. consider adding a cleanup via `afterEach` or using vitest's `onTestFinished`:

```typescript
release();
await first;

// verify reset: a post-cleanup call should be a fresh promise
const third = runCleanup();
expect(third).not.toBe(first);
await third; // resolves instantly (cleanupFunctions is empty)

// cleanupFn should still have run exactly once total
expect(cleanupFn).toHaveBeenCalledTimes(1);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shutdown): make runCleanup idempoten..."](https://github.com/ndycode/codex-multi-auth/commit/8aad2a7c372a072eb3fcc57511e672a6b59649cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28853485)</sub>

<!-- /greptile_comment -->