### PR TITLE
prepare model routing for GPT-5.5 release activation

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -42,6 +42,7 @@ Canonical governance for repository documentation quality and consistency.
 | IA/findability audit (2026-03-01) | `docs/development/IA_FINDABILITY_AUDIT_2026-03-01.md` |
 | Config fields internals | `docs/development/CONFIG_FIELDS.md` |
 | Config flow internals | `docs/development/CONFIG_FLOW.md` |
+| GPT-5.5 activation playbook | `docs/development/RUNBOOK_ENABLE_GPT_5_5_ON_CONFIRMATION.md` |
 | Repository ownership map | `docs/development/REPOSITORY_SCOPE.md` |
 | Testing and release gates | `docs/development/TESTING.md` |
 | TUI parity checklist | `docs/development/TUI_PARITY_CHECKLIST.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ Public documentation for `codex-multi-auth`.
 | [development/RUNBOOK_ADD_AUTH_COMMAND.md](development/RUNBOOK_ADD_AUTH_COMMAND.md) | Safe workflow for adding a new `codex auth ...` command |
 | [development/RUNBOOK_ADD_CONFIG_FIELD.md](development/RUNBOOK_ADD_CONFIG_FIELD.md) | Safe workflow for introducing a new config field |
 | [development/RUNBOOK_CHANGE_ROUTING_POLICY.md](development/RUNBOOK_CHANGE_ROUTING_POLICY.md) | Safe workflow for changing routing, retry, or fallback policy |
+| [development/RUNBOOK_ENABLE_GPT_5_5_ON_CONFIRMATION.md](development/RUNBOOK_ENABLE_GPT_5_5_ON_CONFIRMATION.md) | Launch-day checklist for enabling public GPT-5.5 support after official confirmation |
 | [development/REPOSITORY_SCOPE.md](development/REPOSITORY_SCOPE.md) | Ownership map by repository path |
 | [development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md](development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md) | Safe workflow for adding a new `codex auth` command |
 | [development/RUNBOOK_ADD_CONFIG_FIELD_SAFELY.md](development/RUNBOOK_ADD_CONFIG_FIELD_SAFELY.md) | Safe workflow for introducing a new config/settings field |

--- a/docs/development/RUNBOOK_ENABLE_GPT_5_5_ON_CONFIRMATION.md
+++ b/docs/development/RUNBOOK_ENABLE_GPT_5_5_ON_CONFIRMATION.md
@@ -1,0 +1,59 @@
+# Runbook: Enable GPT-5.5 After Official Confirmation
+
+Internal launch-day checklist for turning the GPT-5.5 readiness prep into real public support.
+
+## Goal
+
+Ship confirmed GPT-5.5 support as a narrow follow-up patch after OpenAI publishes the exact production contract.
+
+## Required Proof From OpenAI
+
+- Official models documentation lists the public GPT-5.5 model IDs.
+- Official release notes or product documentation confirm that GPT-5.5 is publicly available.
+- Official documentation confirms the prompt family or successor prompt asset that should back GPT-5.5 requests.
+- Official documentation confirms default reasoning behavior and the allowed reasoning-effort values for each public GPT-5.5 variant.
+- Official documentation confirms tool-search, computer-use, and compaction support for each public GPT-5.5 variant.
+- Official documentation confirms any user-facing config/example names that should be exposed in shipped templates.
+
+## Activation Files
+
+- `lib/request/helpers/model-map.ts` - add confirmed GPT-5.5 aliases, profiles, prompt-family selection, and capability metadata.
+- `test/model-map.test.ts` - lock the confirmed normalization and capability surface.
+- `test/request-transformer.test.ts` - lock the confirmed reasoning coercion, text defaults, and tool sanitization behavior.
+- `config/codex-legacy.json` - update the shipped legacy config example only after public IDs and reasoning variants are confirmed.
+- User-visible docs only after confirmation:
+  - `README.md`
+  - `docs/getting-started.md`
+  - `docs/features.md`
+  - `docs/configuration.md`
+  - `docs/troubleshooting.md`
+  - relevant `docs/reference/*` pages if command, setting, or example text changes
+
+## Safe Workflow
+
+1. Record the official OpenAI source links in the PR description before editing code.
+2. Update the exact GPT-5.5 aliases and profiles in `model-map.ts`; do not widen fallback heuristics unless the official contract requires it.
+3. Keep unknown or unconfirmed GPT-5.5-style names on the stable fallback path until each new public ID is proven.
+4. Update tests before advertising support in shipped config examples or public docs.
+5. Update `config/codex-legacy.json` only for confirmed public IDs.
+6. Update user-visible docs only after the runtime and tests already pass with the confirmed contract.
+
+## Validation
+
+```bash
+npm run lint
+npm run typecheck
+npm test
+npm test -- test/documentation.test.ts
+npm run build
+```
+
+## Review Checklist
+
+- official OpenAI source links are captured in the PR
+- every new GPT-5.5 alias matches the official public ID exactly
+- reasoning defaults and supported efforts match the official contract
+- tool-search and computer-use assertions match the official contract
+- shipped config examples expose only confirmed public GPT-5.5 entries
+- user-visible docs remain unchanged until confirmation is complete
+- rollback remains a clean revert of the activation patch

--- a/lib/capability-policy.ts
+++ b/lib/capability-policy.ts
@@ -1,4 +1,7 @@
-import { getNormalizedModel } from "./request/helpers/model-map.js";
+import {
+	getNormalizedModel,
+	resolveNormalizedModel,
+} from "./request/helpers/model-map.js";
 
 export interface CapabilityPolicySnapshot {
 	successes: number;
@@ -33,7 +36,13 @@ function normalizeModel(model: string | undefined): string | null {
 	const withoutProvider = trimmedInput.includes("/")
 		? (trimmedInput.split("/").pop() ?? trimmedInput)
 		: trimmedInput;
-	const mapped = getNormalizedModel(withoutProvider) ?? withoutProvider;
+	const exactMatch = getNormalizedModel(withoutProvider);
+	const shouldUseFallbackCatalog = /gpt[-_\s]?5|codex/i.test(withoutProvider);
+	const mapped =
+		exactMatch ??
+		(shouldUseFallbackCatalog
+			? resolveNormalizedModel(withoutProvider)
+			: withoutProvider);
 	const trimmed = mapped.trim().toLowerCase();
 	if (!trimmed) return null;
 	return trimmed.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -36,6 +36,12 @@ export interface ModelProfile {
 	capabilities: ModelCapabilities;
 }
 
+type GeneralGpt5Variant = "base" | "pro" | "mini" | "nano";
+type GeneralGpt5KnownMinor = 1 | 2 | 4;
+type GeneralGpt5VariantCatalog = Partial<
+	Record<GeneralGpt5Variant, string>
+>;
+
 const REASONING_VARIANTS = [
 	"none",
 	"minimal",
@@ -74,6 +80,34 @@ const TOOL_CAPABILITIES = {
 } as const satisfies Record<string, ModelCapabilities>;
 
 export const DEFAULT_MODEL = "gpt-5.4";
+
+const GENERAL_GPT5_VERSION_CATALOG: Record<
+	GeneralGpt5KnownMinor,
+	GeneralGpt5VariantCatalog
+> = {
+	1: {
+		base: "gpt-5.1",
+	},
+	2: {
+		base: "gpt-5.2",
+		pro: "gpt-5.2-pro",
+	},
+	4: {
+		base: DEFAULT_MODEL,
+		pro: "gpt-5.4-pro",
+		mini: "gpt-5-mini",
+		nano: "gpt-5-nano",
+	},
+};
+
+const GENERAL_GPT5_STABLE_VARIANTS = GENERAL_GPT5_VERSION_CATALOG[4];
+
+const GENERAL_GPT5_GENERIC_VARIANTS: Record<GeneralGpt5Variant, string> = {
+	base: DEFAULT_MODEL,
+	pro: "gpt-5-pro",
+	mini: "gpt-5-mini",
+	nano: "gpt-5-nano",
+};
 
 /**
  * Effective model profiles keyed by canonical model name.
@@ -226,6 +260,127 @@ function stripProviderPrefix(modelId: string): string {
 	return modelId.includes("/") ? (modelId.split("/").pop() ?? modelId) : modelId;
 }
 
+function tokenizeModelId(modelId: string): string[] {
+	return modelId
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean);
+}
+
+function getGeneralGpt5CatalogForMinor(
+	minor: number,
+): GeneralGpt5VariantCatalog | undefined {
+	switch (minor) {
+		case 1:
+		case 2:
+		case 4:
+			return GENERAL_GPT5_VERSION_CATALOG[minor];
+		default:
+			return undefined;
+	}
+}
+
+function resolveGeneralGpt5CatalogVariant(
+	catalog: GeneralGpt5VariantCatalog | undefined,
+	variant: GeneralGpt5Variant,
+): string | undefined {
+	return catalog?.[variant] ?? catalog?.base;
+}
+
+function resolveStableGeneralGpt5Variant(
+	variant: GeneralGpt5Variant,
+): string {
+	const fallback =
+		GENERAL_GPT5_STABLE_VARIANTS[variant] ??
+		GENERAL_GPT5_STABLE_VARIANTS.base;
+	if (fallback) {
+		return fallback;
+	}
+
+	throw new Error(`Stable GPT-5 fallback is missing for variant ${variant}`);
+}
+
+function resolveCodexCatalogModel(modelId: string): string | undefined {
+	const normalized = modelId.toLowerCase();
+
+	if (
+		normalized.includes("gpt-5.3-codex-spark") ||
+		normalized.includes("gpt 5.3 codex spark")
+	) {
+		return "gpt-5-codex";
+	}
+	if (
+		normalized.includes("gpt-5.3-codex") ||
+		normalized.includes("gpt 5.3 codex")
+	) {
+		return "gpt-5-codex";
+	}
+	if (
+		normalized.includes("gpt-5.2-codex") ||
+		normalized.includes("gpt 5.2 codex")
+	) {
+		return "gpt-5-codex";
+	}
+	if (
+		normalized.includes("gpt-5.1-codex-max") ||
+		normalized.includes("gpt 5.1 codex max")
+	) {
+		return "gpt-5.1-codex-max";
+	}
+	if (
+		normalized.includes("gpt-5.1-codex-mini") ||
+		normalized.includes("gpt 5.1 codex mini") ||
+		normalized.includes("codex-mini-latest") ||
+		normalized.includes("gpt-5-codex-mini") ||
+		normalized.includes("gpt 5 codex mini")
+	) {
+		return "gpt-5.1-codex-mini";
+	}
+	if (
+		normalized.includes("gpt-5-codex") ||
+		normalized.includes("gpt 5 codex") ||
+		normalized.includes("gpt-5.1-codex") ||
+		normalized.includes("gpt 5.1 codex") ||
+		normalized.includes("codex")
+	) {
+		return "gpt-5-codex";
+	}
+
+	return undefined;
+}
+
+function resolveGeneralGpt5CatalogModel(modelId: string): string | undefined {
+	const tokens = tokenizeModelId(modelId);
+	const gptIndex = tokens.indexOf("gpt");
+	const isGpt5 = gptIndex !== -1 && tokens[gptIndex + 1] === "5";
+	if (!isGpt5 || tokens.includes("codex")) {
+		return undefined;
+	}
+
+	const rawMinor = tokens[gptIndex + 2];
+	const minor =
+		rawMinor && /^\d+$/.test(rawMinor) ? Number(rawMinor) : undefined;
+	const variant: GeneralGpt5Variant = tokens.includes("mini")
+		? "mini"
+		: tokens.includes("nano")
+			? "nano"
+			: tokens.includes("pro")
+				? "pro"
+				: "base";
+
+	if (minor === undefined) {
+		return GENERAL_GPT5_GENERIC_VARIANTS[variant];
+	}
+
+	const exactCatalog = getGeneralGpt5CatalogForMinor(minor);
+	const exactMatch = resolveGeneralGpt5CatalogVariant(exactCatalog, variant);
+	if (exactMatch) {
+		return exactMatch;
+	}
+
+	return resolveStableGeneralGpt5Variant(variant);
+}
+
 function lookupMappedModel(modelId: string): string | undefined {
 	if (Object.hasOwn(MODEL_MAP, modelId)) {
 		return MODEL_MAP[modelId];
@@ -273,104 +428,14 @@ export function resolveNormalizedModel(model: string | undefined): string {
 		return mappedModel;
 	}
 
-	const normalized = modelId.toLowerCase();
+	const codexCatalogModel = resolveCodexCatalogModel(modelId);
+	if (codexCatalogModel) {
+		return codexCatalogModel;
+	}
 
-	if (
-		normalized.includes("gpt-5.3-codex-spark") ||
-		normalized.includes("gpt 5.3 codex spark")
-	) {
-		return "gpt-5-codex";
-	}
-	if (
-		normalized.includes("gpt-5.3-codex") ||
-		normalized.includes("gpt 5.3 codex")
-	) {
-		return "gpt-5-codex";
-	}
-	if (
-		normalized.includes("gpt-5.2-codex") ||
-		normalized.includes("gpt 5.2 codex")
-	) {
-		return "gpt-5-codex";
-	}
-	if (
-		normalized.includes("gpt-5.1-codex-max") ||
-		normalized.includes("gpt 5.1 codex max")
-	) {
-		return "gpt-5.1-codex-max";
-	}
-	if (
-		normalized.includes("gpt-5.1-codex-mini") ||
-		normalized.includes("gpt 5.1 codex mini") ||
-		normalized.includes("codex-mini-latest") ||
-		normalized.includes("gpt-5-codex-mini") ||
-		normalized.includes("gpt 5 codex mini")
-	) {
-		return "gpt-5.1-codex-mini";
-	}
-	if (
-		normalized.includes("gpt-5-codex") ||
-		normalized.includes("gpt 5 codex") ||
-		normalized.includes("gpt-5.1-codex") ||
-		normalized.includes("gpt 5.1 codex") ||
-		normalized.includes("codex")
-	) {
-		return "gpt-5-codex";
-	}
-	if (
-		normalized.includes("gpt-5.4-pro") ||
-		normalized.includes("gpt 5.4 pro")
-	) {
-		return "gpt-5.4-pro";
-	}
-	if (
-		normalized.includes("gpt-5.2-pro") ||
-		normalized.includes("gpt 5.2 pro")
-	) {
-		return "gpt-5.2-pro";
-	}
-	if (
-		normalized.includes("gpt-5-pro") ||
-		normalized.includes("gpt 5 pro")
-	) {
-		return "gpt-5-pro";
-	}
-	if (
-		normalized.includes("gpt-5.4-mini") ||
-		normalized.includes("gpt 5.4 mini") ||
-		normalized.includes("gpt-5-mini") ||
-		normalized.includes("gpt 5 mini")
-	) {
-		return "gpt-5-mini";
-	}
-	if (
-		normalized.includes("gpt-5.4-nano") ||
-		normalized.includes("gpt 5.4 nano") ||
-		normalized.includes("gpt-5-nano") ||
-		normalized.includes("gpt 5 nano")
-	) {
-		return "gpt-5-nano";
-	}
-	if (
-		normalized.includes("gpt-5.4") ||
-		normalized.includes("gpt 5.4")
-	) {
-		return "gpt-5.4";
-	}
-	if (
-		normalized.includes("gpt-5.2") ||
-		normalized.includes("gpt 5.2")
-	) {
-		return "gpt-5.2";
-	}
-	if (
-		normalized.includes("gpt-5.1") ||
-		normalized.includes("gpt 5.1")
-	) {
-		return "gpt-5.1";
-	}
-	if (normalized === "gpt-5" || normalized.includes("gpt-5") || normalized.includes("gpt 5")) {
-		return "gpt-5.4";
+	const generalGpt5CatalogModel = resolveGeneralGpt5CatalogModel(modelId);
+	if (generalGpt5CatalogModel) {
+		return generalGpt5CatalogModel;
 	}
 
 	return DEFAULT_MODEL;

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -201,7 +201,8 @@ function hasCliAuthCredentialsStoreOverride(args) {
 }
 
 // IMPORTANT: Keep this mapping in sync with
-// `lib/request/helpers/model-map.ts` `MODEL_PROFILES`.
+// `lib/request/helpers/model-map.ts` `MODEL_PROFILES`
+// and its GPT-5 normalization helpers.
 // This wrapper runs before the TypeScript build, so it cannot import that source.
 const SUPPORTED_REASONING_EFFORTS_BY_MODEL = {
 	"gpt-5-codex": ["low", "medium", "high", "xhigh"],
@@ -229,6 +230,29 @@ const REASONING_FALLBACKS = {
 
 const KNOWN_REASONING_EFFORTS = new Set(Object.keys(REASONING_FALLBACKS));
 const REQUESTED_MODEL_ALIASES = new Map();
+const DEFAULT_GENERAL_GPT5_MODEL = "gpt-5.4";
+const GENERAL_GPT5_VERSION_CATALOG = {
+	1: {
+		base: "gpt-5.1",
+	},
+	2: {
+		base: "gpt-5.2",
+		pro: "gpt-5.2-pro",
+	},
+	4: {
+		base: DEFAULT_GENERAL_GPT5_MODEL,
+		pro: "gpt-5.4-pro",
+		mini: "gpt-5-mini",
+		nano: "gpt-5-nano",
+	},
+};
+const GENERAL_GPT5_STABLE_VARIANTS = GENERAL_GPT5_VERSION_CATALOG[4];
+const GENERAL_GPT5_GENERIC_VARIANTS = {
+	base: DEFAULT_GENERAL_GPT5_MODEL,
+	pro: "gpt-5-pro",
+	mini: "gpt-5-mini",
+	nano: "gpt-5-nano",
+};
 
 function addRequestedModelAlias(alias, normalizedModel) {
 	REQUESTED_MODEL_ALIASES.set(alias, normalizedModel);
@@ -350,15 +374,36 @@ function stripProviderPrefix(model) {
 		: model;
 }
 
-function normalizeRequestedModel(model) {
-	const stripped = stripProviderPrefix(model ?? "");
-	const normalized = stripped.trim().toLowerCase();
-	if (normalized.length === 0) return "";
-	const exactMatch = REQUESTED_MODEL_ALIASES.get(normalized);
-	if (exactMatch) {
-		return exactMatch;
-	}
+function tokenizeRequestedModel(model) {
+	return String(model ?? "")
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean);
+}
 
+function getGeneralGpt5CatalogForMinor(minor) {
+	switch (minor) {
+		case 1:
+		case 2:
+		case 4:
+			return GENERAL_GPT5_VERSION_CATALOG[minor];
+		default:
+			return undefined;
+	}
+}
+
+function resolveGeneralGpt5CatalogVariant(catalog, variant) {
+	return catalog?.[variant] ?? catalog?.base;
+}
+
+function resolveStableGeneralGpt5Variant(variant) {
+	return (
+		GENERAL_GPT5_STABLE_VARIANTS[variant] ??
+		GENERAL_GPT5_STABLE_VARIANTS.base
+	);
+}
+
+function resolveCodexRequestedModel(normalized) {
 	if (
 		normalized.includes("gpt-5.1-codex-max") ||
 		normalized.includes("gpt 5.1 codex max") ||
@@ -390,51 +435,63 @@ function normalizeRequestedModel(model) {
 	) {
 		return "gpt-5-codex";
 	}
-	if (normalized.includes("gpt-5.4-pro") || normalized.includes("gpt 5.4 pro")) {
-		return "gpt-5.4-pro";
+
+	return "";
+}
+
+function resolveGeneralGpt5RequestedModel(stripped) {
+	const tokens = tokenizeRequestedModel(stripped);
+	const gptIndex = tokens.indexOf("gpt");
+	const isGpt5 = gptIndex !== -1 && tokens[gptIndex + 1] === "5";
+	if (!isGpt5 || tokens.includes("codex")) {
+		return "";
 	}
-	if (normalized.includes("gpt-5.2-pro") || normalized.includes("gpt 5.2 pro")) {
-		return "gpt-5.2-pro";
+
+	const rawMinor = tokens[gptIndex + 2];
+	const minor =
+		typeof rawMinor === "string" && /^\d+$/.test(rawMinor)
+			? Number(rawMinor)
+			: undefined;
+	const variant = tokens.includes("mini")
+		? "mini"
+		: tokens.includes("nano")
+			? "nano"
+			: tokens.includes("pro")
+				? "pro"
+				: "base";
+
+	if (minor === undefined) {
+		return GENERAL_GPT5_GENERIC_VARIANTS[variant];
 	}
-	if (normalized.includes("gpt-5-pro") || normalized.includes("gpt 5 pro")) {
-		return "gpt-5-pro";
+
+	const exactCatalog = getGeneralGpt5CatalogForMinor(minor);
+	const exactMatch = resolveGeneralGpt5CatalogVariant(exactCatalog, variant);
+	if (exactMatch) {
+		return exactMatch;
 	}
-	if (
-		normalized.includes("gpt-5.4-mini") ||
-		normalized.includes("gpt 5.4 mini") ||
-		normalized.includes("gpt-5-mini") ||
-		normalized.includes("gpt 5 mini")
-	) {
-		return "gpt-5-mini";
+
+	return resolveStableGeneralGpt5Variant(variant);
+}
+
+function normalizeRequestedModel(model) {
+	const stripped = stripProviderPrefix(model ?? "");
+	const normalized = stripped.trim().toLowerCase();
+	if (normalized.length === 0) return "";
+	const exactMatch = REQUESTED_MODEL_ALIASES.get(normalized);
+	if (exactMatch) {
+		return exactMatch;
 	}
-	if (
-		normalized.includes("gpt-5.4-nano") ||
-		normalized.includes("gpt 5.4 nano") ||
-		normalized.includes("gpt-5-nano") ||
-		normalized.includes("gpt 5 nano")
-	) {
-		return "gpt-5-nano";
+
+	const codexModel = resolveCodexRequestedModel(normalized);
+	if (codexModel) {
+		return codexModel;
 	}
-	if (normalized.includes("gpt-5.4") || normalized.includes("gpt 5.4")) {
-		return "gpt-5.4";
+
+	const generalModel = resolveGeneralGpt5RequestedModel(stripped);
+	if (generalModel) {
+		return generalModel;
 	}
-	if (normalized.includes("gpt-5.2") || normalized.includes("gpt 5.2")) {
-		return "gpt-5.2";
-	}
-	if (
-		normalized.includes("gpt-5.1-chat-latest") ||
-		normalized.includes("gpt-5.1") ||
-		normalized.includes("gpt 5.1")
-	) {
-		return "gpt-5.1";
-	}
-	if (
-		normalized === "gpt-5-chat-latest" ||
-		normalized === "gpt-5" ||
-		normalized.includes("gpt 5")
-	) {
-		return "gpt-5";
-	}
+
 	return "";
 }
 

--- a/test/capability-policy.test.ts
+++ b/test/capability-policy.test.ts
@@ -44,6 +44,17 @@ describe("capability policy store", () => {
 		const boostFromCanonical = store.getBoost("id:acc_alias", "gpt-5-codex", 1_500);
 		expect(boostFromCanonical).toBeGreaterThan(0);
 	});
+
+	it("shares capability buckets with the stable general fallback for unknown future GPT-5.x aliases", () => {
+		const store = new CapabilityPolicyStore();
+		store.recordUnsupported("id:acc_future", "gpt-5.5-pro", 1_000);
+
+		expect(store.getSnapshot("id:acc_future", "gpt-5.4-pro")).toMatchObject({
+			failures: 1,
+			unsupported: 1,
+		});
+	});
+
 	it("returns zero boost/null snapshot for missing or invalid keys", () => {
 		const store = new CapabilityPolicyStore();
 		expect(store.getBoost("", "gpt-5-codex")).toBe(0);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1122,6 +1122,57 @@ describe("codex bin wrapper", () => {
 		}
 	});
 
+	it("coerces future GPT-5.x aliases using the stable general catalog", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createFakeCodexBin(fixtureRoot);
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "auth.json"), "{}\n", "utf8");
+		writeFileSync(join(originalHome, "config.toml"), "", "utf8");
+
+		const baseResult = runWrapper(
+			fixtureRoot,
+			[
+				"exec",
+				"status",
+				"--model",
+				"gpt-5.5-high",
+				"-c",
+				'model_reasoning_effort="minimal"',
+			],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+			},
+		);
+
+		expect(baseResult.status).toBe(0);
+		expect(baseResult.stdout).toContain(
+			'FORWARDED:exec status --model gpt-5.5-high -c model_reasoning_effort="low" -c cli_auth_credentials_store="file"',
+		);
+
+		const proResult = runWrapper(
+			fixtureRoot,
+			[
+				"exec",
+				"status",
+				"--model",
+				"gpt-5.5-pro",
+				"-c",
+				'model_reasoning_effort="low"',
+			],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+			},
+		);
+
+		expect(proResult.status).toBe(0);
+		expect(proResult.stdout).toContain(
+			'FORWARDED:exec status --model gpt-5.5-pro -c model_reasoning_effort="medium" -c cli_auth_credentials_store="file"',
+		);
+	});
+
 	it("preserves explicit xhigh overrides for models that support them", () => {
 		const fixtureRoot = createWrapperFixture();
 		const fakeBin = createFakeCodexBin(fixtureRoot);

--- a/test/model-map.test.ts
+++ b/test/model-map.test.ts
@@ -51,6 +51,7 @@ describe("model map", () => {
 		it("returns undefined for unknown exact identifiers", () => {
 			expect(getNormalizedModel("unknown-model")).toBeUndefined();
 			expect(getNormalizedModel("gpt-6")).toBeUndefined();
+			expect(getNormalizedModel("gpt-5.5")).toBeUndefined();
 			expect(getNormalizedModel("")).toBeUndefined();
 		});
 	});
@@ -66,6 +67,14 @@ describe("model map", () => {
 		it("defaults unknown GPT-5-ish requests to GPT-5.4 instead of GPT-5.1", () => {
 			expect(resolveNormalizedModel("gpt-5-unknown-preview")).toBe("gpt-5.4");
 			expect(resolveNormalizedModel("gpt 5 experimental build")).toBe("gpt-5.4");
+		});
+
+		it("routes unknown future GPT-5.x variants through the stable general catalog", () => {
+			expect(resolveNormalizedModel("gpt-5.5")).toBe("gpt-5.4");
+			expect(resolveNormalizedModel("gpt-5.5-high")).toBe("gpt-5.4");
+			expect(resolveNormalizedModel("openai/gpt-5.5-pro-high")).toBe(
+				"gpt-5.4-pro",
+			);
 		});
 
 		it("uses the current default model when the request is missing or unrelated", () => {
@@ -108,6 +117,11 @@ describe("model map", () => {
 				computerUse: false,
 				compaction: true,
 			});
+			expect(getModelCapabilities("gpt-5.5-pro")).toEqual({
+				toolSearch: false,
+				computerUse: true,
+				compaction: true,
+			});
 		});
 	});
 
@@ -120,6 +134,7 @@ describe("model map", () => {
 
 		it("returns false for unknown names even though fallback routing exists", () => {
 			expect(isKnownModel("gpt-5-unknown-preview")).toBe(false);
+			expect(isKnownModel("gpt-5.5-pro")).toBe(false);
 			expect(isKnownModel("claude-3")).toBe(false);
 			expect(isKnownModel("")).toBe(false);
 		});

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -52,6 +52,12 @@ describe('Request Transformer Module', () => {
 			expect(normalizeModel('')).toBe('gpt-5.4');
 		});
 
+		it('routes unknown future GPT-5.x variants through the stable general catalog', async () => {
+			expect(normalizeModel('gpt-5.5')).toBe('gpt-5.4');
+			expect(normalizeModel('gpt-5.5-high')).toBe('gpt-5.4');
+			expect(normalizeModel('gpt-5.5-pro')).toBe('gpt-5.4-pro');
+		});
+
 		it('still prioritizes codex detection when model names contain both codex and GPT-5', async () => {
 			expect(normalizeModel('gpt-5-codex-low')).toBe('gpt-5-codex');
 			expect(normalizeModel('my-gpt-5-codex-model')).toBe('gpt-5-codex');
@@ -1632,6 +1638,21 @@ describe('Request Transformer Module', () => {
 			expect(result.reasoning?.effort).toBe('high');
 		});
 
+		it('should use the stable GPT-5.4 reasoning defaults for unknown future general GPT-5.x names', async () => {
+			const body: RequestBody = {
+				model: 'gpt-5.5-high',
+				input: [],
+			};
+			const userConfig: UserConfig = {
+				global: { reasoningEffort: 'minimal' },
+				models: {},
+			};
+			const result = await transformRequestBody(body, codexInstructions, userConfig);
+			expect(result.model).toBe('gpt-5.4');
+			expect(result.reasoning?.effort).toBe('low');
+			expect(result.text?.verbosity).toBe('medium');
+		});
+
 		it('should preserve none for GPT-5.2', async () => {
 			const body: RequestBody = {
 				model: 'gpt-5.2-none',
@@ -2106,6 +2127,43 @@ describe('Request Transformer Module', () => {
 						server_label: 'docs',
 						server_url: 'https://mcp.example.com',
 						defer_loading: true,
+					},
+				]);
+			});
+
+			it('uses the stable pro capability surface for unknown future GPT-5.x pro names', async () => {
+				const body: RequestBody = {
+					model: 'gpt-5.5-pro',
+					input: [],
+					tools: [
+						{ type: 'tool_search', max_num_results: 3 },
+						{
+							type: 'computer_use_preview',
+							display_width: 1024,
+							display_height: 768,
+							environment: 'browser',
+						},
+					] as any,
+				};
+				const userConfig: UserConfig = {
+					global: { reasoningEffort: 'low' },
+					models: {},
+				};
+
+				const result = await transformRequestBody(
+					body,
+					codexInstructions,
+					userConfig,
+				);
+				expect(result.model).toBe('gpt-5.4-pro');
+				expect(result.reasoning?.effort).toBe('medium');
+				expect(result.text?.verbosity).toBe('medium');
+				expect(result.tools).toEqual([
+					{
+						type: 'computer_use_preview',
+						display_width: 1024,
+						display_height: 768,
+						environment: 'browser',
 					},
 				]);
 			});


### PR DESCRIPTION
## Summary

- This is a prep-only PR that reduces launch-day GPT-5.5 activation to a narrow follow-up patch.
- It does not expose public GPT-5.5 support yet.
- Unknown future general GPT-5.x names now normalize through the current stable GPT-5.4 catalog path instead of drifting across older routing surfaces.

## What Changed

- centralized general GPT-5.x fallback handling in `lib/request/helpers/model-map.ts`, kept codex-family routing separate, and aligned `lib/capability-policy.ts` plus the pre-build `scripts/codex.js` wrapper with the same stable fallback rules
- added regression coverage for model normalization, request-transformer reasoning/tool handling, capability buckets, and wrapper reasoning coercion for future GPT-5.x aliases
- added `docs/development/RUNBOOK_ENABLE_GPT_5_5_ON_CONFIRMATION.md` and linked it from maintainer docs so launch-day activation has an explicit proof checklist before any public docs or config examples change

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low. The remaining risk is a mismatch between these prep assumptions and OpenAI's eventual official GPT-5.5 contract.
- Rollback plan: cleanly revert the three prep commits on this branch.

## Additional Notes

- Focused validation passed: `test/model-map.test.ts`, `test/request-transformer.test.ts`, `test/capability-policy.test.ts`, and `test/documentation.test.ts`.
- Direct wrapper smoke passed against the real repo launcher: `gpt-5.5-high` coerced `model_reasoning_effort="minimal"` to `low`, and `gpt-5.5-pro` coerced `model_reasoning_effort="low"` to `medium`.
- `npm test` still fails on this host for unrelated existing issues outside this diff, including the `test/codex-bin-wrapper.test.ts` fixture harness under the current Node runtime, storage-path expectations that assume `.codex` in the host path, `test/benchmark-runtime-path-script.test.ts`, and `test/server.unit.test.ts` registering zero tests.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

prep-only pr that centralizes GPT-5.x fallback routing into a tokenizer + version catalog in `model-map.ts`, mirrors the same logic in the pre-build JS wrapper, gates capability-policy bucket sharing on the same stable catalog, and ships a launch-day runbook. no public GPT-5.5 surface is exposed yet — all remaining findings are P2.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are P2 style/hardening nits; no correctness or data-integrity issues introduced.

the routing refactor is well-structured, both TS and JS implementations are aligned on catalog semantics, tests cover the key normalization and coercion paths, and the runbook adds a clear activation gate. only P2 findings remain: the JS fallback function missing a throw guard, the codex-bin-wrapper test being unexercised in CI, and a cosmetic double-strip nit in capability-policy.

scripts/codex.js (`resolveStableGeneralGpt5Variant` error handling) and test/codex-bin-wrapper.test.ts (new test can't run in CI)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/helpers/model-map.ts | Core routing refactor: replaces flat if/else GPT-5.x chain with a tokenizer + version catalog; codex and general-purpose paths are cleanly separated; `resolveStableGeneralGpt5Variant` throws on missing fallback. |
| scripts/codex.js | JS wrapper synced to TS catalog logic; `resolveStableGeneralGpt5Variant` silently returns `undefined` instead of throwing where TS throws — minor safety-net gap flagged. |
| lib/capability-policy.ts | Adds GPT-5/codex regex gate before calling `resolveNormalizedModel`; unknown GPT-5.x aliases now share capability buckets with their stable fallback; minor double-strip cosmetic nit. |
| test/model-map.test.ts | Adds regression coverage for `gpt-5.5` normalization, stable catalog routing, capability surface for `gpt-5.5-pro`, and `isKnownModel` false-positive guard. |
| test/request-transformer.test.ts | Adds GPT-5.5 routing, reasoning coercion, and tool sanitization tests against the stable GPT-5.4 surface; assertions look correct. |
| test/capability-policy.test.ts | Adds bucket-sharing test for unknown future GPT-5.x aliases; correctly asserts failures and unsupported counts share the stable fallback key. |
| test/codex-bin-wrapper.test.ts | New wrapper test for GPT-5.5 catalog fallback lives in the known-failing fixture harness; cannot run in CI on this host — smoke was manual only. |
| docs/development/RUNBOOK_ENABLE_GPT_5_5_ON_CONFIRMATION.md | New launch-day runbook with activation file list, safe workflow, validation commands, and review checklist; well-structured. |
| docs/DOCUMENTATION.md | Single row added linking the GPT-5.5 runbook; table entry is consistent with the existing format. |
| docs/README.md | Single row added to the runbook index linking the GPT-5.5 activation playbook; no other changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[incoming model string] --> B[stripProviderPrefix]
    B --> C{lookupMappedModel\nexact alias?}
    C -- yes --> Z[return mapped alias]
    C -- no --> D{resolveCodexCatalogModel\ncontains codex token?}
    D -- yes --> E[return codex canonical\ne.g. gpt-5-codex]
    D -- no --> F{resolveGeneralGpt5CatalogModel\ntokenize → isGpt5?}
    F -- no --> G[return DEFAULT_MODEL gpt-5.4]
    F -- yes --> H{known minor\n1 / 2 / 4?}
    H -- yes --> I[resolveGeneralGpt5CatalogVariant\nfrom version catalog]
    H -- no future e.g. 5 --> J[resolveStableGeneralGpt5Variant\nfrom STABLE_VARIANTS = catalog 4]
    I --> K{variant entry\nexists?}
    K -- yes --> Z
    K -- no/partial --> J
    J --> Z
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22prep%2Fgpt-5-5-release-readiness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22prep%2Fgpt-5-5-release-readiness%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fcodex.js%3A399-403%0A**Silent%20%60undefined%60%20return%20diverges%20from%20TS%20error%20throw**%0A%0A%60resolveStableGeneralGpt5Variant%60%20in%20the%20JS%20wrapper%20returns%20%60undefined%60%20when%20both%20%60GENERAL_GPT5_STABLE_VARIANTS%5Bvariant%5D%60%20and%20%60GENERAL_GPT5_STABLE_VARIANTS.base%60%20are%20nullish%2C%20whereas%20the%20TS%20counterpart%20throws%20an%20explicit%20%60Error%60.%20In%20the%20JS%20path%20that%20%60undefined%60%20propagates%20back%20through%20%60resolveGeneralGpt5RequestedModel%60%20as%20a%20falsy%20return%20and%20gets%20silently%20swallowed%20%E2%80%94%20the%20reasoning-effort%20coercion%20then%20falls%20back%20to%20the%20no-op%20path%20%28%60supportedEfforts%20%3D%3D%3D%20null%60%29%20and%20accepts%20whatever%20effort%20the%20user%20passed%20in%20unchecked.%20Because%20%60GENERAL_GPT5_STABLE_VARIANTS.base%60%20is%20hardcoded%20to%20%60%22gpt-5.4%22%60%20today%20this%20can't%20fire%2C%20but%20the%20safety%20net%20that%20the%20sync%20comment%20promises%20is%20missing%20in%20the%20JS%20copy.%0A%0A%60%60%60suggestion%0Afunction%20resolveStableGeneralGpt5Variant%28variant%29%20%7B%0A%09const%20fallback%20%3D%0A%09%09GENERAL_GPT5_STABLE_VARIANTS%5Bvariant%5D%20%3F%3F%0A%09%09GENERAL_GPT5_STABLE_VARIANTS.base%3B%0A%09if%20%28!fallback%29%20%7B%0A%09%09throw%20new%20Error%28%60Stable%20GPT-5%20fallback%20is%20missing%20for%20variant%20%24%7Bvariant%7D%60%29%3B%0A%09%7D%0A%09return%20fallback%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fcodex-bin-wrapper.test.ts%3A1122-1178%0A**New%20wrapper%20test%20is%20in%20the%20known-failing%20fixture%20harness**%0A%0AThe%20PR%20description%20confirms%20%60test%2Fcodex-bin-wrapper.test.ts%60%20cannot%20run%20on%20this%20host%20due%20to%20the%20fixture%20harness%20issue.%20the%20new%20%60coerces%20future%20GPT-5.x%20aliases%20using%20the%20stable%20general%20catalog%60%20case%20is%20therefore%20not%20exercised%20by%20the%20CI%20that%20passed.%20the%20smoke%20results%20mentioned%20in%20the%20PR%20description%20%28%60gpt-5.5-high%60%20coerced%20to%20%60low%60%2C%20%60gpt-5.5-pro%60%20coerced%20to%20%60medium%60%29%20were%20manual%20runs%2C%20not%20vitest%20coverage.%20consider%20adding%20an%20equivalent%20test%20directly%20on%20%60normalizeRequestedModel%60%2F%60coerceReasoningEffortForModel%60%20unit-level%20functions%20in%20a%20test%20file%20that%20does%20run%2C%20so%20the%20catalog%20fallback%20regression%20is%20actually%20locked%20in%20CI.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fcapability-policy.ts%3A39-45%0A**Double%20provider-prefix%20strip%20for%20GPT-5%2Fcodex%20models**%0A%0A%60withoutProvider%60%20has%20already%20had%20the%20provider%20prefix%20removed%20%28line%2037%29.%20for%20models%20that%20hit%20the%20%60shouldUseFallbackCatalog%60%20path%2C%20%60resolveNormalizedModel%28withoutProvider%29%60%20then%20calls%20%60stripProviderPrefix%60%20a%20second%20time%20internally%20%E2%80%94%20harmless%20because%20there's%20no%20%60%2F%60%20left%2C%20but%20it%20adds%20noise.%20if%20you%20ever%20pass%20a%20model%20with%20a%20second-level%20prefix%20%28e.g.%20%60%22org%2Fopenai%2Fgpt-5.5%22%60%29%20this%20path%20silently%20uses%20the%20wrong%20segment.%20passing%20%60withoutProvider%60%20already%20stripped%20is%20fine%3B%20the%20nit%20is%20just%20that%20the%20contract%20is%20slightly%20misleading%20%E2%80%94%20a%20brief%20comment%20noting%20the%20value%20is%20already%20stripped%20would%20keep%20the%20%60normalizeModel%60%20logic%20readable%20at%20a%20glance.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/codex.js
Line: 399-403

Comment:
**Silent `undefined` return diverges from TS error throw**

`resolveStableGeneralGpt5Variant` in the JS wrapper returns `undefined` when both `GENERAL_GPT5_STABLE_VARIANTS[variant]` and `GENERAL_GPT5_STABLE_VARIANTS.base` are nullish, whereas the TS counterpart throws an explicit `Error`. In the JS path that `undefined` propagates back through `resolveGeneralGpt5RequestedModel` as a falsy return and gets silently swallowed — the reasoning-effort coercion then falls back to the no-op path (`supportedEfforts === null`) and accepts whatever effort the user passed in unchecked. Because `GENERAL_GPT5_STABLE_VARIANTS.base` is hardcoded to `"gpt-5.4"` today this can't fire, but the safety net that the sync comment promises is missing in the JS copy.

```suggestion
function resolveStableGeneralGpt5Variant(variant) {
	const fallback =
		GENERAL_GPT5_STABLE_VARIANTS[variant] ??
		GENERAL_GPT5_STABLE_VARIANTS.base;
	if (!fallback) {
		throw new Error(`Stable GPT-5 fallback is missing for variant ${variant}`);
	}
	return fallback;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-bin-wrapper.test.ts
Line: 1122-1178

Comment:
**New wrapper test is in the known-failing fixture harness**

The PR description confirms `test/codex-bin-wrapper.test.ts` cannot run on this host due to the fixture harness issue. the new `coerces future GPT-5.x aliases using the stable general catalog` case is therefore not exercised by the CI that passed. the smoke results mentioned in the PR description (`gpt-5.5-high` coerced to `low`, `gpt-5.5-pro` coerced to `medium`) were manual runs, not vitest coverage. consider adding an equivalent test directly on `normalizeRequestedModel`/`coerceReasoningEffortForModel` unit-level functions in a test file that does run, so the catalog fallback regression is actually locked in CI.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/capability-policy.ts
Line: 39-45

Comment:
**Double provider-prefix strip for GPT-5/codex models**

`withoutProvider` has already had the provider prefix removed (line 37). for models that hit the `shouldUseFallbackCatalog` path, `resolveNormalizedModel(withoutProvider)` then calls `stripProviderPrefix` a second time internally — harmless because there's no `/` left, but it adds noise. if you ever pass a model with a second-level prefix (e.g. `"org/openai/gpt-5.5"`) this path silently uses the wrong segment. passing `withoutProvider` already stripped is fine; the nit is just that the contract is slightly misleading — a brief comment noting the value is already stripped would keep the `normalizeModel` logic readable at a glance.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Document the proof required before adver..."](https://github.com/ndycode/codex-multi-auth/commit/598c7df210b68ebb905726dc8df39f9d5f524b50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29466122)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->