### PR TITLE
Add device auth login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ codex auth forecast --live
 ```
 
 If browser launch is blocked, use the alternate login paths in [docs/getting-started.md](docs/getting-started.md#alternate-login-paths).
+For remote or headless shells, prefer `codex auth login --device-auth`.
 
 ---
 
@@ -305,7 +306,7 @@ codex auth login
 - Requests fail fast after repeated upstream 5xx errors: inspect `codex auth report --json` for runtime traffic and cooldown details
 - Storage cleanup fails with `EBUSY` / `EPERM` (Windows): run `codex auth doctor --fix` to retry, or manually remove `~/.codex/multi-auth/<project-key>/` and re-login
 - OAuth callback on port `1455` fails: free the port and re-run `codex auth login`
-- Browser launch is blocked or you are in a headless shell: re-run `codex auth login --manual` or set `CODEX_AUTH_NO_BROWSER=1`
+- Browser launch is blocked or you are in a headless shell: prefer `codex auth login --device-auth`; use `codex auth login --manual` or `CODEX_AUTH_NO_BROWSER=1` only when you need the callback-paste fallback
 - `missing field id_token` / `token_expired` / `refresh_token_reused`: re-login affected account
 
 </details>

--- a/docs/features.md
+++ b/docs/features.md
@@ -72,9 +72,9 @@ Runtime rotation is the current 2.x architecture addition. It is default-on and 
 | Account action hotkeys | Per-account set, refresh, toggle, and delete shortcuts |
 | In-dashboard settings hub | Runtime and display tuning without editing files directly |
 | Experimental settings hotkeys | Keyboard shortcuts for sync preview, backup export, and refresh-guard tuning |
-| Browser-first OAuth with manual fallback | `codex auth login` stays browser-first, while `--manual`, `--no-browser`, and `CODEX_AUTH_NO_BROWSER=1` keep login usable in browser-restricted shells |
+| Browser-first OAuth with device/manual fallback | `codex auth login` stays browser-first, while `--device-auth` is preferred for remote/headless shells and `--manual`, `--no-browser`, and `CODEX_AUTH_NO_BROWSER=1` remain callback-paste fallbacks |
 
-Manual/non-TTY login accepts the full callback URL on stdin, so automation and host-managed shells can complete auth without relying on a local browser handoff.
+Device auth prints `https://auth.openai.com/codex/device` plus a one-time code and does not rely on a local browser or callback server. Manual/non-TTY login accepts the full callback URL on stdin for environments where device auth is unavailable.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,7 +78,9 @@ For remote, SSH, container, or other headless shells, prefer the device-code flo
 codex auth login --device-auth
 ```
 
-Open `https://auth.openai.com/codex/device` in any browser, enter the printed code, and keep the terminal running until login completes. This path does not open a local browser and does not start the local OAuth callback server.
+Open `https://auth.openai.com/codex/device` in any browser, enter the printed code, and keep the terminal running until login completes. The code expires after 15 minutes; rerun `codex auth login --device-auth` if it times out. This path does not open a local browser and does not start the local OAuth callback server.
+
+`--device-auth` starts a new login directly. If you want to recover a saved backup first, run plain `codex auth login` so the onboarding restore menu can appear.
 
 ### Manual or no-browser login
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,9 +70,19 @@ codex auth forecast --live
 
 Use these only when the normal browser-first flow is unavailable.
 
+### Device auth login
+
+For remote, SSH, container, or other headless shells, prefer the device-code flow:
+
+```bash
+codex auth login --device-auth
+```
+
+Open `https://auth.openai.com/codex/device` in any browser, enter the printed code, and keep the terminal running until login completes. This path does not open a local browser and does not start the local OAuth callback server.
+
 ### Manual or no-browser login
 
-If browser launch is blocked or you want to handle the callback manually:
+If device auth is unavailable or you want to handle the callback manually:
 
 ```bash
 codex auth login --manual
@@ -173,7 +183,8 @@ If the OAuth callback on port `1455` fails:
 
 - stop the process using port `1455`
 - rerun `codex auth login`
-- if browser launch is unavailable, rerun `codex auth login --manual`
+- if browser launch is unavailable, prefer `codex auth login --device-auth`
+- if device auth is unavailable, rerun `codex auth login --manual`
 
 If account state looks stale:
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -66,6 +66,7 @@ Compatibility aliases are supported:
 
 | Flag | Applies to | Meaning |
 | --- | --- | --- |
+| `--device-auth` | login | Use the OpenAI Codex device-code flow for remote/headless login |
 | `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow |
 | `--json` | verify-flagged, verify, why-selected, best, forecast, report, fix, doctor, config explain, debug bundle | Print machine-readable output |
 | `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |
@@ -260,6 +261,7 @@ failure.
 ## Upgrade Notes
 
 - `codex auth login` remains browser-first by default.
+- `codex auth login --device-auth` uses OpenAI Codex device-code login. It prints `https://auth.openai.com/codex/device` and a one-time code, then polls for completion without opening a browser or starting the local callback server.
 - `codex auth login --manual` and `codex auth login --no-browser` force the manual callback flow instead of launching a browser.
 - `CODEX_AUTH_NO_BROWSER=1` suppresses browser launch for automation/headless sessions. False-like values such as `0` and `false` do not disable browser launch by themselves.
 - In non-TTY/manual shells, pass the full redirect URL on stdin, for example: `echo "http://127.0.0.1:1455/auth/callback?code=..." | codex auth login --manual`.
@@ -275,6 +277,7 @@ failure.
 - `codex-multi-auth --version` and `codex-multi-auth -v` report the installed wrapper package version.
 - In non-TTY or host-managed sessions, including `CODEX_TUI=1`, `CODEX_DESKTOP=1`, `TERM_PROGRAM=codex`, or `ELECTRON_RUN_AS_NODE=1`, auth flows degrade to deterministic text behavior.
 - The non-TTY fallback keeps `codex auth login` predictable: it defaults to add-account mode, skips the extra "add another account" prompt, and auto-picks the default workspace selection when a follow-up choice is needed.
+- `codex auth login --device-auth` is the preferred remote/headless login path because it needs only a browser on any device plus the printed one-time code.
 - `codex auth login --manual` keeps the login flow usable in browser-restricted shells by printing the OAuth URL and accepting manual callback input instead of trying to open a browser.
 - In non-TTY/manual shells, provide the full redirect URL on stdin, for example: `echo "http://127.0.0.1:1455/auth/callback?code=..." | codex auth login --manual`.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -66,8 +66,8 @@ Compatibility aliases are supported:
 
 | Flag | Applies to | Meaning |
 | --- | --- | --- |
-| `--device-auth` | login | Use the OpenAI Codex device-code flow for remote/headless login |
-| `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow |
+| `--device-auth` | login | Use the OpenAI Codex device-code flow for remote/headless login (mutually exclusive with `--manual` / `--no-browser`) |
+| `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow (mutually exclusive with `--device-auth`) |
 | `--json` | verify-flagged, verify, why-selected, best, forecast, report, fix, doctor, config explain, debug bundle | Print machine-readable output |
 | `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |
 | `--live` | best, forecast, report, fix | Use live probe before decisions/output |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,6 +50,7 @@ npm i -g codex-multi-auth
 | --- | --- | --- |
 | Browser opens unexpectedly | Normal browser-first OAuth flow | Complete the auth step and return to the terminal |
 | OAuth callback port `1455` is in use | Another local process owns the port | Stop the conflicting process and rerun `codex auth login` |
+| Browser or callback handoff is unavailable | Remote, SSH, container, or headless shell | Run `codex auth login --device-auth`; use `codex auth login --manual` only if device auth is unavailable |
 | `missing field id_token` | Stale or malformed auth payload | Re-login the affected account |
 | `refresh_token_reused` | The token pair rotated in another context | Re-login the affected account |
 | `token_expired` | The refresh token is no longer valid | Re-login the affected account |

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -116,6 +116,7 @@ codex auth forecast --live
 - `Recover saved accounts` appears only when at least one valid named backup exists.
 - No new CLI flags or npm scripts were added for this flow.
 - The backup root remains `~/.codex/multi-auth/backups` by default, or `%CODEX_MULTI_AUTH_DIR%\backups` when `CODEX_MULTI_AUTH_DIR` is set.
+- `codex auth login --device-auth` starts a new device-code login directly and does not open the restore menu. Use plain `codex auth login` first when you want to recover a saved backup.
 
 ---
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -53,7 +53,7 @@ codex auth forecast --live --model gpt-5.3-codex
 ## Login Flow Upgrade Notes
 
 - `codex auth login` remains the default browser-first path.
-- `codex auth login --device-auth` is the preferred remote/headless path. It prints `https://auth.openai.com/codex/device` and a one-time code, then completes without a local browser or callback server.
+- `codex auth login --device-auth` is the preferred remote/headless path. It prints a verification URL like `https://auth.openai.com/codex/device` and a one-time code, then completes without a local browser or callback server.
 - `codex auth login --manual` and `codex auth login --no-browser` force manual callback handling for browser-restricted shells.
 - `CODEX_AUTH_NO_BROWSER=1` suppresses browser launch for automation/headless sessions. False-like values such as `0` and `false` no longer force manual mode.
 - In non-TTY/manual shells, provide the full redirect URL on stdin, for example: `echo "http://127.0.0.1:1455/auth/callback?code=..." | codex auth login --manual`.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -53,6 +53,7 @@ codex auth forecast --live --model gpt-5.3-codex
 ## Login Flow Upgrade Notes
 
 - `codex auth login` remains the default browser-first path.
+- `codex auth login --device-auth` is the preferred remote/headless path. It prints `https://auth.openai.com/codex/device` and a one-time code, then completes without a local browser or callback server.
 - `codex auth login --manual` and `codex auth login --no-browser` force manual callback handling for browser-restricted shells.
 - `CODEX_AUTH_NO_BROWSER=1` suppresses browser launch for automation/headless sessions. False-like values such as `0` and `false` no longer force manual mode.
 - In non-TTY/manual shells, provide the full redirect URL on stdin, for example: `echo "http://127.0.0.1:1455/auth/callback?code=..." | codex auth login --manual`.

--- a/lib/auth/device-auth.ts
+++ b/lib/auth/device-auth.ts
@@ -11,6 +11,14 @@ export const DEVICE_AUTH_VERIFICATION_URL = `${DEVICE_AUTH_BASE_URL}/codex/devic
 export const DEVICE_AUTH_REDIRECT_URI = `${DEVICE_AUTH_BASE_URL}/deviceauth/callback`;
 export const DEVICE_AUTH_TIMEOUT_MS = 15 * 60 * 1000;
 export const DEVICE_AUTH_DEFAULT_INTERVAL_MS = 5_000;
+const DEVICE_AUTH_ABORTED_MESSAGE = "aborted";
+const DEVICE_AUTH_TRANSIENT_PENDING_STATUSES = new Set([
+	408,
+	429,
+	502,
+	503,
+	504,
+]);
 
 type FetchLike = typeof fetch;
 
@@ -38,8 +46,10 @@ export interface DeviceAuthFlowOptions {
 	fetchImpl?: FetchLike;
 	now?: () => number;
 	sleep?: (ms: number) => Promise<void>;
+	signal?: AbortSignal;
 	timeoutMs?: number;
 	log?: (message: string) => void;
+	random?: () => number;
 }
 
 function getFetch(options: DeviceAuthFlowOptions): FetchLike {
@@ -60,6 +70,10 @@ function getSleep(options: DeviceAuthFlowOptions): (ms: number) => Promise<void>
 	);
 }
 
+function getRandom(options: DeviceAuthFlowOptions): () => number {
+	return options.random ?? Math.random;
+}
+
 function failedResult(
 	reason: Extract<TokenResult, { type: "failed" }>["reason"],
 	message: string,
@@ -73,6 +87,63 @@ function failedResult(
 	};
 }
 
+function createAbortError(): Error {
+	const error = new Error(DEVICE_AUTH_ABORTED_MESSAGE);
+	error.name = "AbortError";
+	return error;
+}
+
+function isAbortError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error.name === "AbortError" || error.message === DEVICE_AUTH_ABORTED_MESSAGE)
+	);
+}
+
+function abortedResult(): Extract<TokenResult, { type: "failed" }> {
+	return failedResult("network_error", DEVICE_AUTH_ABORTED_MESSAGE);
+}
+
+function sleepWithAbort(
+	ms: number,
+	options: DeviceAuthFlowOptions,
+): Promise<void> {
+	const signal = options.signal;
+	if (!signal) {
+		return getSleep(options)(ms);
+	}
+	if (signal.aborted) {
+		return Promise.reject(createAbortError());
+	}
+
+	const customSleep = options.sleep;
+	if (customSleep) {
+		let removeAbortListener = () => {};
+		const abortPromise = new Promise<void>((_resolve, reject) => {
+			const onAbort = () => reject(createAbortError());
+			signal.addEventListener("abort", onAbort, { once: true });
+			removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+		});
+		return Promise.race([customSleep(ms), abortPromise]).finally(
+			removeAbortListener,
+		);
+	}
+
+	return new Promise<void>((resolve, reject) => {
+		const onAbort = () => {
+			clearTimeout(timeout);
+			cleanup();
+			reject(createAbortError());
+		};
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		const timeout = setTimeout(() => {
+			cleanup();
+			resolve();
+		}, ms);
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
 function formatWaitBudget(timeoutMs: number): string {
 	const totalSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
 	if (totalSeconds < 60) {
@@ -80,6 +151,58 @@ function formatWaitBudget(timeoutMs: number): string {
 	}
 	const totalMinutes = Math.ceil(totalSeconds / 60);
 	return `${totalMinutes} minute${totalMinutes === 1 ? "" : "s"}`;
+}
+
+function isPendingStatus(status: number): boolean {
+	return (
+		status === 403 ||
+		status === 404 ||
+		DEVICE_AUTH_TRANSIENT_PENDING_STATUSES.has(status)
+	);
+}
+
+function parseRetryAfterMs(value: string | null, nowMs: number): number | null {
+	if (!value) return null;
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+
+	const seconds = Number(trimmed);
+	if (Number.isFinite(seconds) && seconds >= 0) {
+		return Math.ceil(seconds * 1000);
+	}
+
+	const dateMs = Date.parse(trimmed);
+	if (Number.isFinite(dateMs)) {
+		return Math.max(0, dateMs - nowMs);
+	}
+	return null;
+}
+
+function applyLightJitter(
+	delayMs: number,
+	options: DeviceAuthFlowOptions,
+): number {
+	const jitterRatio = 1 + (getRandom(options)() - 0.5) * 0.2;
+	return Math.max(1_000, Math.round(delayMs * jitterRatio));
+}
+
+function resolvePollDelayMs(
+	response: Response,
+	deviceCode: DeviceAuthCode,
+	nowMs: number,
+	options: DeviceAuthFlowOptions,
+): number {
+	const retryAfterMs = parseRetryAfterMs(
+		response.headers.get("retry-after"),
+		nowMs,
+	);
+	if (retryAfterMs !== null) {
+		return Math.max(1_000, retryAfterMs);
+	}
+	if (response.status === 403 || response.status === 404) {
+		return deviceCode.intervalMs;
+	}
+	return applyLightJitter(deviceCode.intervalMs, options);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -161,12 +284,16 @@ async function readFailureText(response: Response): Promise<string> {
 export async function requestDeviceAuthorization(
 	options: DeviceAuthFlowOptions = {},
 ): Promise<DeviceAuthCodeResult> {
+	if (options.signal?.aborted) {
+		return abortedResult();
+	}
 	try {
 		const response = await getFetch(options)(
 			`${DEVICE_AUTH_API_BASE_URL}/deviceauth/usercode`,
 			{
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
+				signal: options.signal,
 				body: JSON.stringify({ client_id: CLIENT_ID }),
 			},
 		);
@@ -196,6 +323,9 @@ export async function requestDeviceAuthorization(
 		}
 		return { type: "success", deviceCode };
 	} catch (error) {
+		if (isAbortError(error) || options.signal?.aborted) {
+			return abortedResult();
+		}
 		return failedResult(
 			"network_error",
 			error instanceof Error ? error.message : String(error),
@@ -219,17 +349,20 @@ export async function pollDeviceAuthorization(
 	options: DeviceAuthFlowOptions = {},
 ): Promise<DeviceAuthCompletionResult> {
 	const now = getNow(options);
-	const sleep = getSleep(options);
 	const timeoutMs = options.timeoutMs ?? DEVICE_AUTH_TIMEOUT_MS;
 	const deadline = now() + timeoutMs;
 
 	try {
 		while (true) {
+			if (options.signal?.aborted) {
+				return abortedResult();
+			}
 			const response = await getFetch(options)(
 				`${DEVICE_AUTH_API_BASE_URL}/deviceauth/token`,
 				{
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
+					signal: options.signal,
 					body: JSON.stringify({
 						device_auth_id: deviceCode.deviceAuthId,
 						user_code: deviceCode.userCode,
@@ -249,15 +382,22 @@ export async function pollDeviceAuthorization(
 				return { type: "success", completion };
 			}
 
-			if (response.status === 403 || response.status === 404) {
-				const remainingMs = deadline - now();
+			if (isPendingStatus(response.status)) {
+				const nowMs = now();
+				const remainingMs = deadline - nowMs;
 				if (remainingMs <= 0) {
 					return failedResult(
-						"unknown",
+						"timeout",
 						`Device auth timed out after ${formatWaitBudget(timeoutMs)}`,
 					);
 				}
-				await sleep(Math.min(deviceCode.intervalMs, remainingMs));
+				const delayMs = resolvePollDelayMs(
+					response,
+					deviceCode,
+					nowMs,
+					options,
+				);
+				await sleepWithAbort(Math.min(delayMs, remainingMs), options);
 				continue;
 			}
 
@@ -269,6 +409,9 @@ export async function pollDeviceAuthorization(
 			);
 		}
 	} catch (error) {
+		if (isAbortError(error) || options.signal?.aborted) {
+			return abortedResult();
+		}
 		return failedResult(
 			"network_error",
 			error instanceof Error ? error.message : String(error),

--- a/lib/auth/device-auth.ts
+++ b/lib/auth/device-auth.ts
@@ -27,6 +27,7 @@ export interface DeviceAuthCode {
 	userCode: string;
 	deviceAuthId: string;
 	intervalMs: number;
+	expiresAtMs?: number;
 }
 
 export interface DeviceAuthCompletion {
@@ -60,12 +61,17 @@ function getNow(options: DeviceAuthFlowOptions): () => number {
 	return options.now ?? Date.now;
 }
 
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+	(timer as { unref?: () => void }).unref?.();
+}
+
 function getSleep(options: DeviceAuthFlowOptions): (ms: number) => Promise<void> {
 	return (
 		options.sleep ??
 		((ms: number) =>
 			new Promise<void>((resolve) => {
-				setTimeout(resolve, ms);
+				const timeout = setTimeout(resolve, ms);
+				unrefTimer(timeout);
 			}))
 	);
 }
@@ -94,10 +100,7 @@ function createAbortError(): Error {
 }
 
 function isAbortError(error: unknown): boolean {
-	return (
-		error instanceof Error &&
-		(error.name === "AbortError" || error.message === DEVICE_AUTH_ABORTED_MESSAGE)
-	);
+	return error instanceof Error && error.name === "AbortError";
 }
 
 function abortedResult(): Extract<TokenResult, { type: "failed" }> {
@@ -140,6 +143,7 @@ function sleepWithAbort(
 			cleanup();
 			resolve();
 		}, ms);
+		unrefTimer(timeout);
 		signal.addEventListener("abort", onAbort, { once: true });
 	});
 }
@@ -237,6 +241,24 @@ function parseIntervalMs(value: unknown): number {
 	return DEVICE_AUTH_DEFAULT_INTERVAL_MS;
 }
 
+function parseExpirationMs(value: unknown, nowMs: number): number | null {
+	if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+		return nowMs + Math.trunc(value * 1000);
+	}
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
+			const seconds = Number.parseFloat(trimmed);
+			return nowMs + Math.trunc(seconds * 1000);
+		}
+		const dateMs = Date.parse(trimmed);
+		if (Number.isFinite(dateMs)) {
+			return dateMs;
+		}
+	}
+	return null;
+}
+
 function parseNonEmptyString(value: unknown): string | null {
 	if (typeof value !== "string") {
 		return null;
@@ -245,7 +267,10 @@ function parseNonEmptyString(value: unknown): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
-function parseDeviceCodePayload(payload: Record<string, unknown>): DeviceAuthCode | null {
+function parseDeviceCodePayload(
+	payload: Record<string, unknown>,
+	nowMs: number,
+): DeviceAuthCode | null {
 	const deviceAuthId = parseNonEmptyString(payload.device_auth_id);
 	const userCode =
 		parseNonEmptyString(payload.user_code) ??
@@ -253,11 +278,15 @@ function parseDeviceCodePayload(payload: Record<string, unknown>): DeviceAuthCod
 	if (!deviceAuthId || !userCode) {
 		return null;
 	}
+	const expiresAtMs =
+		parseExpirationMs(payload.expires_at, nowMs) ??
+		parseExpirationMs(payload.expires_in, nowMs);
 	return {
 		verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
 		userCode,
 		deviceAuthId,
 		intervalMs: parseIntervalMs(payload.interval),
+		...(expiresAtMs === null ? {} : { expiresAtMs }),
 	};
 }
 
@@ -298,7 +327,6 @@ export async function requestDeviceAuthorization(
 			},
 		);
 		if (!response.ok) {
-			const safeText = await readFailureText(response);
 			if (response.status === 404) {
 				return failedResult(
 					"http_error",
@@ -306,6 +334,7 @@ export async function requestDeviceAuthorization(
 					response.status,
 				);
 			}
+			const safeText = await readFailureText(response);
 			return failedResult(
 				"http_error",
 				safeText || `Device code request failed with status ${response.status}`,
@@ -314,7 +343,9 @@ export async function requestDeviceAuthorization(
 		}
 
 		const payload = await readJsonRecord(response);
-		const deviceCode = payload ? parseDeviceCodePayload(payload) : null;
+		const deviceCode = payload
+			? parseDeviceCodePayload(payload, getNow(options)())
+			: null;
 		if (!deviceCode) {
 			return failedResult(
 				"invalid_response",
@@ -337,11 +368,18 @@ export function printDeviceAuthorizationPrompt(
 	deviceCode: DeviceAuthCode,
 	log: (message: string) => void = console.log,
 	timeoutMs = DEVICE_AUTH_TIMEOUT_MS,
+	nowMs = Date.now(),
 ): void {
+	const effectiveTimeoutMs =
+		deviceCode.expiresAtMs === undefined
+			? timeoutMs
+			: Math.min(timeoutMs, Math.max(0, deviceCode.expiresAtMs - nowMs));
 	log("Device auth login");
 	log(`Open: ${deviceCode.verificationUrl}`);
 	log(`Code: ${deviceCode.userCode}`);
-	log(`This code expires in ${formatWaitBudget(timeoutMs)}. Never share it.`);
+	log(
+		`This code expires in ${formatWaitBudget(effectiveTimeoutMs)}. Never share it.`,
+	);
 }
 
 export async function pollDeviceAuthorization(
@@ -349,8 +387,13 @@ export async function pollDeviceAuthorization(
 	options: DeviceAuthFlowOptions = {},
 ): Promise<DeviceAuthCompletionResult> {
 	const now = getNow(options);
+	const startMs = now();
 	const timeoutMs = options.timeoutMs ?? DEVICE_AUTH_TIMEOUT_MS;
-	const deadline = now() + timeoutMs;
+	const deadline = Math.min(
+		startMs + timeoutMs,
+		deviceCode.expiresAtMs ?? Number.POSITIVE_INFINITY,
+	);
+	const effectiveTimeoutMs = Math.max(0, deadline - startMs);
 
 	try {
 		while (true) {
@@ -388,7 +431,7 @@ export async function pollDeviceAuthorization(
 				if (remainingMs <= 0) {
 					return failedResult(
 						"timeout",
-						`Device auth timed out after ${formatWaitBudget(timeoutMs)}`,
+						`Device auth timed out after ${formatWaitBudget(effectiveTimeoutMs)}`,
 					);
 				}
 				const delayMs = resolvePollDelayMs(
@@ -426,11 +469,15 @@ export async function runDeviceAuthFlow(
 	if (deviceCodeResult.type !== "success") {
 		return deviceCodeResult;
 	}
+	if (options.signal?.aborted) {
+		return abortedResult();
+	}
 
 	printDeviceAuthorizationPrompt(
 		deviceCodeResult.deviceCode,
 		options.log ?? console.log,
 		options.timeoutMs ?? DEVICE_AUTH_TIMEOUT_MS,
+		getNow(options)(),
 	);
 
 	const completionResult = await pollDeviceAuthorization(

--- a/lib/auth/device-auth.ts
+++ b/lib/auth/device-auth.ts
@@ -1,0 +1,291 @@
+import type { TokenResult } from "../types.js";
+import {
+	CLIENT_ID,
+	exchangeAuthorizationCode,
+	sanitizeOAuthResponseBodyForLog,
+} from "./auth.js";
+
+export const DEVICE_AUTH_BASE_URL = "https://auth.openai.com";
+export const DEVICE_AUTH_API_BASE_URL = `${DEVICE_AUTH_BASE_URL}/api/accounts`;
+export const DEVICE_AUTH_VERIFICATION_URL = `${DEVICE_AUTH_BASE_URL}/codex/device`;
+export const DEVICE_AUTH_REDIRECT_URI = `${DEVICE_AUTH_BASE_URL}/deviceauth/callback`;
+export const DEVICE_AUTH_TIMEOUT_MS = 15 * 60 * 1000;
+export const DEVICE_AUTH_DEFAULT_INTERVAL_MS = 5_000;
+
+type FetchLike = typeof fetch;
+
+export interface DeviceAuthCode {
+	verificationUrl: string;
+	userCode: string;
+	deviceAuthId: string;
+	intervalMs: number;
+}
+
+export interface DeviceAuthCompletion {
+	authorizationCode: string;
+	codeVerifier: string;
+}
+
+export type DeviceAuthCodeResult =
+	| { type: "success"; deviceCode: DeviceAuthCode }
+	| Extract<TokenResult, { type: "failed" }>;
+
+export type DeviceAuthCompletionResult =
+	| { type: "success"; completion: DeviceAuthCompletion }
+	| Extract<TokenResult, { type: "failed" }>;
+
+export interface DeviceAuthFlowOptions {
+	fetchImpl?: FetchLike;
+	now?: () => number;
+	sleep?: (ms: number) => Promise<void>;
+	timeoutMs?: number;
+	log?: (message: string) => void;
+}
+
+function getFetch(options: DeviceAuthFlowOptions): FetchLike {
+	return options.fetchImpl ?? fetch;
+}
+
+function getNow(options: DeviceAuthFlowOptions): () => number {
+	return options.now ?? Date.now;
+}
+
+function getSleep(options: DeviceAuthFlowOptions): (ms: number) => Promise<void> {
+	return (
+		options.sleep ??
+		((ms: number) =>
+			new Promise<void>((resolve) => {
+				setTimeout(resolve, ms);
+			}))
+	);
+}
+
+function failedResult(
+	reason: Extract<TokenResult, { type: "failed" }>["reason"],
+	message: string,
+	statusCode?: number,
+): Extract<TokenResult, { type: "failed" }> {
+	return {
+		type: "failed",
+		reason,
+		statusCode,
+		message,
+	};
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return null;
+	}
+	return value as Record<string, unknown>;
+}
+
+async function readJsonRecord(response: Response): Promise<Record<string, unknown> | null> {
+	const text = await response.text().catch(() => "");
+	if (!text.trim()) {
+		return null;
+	}
+	try {
+		return asRecord(JSON.parse(text) as unknown);
+	} catch {
+		return null;
+	}
+}
+
+function parseIntervalMs(value: unknown): number {
+	if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+		return Math.trunc(value * 1000);
+	}
+	if (typeof value === "string") {
+		const parsed = Number.parseInt(value.trim(), 10);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return parsed * 1000;
+		}
+	}
+	return DEVICE_AUTH_DEFAULT_INTERVAL_MS;
+}
+
+function parseNonEmptyString(value: unknown): string | null {
+	if (typeof value !== "string") {
+		return null;
+	}
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseDeviceCodePayload(payload: Record<string, unknown>): DeviceAuthCode | null {
+	const deviceAuthId = parseNonEmptyString(payload.device_auth_id);
+	const userCode =
+		parseNonEmptyString(payload.user_code) ??
+		parseNonEmptyString(payload.usercode);
+	if (!deviceAuthId || !userCode) {
+		return null;
+	}
+	return {
+		verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+		userCode,
+		deviceAuthId,
+		intervalMs: parseIntervalMs(payload.interval),
+	};
+}
+
+function parseCompletionPayload(
+	payload: Record<string, unknown>,
+): DeviceAuthCompletion | null {
+	const authorizationCode = parseNonEmptyString(payload.authorization_code);
+	const codeVerifier = parseNonEmptyString(payload.code_verifier);
+	if (!authorizationCode || !codeVerifier) {
+		return null;
+	}
+	return { authorizationCode, codeVerifier };
+}
+
+async function readFailureText(response: Response): Promise<string> {
+	const text = await response.text().catch(() => "");
+	return sanitizeOAuthResponseBodyForLog(text);
+}
+
+export async function requestDeviceAuthorization(
+	options: DeviceAuthFlowOptions = {},
+): Promise<DeviceAuthCodeResult> {
+	try {
+		const response = await getFetch(options)(
+			`${DEVICE_AUTH_API_BASE_URL}/deviceauth/usercode`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ client_id: CLIENT_ID }),
+			},
+		);
+		if (!response.ok) {
+			const safeText = await readFailureText(response);
+			if (response.status === 404) {
+				return failedResult(
+					"http_error",
+					"Device auth login is not enabled for this Codex server. Use browser login or --manual.",
+					response.status,
+				);
+			}
+			return failedResult(
+				"http_error",
+				safeText || `Device code request failed with status ${response.status}`,
+				response.status,
+			);
+		}
+
+		const payload = await readJsonRecord(response);
+		const deviceCode = payload ? parseDeviceCodePayload(payload) : null;
+		if (!deviceCode) {
+			return failedResult(
+				"invalid_response",
+				"Device code request response failed schema validation",
+			);
+		}
+		return { type: "success", deviceCode };
+	} catch (error) {
+		return failedResult(
+			"network_error",
+			error instanceof Error ? error.message : String(error),
+		);
+	}
+}
+
+export function printDeviceAuthorizationPrompt(
+	deviceCode: DeviceAuthCode,
+	log: (message: string) => void = console.log,
+): void {
+	log("Device auth login");
+	log(`Open: ${deviceCode.verificationUrl}`);
+	log(`Code: ${deviceCode.userCode}`);
+	log("This code expires in 15 minutes. Never share it.");
+}
+
+export async function pollDeviceAuthorization(
+	deviceCode: DeviceAuthCode,
+	options: DeviceAuthFlowOptions = {},
+): Promise<DeviceAuthCompletionResult> {
+	const now = getNow(options);
+	const sleep = getSleep(options);
+	const timeoutMs = options.timeoutMs ?? DEVICE_AUTH_TIMEOUT_MS;
+	const deadline = now() + timeoutMs;
+
+	try {
+		while (true) {
+			const response = await getFetch(options)(
+				`${DEVICE_AUTH_API_BASE_URL}/deviceauth/token`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						device_auth_id: deviceCode.deviceAuthId,
+						user_code: deviceCode.userCode,
+					}),
+				},
+			);
+
+			if (response.ok) {
+				const payload = await readJsonRecord(response);
+				const completion = payload ? parseCompletionPayload(payload) : null;
+				if (!completion) {
+					return failedResult(
+						"invalid_response",
+						"Device auth token response failed schema validation",
+					);
+				}
+				return { type: "success", completion };
+			}
+
+			if (response.status === 403 || response.status === 404) {
+				const remainingMs = deadline - now();
+				if (remainingMs <= 0) {
+					return failedResult(
+						"unknown",
+						"Device auth timed out after 15 minutes",
+					);
+				}
+				await sleep(Math.min(deviceCode.intervalMs, remainingMs));
+				continue;
+			}
+
+			const safeText = await readFailureText(response);
+			return failedResult(
+				"http_error",
+				safeText || `Device auth failed with status ${response.status}`,
+				response.status,
+			);
+		}
+	} catch (error) {
+		return failedResult(
+			"network_error",
+			error instanceof Error ? error.message : String(error),
+		);
+	}
+}
+
+export async function runDeviceAuthFlow(
+	options: DeviceAuthFlowOptions = {},
+): Promise<TokenResult> {
+	const deviceCodeResult = await requestDeviceAuthorization(options);
+	if (deviceCodeResult.type !== "success") {
+		return deviceCodeResult;
+	}
+
+	printDeviceAuthorizationPrompt(
+		deviceCodeResult.deviceCode,
+		options.log ?? console.log,
+	);
+
+	const completionResult = await pollDeviceAuthorization(
+		deviceCodeResult.deviceCode,
+		options,
+	);
+	if (completionResult.type !== "success") {
+		return completionResult;
+	}
+
+	return exchangeAuthorizationCode(
+		completionResult.completion.authorizationCode,
+		completionResult.completion.codeVerifier,
+		DEVICE_AUTH_REDIRECT_URI,
+	);
+}

--- a/lib/auth/device-auth.ts
+++ b/lib/auth/device-auth.ts
@@ -137,6 +137,10 @@ function parseCompletionPayload(
 	if (!authorizationCode || !codeVerifier) {
 		return null;
 	}
+	// OpenAI Codex's device-code endpoint intentionally returns the PKCE
+	// verifier with the issued authorization code. This mirrors the upstream
+	// Codex CLI flow; keep this poll response out of logs and only hand it
+	// directly to the token exchange.
 	return { authorizationCode, codeVerifier };
 }
 

--- a/lib/auth/device-auth.ts
+++ b/lib/auth/device-auth.ts
@@ -300,8 +300,9 @@ function parseCompletionPayload(
 	}
 	// OpenAI Codex's device-code endpoint intentionally returns the PKCE
 	// verifier with the issued authorization code. This mirrors the upstream
-	// Codex CLI flow; keep this poll response out of logs and only hand it
-	// directly to the token exchange.
+	// Codex CLI flow. The verifier is never persisted to account storage; keep
+	// this poll response out of logs and only hand it directly to the token
+	// exchange.
 	return { authorizationCode, codeVerifier };
 }
 

--- a/lib/auth/device-auth.ts
+++ b/lib/auth/device-auth.ts
@@ -73,6 +73,15 @@ function failedResult(
 	};
 }
 
+function formatWaitBudget(timeoutMs: number): string {
+	const totalSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+	if (totalSeconds < 60) {
+		return `${totalSeconds} second${totalSeconds === 1 ? "" : "s"}`;
+	}
+	const totalMinutes = Math.ceil(totalSeconds / 60);
+	return `${totalMinutes} minute${totalMinutes === 1 ? "" : "s"}`;
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) {
 		return null;
@@ -197,11 +206,12 @@ export async function requestDeviceAuthorization(
 export function printDeviceAuthorizationPrompt(
 	deviceCode: DeviceAuthCode,
 	log: (message: string) => void = console.log,
+	timeoutMs = DEVICE_AUTH_TIMEOUT_MS,
 ): void {
 	log("Device auth login");
 	log(`Open: ${deviceCode.verificationUrl}`);
 	log(`Code: ${deviceCode.userCode}`);
-	log("This code expires in 15 minutes. Never share it.");
+	log(`This code expires in ${formatWaitBudget(timeoutMs)}. Never share it.`);
 }
 
 export async function pollDeviceAuthorization(
@@ -244,7 +254,7 @@ export async function pollDeviceAuthorization(
 				if (remainingMs <= 0) {
 					return failedResult(
 						"unknown",
-						"Device auth timed out after 15 minutes",
+						`Device auth timed out after ${formatWaitBudget(timeoutMs)}`,
 					);
 				}
 				await sleep(Math.min(deviceCode.intervalMs, remainingMs));
@@ -277,6 +287,7 @@ export async function runDeviceAuthFlow(
 	printDeviceAuthorizationPrompt(
 		deviceCodeResult.deviceCode,
 		options.log ?? console.log,
+		options.timeoutMs ?? DEVICE_AUTH_TIMEOUT_MS,
 	);
 
 	const completionResult = await pollDeviceAuthorization(

--- a/lib/auth/device-auth.ts
+++ b/lib/auth/device-auth.ts
@@ -229,9 +229,9 @@ function parseIntervalMs(value: unknown): number {
 		return Math.trunc(value * 1000);
 	}
 	if (typeof value === "string") {
-		const parsed = Number.parseInt(value.trim(), 10);
+		const parsed = Number.parseFloat(value.trim());
 		if (Number.isFinite(parsed) && parsed > 0) {
-			return parsed * 1000;
+			return Math.trunc(parsed * 1000);
 		}
 	}
 	return DEVICE_AUTH_DEFAULT_INTERVAL_MS;

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,1 +1,2 @@
 export * from "./auth.js";
+export * from "./device-auth.js";

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,2 +1,3 @@
 export * from "./auth.js";
-export * from "./device-auth.js";
+export { runDeviceAuthFlow } from "./device-auth.js";
+export type { DeviceAuthFlowOptions } from "./device-auth.js";

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -1982,7 +1982,7 @@ async function runSignInFlow(
 	if (signInMode === "device") {
 		// OpenAI owns the device-code account picker; there is no force-new-login
 		// equivalent to pass through for this mode.
-		return runDeviceAuthFlow();
+		return runDeviceAuthFlow({ log: console.log });
 	}
 	return runOAuthFlow(forceNewLogin, signInMode);
 }

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -18,6 +18,7 @@ import {
 	redactOAuthUrlForLog,
 	REDIRECT_URI,
 } from "./auth/auth.js";
+import { runDeviceAuthFlow } from "./auth/device-auth.js";
 import {
 	copyTextToClipboard,
 	isBrowserLaunchSuppressed,
@@ -1432,7 +1433,12 @@ function isReadlineClosedError(error: unknown): boolean {
 	);
 }
 
-type OAuthSignInMode = "browser" | "manual" | "restore-backup" | "cancel";
+type OAuthSignInMode =
+	| "browser"
+	| "manual"
+	| "device"
+	| "restore-backup"
+	| "cancel";
 type BackupRestoreMode = "latest" | "manual" | "back";
 
 export function formatBackupSavedAt(mtimeMs: number): string {
@@ -1967,6 +1973,16 @@ async function runOAuthFlow(
 		};
 	}
 	return exchangeAuthorizationCode(code, pkce.verifier, REDIRECT_URI);
+}
+
+async function runSignInFlow(
+	forceNewLogin: boolean,
+	signInMode: Extract<OAuthSignInMode, "browser" | "manual" | "device">,
+): Promise<TokenResult> {
+	if (signInMode === "device") {
+		return runDeviceAuthFlow();
+	}
+	return runOAuthFlow(forceNewLogin, signInMode);
 }
 
 async function persistAccountPool(
@@ -2934,12 +2950,14 @@ async function runAuthLogin(args: string[]): Promise<number> {
 			const latestNamedBackup = namedBackups[0] ?? null;
 			const preferManualMode =
 				loginOptions.manual || isBrowserLaunchSuppressed();
-			const signInMode = preferManualMode
-				? "manual"
-				: await promptOAuthSignInMode(
-						latestNamedBackup,
-						onboardingBackupDiscoveryWarning,
-					);
+			const signInMode: OAuthSignInMode = loginOptions.deviceAuth
+				? "device"
+				: preferManualMode
+					? "manual"
+					: await promptOAuthSignInMode(
+							latestNamedBackup,
+							onboardingBackupDiscoveryWarning,
+						);
 			if (signInMode === "cancel") {
 				if (existingCount > 0) {
 					console.log(
@@ -3035,11 +3053,15 @@ async function runAuthLogin(args: string[]): Promise<number> {
 				continue loginFlow;
 			}
 
-			if (signInMode !== "browser" && signInMode !== "manual") {
+			if (
+				signInMode !== "browser" &&
+				signInMode !== "manual" &&
+				signInMode !== "device"
+			) {
 				continue;
 			}
 
-			const tokenResult = await runOAuthFlow(forceNewLogin, signInMode);
+			const tokenResult = await runSignInFlow(forceNewLogin, signInMode);
 			if (tokenResult.type !== "success") {
 				if (isOAuthCancellation(tokenResult)) {
 					if (existingCount > 0) {

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -1982,7 +1982,7 @@ async function runSignInFlow(
 	if (signInMode === "device") {
 		// OpenAI owns the device-code account picker; there is no force-new-login
 		// equivalent to pass through for this mode.
-		return runDeviceAuthFlow({ log: (message) => console.log(message) });
+		return runDeviceAuthFlow();
 	}
 	return runOAuthFlow(forceNewLogin, signInMode);
 }

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -1982,6 +1982,7 @@ async function runSignInFlow(
 	if (signInMode === "device") {
 		// OpenAI owns the device-code account picker; there is no force-new-login
 		// equivalent to pass through for this mode.
+		// TODO: Thread a manager-level AbortSignal when login cancellation exists.
 		return runDeviceAuthFlow({ log: console.log });
 	}
 	return runOAuthFlow(forceNewLogin, signInMode);

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -1980,6 +1980,8 @@ async function runSignInFlow(
 	signInMode: Extract<OAuthSignInMode, "browser" | "manual" | "device">,
 ): Promise<TokenResult> {
 	if (signInMode === "device") {
+		// OpenAI owns the device-code account picker; there is no force-new-login
+		// equivalent to pass through for this mode.
 		return runDeviceAuthFlow({ log: (message) => console.log(message) });
 	}
 	return runOAuthFlow(forceNewLogin, signInMode);

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -1980,7 +1980,7 @@ async function runSignInFlow(
 	signInMode: Extract<OAuthSignInMode, "browser" | "manual" | "device">,
 ): Promise<TokenResult> {
 	if (signInMode === "device") {
-		return runDeviceAuthFlow();
+		return runDeviceAuthFlow({ log: (message) => console.log(message) });
 	}
 	return runOAuthFlow(forceNewLogin, signInMode);
 }

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -1440,6 +1440,9 @@ type OAuthSignInMode =
 	| "restore-backup"
 	| "cancel";
 type BackupRestoreMode = "latest" | "manual" | "back";
+type SignInFlowOptions = {
+	timeoutMs?: number;
+};
 
 export function formatBackupSavedAt(mtimeMs: number): string {
 	return new Date(mtimeMs).toLocaleString(undefined, {
@@ -1978,12 +1981,16 @@ async function runOAuthFlow(
 async function runSignInFlow(
 	forceNewLogin: boolean,
 	signInMode: Extract<OAuthSignInMode, "browser" | "manual" | "device">,
+	options: SignInFlowOptions = {},
 ): Promise<TokenResult> {
 	if (signInMode === "device") {
 		// OpenAI owns the device-code account picker; there is no force-new-login
 		// equivalent to pass through for this mode.
 		// TODO: Thread a manager-level AbortSignal when login cancellation exists.
-		return runDeviceAuthFlow({ log: console.log });
+		return runDeviceAuthFlow({
+			log: console.log,
+			timeoutMs: options.timeoutMs,
+		});
 	}
 	return runOAuthFlow(forceNewLogin, signInMode);
 }

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -4,7 +4,7 @@ export function printUsage(): void {
 			"Codex Multi-Auth CLI",
 			"",
 			"Start here:",
-			"  codex auth login [--manual|--no-browser]",
+			"  codex auth login [--device-auth|--manual|--no-browser]",
 			"  codex auth status",
 			"  codex auth check",
 			"",
@@ -40,6 +40,7 @@ export function printUsage(): void {
 
 export type AuthLoginOptions = {
 	manual: boolean;
+	deviceAuth: boolean;
 };
 
 export type ParsedAuthLoginArgs =
@@ -50,11 +51,16 @@ export type ParsedAuthLoginArgs =
 export function parseAuthLoginArgs(args: string[]): ParsedAuthLoginArgs {
 	const options: AuthLoginOptions = {
 		manual: false,
+		deviceAuth: false,
 	};
 
 	for (const arg of args) {
 		if (arg === "--manual" || arg === "--no-browser") {
 			options.manual = true;
+			continue;
+		}
+		if (arg === "--device-auth") {
+			options.deviceAuth = true;
 			continue;
 		}
 		if (arg === "--help" || arg === "-h") {
@@ -64,6 +70,14 @@ export function parseAuthLoginArgs(args: string[]): ParsedAuthLoginArgs {
 			ok: false,
 			reason: "error",
 			message: `Unknown login option: ${arg}`,
+		};
+	}
+
+	if (options.deviceAuth && options.manual) {
+		return {
+			ok: false,
+			reason: "error",
+			message: "Cannot combine --device-auth with --manual or --no-browser",
 		};
 	}
 

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -53,10 +53,14 @@ export function parseAuthLoginArgs(args: string[]): ParsedAuthLoginArgs {
 		manual: false,
 		deviceAuth: false,
 	};
+	const manualFlags: string[] = [];
 
 	for (const arg of args) {
 		if (arg === "--manual" || arg === "--no-browser") {
 			options.manual = true;
+			if (!manualFlags.includes(arg)) {
+				manualFlags.push(arg);
+			}
 			continue;
 		}
 		if (arg === "--device-auth") {
@@ -74,10 +78,12 @@ export function parseAuthLoginArgs(args: string[]): ParsedAuthLoginArgs {
 	}
 
 	if (options.deviceAuth && options.manual) {
+		const conflict =
+			manualFlags.length > 0 ? manualFlags.join(" or ") : "--manual";
 		return {
 			ok: false,
 			reason: "error",
-			message: "Cannot combine --device-auth with --manual or --no-browser",
+			message: `Cannot combine --device-auth with ${conflict}`,
 		};
 	}
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -298,6 +298,7 @@ export const TokenFailureReasonSchema = z.enum([
 	"invalid_response",
 	"network_error",
 	"missing_refresh",
+	"timeout",
 	"unknown",
 ]);
 

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -4807,6 +4807,10 @@ describe("codex manager cli commands", () => {
 			});
 			promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
 			promptAddAnotherAccountMock.mockResolvedValue(false);
+			let resolveSecondPollStarted: () => void = () => undefined;
+			const secondPollStarted = new Promise<void>((resolve) => {
+				resolveSecondPollStarted = resolve;
+			});
 			const fetchMock = vi
 				.fn<typeof fetch>()
 				.mockResolvedValueOnce(
@@ -4820,12 +4824,13 @@ describe("codex manager cli commands", () => {
 						{ status: 200, headers: { "Content-Type": "application/json" } },
 					),
 				)
-				.mockResolvedValueOnce(
-					new Response("", {
+				.mockImplementationOnce(async () => {
+					resolveSecondPollStarted();
+					return new Response("", {
 						status: 429,
 						headers: { "Retry-After": "1" },
-					}),
-				)
+					});
+				})
 				.mockResolvedValueOnce(
 					new Response(
 						JSON.stringify({
@@ -4856,7 +4861,8 @@ describe("codex manager cli commands", () => {
 				"--device-auth",
 			]);
 
-			await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+			await secondPollStarted;
+			expect(fetchMock).toHaveBeenCalledTimes(2);
 			await vi.advanceTimersByTimeAsync(1_000);
 			const exitCode = await exitCodePromise;
 

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -58,6 +58,7 @@ vi.mock("../lib/logger.js", () => ({
 }));
 
 vi.mock("../lib/auth/auth.js", () => ({
+	CLIENT_ID: "app_EMoamEEZ73f0CkXaXp7hrann",
 	createAuthorizationFlow: vi.fn(),
 	exchangeAuthorizationCode: vi.fn(),
 	parseAuthorizationInput: vi.fn((input: string) => {
@@ -81,6 +82,7 @@ vi.mock("../lib/auth/auth.js", () => ({
 			return url;
 		}
 	}),
+	sanitizeOAuthResponseBodyForLog: vi.fn((body: string) => body),
 	REDIRECT_URI: "http://localhost:1455/auth/callback",
 	AUTH_REDIRECT: {
 		host: "localhost",
@@ -893,6 +895,7 @@ describe("codex manager cli commands", () => {
 
 	afterEach(() => {
 		restoreTTYDescriptors();
+		vi.unstubAllGlobals();
 		vi.restoreAllMocks();
 	});
 
@@ -4626,6 +4629,87 @@ describe("codex manager cli commands", () => {
 			renderedLogs.some((entry) => entry.includes("No callback received")),
 		).toBe(false);
 		expect(storageState.accounts).toHaveLength(1);
+	});
+
+	it("supports non-TTY --device-auth without browser or local callback", async () => {
+		setInteractiveTTY(false);
+		const now = Date.now();
+		let storageState = {
+			version: 3 as const,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [] as Array<Record<string, unknown>>,
+		};
+		loadAccountsMock.mockImplementation(async () =>
+			structuredClone(storageState),
+		);
+		saveAccountsMock.mockImplementation(async (nextStorage) => {
+			storageState = structuredClone(nextStorage);
+		});
+		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
+		promptAddAnotherAccountMock.mockResolvedValue(false);
+
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						device_auth_id: "device-auth-1",
+						user_code: "ABCD-1234",
+						interval: "1",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						authorization_code: "authorization-code",
+						code_verifier: "code-verifier",
+						code_challenge: "code-challenge",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const authModule = await import("../lib/auth/auth.js");
+		vi.mocked(authModule.exchangeAuthorizationCode).mockResolvedValueOnce({
+			type: "success",
+			access: "access-device",
+			refresh: "refresh-device",
+			expires: now + 7_200_000,
+			idToken: "id-token-device",
+			multiAccount: true,
+		});
+
+		const browserModule = await import("../lib/auth/browser.js");
+		const serverModule = await import("../lib/auth/server.js");
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli([
+			"auth",
+			"login",
+			"--device-auth",
+		]);
+		const renderedLogs = logSpy.mock.calls.flat().map((entry) => String(entry));
+
+		expect(exitCode).toBe(0);
+		expect(renderedLogs).toContain("Device auth login");
+		expect(renderedLogs).toContain("Open: https://auth.openai.com/codex/device");
+		expect(renderedLogs).toContain("Code: ABCD-1234");
+		expect(browserModule.openBrowserUrl).not.toHaveBeenCalled();
+		expect(
+			vi.mocked(serverModule.startLocalOAuthServer),
+		).not.toHaveBeenCalled();
+		expect(authModule.exchangeAuthorizationCode).toHaveBeenCalledWith(
+			"authorization-code",
+			"code-verifier",
+			"https://auth.openai.com/deviceauth/callback",
+		);
+		expect(storageState.accounts).toHaveLength(1);
+		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("restores the latest named backup from onboarding when no accounts exist", async () => {

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -4745,6 +4745,135 @@ describe("codex manager cli commands", () => {
 		},
 	);
 
+	it("returns a clear failure when --device-auth polling reaches server expiry", async () => {
+		setInteractiveTTY(false);
+		loadAccountsMock.mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [],
+		});
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						device_auth_id: "device-auth-expired",
+						user_code: "ABCD-1234",
+						interval: "1",
+						expires_at: new Date(Date.now() - 1_000).toISOString(),
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			)
+			.mockResolvedValueOnce(new Response("", { status: 403 }));
+		vi.stubGlobal("fetch", fetchMock);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+		const exitCode = await runCodexMultiAuthCli([
+			"auth",
+			"login",
+			"--device-auth",
+		]);
+
+		expect(exitCode).toBe(1);
+		expect(logSpy).toHaveBeenCalledWith("Device auth login");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Login failed: Device auth timed out after 1 second",
+		);
+		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+	});
+
+	it("honors Retry-After during --device-auth polling before persisting login", async () => {
+		vi.useFakeTimers();
+		try {
+			setInteractiveTTY(false);
+			const now = Date.now();
+			let storageState = {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [] as Array<Record<string, unknown>>,
+			};
+			loadAccountsMock.mockImplementation(async () =>
+				structuredClone(storageState),
+			);
+			saveAccountsMock.mockImplementation(async (nextStorage) => {
+				storageState = structuredClone(nextStorage);
+			});
+			promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
+			promptAddAnotherAccountMock.mockResolvedValue(false);
+			const fetchMock = vi
+				.fn<typeof fetch>()
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							device_auth_id: "device-auth-retry-after",
+							user_code: "ABCD-1234",
+							interval: "1",
+							expires_at: new Date(now + 60_000).toISOString(),
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				)
+				.mockResolvedValueOnce(
+					new Response("", {
+						status: 429,
+						headers: { "Retry-After": "1" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							authorization_code: "authorization-code",
+							code_verifier: "code-verifier",
+							code_challenge: "code-challenge",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const authModule = await import("../lib/auth/auth.js");
+			vi.mocked(authModule.exchangeAuthorizationCode).mockResolvedValueOnce({
+				type: "success",
+				access: "access-device",
+				refresh: "refresh-device",
+				expires: now + 7_200_000,
+				idToken: "id-token-device",
+				multiAccount: true,
+			});
+			vi.spyOn(console, "log").mockImplementation(() => {});
+
+			const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+			const exitCodePromise = runCodexMultiAuthCli([
+				"auth",
+				"login",
+				"--device-auth",
+			]);
+
+			await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+			await vi.advanceTimersByTimeAsync(1_000);
+			const exitCode = await exitCodePromise;
+
+			expect(exitCode).toBe(0);
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+			expect(authModule.exchangeAuthorizationCode).toHaveBeenCalledWith(
+				"authorization-code",
+				"code-verifier",
+				"https://auth.openai.com/deviceauth/callback",
+			);
+			expect(storageState.accounts).toHaveLength(1);
+			expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("restores the latest named backup from onboarding when no accounts exist", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -4708,6 +4708,28 @@ describe("codex manager cli commands", () => {
 				"Open: https://auth.openai.com/codex/device",
 			);
 			expect(renderedLogs).toContain("Code: ABCD-1234");
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			expect(fetchMock).toHaveBeenNthCalledWith(
+				1,
+				"https://auth.openai.com/api/accounts/deviceauth/usercode",
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({
+						client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
+					}),
+				}),
+			);
+			expect(fetchMock).toHaveBeenNthCalledWith(
+				2,
+				"https://auth.openai.com/api/accounts/deviceauth/token",
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({
+						device_auth_id: "device-auth-1",
+						user_code: "ABCD-1234",
+					}),
+				}),
+			);
 			expect(browserModule.openBrowserUrl).not.toHaveBeenCalled();
 			expect(
 				vi.mocked(serverModule.startLocalOAuthServer),

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -4631,86 +4631,97 @@ describe("codex manager cli commands", () => {
 		expect(storageState.accounts).toHaveLength(1);
 	});
 
-	it("supports non-TTY --device-auth without browser or local callback", async () => {
-		setInteractiveTTY(false);
-		const now = Date.now();
-		let storageState = {
-			version: 3 as const,
-			activeIndex: 0,
-			activeIndexByFamily: { codex: 0 },
-			accounts: [] as Array<Record<string, unknown>>,
-		};
-		loadAccountsMock.mockImplementation(async () =>
-			structuredClone(storageState),
-		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
-			storageState = structuredClone(nextStorage);
-		});
-		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
-		promptAddAnotherAccountMock.mockResolvedValue(false);
-
-		const fetchMock = vi
-			.fn<typeof fetch>()
-			.mockResolvedValueOnce(
-				new Response(
-					JSON.stringify({
-						device_auth_id: "device-auth-1",
-						user_code: "ABCD-1234",
-						interval: "1",
-					}),
-					{ status: 200, headers: { "Content-Type": "application/json" } },
-				),
-			)
-			.mockResolvedValueOnce(
-				new Response(
-					JSON.stringify({
-						authorization_code: "authorization-code",
-						code_verifier: "code-verifier",
-						code_challenge: "code-challenge",
-					}),
-					{ status: 200, headers: { "Content-Type": "application/json" } },
-				),
+	it.each([
+		{ label: "non-TTY", interactive: false },
+		{ label: "TTY", interactive: true },
+	])(
+		"supports $label --device-auth without browser or local callback",
+		async ({ interactive }) => {
+			setInteractiveTTY(interactive);
+			const now = Date.now();
+			let storageState = {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [] as Array<Record<string, unknown>>,
+			};
+			loadAccountsMock.mockImplementation(async () =>
+				structuredClone(storageState),
 			);
-		vi.stubGlobal("fetch", fetchMock);
+			saveAccountsMock.mockImplementation(async (nextStorage) => {
+				storageState = structuredClone(nextStorage);
+			});
+			promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
+			promptAddAnotherAccountMock.mockResolvedValue(false);
 
-		const authModule = await import("../lib/auth/auth.js");
-		vi.mocked(authModule.exchangeAuthorizationCode).mockResolvedValueOnce({
-			type: "success",
-			access: "access-device",
-			refresh: "refresh-device",
-			expires: now + 7_200_000,
-			idToken: "id-token-device",
-			multiAccount: true,
-		});
+			const fetchMock = vi
+				.fn<typeof fetch>()
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							device_auth_id: "device-auth-1",
+							user_code: "ABCD-1234",
+							interval: "1",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				)
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							authorization_code: "authorization-code",
+							code_verifier: "code-verifier",
+							code_challenge: "code-challenge",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				);
+			vi.stubGlobal("fetch", fetchMock);
 
-		const browserModule = await import("../lib/auth/browser.js");
-		const serverModule = await import("../lib/auth/server.js");
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+			const authModule = await import("../lib/auth/auth.js");
+			vi.mocked(authModule.exchangeAuthorizationCode).mockResolvedValueOnce({
+				type: "success",
+				access: "access-device",
+				refresh: "refresh-device",
+				expires: now + 7_200_000,
+				idToken: "id-token-device",
+				multiAccount: true,
+			});
 
-		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
-		const exitCode = await runCodexMultiAuthCli([
-			"auth",
-			"login",
-			"--device-auth",
-		]);
-		const renderedLogs = logSpy.mock.calls.flat().map((entry) => String(entry));
+			const browserModule = await import("../lib/auth/browser.js");
+			const serverModule = await import("../lib/auth/server.js");
+			const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-		expect(exitCode).toBe(0);
-		expect(renderedLogs).toContain("Device auth login");
-		expect(renderedLogs).toContain("Open: https://auth.openai.com/codex/device");
-		expect(renderedLogs).toContain("Code: ABCD-1234");
-		expect(browserModule.openBrowserUrl).not.toHaveBeenCalled();
-		expect(
-			vi.mocked(serverModule.startLocalOAuthServer),
-		).not.toHaveBeenCalled();
-		expect(authModule.exchangeAuthorizationCode).toHaveBeenCalledWith(
-			"authorization-code",
-			"code-verifier",
-			"https://auth.openai.com/deviceauth/callback",
-		);
-		expect(storageState.accounts).toHaveLength(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
-	});
+			const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+			const exitCode = await runCodexMultiAuthCli([
+				"auth",
+				"login",
+				"--device-auth",
+			]);
+			const renderedLogs = logSpy.mock.calls
+				.flat()
+				.map((entry) => String(entry));
+
+			expect(exitCode).toBe(0);
+			expect(renderedLogs).toContain("Device auth login");
+			expect(renderedLogs).toContain(
+				"Open: https://auth.openai.com/codex/device",
+			);
+			expect(renderedLogs).toContain("Code: ABCD-1234");
+			expect(browserModule.openBrowserUrl).not.toHaveBeenCalled();
+			expect(
+				vi.mocked(serverModule.startLocalOAuthServer),
+			).not.toHaveBeenCalled();
+			expect(promptQuestionMock).not.toHaveBeenCalled();
+			expect(authModule.exchangeAuthorizationCode).toHaveBeenCalledWith(
+				"authorization-code",
+				"code-verifier",
+				"https://auth.openai.com/deviceauth/callback",
+			);
+			expect(storageState.accounts).toHaveLength(1);
+			expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		},
+	);
 
 	it("restores the latest named backup from onboarding when no accounts exist", async () => {
 		const now = Date.now();

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -49,6 +49,13 @@ describe("codex-manager help parsers", () => {
 			reason: "error",
 			message: "Cannot combine --device-auth with --no-browser",
 		});
+		expect(
+			parseAuthLoginArgs(["--device-auth", "--manual", "--no-browser"]),
+		).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Cannot combine --device-auth with --manual or --no-browser",
+		});
 	});
 
 	it("parses best args and treats help as a first-class result", () => {

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -10,11 +10,15 @@ describe("codex-manager help parsers", () => {
 
 		expect(parseAuthLoginArgs(["--manual"])).toEqual({
 			ok: true,
-			options: { manual: true },
+			options: { manual: true, deviceAuth: false },
 		});
 		expect(parseAuthLoginArgs(["--no-browser"])).toEqual({
 			ok: true,
-			options: { manual: true },
+			options: { manual: true, deviceAuth: false },
+		});
+		expect(parseAuthLoginArgs(["--device-auth"])).toEqual({
+			ok: true,
+			options: { manual: false, deviceAuth: true },
 		});
 		expect(parseAuthLoginArgs(["--help"])).toEqual({
 			ok: false,
@@ -29,6 +33,16 @@ describe("codex-manager help parsers", () => {
 			ok: false,
 			reason: "error",
 			message: "Unknown login option: --bogus",
+		});
+		expect(parseAuthLoginArgs(["--device-auth", "--manual"])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Cannot combine --device-auth with --manual or --no-browser",
+		});
+		expect(parseAuthLoginArgs(["--no-browser", "--device-auth"])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Cannot combine --device-auth with --manual or --no-browser",
 		});
 	});
 

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -37,12 +37,17 @@ describe("codex-manager help parsers", () => {
 		expect(parseAuthLoginArgs(["--device-auth", "--manual"])).toEqual({
 			ok: false,
 			reason: "error",
-			message: "Cannot combine --device-auth with --manual or --no-browser",
+			message: "Cannot combine --device-auth with --manual",
 		});
 		expect(parseAuthLoginArgs(["--no-browser", "--device-auth"])).toEqual({
 			ok: false,
 			reason: "error",
-			message: "Cannot combine --device-auth with --manual or --no-browser",
+			message: "Cannot combine --device-auth with --no-browser",
+		});
+		expect(parseAuthLoginArgs(["--device-auth", "--no-browser"])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Cannot combine --device-auth with --no-browser",
 		});
 	});
 

--- a/test/device-auth.test.ts
+++ b/test/device-auth.test.ts
@@ -182,7 +182,7 @@ describe("device auth flow", () => {
 		expect(result).toEqual({
 			type: "failed",
 			reason: "unknown",
-			message: "Device auth timed out after 15 minutes",
+			message: "Device auth timed out after 10 seconds",
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(3);
 		expect(sleepMock).toHaveBeenCalledTimes(2);
@@ -250,6 +250,9 @@ describe("device auth flow", () => {
 		expect(logMock).toHaveBeenCalledWith("Device auth login");
 		expect(logMock).toHaveBeenCalledWith(`Open: ${DEVICE_AUTH_VERIFICATION_URL}`);
 		expect(logMock).toHaveBeenCalledWith("Code: ABCD-1234");
+		expect(logMock).toHaveBeenCalledWith(
+			"This code expires in 15 minutes. Never share it.",
+		);
 		const tokenExchangeCall = fetchMock.mock.calls[2];
 		expect(tokenExchangeCall?.[0]).toBe("https://auth.openai.com/oauth/token");
 		const tokenExchangeBody = tokenExchangeCall?.[1]?.body;

--- a/test/device-auth.test.ts
+++ b/test/device-auth.test.ts
@@ -21,16 +21,19 @@ describe("device auth flow", () => {
 	});
 
 	it("requests a user code and parses user_code plus string interval", async () => {
+		const nowMs = Date.parse("2026-04-26T00:00:00Z");
+		const expiresAtMs = nowMs + 15 * 60 * 1000;
 		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
 			jsonResponse({
 				device_auth_id: "device-auth-1",
 				user_code: "ABCD-1234",
 				interval: "7.5",
+				expires_at: new Date(expiresAtMs).toISOString(),
 			}),
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
-		const result = await requestDeviceAuthorization();
+		const result = await requestDeviceAuthorization({ now: () => nowMs });
 
 		expect(result).toEqual({
 			type: "success",
@@ -39,6 +42,7 @@ describe("device auth flow", () => {
 				userCode: "ABCD-1234",
 				deviceAuthId: "device-auth-1",
 				intervalMs: 7_500,
+				expiresAtMs,
 			},
 		});
 		expect(fetchMock).toHaveBeenCalledWith(
@@ -105,6 +109,42 @@ describe("device auth flow", () => {
 			type: "failed",
 			reason: "network_error",
 			message: "connection reset",
+		});
+	});
+
+	it("does not request a user code when the signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const fetchMock = vi.fn<typeof fetch>();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await requestDeviceAuthorization({
+			signal: controller.signal,
+		});
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "network_error",
+			message: "aborted",
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("fails user-code requests on invalid success payloads", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+			jsonResponse({
+				user_code: "ABCD-1234",
+				interval: "5",
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await requestDeviceAuthorization();
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "invalid_response",
+			message: "Device code request response failed schema validation",
 		});
 	});
 
@@ -256,6 +296,7 @@ describe("device auth flow", () => {
 		const fetchMock = vi
 			.fn<typeof fetch>()
 			.mockResolvedValue(new Response("", { status: 403 }));
+		const sleepMock = vi.fn(() => new Promise<void>(() => {}));
 		vi.stubGlobal("fetch", fetchMock);
 
 		const resultPromise = pollDeviceAuthorization(
@@ -265,10 +306,14 @@ describe("device auth flow", () => {
 				deviceAuthId: "device-auth-1",
 				intervalMs: 5_000,
 			},
-			{ signal: controller.signal, timeoutMs: 10_000 },
+			{
+				signal: controller.signal,
+				sleep: sleepMock,
+				timeoutMs: 10_000,
+			},
 		);
 
-		await Promise.resolve();
+		await vi.waitFor(() => expect(sleepMock).toHaveBeenCalledTimes(1));
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		controller.abort();
 		await expect(resultPromise).resolves.toEqual({
@@ -277,6 +322,41 @@ describe("device auth flow", () => {
 			message: "aborted",
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the server expiration as the polling deadline", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(new Response("", { status: 403 }));
+		let nowMs = 0;
+		const sleepMock = vi.fn(async (ms: number) => {
+			nowMs += ms;
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await pollDeviceAuthorization(
+			{
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "ABCD-1234",
+				deviceAuthId: "device-auth-1",
+				intervalMs: 5_000,
+				expiresAtMs: 6_000,
+			},
+			{
+				now: () => nowMs,
+				sleep: sleepMock,
+				timeoutMs: 15_000,
+			},
+		);
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "timeout",
+			message: "Device auth timed out after 6 seconds",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(sleepMock).toHaveBeenNthCalledWith(1, 5_000);
+		expect(sleepMock).toHaveBeenNthCalledWith(2, 1_000);
 	});
 
 	it("times out polling after the configured wait budget", async () => {
@@ -354,6 +434,7 @@ describe("device auth flow", () => {
 	});
 
 	it("exchanges the authorization code with the device redirect URI", async () => {
+		const nowMs = Date.parse("2026-04-26T00:00:00Z");
 		const fetchMock = vi
 			.fn<typeof fetch>()
 			.mockResolvedValueOnce(
@@ -361,6 +442,7 @@ describe("device auth flow", () => {
 					device_auth_id: "device-auth-1",
 					user_code: "ABCD-1234",
 					interval: "1",
+					expires_in: "600",
 				}),
 			)
 			.mockResolvedValueOnce(
@@ -381,7 +463,10 @@ describe("device auth flow", () => {
 		const logMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 
-		const result = await runDeviceAuthFlow({ log: logMock });
+		const result = await runDeviceAuthFlow({
+			log: logMock,
+			now: () => nowMs,
+		});
 
 		expect(result).toEqual({
 			type: "success",
@@ -395,16 +480,45 @@ describe("device auth flow", () => {
 		expect(logMock).toHaveBeenCalledWith(`Open: ${DEVICE_AUTH_VERIFICATION_URL}`);
 		expect(logMock).toHaveBeenCalledWith("Code: ABCD-1234");
 		expect(logMock).toHaveBeenCalledWith(
-			"This code expires in 15 minutes. Never share it.",
+			"This code expires in 10 minutes. Never share it.",
 		);
 		const tokenExchangeCall = fetchMock.mock.calls[2];
 		expect(tokenExchangeCall?.[0]).toBe("https://auth.openai.com/oauth/token");
 		const tokenExchangeBody = tokenExchangeCall?.[1]?.body;
 		expect(tokenExchangeBody).toBeInstanceOf(URLSearchParams);
 		const params = tokenExchangeBody as URLSearchParams;
+		expect(params.get("grant_type")).toBe("authorization_code");
+		expect(params.get("client_id")).toBe("app_EMoamEEZ73f0CkXaXp7hrann");
 		expect(params.get("code")).toBe("authorization-code");
 		expect(params.get("code_verifier")).toBe("code-verifier");
 		expect(params.get("redirect_uri")).toBe(DEVICE_AUTH_REDIRECT_URI);
+	});
+
+	it("does not print or poll when aborted after the user-code response", async () => {
+		const controller = new AbortController();
+		const fetchMock = vi.fn<typeof fetch>().mockImplementationOnce(async () => {
+			controller.abort();
+			return jsonResponse({
+				device_auth_id: "device-auth-1",
+				user_code: "ABCD-1234",
+				interval: "1",
+			});
+		});
+		const logMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await runDeviceAuthFlow({
+			log: logMock,
+			signal: controller.signal,
+		});
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "network_error",
+			message: "aborted",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(logMock).not.toHaveBeenCalled();
 	});
 
 	it("returns token exchange failures from the device auth flow", async () => {

--- a/test/device-auth.test.ts
+++ b/test/device-auth.test.ts
@@ -148,6 +148,22 @@ describe("device auth flow", () => {
 		});
 	});
 
+	it("returns sanitized user-code request failures", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(new Response("server unavailable", { status: 500 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await requestDeviceAuthorization();
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "http_error",
+			statusCode: 500,
+			message: "server unavailable",
+		});
+	});
+
 	it("treats 403 and 404 poll responses as pending before success", async () => {
 		const fetchMock = vi
 			.fn<typeof fetch>()
@@ -482,6 +498,10 @@ describe("device auth flow", () => {
 		expect(logMock).toHaveBeenCalledWith(
 			"This code expires in 10 minutes. Never share it.",
 		);
+		const renderedLogs = logMock.mock.calls.flat().map((entry) => String(entry));
+		expect(renderedLogs.join("\n")).not.toMatch(
+			/access-token|refresh-token|id-token|code-verifier|code_verifier|user@example\.com/,
+		);
 		const tokenExchangeCall = fetchMock.mock.calls[2];
 		expect(tokenExchangeCall?.[0]).toBe("https://auth.openai.com/oauth/token");
 		const tokenExchangeBody = tokenExchangeCall?.[1]?.body;
@@ -521,6 +541,42 @@ describe("device auth flow", () => {
 		expect(logMock).not.toHaveBeenCalled();
 	});
 
+	it("does not leak tokens or email strings through device auth logs on timeout", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				jsonResponse({
+					device_auth_id: "device-auth-1",
+					user_code: "ABCD-1234",
+					interval: "1",
+				}),
+			)
+			.mockResolvedValue(new Response("", { status: 403 }));
+		let nowMs = 0;
+		const sleepMock = vi.fn(async (ms: number) => {
+			nowMs += ms;
+		});
+		const logMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await runDeviceAuthFlow({
+			log: logMock,
+			now: () => nowMs,
+			sleep: sleepMock,
+			timeoutMs: 2_000,
+		});
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "timeout",
+			message: "Device auth timed out after 2 seconds",
+		});
+		const renderedLogs = logMock.mock.calls.flat().map((entry) => String(entry));
+		expect(renderedLogs.join("\n")).not.toMatch(
+			/access-token|refresh-token|id-token|code-verifier|code_verifier|user@example\.com/,
+		);
+	});
+
 	it("returns token exchange failures from the device auth flow", async () => {
 		const fetchMock = vi
 			.fn<typeof fetch>()
@@ -538,9 +594,10 @@ describe("device auth flow", () => {
 				}),
 			)
 			.mockResolvedValueOnce(new Response("bad token", { status: 400 }));
+		const logMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 
-		const result = await runDeviceAuthFlow({ log: vi.fn() });
+		const result = await runDeviceAuthFlow({ log: logMock });
 
 		expect(result).toEqual({
 			type: "failed",
@@ -549,5 +606,9 @@ describe("device auth flow", () => {
 			message: "bad token",
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(3);
+		const renderedLogs = logMock.mock.calls.flat().map((entry) => String(entry));
+		expect(renderedLogs.join("\n")).not.toMatch(
+			/access-token|refresh-token|id-token|code-verifier|code_verifier|user@example\.com/,
+		);
 	});
 });

--- a/test/device-auth.test.ts
+++ b/test/device-auth.test.ts
@@ -155,6 +155,132 @@ describe("device auth flow", () => {
 		);
 	});
 
+	it("honors Retry-After seconds for 429 poll responses", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response("", {
+					status: 429,
+					headers: { "Retry-After": "7" },
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					authorization_code: "authorization-code",
+					code_verifier: "code-verifier",
+				}),
+			);
+		const sleepMock = vi.fn(async () => undefined);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await pollDeviceAuthorization(
+			{
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "ABCD-1234",
+				deviceAuthId: "device-auth-1",
+				intervalMs: 2_000,
+			},
+			{ sleep: sleepMock },
+		);
+
+		expect(result.type).toBe("success");
+		expect(sleepMock).toHaveBeenCalledWith(7_000);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("honors Retry-After HTTP dates for transient poll responses", async () => {
+		const nowMs = Date.parse("2026-04-26T00:00:00Z");
+		const retryAt = new Date(nowMs + 4_000).toUTCString();
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response("", {
+					status: 503,
+					headers: { "Retry-After": retryAt },
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					authorization_code: "authorization-code",
+					code_verifier: "code-verifier",
+				}),
+			);
+		const sleepMock = vi.fn(async () => undefined);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await pollDeviceAuthorization(
+			{
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "ABCD-1234",
+				deviceAuthId: "device-auth-1",
+				intervalMs: 2_000,
+			},
+			{ now: () => nowMs, sleep: sleepMock },
+		);
+
+		expect(result.type).toBe("success");
+		expect(sleepMock).toHaveBeenCalledWith(4_000);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("falls back to jittered interval polling for 429 without Retry-After", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(new Response("", { status: 429 }))
+			.mockResolvedValueOnce(
+				jsonResponse({
+					authorization_code: "authorization-code",
+					code_verifier: "code-verifier",
+				}),
+			);
+		const sleepMock = vi.fn(async () => undefined);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await pollDeviceAuthorization(
+			{
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "ABCD-1234",
+				deviceAuthId: "device-auth-1",
+				intervalMs: 3_000,
+			},
+			{ random: () => 0.5, sleep: sleepMock },
+		);
+
+		expect(result.type).toBe("success");
+		expect(sleepMock).toHaveBeenCalledWith(3_000);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("aborts polling without issuing another token request", async () => {
+		const controller = new AbortController();
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(new Response("", { status: 403 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resultPromise = pollDeviceAuthorization(
+			{
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "ABCD-1234",
+				deviceAuthId: "device-auth-1",
+				intervalMs: 5_000,
+			},
+			{ signal: controller.signal, timeoutMs: 10_000 },
+		);
+		for (let i = 0; i < 10 && fetchMock.mock.calls.length === 0; i += 1) {
+			await Promise.resolve();
+		}
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		controller.abort();
+		await expect(resultPromise).resolves.toEqual({
+			type: "failed",
+			reason: "network_error",
+			message: "aborted",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("times out polling after the configured wait budget", async () => {
 		const fetchMock = vi
 			.fn<typeof fetch>()
@@ -181,7 +307,7 @@ describe("device auth flow", () => {
 
 		expect(result).toEqual({
 			type: "failed",
-			reason: "unknown",
+			reason: "timeout",
 			message: "Device auth timed out after 10 seconds",
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -191,7 +317,7 @@ describe("device auth flow", () => {
 	it("fails polling on hard non-pending responses", async () => {
 		const fetchMock = vi
 			.fn<typeof fetch>()
-			.mockResolvedValueOnce(new Response("server unavailable", { status: 503 }));
+			.mockResolvedValueOnce(new Response("bad request", { status: 400 }));
 		vi.stubGlobal("fetch", fetchMock);
 
 		const result = await pollDeviceAuthorization({
@@ -204,8 +330,28 @@ describe("device auth flow", () => {
 		expect(result).toEqual({
 			type: "failed",
 			reason: "http_error",
-			statusCode: 503,
-			message: "server unavailable",
+			statusCode: 400,
+			message: "bad request",
+		});
+	});
+
+	it("fails polling on invalid completion payloads", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(jsonResponse({ authorization_code: "missing-verifier" }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await pollDeviceAuthorization({
+			verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+			userCode: "ABCD-1234",
+			deviceAuthId: "device-auth-1",
+			intervalMs: 5_000,
+		});
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "invalid_response",
+			message: "Device auth token response failed schema validation",
 		});
 	});
 
@@ -261,5 +407,35 @@ describe("device auth flow", () => {
 		expect(params.get("code")).toBe("authorization-code");
 		expect(params.get("code_verifier")).toBe("code-verifier");
 		expect(params.get("redirect_uri")).toBe(DEVICE_AUTH_REDIRECT_URI);
+	});
+
+	it("returns token exchange failures from the device auth flow", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				jsonResponse({
+					device_auth_id: "device-auth-1",
+					user_code: "ABCD-1234",
+					interval: "1",
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					authorization_code: "authorization-code",
+					code_verifier: "code-verifier",
+				}),
+			)
+			.mockResolvedValueOnce(new Response("bad token", { status: 400 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await runDeviceAuthFlow({ log: vi.fn() });
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "http_error",
+			statusCode: 400,
+			message: "bad token",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(3);
 	});
 });

--- a/test/device-auth.test.ts
+++ b/test/device-auth.test.ts
@@ -267,10 +267,8 @@ describe("device auth flow", () => {
 			},
 			{ signal: controller.signal, timeoutMs: 10_000 },
 		);
-		for (let i = 0; i < 10 && fetchMock.mock.calls.length === 0; i += 1) {
-			await Promise.resolve();
-		}
 
+		await Promise.resolve();
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		controller.abort();
 		await expect(resultPromise).resolves.toEqual({

--- a/test/device-auth.test.ts
+++ b/test/device-auth.test.ts
@@ -25,7 +25,7 @@ describe("device auth flow", () => {
 			jsonResponse({
 				device_auth_id: "device-auth-1",
 				user_code: "ABCD-1234",
-				interval: "7",
+				interval: "7.5",
 			}),
 		);
 		vi.stubGlobal("fetch", fetchMock);
@@ -38,7 +38,7 @@ describe("device auth flow", () => {
 				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
 				userCode: "ABCD-1234",
 				deviceAuthId: "device-auth-1",
-				intervalMs: 7_000,
+				intervalMs: 7_500,
 			},
 		});
 		expect(fetchMock).toHaveBeenCalledWith(

--- a/test/device-auth.test.ts
+++ b/test/device-auth.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	DEVICE_AUTH_REDIRECT_URI,
+	DEVICE_AUTH_VERIFICATION_URL,
+	pollDeviceAuthorization,
+	requestDeviceAuthorization,
+	runDeviceAuthFlow,
+} from "../lib/auth/device-auth.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("device auth flow", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("requests a user code and parses user_code plus string interval", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+			jsonResponse({
+				device_auth_id: "device-auth-1",
+				user_code: "ABCD-1234",
+				interval: "7",
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await requestDeviceAuthorization();
+
+		expect(result).toEqual({
+			type: "success",
+			deviceCode: {
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "ABCD-1234",
+				deviceAuthId: "device-auth-1",
+				intervalMs: 7_000,
+			},
+		});
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://auth.openai.com/api/accounts/deviceauth/usercode",
+			expect.objectContaining({
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
+				}),
+			}),
+		);
+	});
+
+	it("accepts the usercode alias and numeric interval", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+			jsonResponse({
+				device_auth_id: "device-auth-2",
+				usercode: "WXYZ-9876",
+				interval: 3,
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await requestDeviceAuthorization();
+
+		expect(result).toEqual({
+			type: "success",
+			deviceCode: {
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "WXYZ-9876",
+				deviceAuthId: "device-auth-2",
+				intervalMs: 3_000,
+			},
+		});
+	});
+
+	it("returns a clear failure when the user-code endpoint is disabled", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(new Response("not found", { status: 404 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await requestDeviceAuthorization();
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "http_error",
+			statusCode: 404,
+			message:
+				"Device auth login is not enabled for this Codex server. Use browser login or --manual.",
+		});
+	});
+
+	it("returns a network failure when the user-code request rejects", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockRejectedValueOnce(new Error("connection reset"));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await requestDeviceAuthorization();
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "network_error",
+			message: "connection reset",
+		});
+	});
+
+	it("treats 403 and 404 poll responses as pending before success", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(new Response("", { status: 403 }))
+			.mockResolvedValueOnce(new Response("", { status: 404 }))
+			.mockResolvedValueOnce(
+				jsonResponse({
+					authorization_code: "authorization-code",
+					code_verifier: "code-verifier",
+					code_challenge: "code-challenge",
+				}),
+			);
+		const sleepMock = vi.fn(async () => undefined);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await pollDeviceAuthorization(
+			{
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "ABCD-1234",
+				deviceAuthId: "device-auth-1",
+				intervalMs: 2_000,
+			},
+			{ sleep: sleepMock },
+		);
+
+		expect(result).toEqual({
+			type: "success",
+			completion: {
+				authorizationCode: "authorization-code",
+				codeVerifier: "code-verifier",
+			},
+		});
+		expect(sleepMock).toHaveBeenCalledTimes(2);
+		expect(sleepMock).toHaveBeenNthCalledWith(1, 2_000);
+		expect(sleepMock).toHaveBeenNthCalledWith(2, 2_000);
+		expect(fetchMock).toHaveBeenLastCalledWith(
+			"https://auth.openai.com/api/accounts/deviceauth/token",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					device_auth_id: "device-auth-1",
+					user_code: "ABCD-1234",
+				}),
+			}),
+		);
+	});
+
+	it("times out polling after the configured wait budget", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(new Response("", { status: 403 }));
+		let nowMs = 0;
+		const sleepMock = vi.fn(async (ms: number) => {
+			nowMs += ms;
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await pollDeviceAuthorization(
+			{
+				verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+				userCode: "ABCD-1234",
+				deviceAuthId: "device-auth-1",
+				intervalMs: 5_000,
+			},
+			{
+				now: () => nowMs,
+				sleep: sleepMock,
+				timeoutMs: 10_000,
+			},
+		);
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "unknown",
+			message: "Device auth timed out after 15 minutes",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(sleepMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("fails polling on hard non-pending responses", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(new Response("server unavailable", { status: 503 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await pollDeviceAuthorization({
+			verificationUrl: DEVICE_AUTH_VERIFICATION_URL,
+			userCode: "ABCD-1234",
+			deviceAuthId: "device-auth-1",
+			intervalMs: 5_000,
+		});
+
+		expect(result).toEqual({
+			type: "failed",
+			reason: "http_error",
+			statusCode: 503,
+			message: "server unavailable",
+		});
+	});
+
+	it("exchanges the authorization code with the device redirect URI", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				jsonResponse({
+					device_auth_id: "device-auth-1",
+					user_code: "ABCD-1234",
+					interval: "1",
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					authorization_code: "authorization-code",
+					code_verifier: "code-verifier",
+					code_challenge: "code-challenge",
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					access_token: "access-token",
+					refresh_token: "refresh-token",
+					expires_in: 3600,
+					id_token: "id-token",
+				}),
+			);
+		const logMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await runDeviceAuthFlow({ log: logMock });
+
+		expect(result).toEqual({
+			type: "success",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: expect.any(Number),
+			idToken: "id-token",
+			multiAccount: true,
+		});
+		expect(logMock).toHaveBeenCalledWith("Device auth login");
+		expect(logMock).toHaveBeenCalledWith(`Open: ${DEVICE_AUTH_VERIFICATION_URL}`);
+		expect(logMock).toHaveBeenCalledWith("Code: ABCD-1234");
+		const tokenExchangeCall = fetchMock.mock.calls[2];
+		expect(tokenExchangeCall?.[0]).toBe("https://auth.openai.com/oauth/token");
+		const tokenExchangeBody = tokenExchangeCall?.[1]?.body;
+		expect(tokenExchangeBody).toBeInstanceOf(URLSearchParams);
+		const params = tokenExchangeBody as URLSearchParams;
+		expect(params.get("code")).toBe("authorization-code");
+		expect(params.get("code_verifier")).toBe("code-verifier");
+		expect(params.get("redirect_uri")).toBe(DEVICE_AUTH_REDIRECT_URI);
+	});
+});


### PR DESCRIPTION
## Summary

- Add `codex auth login --device-auth` for remote/headless ChatGPT login using OpenAI Codex device-code endpoints.
- Preserve browser, manual, no-browser, storage persistence, Codex CLI sync, and active-account behavior.
- Fixes #440.

## What Changed

- Added a device auth helper for user-code request, URL/code printing, pending polling, timeout handling, and authorization-code exchange through `https://auth.openai.com/deviceauth/callback`.
- Added parser/help support for `--device-auth` and explicit conflict handling with `--manual` or `--no-browser`.
- Hardened polling with optional abort support, retry handling for 408/429/502/503/504, `Retry-After` support, light jitter, and a specific timeout failure reason.
- Documented the server-supplied PKCE verifier boundary used by the upstream Codex device-code flow.
- Added helper, parser, CLI, docs, schema, and regression coverage for the new flow and review feedback.

## Validation

- [x] `npm.cmd run lint`
- [x] `npm.cmd run typecheck`
- [x] `npm.cmd run build`
- [x] `npm.cmd test`
- [x] `npx.cmd vitest run test/device-auth.test.ts test/codex-manager-help.test.ts test/codex-manager-cli.test.ts test/documentation.test.ts test/schemas.test.ts`

## Docs and Governance Checklist

- [x] README updated
- [x] `docs/getting-started.md` updated
- [x] `docs/features.md` updated
- [x] `docs/reference/commands.md` updated
- [x] `docs/troubleshooting.md` updated
- [x] `docs/upgrade.md` updated
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: Low. Additive login path behind an explicit flag; existing browser/manual flows remain unchanged.
- Rollback plan: Revert the device auth feature, docs, and review cleanup commits.

## Additional Notes

- No live account login was completed; network/auth behavior is covered with mocked endpoint tests.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `codex auth login --device-auth` — a new polling-based device-code flow for remote/headless environments. the implementation is additive behind an explicit flag, preserves all existing browser/manual paths, and correctly conflicts with `--manual`/`--no-browser`. previous review feedback (hardcoded \"15 minutes\" timeout string, missing interactive-TTY vitest coverage) is addressed in this revision.

<h3>Confidence Score: 5/5</h3>

safe to merge — additive flag behind explicit opt-in, existing flows unchanged, no P0/P1 issues found

only P2 findings: formatWaitBudget floor-to-1-second edge case for already-expired codes, and 404-as-pending semantic ambiguity. both are non-blocking. previous P1/P2 comments (hardcoded timeout string, missing TTY coverage) are addressed.

lib/auth/device-auth.ts — isPendingStatus 404 contract and formatWaitBudget floor

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/auth/device-auth.ts | new 497-line device-auth helper; poll loop, abort handling, retry-after, and jitter are solid; two P2 UX nits: formatWaitBudget floor-to-1-second and 404-as-pending semantic ambiguity |
| lib/codex-manager.ts | adds runSignInFlow wrapper and device sign-in mode; conflict detection between --device-auth and --manual/--no-browser is correct; timeoutMs in SignInFlowOptions is defined but currently always undefined |
| lib/codex-manager/help.ts | parser correctly tracks manualFlags for conflict message, conflict detection with --device-auth covers all flag orderings |
| lib/schemas.ts | adds timeout to TokenFailureReasonSchema; correct and backward-compatible |
| test/device-auth.test.ts | 614-line vitest suite covering request, polling, abort, retry-after, jitter, timeout, token exchange, and log-redaction paths; previous hardcoded timeout and wrong-assertion issues are resolved |
| test/codex-manager-cli.test.ts | adds it.each covering both TTY and non-TTY --device-auth paths, server-expiry regression, and Retry-After honoring; previous gap about missing interactive TTY coverage is addressed |
| lib/auth/index.ts | exports runDeviceAuthFlow and DeviceAuthFlowOptions through the auth barrel; clean |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[codex auth login --device-auth] --> B[requestDeviceAuthorization]
    B --> C{response ok?}
    C -->|404| D[fail: device-auth not enabled]
    C -->|other error| E[fail: http_error]
    C -->|success| F[printDeviceAuthorizationPrompt]
    F --> G[pollDeviceAuthorization loop]
    G --> H{poll response}
    H -->|200 ok| I[parseCompletionPayload]
    H -->|403/404 pending| J[sleep intervalMs]
    H -->|429/5xx transient| K[sleep Retry-After or jitter]
    H -->|deadline reached| L[fail: timeout]
    H -->|hard error| M[fail: http_error]
    H -->|AbortSignal| N[fail: aborted]
    J --> G
    K --> G
    I --> O[exchangeAuthorizationCode]
    O -->|success| P[persist account and sync Codex CLI]
    O -->|failure| Q[fail: token exchange error]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feature%2Fissue-440-device-auth%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fissue-440-device-auth%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fauth%2Fdevice-auth.ts%3A296-301%0A**%60formatWaitBudget%280%29%60%20floors%20to%20%221%20second%22%20for%20already-expired%20codes**%0A%0Athe%20%60Math.max%281%2C%20...%29%60%20clamp%20means%20that%20when%20%60effectiveTimeoutMs%60%20is%200%20%28server%20returns%20an%20already-expired%20%60expires_at%60%29%2C%20both%20%60printDeviceAuthorizationPrompt%60%20and%20the%20polling%20timeout%20error%20message%20will%20say%20%221%20second%22%20rather%20than%20indicating%20the%20code%20is%20already%20expired.%20the%20%60codex-manager-cli.test.ts%60%20expiry%20regression%20test%20confirms%20this%20%E2%80%94%20the%20assertion%20%60%22Device%20auth%20timed%20out%20after%201%20second%22%60%20reflects%20the%20clamped%20value%2C%20not%20the%20actual%20elapsed%20time.%20dropping%20the%20floor%20to%200%20and%20branching%20on%20it%20in%20callers%20%28or%20returning%20a%20dedicated%20%22expired%22%20string%29%20would%20give%20a%20more%20actionable%20message.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fauth%2Fdevice-auth.ts%3A304-310%0A**%60isPendingStatus%28404%29%60%20retries%20until%20timeout%20on%20genuinely-invalid%20device%20auth%20IDs**%0A%0Atreating%20HTTP%20404%20as%20a%20retryable%20pending%20state%20is%20non-standard%3A%20if%20the%20openai%20server%20returns%20404%20because%20%60device_auth_id%60%20is%20not%20found%20%28expired%2C%20already%20consumed%2C%20or%20mis-formed%29%2C%20the%20loop%20will%20silently%20poll%20until%20%60timeoutMs%60%20expires%20instead%20of%20surfacing%20a%20hard%20failure.%20the%20test%20suite%20confirms%20404%20is%20intentionally%20retried%20here%2C%20but%20if%20the%20upstream%20api%20uses%20404%20to%20signal%20%22code%20not%20found%22%20the%20UX%20will%20be%20a%20silent%2015-minute%20wait.%20if%20the%20openai%20device-auth%20api%20guarantees%20404%20means%20%22not%20authorized%20yet%22%20%28not%20%22unknown%20session%22%29%2C%20an%20inline%20comment%20explaining%20that%20contract%20would%20make%20this%20safe%20and%20reviewable%3B%20otherwise%20consider%20treating%20404%20differently%20from%20403.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/auth/device-auth.ts
Line: 296-301

Comment:
**`formatWaitBudget(0)` floors to "1 second" for already-expired codes**

the `Math.max(1, ...)` clamp means that when `effectiveTimeoutMs` is 0 (server returns an already-expired `expires_at`), both `printDeviceAuthorizationPrompt` and the polling timeout error message will say "1 second" rather than indicating the code is already expired. the `codex-manager-cli.test.ts` expiry regression test confirms this — the assertion `"Device auth timed out after 1 second"` reflects the clamped value, not the actual elapsed time. dropping the floor to 0 and branching on it in callers (or returning a dedicated "expired" string) would give a more actionable message.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/auth/device-auth.ts
Line: 304-310

Comment:
**`isPendingStatus(404)` retries until timeout on genuinely-invalid device auth IDs**

treating HTTP 404 as a retryable pending state is non-standard: if the openai server returns 404 because `device_auth_id` is not found (expired, already consumed, or mis-formed), the loop will silently poll until `timeoutMs` expires instead of surfacing a hard failure. the test suite confirms 404 is intentionally retried here, but if the upstream api uses 404 to signal "code not found" the UX will be a silent 15-minute wait. if the openai device-auth api guarantees 404 means "not authorized yet" (not "unknown session"), an inline comment explaining that contract would make this safe and reviewable; otherwise consider treating 404 differently from 403.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (9): Last reviewed commit: ["fix: close device auth review nits"](https://github.com/ndycode/codex-multi-auth/commit/a9ce87cc110c5a5441c6bb8cfb0451233ec896c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29757237)</sub>

<!-- /greptile_comment -->