### PR TITLE
fix: preserve tty when forwarding codex

### DIFF
--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -253,11 +253,29 @@ function replaceRequestedModel(args, nextModel) {
 	return nextArgs;
 }
 
-function forwardToRealCodexOnce(codexBin, args, env = process.env, cleanup) {
+function shouldCaptureForwardedCodexOutput(env = process.env) {
+	const override = (env.CODEX_MULTI_AUTH_CAPTURE_FORWARD_OUTPUT ?? "").trim();
+	if (override === "1") {
+		return true;
+	}
+	if (override === "0") {
+		return false;
+	}
+	return process.stdout.isTTY !== true || process.stderr.isTTY !== true;
+}
+
+function forwardToRealCodexOnce(
+	codexBin,
+	args,
+	env = process.env,
+	cleanup,
+	options = {},
+) {
 	return new Promise((resolve) => {
 		let settled = false;
 		let stdout = "";
 		let stderr = "";
+		const captureOutput = options.captureOutput === true;
 		const finalize = (exitCode) => {
 			if (settled) {
 				return;
@@ -276,27 +294,38 @@ function forwardToRealCodexOnce(codexBin, args, env = process.env, cleanup) {
 
 		const command = codexBin.launchWithNode ? process.execPath : codexBin.path;
 		const commandArgs = codexBin.launchWithNode ? [codexBin.path, ...args] : args;
-		const child = spawn(command, commandArgs, {
-			stdio: ["inherit", "pipe", "pipe"],
-			env,
-		});
-
-		child.stdout?.on("data", (chunk) => {
-			const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-			stdout += text;
-			process.stdout.write(chunk);
-		});
-		child.stderr?.on("data", (chunk) => {
-			const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-			stderr += text;
-			process.stderr.write(chunk);
-		});
-
-		child.once("error", (error) => {
+		let child;
+		const failLaunch = (error) => {
 			const message = `Failed to launch real Codex CLI: ${String(error)}`;
 			stderr += `${stderr ? "\n" : ""}${message}`;
 			console.error(message);
 			finalize(1);
+		};
+		try {
+			child = spawn(command, commandArgs, {
+				stdio: captureOutput ? ["inherit", "pipe", "pipe"] : "inherit",
+				env,
+			});
+		} catch (error) {
+			failLaunch(error);
+			return;
+		}
+
+		if (captureOutput) {
+			child.stdout?.on("data", (chunk) => {
+				const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+				stdout += text;
+				process.stdout.write(chunk);
+			});
+			child.stderr?.on("data", (chunk) => {
+				const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+				stderr += text;
+				process.stderr.write(chunk);
+			});
+		}
+
+		child.once("error", (error) => {
+			failLaunch(error);
 		});
 
 		child.once("close", (code, signal) => {
@@ -333,6 +362,9 @@ async function forwardToRealCodex(codexBin, rawArgs, baseEnv = process.env) {
 			compatibility.args,
 			compatibility.env,
 			compatibility.cleanup,
+			{
+				captureOutput: shouldCaptureForwardedCodexOutput(compatibility.env),
+			},
 		);
 		lastExitCode = result.exitCode;
 		if (result.exitCode === 0) {

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -261,6 +261,7 @@ function shouldCaptureForwardedCodexOutput(env = process.env) {
 	if (override === "0") {
 		return false;
 	}
+	// Windows child processes can report undefined isTTY; treat that as non-TTY so retry capture remains available.
 	return process.stdout.isTTY !== true || process.stderr.isTTY !== true;
 }
 

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -289,6 +289,8 @@ function forwardToRealCodexOnce(
 			}
 			resolve({
 				exitCode,
+				// No-capture output stays empty by design so retry parsing cannot
+				// reintroduce pipes that break terminal passthrough.
 				output: `${stdout}\n${stderr}`.trim(),
 			});
 		};

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1231,6 +1231,35 @@ describe("codex bin wrapper", () => {
 		);
 	});
 
+	it("can forward without capturing child stdio for terminal-sensitive Codex runs", () => {
+		const fixtureRoot = createWrapperFixture();
+		const stateDir = join(fixtureRoot, "no-capture-state");
+		mkdirSync(stateDir, { recursive: true });
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"const fs = require('node:fs');",
+			"const path = require('node:path');",
+			"const counterPath = path.join(process.env.CODEX_MULTI_AUTH_TEST_STATE_DIR, 'attempt.txt');",
+			"const attempt = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, 'utf8')) : 0;",
+			"fs.writeFileSync(counterPath, String(attempt + 1), 'utf8');",
+			"console.error(\"The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.\");",
+			"process.exit(1);",
+		]);
+
+		const result = runWrapper(fixtureRoot, ["exec", "status", "--model", "gpt-5.5"], {
+			CODEX_MULTI_AUTH_CAPTURE_FORWARD_OUTPUT: "0",
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_MULTI_AUTH_TEST_STATE_DIR: stateDir,
+		});
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(1);
+		expect(readFileSync(join(stateDir, "attempt.txt"), "utf8")).toBe("1");
+		expect(output).toContain(
+			"The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
+		);
+		expect(output).not.toContain("Retrying with gpt-5.4");
+	});
+
 	it("retries GPT-5.5 after access-denied style model errors", () => {
 		const fixtureRoot = createWrapperFixture();
 		const stateDir = join(fixtureRoot, "retry-state-access");

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1231,10 +1231,54 @@ describe("codex bin wrapper", () => {
 		);
 	});
 
+	it("honors explicit capture output override for unsupported-model retries", () => {
+		const fixtureRoot = createWrapperFixture();
+		const stateDir = join(fixtureRoot, "retry-state-capture-override");
+		mkdirSync(stateDir, { recursive: true });
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"const fs = require('node:fs');",
+			"const path = require('node:path');",
+			"const counterPath = path.join(process.env.CODEX_MULTI_AUTH_TEST_STATE_DIR, 'attempt.txt');",
+			"const attempt = fs.existsSync(counterPath) ? Number(fs.readFileSync(counterPath, 'utf8')) : 0;",
+			"fs.writeFileSync(counterPath, String(attempt + 1), 'utf8');",
+			"const args = process.argv.slice(2);",
+			"const modelIndex = args.indexOf('--model');",
+			"const requestedModel = modelIndex >= 0 ? args[modelIndex + 1] : 'unknown-model';",
+			"if (attempt === 0) {",
+			`  console.error("ERROR: {\\\"type\\\":\\\"error\\\",\\\"status\\\":400,\\\"error\\\":{\\\"type\\\":\\\"invalid_request_error\\\",\\\"message\\\":\\\"The '" + requestedModel + "' model is not supported when using Codex with a ChatGPT account.\\\"}}");`,
+			"  process.exit(1);",
+			"}",
+			"console.log(`FORWARDED:${args.join(' ')}`);",
+			"process.exit(0);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "auth.json"), "{}\n", "utf8");
+		writeFileSync(join(originalHome, "config.toml"), "", "utf8");
+
+		const result = runWrapper(fixtureRoot, ["exec", "status", "--model", "gpt-5.5"], {
+			CODEX_MULTI_AUTH_CAPTURE_FORWARD_OUTPUT: "1",
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_MULTI_AUTH_TEST_STATE_DIR: stateDir,
+			CODEX_HOME: originalHome,
+		});
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(0);
+		expect(readFileSync(join(stateDir, "attempt.txt"), "utf8")).toBe("2");
+		expect(output).toContain("Retrying with gpt-5.4");
+		expect(output).toContain(
+			'FORWARDED:exec status --model gpt-5.4 -c cli_auth_credentials_store="file"',
+		);
+	});
+
 	it("can forward without capturing child stdio for terminal-sensitive Codex runs", () => {
 		const fixtureRoot = createWrapperFixture();
 		const stateDir = join(fixtureRoot, "no-capture-state");
 		mkdirSync(stateDir, { recursive: true });
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "config.toml"), "", "utf8");
 		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
 			"const fs = require('node:fs');",
 			"const path = require('node:path');",
@@ -1249,6 +1293,7 @@ describe("codex bin wrapper", () => {
 			CODEX_MULTI_AUTH_CAPTURE_FORWARD_OUTPUT: "0",
 			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
 			CODEX_MULTI_AUTH_TEST_STATE_DIR: stateDir,
+			CODEX_HOME: originalHome,
 		});
 
 		const output = combinedOutput(result);


### PR DESCRIPTION
## Summary
- Preserve inherited stdout/stderr for terminal-attached forwarded Codex runs.
- Keep output capture for non-TTY forwarded runs so unsupported-model fallback can still inspect errors.
- Add wrapper regression coverage for the no-capture path.

## Verification
- node --check scripts/codex.js
- npm install --ignore-scripts
- npx vitest run test/codex-bin-wrapper.test.ts (blocked: esbuild spawn EPERM in local Windows sandbox)

## Notes
- npm ci was also blocked locally by Windows spawn EPERM during lifecycle/rebuild cleanup.

Fixes #436

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes tty passthrough for forwarded codex runs by introducing `shouldCaptureForwardedCodexOutput`, which skips piping when both stdout and stderr are tty-attached, and falls back to capture mode for non-tty (ci/pipe) runs so unsupported-model retries can still inspect stderr. it also hardens `spawn()` with a try/catch to handle synchronous launch failures (e.g. windows EPERM) and adds two explicit-override integration tests.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are P2 style/coverage gaps with no runtime correctness risk

the logic is sound: tty detection uses `!== true` to safely handle windows `undefined` isTTY, the two explicit-override tests cover the primary regression scenarios, and the spawn try/catch is a net improvement. the only gaps are the untested tty auto-detect fallback branch and the minor `failLaunch`/no-capture stderr inconsistency, neither of which causes incorrect retries or data loss in practice

no files require blocking attention; `test/codex-bin-wrapper.test.ts` could add a test omitting the override to exercise the tty auto-detect path

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/codex.js | adds `shouldCaptureForwardedCodexOutput` to skip piping when stdin/stdout are TTY, and wraps `spawn()` in try/catch for synchronous-failure resilience; minor inconsistency where `failLaunch` still mutates `stderr` in no-capture mode |
| test/codex-bin-wrapper.test.ts | adds two integration tests for explicit capture-override paths; TTY auto-detect fallback branch in `shouldCaptureForwardedCodexOutput` remains untested |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[forwardToRealCodex] --> B[shouldCaptureForwardedCodexOutput]
    B --> C{CODEX_MULTI_AUTH_CAPTURE_FORWARD_OUTPUT}
    C -- "1" --> D[captureOutput = true]
    C -- "0" --> E[captureOutput = false]
    C -- unset --> F{stdout.isTTY === true AND stderr.isTTY === true}
    F -- yes --> E
    F -- no/undefined Windows safe --> D
    D --> G[spawn with stdio: inherit,pipe,pipe]
    E --> H[spawn with stdio: inherit]
    G --> I[buffer stdout+stderr, write to process streams]
    H --> J[child inherits parent TTY, no buffering]
    I --> K[result.output = buffered text]
    J --> L[result.output = empty string]
    K --> M{resolveUnsupportedModelRetryTarget}
    L --> N[retry skipped by design]
    M -- match --> O[retry with fallback model]
    M -- no match --> P[return exitCode]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fissue-436-tty-forwarding%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fissue-436-tty-forwarding%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fcodex.js%3A301-306%0A**%60failLaunch%60%20leaks%20into%20%60result.output%60%20even%20in%20no-capture%20mode**%0A%0Awhen%20%60captureOutput%60%20is%20%60false%60%20and%20%60spawn%28%29%60%20throws%20synchronously%20%28e.g.%20windows%20EPERM%20during%20rebuild%29%2C%20%60failLaunch%60%20still%20appends%20to%20%60stderr%60%20and%20%60finalize%60%20resolves%20with%20%60output%3A%20%5C%60%24%7Bstdout%7D%5Cn%24%7Bstderr%7D%5C%60.trim%28%29%60.%20this%20means%20%60resolveUnsupportedModelRetryTarget%60%20receives%20a%20non-empty%20%60result.output%60%20on%20a%20spawn%20error%20in%20the%20no-capture%20path%2C%20breaking%20the%20%22no-capture%20output%20stays%20empty%20by%20design%22%20invariant.%20in%20practice%2C%20the%20spawn-error%20message%20won't%20match%20any%20unsupported-model%20pattern%2C%20so%20no%20incorrect%20retry%20fires%20%E2%80%94%20but%20it's%20a%20silent%20contract%20hole%20worth%20closing%2C%20especially%20on%20windows%20where%20EPERM%20spawns%20are%20possible%20per%20the%20PR%20notes.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fcodex-bin-wrapper.test.ts%3A1262%0A**missing%20vitest%20coverage%20for%20TTY%20auto-detect%20path**%0A%0Aboth%20new%20tests%20set%20%60CODEX_MULTI_AUTH_CAPTURE_FORWARD_OUTPUT%60%20explicitly%20%28%60%221%22%60%20and%20%60%220%22%60%29%2C%20so%20the%20%60else%60%20branch%20in%20%60shouldCaptureForwardedCodexOutput%60%20%E2%80%94%20the%20%60process.stdout.isTTY%20!%3D%3D%20true%20%7C%7C%20process.stderr.isTTY%20!%3D%3D%20true%60%20fallback%20%E2%80%94%20has%20zero%20test%20coverage.%20a%20test%20that%20omits%20the%20override%20env%20var%20entirely%20and%20asserts%20%60captureOutput%60%20behaviour%20%28e.g.%20via%20the%20attempt%20counter%20or%20retry%20message%29%20would%20cover%20that%20path.%20the%20TTY%20auto-detect%20branch%20is%20the%20main%20new%20production%20behaviour%20in%20this%20PR.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/codex.js
Line: 301-306

Comment:
**`failLaunch` leaks into `result.output` even in no-capture mode**

when `captureOutput` is `false` and `spawn()` throws synchronously (e.g. windows EPERM during rebuild), `failLaunch` still appends to `stderr` and `finalize` resolves with `output: \`${stdout}\n${stderr}\`.trim()`. this means `resolveUnsupportedModelRetryTarget` receives a non-empty `result.output` on a spawn error in the no-capture path, breaking the "no-capture output stays empty by design" invariant. in practice, the spawn-error message won't match any unsupported-model pattern, so no incorrect retry fires — but it's a silent contract hole worth closing, especially on windows where EPERM spawns are possible per the PR notes.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-bin-wrapper.test.ts
Line: 1262

Comment:
**missing vitest coverage for TTY auto-detect path**

both new tests set `CODEX_MULTI_AUTH_CAPTURE_FORWARD_OUTPUT` explicitly (`"1"` and `"0"`), so the `else` branch in `shouldCaptureForwardedCodexOutput` — the `process.stdout.isTTY !== true || process.stderr.isTTY !== true` fallback — has zero test coverage. a test that omits the override env var entirely and asserts `captureOutput` behaviour (e.g. via the attempt counter or retry message) would cover that path. the TTY auto-detect branch is the main new production behaviour in this PR.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: clarify no-capture retry behavior"](https://github.com/ndycode/codex-multi-auth/commit/0545f58e8fdf571677fc41bcd5929c776e422f44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29560996)</sub>

<!-- /greptile_comment -->