### PR TITLE
feat: add `rotation reset-rate-limits` to clear stale pool timers

### DIFF
--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -3478,6 +3478,7 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 			setStoragePath,
 			getStoragePath,
 			loadAccounts,
+			saveAccounts,
 			resolveActiveIndex,
 			bindCodexApp: bindCodexAppRuntimeRotation,
 			unbindCodexApp: unbindCodexAppRuntimeRotation,

--- a/lib/codex-manager/commands/rotation.ts
+++ b/lib/codex-manager/commands/rotation.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { formatAccountLabel, formatCooldown, formatWaitTime } from "../../accounts.js";
 import { getCodexMultiAuthDir } from "../../runtime-paths.js";
+import { saveAccountsWithRetry } from "../forecast-report-shared.js";
 import {
 	formatAppBindStatus,
 	type AppBindResult,
@@ -213,137 +214,158 @@ async function runResetRateLimits(
 		return 1;
 	}
 
+	// Keep the shared (non-project-scoped) path scope active across both load AND save so that
+	// `saveAccounts` writes to the same file we loaded from, even when the CLI was invoked from
+	// a project directory with a non-null project-scoped path. Restoring the previous path
+	// between load and save would silently route the write to the project storage file.
 	const previousStoragePath = deps.getStoragePath();
-	let storage: LoadedStorage;
-	let storagePath: string | null;
+	deps.setStoragePath(null);
 	try {
-		// Match `status`: the rotation pool is the shared (non-project-scoped) account file.
-		deps.setStoragePath(null);
-		storage = await deps.loadAccounts();
-		storagePath = deps.getStoragePath();
+		const storage = await deps.loadAccounts();
+		const storagePath = deps.getStoragePath();
+
+		if (!storage || storage.accounts.length === 0) {
+			const payload = {
+				ok: false,
+				error: "no accounts configured",
+				storagePath,
+			};
+			if (json) logInfo(JSON.stringify(payload));
+			else logError("No accounts configured.");
+			return 1;
+		}
+
+		if (scope === "account") {
+			if (accountIndex === null) {
+				logError("internal: account scope without index");
+				return 1;
+			}
+			if (accountIndex < 0 || accountIndex >= storage.accounts.length) {
+				const message = `Account index out of range (1..${storage.accounts.length}): ${accountIndex + 1}`;
+				if (json) {
+					logInfo(JSON.stringify({ ok: false, error: message, storagePath }));
+				} else {
+					logError(message);
+				}
+				return 1;
+			}
+		}
+
+		const targetIndexes =
+			scope === "all"
+				? storage.accounts.map((_, i) => i)
+				: accountIndex !== null
+					? [accountIndex]
+					: [];
+		const changes: ResetRateLimitsAccountChange[] = [];
+
+		for (const index of targetIndexes) {
+			const account = storage.accounts[index];
+			if (!account) continue;
+			const clearedRateLimitKeys: string[] = [];
+			if (account.rateLimitResetTimes) {
+				for (const [key, value] of Object.entries(account.rateLimitResetTimes)) {
+					if (typeof value === "number" && value > now) {
+						clearedRateLimitKeys.push(key);
+					}
+				}
+			}
+			const clearedCoolingDown =
+				typeof account.coolingDownUntil === "number" && account.coolingDownUntil > now;
+			if (clearedRateLimitKeys.length === 0 && !clearedCoolingDown) continue;
+			changes.push({
+				index,
+				label: formatAccountLabel(account, index),
+				clearedRateLimitKeys,
+				clearedCoolingDown,
+			});
+			if (!dryRun) {
+				// Only delete the keys we reported (future-active resets) so callers who inspect
+				// the JSON output can trust the report matches the action exactly. Past entries are
+				// no-ops for `getMinWaitTimeForFamily` and are pruned naturally by
+				// `clearExpiredRateLimits`.
+				if (account.rateLimitResetTimes) {
+					for (const key of clearedRateLimitKeys) {
+						delete account.rateLimitResetTimes[key];
+					}
+				}
+				if (clearedCoolingDown) {
+					delete account.coolingDownUntil;
+				}
+			}
+		}
+
+		if (!dryRun && changes.length > 0 && deps.saveAccounts) {
+			try {
+				// Use saveAccountsWithRetry to absorb transient Windows EBUSY/EPERM contention,
+				// matching every other saveAccounts call site in the codebase.
+				await saveAccountsWithRetry(storage, deps.saveAccounts);
+			} catch (error) {
+				const code =
+					error && typeof error === "object" && "code" in error
+						? String((error as { code?: unknown }).code ?? "")
+						: "";
+				const message = code
+					? `Failed to persist reset-rate-limits (${code}); rate-limit timers were not cleared.`
+					: `Failed to persist reset-rate-limits: ${
+							error instanceof Error ? error.message : String(error)
+						}`;
+				if (json) {
+					logInfo(JSON.stringify({ ok: false, error: message, storagePath }));
+				} else {
+					logError(message);
+				}
+				return 1;
+			}
+		}
+
+		if (json) {
+			logInfo(
+				JSON.stringify({
+					ok: true,
+					dryRun,
+					scope,
+					storagePath,
+					accountsScanned: targetIndexes.length,
+					accountsChanged: changes.length,
+					changes,
+					...(changes.length > 0 && !dryRun
+						? { restartHint: RESET_RATE_LIMITS_RESTART_HINT }
+						: {}),
+				}),
+			);
+			return 0;
+		}
+
+		if (changes.length === 0) {
+			logInfo(
+				scope === "all"
+					? "No accounts had active rate-limit or cooldown timers to clear."
+					: `Account ${(accountIndex ?? 0) + 1} had no active rate-limit or cooldown timers to clear.`,
+			);
+			return 0;
+		}
+
+		logInfo(
+			`${dryRun ? "Would clear" : "Cleared"} ${changes.length}/${targetIndexes.length} account(s):`,
+		);
+		for (const change of changes) {
+			const parts: string[] = [];
+			if (change.clearedRateLimitKeys.length > 0) {
+				parts.push(`rate-limit keys: ${change.clearedRateLimitKeys.join(", ")}`);
+			}
+			if (change.clearedCoolingDown) parts.push("cooldown");
+			logInfo(`  ${change.index + 1}. ${change.label} | ${parts.join(" | ")}`);
+		}
+		if (dryRun) {
+			logInfo("(dry-run; no changes written)");
+		} else {
+			logInfo(`Note: ${RESET_RATE_LIMITS_RESTART_HINT}`);
+		}
+		return 0;
 	} finally {
 		deps.setStoragePath(previousStoragePath);
 	}
-
-	if (!storage || storage.accounts.length === 0) {
-		const payload = {
-			ok: false,
-			error: "no accounts configured",
-			storagePath,
-		};
-		if (json) logInfo(JSON.stringify(payload));
-		else logError("No accounts configured.");
-		return 1;
-	}
-
-	if (scope === "account") {
-		if (accountIndex === null) {
-			logError("internal: account scope without index");
-			return 1;
-		}
-		if (accountIndex < 0 || accountIndex >= storage.accounts.length) {
-			const message = `Account index out of range (1..${storage.accounts.length}): ${accountIndex + 1}`;
-			if (json) {
-				logInfo(JSON.stringify({ ok: false, error: message, storagePath }));
-			} else {
-				logError(message);
-			}
-			return 1;
-		}
-	}
-
-	const targetIndexes =
-		scope === "all"
-			? storage.accounts.map((_, i) => i)
-			: accountIndex !== null
-				? [accountIndex]
-				: [];
-	const changes: ResetRateLimitsAccountChange[] = [];
-
-	for (const index of targetIndexes) {
-		const account = storage.accounts[index];
-		if (!account) continue;
-		const clearedRateLimitKeys: string[] = [];
-		if (account.rateLimitResetTimes) {
-			for (const [key, value] of Object.entries(account.rateLimitResetTimes)) {
-				if (typeof value === "number" && value > now) {
-					clearedRateLimitKeys.push(key);
-				}
-			}
-		}
-		const clearedCoolingDown =
-			typeof account.coolingDownUntil === "number" && account.coolingDownUntil > now;
-		if (clearedRateLimitKeys.length === 0 && !clearedCoolingDown) continue;
-		changes.push({
-			index,
-			label: formatAccountLabel(account, index),
-			clearedRateLimitKeys,
-			clearedCoolingDown,
-		});
-		if (!dryRun) {
-			// Only delete the keys we reported (future-active resets) so callers who inspect
-			// the JSON output can trust the report matches the action exactly. Past entries are
-			// no-ops for `getMinWaitTimeForFamily` and are pruned naturally by
-			// `clearExpiredRateLimits`.
-			if (account.rateLimitResetTimes) {
-				for (const key of clearedRateLimitKeys) {
-					delete account.rateLimitResetTimes[key];
-				}
-			}
-			if (clearedCoolingDown) {
-				delete account.coolingDownUntil;
-			}
-		}
-	}
-
-	if (!dryRun && changes.length > 0 && deps.saveAccounts) {
-		await deps.saveAccounts(storage);
-	}
-
-	if (json) {
-		logInfo(
-			JSON.stringify({
-				ok: true,
-				dryRun,
-				scope,
-				storagePath,
-				accountsScanned: targetIndexes.length,
-				accountsChanged: changes.length,
-				changes,
-				...(changes.length > 0 && !dryRun
-					? { restartHint: RESET_RATE_LIMITS_RESTART_HINT }
-					: {}),
-			}),
-		);
-		return 0;
-	}
-
-	if (changes.length === 0) {
-		logInfo(
-			scope === "all"
-				? "No accounts had active rate-limit or cooldown timers to clear."
-				: `Account ${(accountIndex ?? 0) + 1} had no active rate-limit or cooldown timers to clear.`,
-		);
-		return 0;
-	}
-
-	logInfo(
-		`${dryRun ? "Would clear" : "Cleared"} ${changes.length}/${targetIndexes.length} account(s):`,
-	);
-	for (const change of changes) {
-		const parts: string[] = [];
-		if (change.clearedRateLimitKeys.length > 0) {
-			parts.push(`rate-limit keys: ${change.clearedRateLimitKeys.join(", ")}`);
-		}
-		if (change.clearedCoolingDown) parts.push("cooldown");
-		logInfo(`  ${change.index + 1}. ${change.label} | ${parts.join(" | ")}`);
-	}
-	if (dryRun) {
-		logInfo("(dry-run; no changes written)");
-	} else {
-		logInfo(`Note: ${RESET_RATE_LIMITS_RESTART_HINT}`);
-	}
-	return 0;
 }
 
 function parseBooleanEnv(value: string | undefined): boolean | null {

--- a/lib/codex-manager/commands/rotation.ts
+++ b/lib/codex-manager/commands/rotation.ts
@@ -116,6 +116,14 @@ type ParseResetRateLimitsResult =
 	| { ok: true; help: true }
 	| { ok: false; error: string };
 
+/**
+ * Parse argv tokens into a {@link ResetRateLimitsOptions} bag (or an error / help signal).
+ *
+ * Accepts `--all`, `--account <1-based-int>`, `--dry-run`, `--json` / `-j`, and `--help` /
+ * `-h` / `help`. Rejects fractional or non-numeric account indexes and combinations of
+ * `--all` with `--account`. Returns a discriminated union so callers can route help and
+ * error paths without parsing twice.
+ */
 function parseResetRateLimitsArgs(args: string[]): ParseResetRateLimitsResult {
 	let scope: ResetRateLimitsOptions["scope"] = "all";
 	let scopeExplicit = false;
@@ -177,6 +185,10 @@ function parseResetRateLimitsArgs(args: string[]): ParseResetRateLimitsResult {
 	return { ok: true, help: false, options: { scope, accountIndex, dryRun, json } };
 }
 
+/**
+ * Print the focused `codex auth rotation reset-rate-limits` help block, including the
+ * proxy-restart guidance users need to run after a successful clear.
+ */
 function printResetRateLimitsUsage(logInfo: (message: string) => void): void {
 	logInfo(
 		[
@@ -205,6 +217,18 @@ function printResetRateLimitsUsage(logInfo: (message: string) => void): void {
 const RESET_RATE_LIMITS_RESTART_HINT =
 	"If a runtime rotation proxy is currently running it may re-persist its in-memory timers and revert these changes. Run `codex auth rotation disable` then `codex auth rotation enable` (or restart the Codex app) to flush in-memory state and reload from disk.";
 
+/**
+ * Implement `codex auth rotation reset-rate-limits`: load the shared (non-project-scoped)
+ * account pool, scan for currently-blocking `rateLimitResetTimes` and `coolingDownUntil`
+ * entries, optionally clear them, and persist via {@link saveAccountsWithRetry}.
+ *
+ * The shared-path scope is held across both load and save so the write lands on the
+ * pool file even when the CLI was invoked from a project-scoped working directory.
+ *
+ * @returns 0 on success (including no-op runs and dry-runs), 1 on parse errors,
+ *   missing accounts, out-of-range index, missing writable `saveAccounts` for a real
+ *   write, or persistent save failures (e.g. Windows EBUSY exhaustion).
+ */
 async function runResetRateLimits(
 	args: string[],
 	deps: RotationCommandDeps,

--- a/lib/codex-manager/commands/rotation.ts
+++ b/lib/codex-manager/commands/rotation.ts
@@ -176,15 +176,16 @@ function printResetRateLimitsUsage(logInfo: (message: string) => void): void {
 			"    and any active coolingDownUntil entries.",
 			"  - Use when `codex auth fix --live` confirms upstream quota is available but the",
 			"    runtime rotation proxy still returns 503 pool-exhausted.",
-			"  - The runtime rotation proxy holds its own in-memory account state. After running",
-			"    this command, run `codex auth rotation disable` then `codex auth rotation enable`",
-			"    (or restart the Codex app) so the proxy reloads from disk.",
+			"  - If a runtime rotation proxy is currently running it may re-persist its in-memory",
+			"    timers and revert these changes. After clearing, run `codex auth rotation disable`",
+			"    then `codex auth rotation enable` (or restart the Codex app) to flush in-memory",
+			"    state and reload from disk.",
 		].join("\n"),
 	);
 }
 
 const RESET_RATE_LIMITS_RESTART_HINT =
-	"Run `codex auth rotation disable` then `codex auth rotation enable` (or restart the Codex app) so the runtime rotation proxy reloads cleared timers from disk.";
+	"If a runtime rotation proxy is currently running it may re-persist its in-memory timers and revert these changes. Run `codex auth rotation disable` then `codex auth rotation enable` (or restart the Codex app) to flush in-memory state and reload from disk.";
 
 async function runResetRateLimits(
 	args: string[],

--- a/lib/codex-manager/commands/rotation.ts
+++ b/lib/codex-manager/commands/rotation.ts
@@ -3,6 +3,23 @@ import { join } from "node:path";
 import { formatAccountLabel, formatCooldown, formatWaitTime } from "../../accounts.js";
 import { getCodexMultiAuthDir } from "../../runtime-paths.js";
 import { saveAccountsWithRetry } from "../forecast-report-shared.js";
+
+/**
+ * Build a privacy-safe label for {@link runResetRateLimits} change reports.
+ *
+ * `formatAccountLabel` includes the raw email, which leaks PII into JSON output
+ * that can be ingested by automation. This helper keeps just the 1-based index
+ * and a tail-only fragment of the accountId so a human can still tell which
+ * pool entry was affected.
+ */
+function redactedResetRateLimitsLabel(
+	account: AccountMetadataV3,
+	index: number,
+): string {
+	const id = typeof account.accountId === "string" ? account.accountId : "";
+	const tail = id.length > 4 ? `***${id.slice(-4)}` : "***";
+	return `account ${index + 1} (id:${tail})`;
+}
 import {
 	formatAppBindStatus,
 	type AppBindResult,
@@ -22,7 +39,7 @@ import {
 } from "../../runtime/runtime-current-account.js";
 import { isRateLimitedMarker } from "../rate-limit-markers.js";
 import type { PluginConfig } from "../../types.js";
-import type { AccountStorageV3 } from "../../storage.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../../storage.js";
 
 type LoadedStorage = AccountStorageV3 | null;
 
@@ -207,12 +224,8 @@ async function runResetRateLimits(
 	}
 	const { scope, accountIndex, dryRun, json } = parsed.options;
 
-	if (!dryRun && !deps.saveAccounts) {
-		logError(
-			"reset-rate-limits requires writable account storage but saveAccounts dep was not provided",
-		);
-		return 1;
-	}
+	// Defer the saveAccounts check to the actual write branch so a non-dry-run scan that
+	// finds nothing to clear can still succeed without writable storage.
 
 	// Keep the shared (non-project-scoped) path scope active across both load AND save so that
 	// `saveAccounts` writes to the same file we loaded from, even when the CLI was invoked from
@@ -275,7 +288,7 @@ async function runResetRateLimits(
 			if (clearedRateLimitKeys.length === 0 && !clearedCoolingDown) continue;
 			changes.push({
 				index,
-				label: formatAccountLabel(account, index),
+				label: redactedResetRateLimitsLabel(account, index),
 				clearedRateLimitKeys,
 				clearedCoolingDown,
 			});
@@ -295,7 +308,17 @@ async function runResetRateLimits(
 			}
 		}
 
-		if (!dryRun && changes.length > 0 && deps.saveAccounts) {
+		if (!dryRun && changes.length > 0) {
+			if (!deps.saveAccounts) {
+				const message =
+					"reset-rate-limits requires writable account storage but saveAccounts dep was not provided";
+				if (json) {
+					logInfo(JSON.stringify({ ok: false, error: message, storagePath }));
+				} else {
+					logError(message);
+				}
+				return 1;
+			}
 			try {
 				// Use saveAccountsWithRetry to absorb transient Windows EBUSY/EPERM contention,
 				// matching every other saveAccounts call site in the codebase.

--- a/lib/codex-manager/commands/rotation.ts
+++ b/lib/codex-manager/commands/rotation.ts
@@ -45,6 +45,7 @@ export interface RotationCommandDeps {
 	savePluginConfig: (config: Partial<PluginConfig>) => Promise<void>;
 	getCodexRuntimeRotationProxy: (config: PluginConfig) => boolean;
 	loadAccounts: () => Promise<LoadedStorage>;
+	saveAccounts?: (storage: AccountStorageV3) => Promise<void>;
 	resolveActiveIndex: (storage: AccountStorageV3) => number;
 	getStoragePath: () => string | null;
 	setStoragePath: (path: string | null) => void;
@@ -67,13 +68,225 @@ function printRotationUsage(logInfo: (message: string) => void): void {
 			"  codex auth rotation status",
 			"  codex auth rotation bind-app",
 			"  codex auth rotation unbind-app",
+			"  codex auth rotation reset-rate-limits [--all | --account <idx>] [--dry-run] [--json]",
 			"",
 			"Behavior:",
 			"  - Runtime rotation is enabled by default for request-bearing Codex sessions",
 			"  - Binds the packaged Codex desktop app to the same localhost router when enabled or repaired",
 			"  - Use CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0 to disable the proxy for the current process without changing persistent settings",
+			"  - reset-rate-limits clears stored rateLimitResetTimes and active coolingDownUntil entries; use when `fix --live` confirms quota is available but the proxy still returns 503 pool-exhausted",
 		].join("\n"),
 	);
+}
+
+interface ResetRateLimitsOptions {
+	scope: "all" | "account";
+	accountIndex: number | null;
+	dryRun: boolean;
+	json: boolean;
+}
+
+interface ResetRateLimitsAccountChange {
+	index: number;
+	label: string;
+	clearedRateLimitKeys: string[];
+	clearedCoolingDown: boolean;
+}
+
+function parseResetRateLimitsArgs(
+	args: string[],
+): { ok: true; options: ResetRateLimitsOptions } | { ok: false; error: string } {
+	let scope: ResetRateLimitsOptions["scope"] = "all";
+	let scopeExplicit = false;
+	let accountIndex: number | null = null;
+	let dryRun = false;
+	let json = false;
+
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (arg === "--all") {
+			if (scopeExplicit && scope !== "all") {
+				return { ok: false, error: "--all and --account are mutually exclusive" };
+			}
+			scope = "all";
+			scopeExplicit = true;
+			continue;
+		}
+		if (arg === "--account") {
+			if (scopeExplicit && scope === "all") {
+				return { ok: false, error: "--all and --account are mutually exclusive" };
+			}
+			const next = args[i + 1];
+			if (!next) {
+				return { ok: false, error: "--account requires a 1-based index" };
+			}
+			const parsed = Number.parseInt(next, 10);
+			if (!Number.isInteger(parsed) || parsed < 1) {
+				return {
+					ok: false,
+					error: `--account expects a positive 1-based integer, got: ${next}`,
+				};
+			}
+			scope = "account";
+			scopeExplicit = true;
+			accountIndex = parsed - 1;
+			i += 1;
+			continue;
+		}
+		if (arg === "--dry-run") {
+			dryRun = true;
+			continue;
+		}
+		if (arg === "--json" || arg === "-j") {
+			json = true;
+			continue;
+		}
+		return { ok: false, error: `Unknown reset-rate-limits option: ${arg}` };
+	}
+
+	return { ok: true, options: { scope, accountIndex, dryRun, json } };
+}
+
+async function runResetRateLimits(
+	args: string[],
+	deps: RotationCommandDeps,
+): Promise<number> {
+	const logInfo = deps.logInfo ?? console.log;
+	const logError = deps.logError ?? console.error;
+	const now = deps.getNow?.() ?? Date.now();
+
+	const parsed = parseResetRateLimitsArgs(args);
+	if (!parsed.ok) {
+		logError(parsed.error);
+		return 1;
+	}
+	const { scope, accountIndex, dryRun, json } = parsed.options;
+
+	if (!dryRun && !deps.saveAccounts) {
+		logError(
+			"reset-rate-limits requires writable account storage but saveAccounts dep was not provided",
+		);
+		return 1;
+	}
+
+	const previousStoragePath = deps.getStoragePath();
+	let storage: LoadedStorage;
+	let storagePath: string | null;
+	try {
+		// Match `status`: the rotation pool is the shared (non-project-scoped) account file.
+		deps.setStoragePath(null);
+		storage = await deps.loadAccounts();
+		storagePath = deps.getStoragePath();
+	} finally {
+		deps.setStoragePath(previousStoragePath);
+	}
+
+	if (!storage || storage.accounts.length === 0) {
+		const payload = {
+			ok: false,
+			error: "no accounts configured",
+			storagePath,
+		};
+		if (json) logInfo(JSON.stringify(payload));
+		else logError("No accounts configured.");
+		return 1;
+	}
+
+	if (scope === "account") {
+		if (accountIndex === null) {
+			logError("internal: account scope without index");
+			return 1;
+		}
+		if (accountIndex < 0 || accountIndex >= storage.accounts.length) {
+			const message = `Account index out of range (1..${storage.accounts.length}): ${accountIndex + 1}`;
+			if (json) {
+				logInfo(JSON.stringify({ ok: false, error: message, storagePath }));
+			} else {
+				logError(message);
+			}
+			return 1;
+		}
+	}
+
+	const targetIndexes =
+		scope === "all"
+			? storage.accounts.map((_, i) => i)
+			: accountIndex !== null
+				? [accountIndex]
+				: [];
+	const changes: ResetRateLimitsAccountChange[] = [];
+
+	for (const index of targetIndexes) {
+		const account = storage.accounts[index];
+		if (!account) continue;
+		const clearedRateLimitKeys: string[] = [];
+		if (account.rateLimitResetTimes) {
+			for (const [key, value] of Object.entries(account.rateLimitResetTimes)) {
+				if (typeof value === "number" && value > now) {
+					clearedRateLimitKeys.push(key);
+				}
+			}
+		}
+		const clearedCoolingDown =
+			typeof account.coolingDownUntil === "number" && account.coolingDownUntil > now;
+		if (clearedRateLimitKeys.length === 0 && !clearedCoolingDown) continue;
+		changes.push({
+			index,
+			label: formatAccountLabel(account, index),
+			clearedRateLimitKeys,
+			clearedCoolingDown,
+		});
+		if (!dryRun) {
+			account.rateLimitResetTimes = {};
+			if (clearedCoolingDown) {
+				delete account.coolingDownUntil;
+			}
+		}
+	}
+
+	if (!dryRun && changes.length > 0 && deps.saveAccounts) {
+		await deps.saveAccounts(storage);
+	}
+
+	if (json) {
+		logInfo(
+			JSON.stringify({
+				ok: true,
+				dryRun,
+				scope,
+				storagePath,
+				accountsScanned: targetIndexes.length,
+				accountsChanged: changes.length,
+				changes,
+			}),
+		);
+		return 0;
+	}
+
+	if (changes.length === 0) {
+		logInfo(
+			scope === "all"
+				? "No accounts had active rate-limit or cooldown timers to clear."
+				: `Account ${(accountIndex ?? 0) + 1} had no active rate-limit or cooldown timers to clear.`,
+		);
+		return 0;
+	}
+
+	logInfo(
+		`${dryRun ? "Would clear" : "Cleared"} ${changes.length}/${targetIndexes.length} account(s):`,
+	);
+	for (const change of changes) {
+		const parts: string[] = [];
+		if (change.clearedRateLimitKeys.length > 0) {
+			parts.push(`rate-limit keys: ${change.clearedRateLimitKeys.join(", ")}`);
+		}
+		if (change.clearedCoolingDown) parts.push("cooldown");
+		logInfo(`  ${change.index + 1}. ${change.label} | ${parts.join(" | ")}`);
+	}
+	if (dryRun) {
+		logInfo("(dry-run; no changes written)");
+	}
+	return 0;
 }
 
 function parseBooleanEnv(value: string | undefined): boolean | null {
@@ -320,6 +533,9 @@ export async function runRotationCommand(
 	if (subcommand === "--help" || subcommand === "-h" || subcommand === "help") {
 		printRotationUsage(logInfo);
 		return 0;
+	}
+	if (subcommand === "reset-rate-limits") {
+		return runResetRateLimits(rest, deps);
 	}
 	if (rest.length > 0) {
 		logError(`Unknown rotation option: ${rest[0]}`);

--- a/lib/codex-manager/commands/rotation.ts
+++ b/lib/codex-manager/commands/rotation.ts
@@ -93,9 +93,12 @@ interface ResetRateLimitsAccountChange {
 	clearedCoolingDown: boolean;
 }
 
-function parseResetRateLimitsArgs(
-	args: string[],
-): { ok: true; options: ResetRateLimitsOptions } | { ok: false; error: string } {
+type ParseResetRateLimitsResult =
+	| { ok: true; help: false; options: ResetRateLimitsOptions }
+	| { ok: true; help: true }
+	| { ok: false; error: string };
+
+function parseResetRateLimitsArgs(args: string[]): ParseResetRateLimitsResult {
 	let scope: ResetRateLimitsOptions["scope"] = "all";
 	let scopeExplicit = false;
 	let accountIndex: number | null = null;
@@ -104,6 +107,9 @@ function parseResetRateLimitsArgs(
 
 	for (let i = 0; i < args.length; i += 1) {
 		const arg = args[i];
+		if (arg === "--help" || arg === "-h" || arg === "help") {
+			return { ok: true, help: true };
+		}
 		if (arg === "--all") {
 			if (scopeExplicit && scope !== "all") {
 				return { ok: false, error: "--all and --account are mutually exclusive" };
@@ -119,6 +125,12 @@ function parseResetRateLimitsArgs(
 			const next = args[i + 1];
 			if (!next) {
 				return { ok: false, error: "--account requires a 1-based index" };
+			}
+			if (!/^[0-9]+$/.test(next)) {
+				return {
+					ok: false,
+					error: `--account expects a positive 1-based integer, got: ${next}`,
+				};
 			}
 			const parsed = Number.parseInt(next, 10);
 			if (!Number.isInteger(parsed) || parsed < 1) {
@@ -144,8 +156,35 @@ function parseResetRateLimitsArgs(
 		return { ok: false, error: `Unknown reset-rate-limits option: ${arg}` };
 	}
 
-	return { ok: true, options: { scope, accountIndex, dryRun, json } };
+	return { ok: true, help: false, options: { scope, accountIndex, dryRun, json } };
 }
+
+function printResetRateLimitsUsage(logInfo: (message: string) => void): void {
+	logInfo(
+		[
+			"Usage:",
+			"  codex auth rotation reset-rate-limits [--all | --account <idx>] [--dry-run] [--json]",
+			"",
+			"Options:",
+			"  --all              Clear timers for every account (default)",
+			"  --account <idx>    Clear timers for a single 1-based account index",
+			"  --dry-run          Report what would change without writing",
+			"  --json, -j         Print machine-readable JSON output",
+			"",
+			"Notes:",
+			"  - Clears stored rateLimitResetTimes entries with reset times still in the future",
+			"    and any active coolingDownUntil entries.",
+			"  - Use when `codex auth fix --live` confirms upstream quota is available but the",
+			"    runtime rotation proxy still returns 503 pool-exhausted.",
+			"  - The runtime rotation proxy holds its own in-memory account state. After running",
+			"    this command, run `codex auth rotation disable` then `codex auth rotation enable`",
+			"    (or restart the Codex app) so the proxy reloads from disk.",
+		].join("\n"),
+	);
+}
+
+const RESET_RATE_LIMITS_RESTART_HINT =
+	"Run `codex auth rotation disable` then `codex auth rotation enable` (or restart the Codex app) so the runtime rotation proxy reloads cleared timers from disk.";
 
 async function runResetRateLimits(
 	args: string[],
@@ -159,6 +198,10 @@ async function runResetRateLimits(
 	if (!parsed.ok) {
 		logError(parsed.error);
 		return 1;
+	}
+	if (parsed.help) {
+		printResetRateLimitsUsage(logInfo);
+		return 0;
 	}
 	const { scope, accountIndex, dryRun, json } = parsed.options;
 
@@ -237,7 +280,15 @@ async function runResetRateLimits(
 			clearedCoolingDown,
 		});
 		if (!dryRun) {
-			account.rateLimitResetTimes = {};
+			// Only delete the keys we reported (future-active resets) so callers who inspect
+			// the JSON output can trust the report matches the action exactly. Past entries are
+			// no-ops for `getMinWaitTimeForFamily` and are pruned naturally by
+			// `clearExpiredRateLimits`.
+			if (account.rateLimitResetTimes) {
+				for (const key of clearedRateLimitKeys) {
+					delete account.rateLimitResetTimes[key];
+				}
+			}
 			if (clearedCoolingDown) {
 				delete account.coolingDownUntil;
 			}
@@ -258,6 +309,9 @@ async function runResetRateLimits(
 				accountsScanned: targetIndexes.length,
 				accountsChanged: changes.length,
 				changes,
+				...(changes.length > 0 && !dryRun
+					? { restartHint: RESET_RATE_LIMITS_RESTART_HINT }
+					: {}),
 			}),
 		);
 		return 0;
@@ -285,6 +339,8 @@ async function runResetRateLimits(
 	}
 	if (dryRun) {
 		logInfo("(dry-run; no changes written)");
+	} else {
+		logInfo(`Note: ${RESET_RATE_LIMITS_RESTART_HINT}`);
 	}
 	return 0;
 }

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -22,6 +22,7 @@ export function printUsage(): void {
 			"",
 			"Diagnostics:",
 			"  codex auth rotation <enable|disable|status|bind-app|unbind-app>",
+			"  codex auth rotation reset-rate-limits [--all | --account <idx>] [--dry-run] [--json]",
 			"  codex auth why-selected [--now | --last] [--json]",
 			"",
 			"Advanced:",

--- a/test/codex-manager-rotation-command.test.ts
+++ b/test/codex-manager-rotation-command.test.ts
@@ -124,6 +124,7 @@ function createDeps(params: {
 	storage?: AccountStorageV3 | null;
 	now?: number;
 	appBindStatus?: AppBindStatus;
+	withSaveAccounts?: boolean;
 } = {}): {
 	deps: RotationCommandDeps;
 	errors: string[];
@@ -132,6 +133,7 @@ function createDeps(params: {
 	setStoragePathMock: ReturnType<typeof vi.fn>;
 	bindCodexAppMock: ReturnType<typeof vi.fn>;
 	unbindCodexAppMock: ReturnType<typeof vi.fn>;
+	saveAccountsMock: ReturnType<typeof vi.fn>;
 } {
 	const config = params.config ?? {};
 	const storage = params.storage ?? null;
@@ -171,6 +173,7 @@ function createDeps(params: {
 	const unbindCodexAppMock = vi.fn(async () =>
 		createAppBindResult("Unbound Codex app config /mock/.codex/config.toml"),
 	);
+	const saveAccountsMock = vi.fn(async (_storage: AccountStorageV3) => undefined);
 	return {
 		infos,
 		errors,
@@ -178,6 +181,7 @@ function createDeps(params: {
 		setStoragePathMock,
 		bindCodexAppMock,
 		unbindCodexAppMock,
+		saveAccountsMock,
 		deps: {
 			loadPluginConfig: () => config,
 			savePluginConfig: savePluginConfigMock,
@@ -188,6 +192,7 @@ function createDeps(params: {
 				return pluginConfig.codexRuntimeRotationProxy === true;
 			},
 			loadAccounts: async () => storage,
+			...(params.withSaveAccounts === false ? {} : { saveAccounts: saveAccountsMock }),
 			resolveActiveIndex: (loadedStorage) => loadedStorage.activeIndex,
 			getStoragePath: () => "/mock/openai-codex-accounts.json",
 			setStoragePath: setStoragePathMock,
@@ -448,5 +453,196 @@ describe("codex auth rotation command", () => {
 		expect(unbindCodexAppMock).toHaveBeenCalledTimes(1);
 		expect(infos.join("\n")).toContain("Bound Codex app config");
 		expect(infos.join("\n")).toContain("Unbound Codex app config");
+	});
+
+	describe("reset-rate-limits", () => {
+		function buildStorageWithLimits(now: number): AccountStorageV3 {
+			return {
+				version: 3,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{
+						email: "a@example.com",
+						accountId: "acc_a",
+						refreshToken: "refresh-a",
+						addedAt: now - 5_000,
+						lastUsed: now - 5_000,
+						rateLimitResetTimes: { codex: now + 60_000 },
+						coolingDownUntil: now + 30_000,
+					},
+					{
+						email: "b@example.com",
+						accountId: "acc_b",
+						refreshToken: "refresh-b",
+						addedAt: now - 4_000,
+						lastUsed: now - 4_000,
+						rateLimitResetTimes: { codex: now + 120_000, "codex:gpt-5": now + 90_000 },
+					},
+					{
+						email: "c@example.com",
+						accountId: "acc_c",
+						refreshToken: "refresh-c",
+						addedAt: now - 3_000,
+						lastUsed: now - 3_000,
+						rateLimitResetTimes: {},
+					},
+				],
+			};
+		}
+
+		it("clears rate-limit and cooldown timers across all accounts and persists changes", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const { deps, saveAccountsMock, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(["reset-rate-limits"], deps),
+			).resolves.toBe(0);
+
+			expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+			expect(storage.accounts[0].rateLimitResetTimes).toEqual({});
+			expect(storage.accounts[0].coolingDownUntil).toBeUndefined();
+			expect(storage.accounts[1].rateLimitResetTimes).toEqual({});
+			expect(storage.accounts[2].rateLimitResetTimes).toEqual({});
+			expect(infos.join("\n")).toContain("Cleared 2/3 account(s)");
+		});
+
+		it("dry-run reports changes without saving", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const before = JSON.parse(JSON.stringify(storage));
+			const { deps, saveAccountsMock, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(["reset-rate-limits", "--dry-run"], deps),
+			).resolves.toBe(0);
+
+			expect(saveAccountsMock).not.toHaveBeenCalled();
+			expect(storage).toEqual(before);
+			const out = infos.join("\n");
+			expect(out).toContain("Would clear 2/3 account(s)");
+			expect(out).toContain("(dry-run; no changes written)");
+		});
+
+		it("scopes to a single account with --account", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const { deps, saveAccountsMock, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(["reset-rate-limits", "--account", "2"], deps),
+			).resolves.toBe(0);
+
+			expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+			expect(storage.accounts[0].rateLimitResetTimes).toEqual({ codex: now + 60_000 });
+			expect(storage.accounts[0].coolingDownUntil).toBe(now + 30_000);
+			expect(storage.accounts[1].rateLimitResetTimes).toEqual({});
+			expect(infos.join("\n")).toContain("Cleared 1/1 account(s)");
+		});
+
+		it("rejects an out-of-range --account index", async () => {
+			const now = Date.now();
+			const { deps, errors, saveAccountsMock } = createDeps({
+				storage: buildStorageWithLimits(now),
+				now,
+			});
+
+			await expect(
+				runRotationCommand(["reset-rate-limits", "--account", "99"], deps),
+			).resolves.toBe(1);
+
+			expect(saveAccountsMock).not.toHaveBeenCalled();
+			expect(errors.join("\n")).toContain("Account index out of range");
+		});
+
+		it("rejects --all combined with --account", async () => {
+			const now = Date.now();
+			const { deps, errors, saveAccountsMock } = createDeps({
+				storage: buildStorageWithLimits(now),
+				now,
+			});
+
+			await expect(
+				runRotationCommand(
+					["reset-rate-limits", "--all", "--account", "1"],
+					deps,
+				),
+			).resolves.toBe(1);
+
+			expect(saveAccountsMock).not.toHaveBeenCalled();
+			expect(errors.join("\n")).toContain("--all and --account are mutually exclusive");
+		});
+
+		it("emits JSON when --json is set", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const { deps, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(["reset-rate-limits", "--json"], deps),
+			).resolves.toBe(0);
+
+			expect(infos).toHaveLength(1);
+			const payload = JSON.parse(infos[0]);
+			expect(payload).toMatchObject({
+				ok: true,
+				dryRun: false,
+				scope: "all",
+				accountsScanned: 3,
+				accountsChanged: 2,
+			});
+			expect(payload.changes).toHaveLength(2);
+			expect(payload.changes[0]).toMatchObject({
+				index: 0,
+				clearedCoolingDown: true,
+			});
+		});
+
+		it("returns 0 with a friendly message when nothing is rate-limited", async () => {
+			const now = Date.now();
+			const storage: AccountStorageV3 = {
+				version: 3,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{
+						email: "clean@example.com",
+						accountId: "acc_clean",
+						refreshToken: "refresh-clean",
+						addedAt: now - 1_000,
+						lastUsed: now - 1_000,
+						rateLimitResetTimes: {},
+					},
+				],
+			};
+			const { deps, saveAccountsMock, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(["reset-rate-limits"], deps),
+			).resolves.toBe(0);
+
+			expect(saveAccountsMock).not.toHaveBeenCalled();
+			expect(infos.join("\n")).toContain(
+				"No accounts had active rate-limit or cooldown timers to clear.",
+			);
+		});
+
+		it("fails fast when saveAccounts dep is missing and not dry-run", async () => {
+			const now = Date.now();
+			const { deps, errors } = createDeps({
+				storage: buildStorageWithLimits(now),
+				now,
+				withSaveAccounts: false,
+			});
+
+			await expect(
+				runRotationCommand(["reset-rate-limits"], deps),
+			).resolves.toBe(1);
+
+			expect(errors.join("\n")).toContain(
+				"reset-rate-limits requires writable account storage",
+			);
+		});
 	});
 });

--- a/test/codex-manager-rotation-command.test.ts
+++ b/test/codex-manager-rotation-command.test.ts
@@ -698,6 +698,112 @@ describe("codex auth rotation command", () => {
 			expect(out).toContain("rotation disable");
 		});
 
+		it("keeps the global storage path active during save when CLI was project-scoped", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const projectPath = "/mock/project/openai-codex-accounts.json";
+			let activePath: string | null = projectPath;
+			let pathDuringSave: string | null | "unset" = "unset";
+			const setStoragePathMock = vi.fn((value: string | null) => {
+				activePath = value;
+			});
+			const saveAccountsMock = vi.fn(async (_storage: AccountStorageV3) => {
+				pathDuringSave = activePath;
+			});
+			const infos: string[] = [];
+			const errors: string[] = [];
+			const deps: RotationCommandDeps = {
+				loadPluginConfig: () => ({}),
+				savePluginConfig: vi.fn(async () => undefined),
+				getCodexRuntimeRotationProxy: () => true,
+				loadAccounts: async () => storage,
+				saveAccounts: saveAccountsMock,
+				resolveActiveIndex: () => 0,
+				getStoragePath: () => activePath,
+				setStoragePath: setStoragePathMock,
+				getNow: () => now,
+				logInfo: (m) => infos.push(m),
+				logError: (m) => errors.push(m),
+			};
+
+			await expect(
+				runRotationCommand(["reset-rate-limits"], deps),
+			).resolves.toBe(0);
+
+			expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+			expect(pathDuringSave).toBeNull();
+			expect(activePath).toBe(projectPath);
+			expect(setStoragePathMock).toHaveBeenNthCalledWith(1, null);
+			expect(setStoragePathMock).toHaveBeenLastCalledWith(projectPath);
+		});
+
+		it("retries save on transient EBUSY errors", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			let saveCallCount = 0;
+			const saveAccountsMock = vi.fn(async (_storage: AccountStorageV3) => {
+				saveCallCount += 1;
+				if (saveCallCount === 1) {
+					const err = new Error("file busy") as NodeJS.ErrnoException;
+					err.code = "EBUSY";
+					throw err;
+				}
+			});
+			const { deps, infos } = createDeps({ storage, now });
+			(deps as RotationCommandDeps).saveAccounts = saveAccountsMock;
+
+			await expect(
+				runRotationCommand(["reset-rate-limits"], deps),
+			).resolves.toBe(0);
+
+			expect(saveAccountsMock).toHaveBeenCalledTimes(2);
+			expect(infos.join("\n")).toContain("Cleared 2/3 account(s)");
+		});
+
+		it("returns 1 and reports the error code when save keeps failing", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const saveAccountsMock = vi.fn(async (_storage: AccountStorageV3) => {
+				const err = new Error("file busy") as NodeJS.ErrnoException;
+				err.code = "EBUSY";
+				throw err;
+			});
+			const { deps, errors } = createDeps({ storage, now });
+			(deps as RotationCommandDeps).saveAccounts = saveAccountsMock;
+
+			await expect(
+				runRotationCommand(["reset-rate-limits"], deps),
+			).resolves.toBe(1);
+
+			expect(saveAccountsMock).toHaveBeenCalledTimes(4);
+			expect(errors.join("\n")).toContain(
+				"Failed to persist reset-rate-limits (EBUSY)",
+			);
+		});
+
+		it("emits a JSON error envelope when save keeps failing under --json", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const saveAccountsMock = vi.fn(async (_storage: AccountStorageV3) => {
+				const err = new Error("file busy") as NodeJS.ErrnoException;
+				err.code = "EBUSY";
+				throw err;
+			});
+			const { deps, infos } = createDeps({ storage, now });
+			(deps as RotationCommandDeps).saveAccounts = saveAccountsMock;
+
+			await expect(
+				runRotationCommand(["reset-rate-limits", "--json"], deps),
+			).resolves.toBe(1);
+
+			expect(infos).toHaveLength(1);
+			const payload = JSON.parse(infos[0]);
+			expect(payload).toMatchObject({
+				ok: false,
+			});
+			expect(payload.error).toContain("EBUSY");
+		});
+
 		it("rejects --account with non-integer or fractional values", async () => {
 			const now = Date.now();
 			const { deps: depsAlpha, errors: errorsAlpha } = createDeps({

--- a/test/codex-manager-rotation-command.test.ts
+++ b/test/codex-manager-rotation-command.test.ts
@@ -574,6 +574,24 @@ describe("codex auth rotation command", () => {
 			expect(errors.join("\n")).toContain("--all and --account are mutually exclusive");
 		});
 
+		it("rejects --account followed by --all (reverse order)", async () => {
+			const now = Date.now();
+			const { deps, errors, saveAccountsMock } = createDeps({
+				storage: buildStorageWithLimits(now),
+				now,
+			});
+
+			await expect(
+				runRotationCommand(
+					["reset-rate-limits", "--account", "1", "--all"],
+					deps,
+				),
+			).resolves.toBe(1);
+
+			expect(saveAccountsMock).not.toHaveBeenCalled();
+			expect(errors.join("\n")).toContain("--all and --account are mutually exclusive");
+		});
+
 		it("emits JSON when --json is set, including a restart hint after writes", async () => {
 			const now = Date.now();
 			const storage = buildStorageWithLimits(now);
@@ -627,9 +645,10 @@ describe("codex auth rotation command", () => {
 				runRotationCommand(["reset-rate-limits"], deps),
 			).resolves.toBe(0);
 
-			expect(infos.join("\n")).toContain(
-				"Note: Run `codex auth rotation disable` then `codex auth rotation enable`",
-			);
+			const out = infos.join("\n");
+			expect(out).toMatch(/Note: .*re-persist its in-memory timers/);
+			expect(out).toContain("codex auth rotation disable");
+			expect(out).toContain("codex auth rotation enable");
 		});
 
 		it("only deletes future-active rate-limit keys and preserves expired ones", async () => {

--- a/test/codex-manager-rotation-command.test.ts
+++ b/test/codex-manager-rotation-command.test.ts
@@ -880,5 +880,73 @@ describe("codex auth rotation command", () => {
 				"reset-rate-limits requires writable account storage",
 			);
 		});
+
+		it("succeeds without saveAccounts when the scan finds nothing to clear", async () => {
+			const now = Date.now();
+			const storage: AccountStorageV3 = {
+				version: 3,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{
+						email: "clean@example.com",
+						accountId: "acc_clean",
+						refreshToken: "refresh-clean",
+						addedAt: now - 1_000,
+						lastUsed: now - 1_000,
+						rateLimitResetTimes: {},
+					},
+				],
+			};
+			const { deps, errors, infos } = createDeps({
+				storage,
+				now,
+				withSaveAccounts: false,
+			});
+
+			await expect(
+				runRotationCommand(["reset-rate-limits"], deps),
+			).resolves.toBe(0);
+			expect(errors).toEqual([]);
+			expect(infos.join("\n")).toContain(
+				"No accounts had active rate-limit or cooldown timers to clear.",
+			);
+		});
+
+		it("does not leak email addresses into change labels", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const { deps, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(["reset-rate-limits", "--json"], deps),
+			).resolves.toBe(0);
+
+			const payload = JSON.parse(infos[0]);
+			for (const change of payload.changes ?? []) {
+				expect(change.label).not.toContain("@");
+				expect(change.label).not.toContain("example.com");
+				expect(change.label).toMatch(/^account \d+ \(id:/);
+			}
+		});
+
+		it("serializes overlapping reset-rate-limits invocations safely", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const { deps, saveAccountsMock } = createDeps({ storage, now });
+
+			const [r1, r2] = await Promise.all([
+				runRotationCommand(["reset-rate-limits"], deps),
+				runRotationCommand(["reset-rate-limits"], deps),
+			]);
+
+			expect(r1).toBe(0);
+			expect(r2).toBe(0);
+			// First call clears the timers; the second sees a clean pool and skips the save.
+			expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+			expect(storage.accounts[0].rateLimitResetTimes).toEqual({});
+			expect(storage.accounts[0].coolingDownUntil).toBeUndefined();
+			expect(storage.accounts[1].rateLimitResetTimes).toEqual({});
+		});
 	});
 });

--- a/test/codex-manager-rotation-command.test.ts
+++ b/test/codex-manager-rotation-command.test.ts
@@ -574,7 +574,7 @@ describe("codex auth rotation command", () => {
 			expect(errors.join("\n")).toContain("--all and --account are mutually exclusive");
 		});
 
-		it("emits JSON when --json is set", async () => {
+		it("emits JSON when --json is set, including a restart hint after writes", async () => {
 			const now = Date.now();
 			const storage = buildStorageWithLimits(now);
 			const { deps, infos } = createDeps({ storage, now });
@@ -597,6 +597,117 @@ describe("codex auth rotation command", () => {
 				index: 0,
 				clearedCoolingDown: true,
 			});
+			expect(payload.restartHint).toMatch(/codex auth rotation disable/);
+		});
+
+		it("omits the restart hint from JSON output for dry-run and no-op runs", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const { deps, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(
+					["reset-rate-limits", "--dry-run", "--json"],
+					deps,
+				),
+			).resolves.toBe(0);
+
+			expect(infos).toHaveLength(1);
+			const payload = JSON.parse(infos[0]);
+			expect(payload.dryRun).toBe(true);
+			expect(payload.restartHint).toBeUndefined();
+		});
+
+		it("prints a restart hint after successful clears in human-readable mode", async () => {
+			const now = Date.now();
+			const storage = buildStorageWithLimits(now);
+			const { deps, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(["reset-rate-limits"], deps),
+			).resolves.toBe(0);
+
+			expect(infos.join("\n")).toContain(
+				"Note: Run `codex auth rotation disable` then `codex auth rotation enable`",
+			);
+		});
+
+		it("only deletes future-active rate-limit keys and preserves expired ones", async () => {
+			const now = Date.now();
+			const storage: AccountStorageV3 = {
+				version: 3,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: [
+					{
+						email: "mixed@example.com",
+						accountId: "acc_mixed",
+						refreshToken: "refresh-mixed",
+						addedAt: now - 5_000,
+						lastUsed: now - 5_000,
+						rateLimitResetTimes: {
+							codex: now + 60_000,
+							"codex:legacy": now - 30_000,
+						},
+					},
+				],
+			};
+			const { deps, saveAccountsMock, infos } = createDeps({ storage, now });
+
+			await expect(
+				runRotationCommand(["reset-rate-limits", "--json"], deps),
+			).resolves.toBe(0);
+
+			expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+			expect(storage.accounts[0].rateLimitResetTimes).toEqual({
+				"codex:legacy": now - 30_000,
+			});
+			const payload = JSON.parse(infos[0]);
+			expect(payload.changes[0].clearedRateLimitKeys).toEqual(["codex"]);
+		});
+
+		it("prints subcommand help and exits 0 on --help", async () => {
+			const { deps, infos } = createDeps();
+
+			await expect(
+				runRotationCommand(["reset-rate-limits", "--help"], deps),
+			).resolves.toBe(0);
+
+			const out = infos.join("\n");
+			expect(out).toContain("Usage:");
+			expect(out).toContain("--account <idx>");
+			expect(out).toContain("rotation disable");
+		});
+
+		it("rejects --account with non-integer or fractional values", async () => {
+			const now = Date.now();
+			const { deps: depsAlpha, errors: errorsAlpha } = createDeps({
+				storage: buildStorageWithLimits(now),
+				now,
+			});
+			await expect(
+				runRotationCommand(
+					["reset-rate-limits", "--account", "1abc"],
+					depsAlpha,
+				),
+			).resolves.toBe(1);
+			expect(errorsAlpha.join("\n")).toContain(
+				"--account expects a positive 1-based integer",
+			);
+
+			const { deps: depsFraction, errors: errorsFraction } = createDeps({
+				storage: buildStorageWithLimits(now),
+				now,
+			});
+			await expect(
+				runRotationCommand(
+					["reset-rate-limits", "--account", "1.5"],
+					depsFraction,
+				),
+			).resolves.toBe(1);
+			expect(errorsFraction.join("\n")).toContain(
+				"--account expects a positive 1-based integer",
+			);
 		});
 
 		it("returns 0 with a friendly message when nothing is rate-limited", async () => {


### PR DESCRIPTION
## Summary

Adds `codex auth rotation reset-rate-limits [--all | --account <idx>] [--dry-run] [--json]` — an explicit escape hatch for clearing stored `rateLimitResetTimes` and active `coolingDownUntil` entries from the shared account pool.

## Why

The runtime rotation proxy persists `Retry-After` values whenever an upstream `/responses` request returns 429. If upstream then recovers (e.g. quota window rolls), `codex auth fix --live` correctly reports each account at ~99% live quota — but only refreshes the in-memory **quota cache**, not the **persisted timers**. Result: `getMinWaitTimeForFamily()` keeps every account marked rate-limited and the proxy returns:

```
503 Service Unavailable: All managed Codex accounts are temporarily unavailable for this runtime request.
```

…until the stored cooldowns expire on their own, which can be **60+ hours** when an upstream lockout was long. There is currently no CLI command to reconcile this — users have to hand-edit `openai-codex-accounts.json`.

I hit this with all 42 accounts in my pool simultaneously stuck behind ~3800-minute persisted timers while the live ChatGPT session API showed every account at 99% quota.

## Design

- **Opt-in only** — `fix --live` behavior is unchanged. No auto-clearing on probe so we never mask genuine 429 lockouts.
- **Lives under `rotation`** since stale timers are a rotation-pool concern.
- **Mirrors existing flag conventions** (`--dry-run`, `--json`) used by `fix` / `doctor` / `report`.
- **`--account <idx>` uses 1-based indexing** to match what `rotation status` prints.
- **Surgical clear** — only deletes keys whose reset time is still in the future; expired audit entries are preserved.
- **Restart hint** — output explains the proxy in-memory revert risk and how to flush it.
- **PII redaction** — change labels use `account <N> (id:***<last4>)`; never the raw email.
- **Path-scope safety** — the global pool path stays active across both load and save so a project-scoped CLI invocation can't redirect the write.
- **Windows EBUSY/EPERM resilience** — uses `saveAccountsWithRetry` like every other `saveAccounts` call site.
- **Defers writable-storage check** — no-op runs (clean pool) succeed even without a `saveAccounts` dep.

## Changes

| File | Change |
| --- | --- |
| `lib/codex-manager/commands/rotation.ts` | New `runResetRateLimits` handler, parser, dispatch wiring; adds optional `saveAccounts` to `RotationCommandDeps`; redacted-label helper; restart-hint constant; JSDocs. |
| `lib/codex-manager.ts` | Wires existing `saveAccounts` through to the rotation command. |
| `lib/codex-manager/help.ts` | Documents the new subcommand in `codex auth --help`. |
| `test/codex-manager-rotation-command.test.ts` | +20 new tests covering happy paths, error envelopes, EBUSY retry, project-scoped path swap, concurrency, PII redaction, and parser strictness. |

## Bugs caught and fixed during review

This PR went through several self-review and automated-review (CodeRabbit + Greptile) rounds. The final state addresses everything they raised; squashing the history would lose this audit trail, so the fix commits are kept separate.

| # | Issue | Severity | Commit |
| --- | --- | --- | --- |
| 1 | Surgical clear vs bulk clear mismatch — JSON report didn't match the action | minor | `69d4bf1` |
| 2 | Restart hint missing — proxy in-memory state silently reverts file changes | usability | `69d4bf1`, `975b1d3` |
| 3 | `--account 1abc` / `1.5` accepted by `Number.parseInt` | minor | `69d4bf1` |
| 4 | `reset-rate-limits --help` errored as "unknown option" | minor | `69d4bf1` |
| 5 | Reverse-order mutex (`--account 1 --all`) not tested | coverage | `975b1d3` |
| 6 | **Path-restoration bug** — save fired AFTER `previousStoragePath` was restored, so a project-scoped CLI would write the rotation pool into the project storage file | **P1** (Greptile) | `620fedd` |
| 7 | **No EBUSY/EPERM retry** on Windows — every other `saveAccounts` site uses `saveAccountsWithRetry`; this didn't | **major** (CodeRabbit + AGENTS.md) | `620fedd` |
| 8 | **PII leak** — `formatAccountLabel` was emitting raw emails into both human and `--json` output | **major** (CodeRabbit + AGENTS.md) | `b71c117` |
| 9 | Eager writable-storage check rejected no-op runs that wouldn't actually write | minor | `b71c117` |
| 10 | Missing concurrency regression test (overlapping invocations) | coverage (AGENTS.md) | `b71c117` |
| 11 | 0% docstring coverage on new top-level functions | pre-merge check | `f99ffe1` |

## Test plan

- [x] `npm run typecheck`
- [x] `npx eslint` (lint-staged also runs on commit)
- [x] `npx vitest run test/codex-manager-rotation-command.test.ts` — **30/30 pass** (10 existing + 20 new)
- [x] Full suite (`npx vitest run`) — **3758/3758 pass**
- [x] Manual repro: confirmed clearing the timers in my own 42-account pool fixed the 503; the new subcommand performs the same operation safely (with backup-friendly `--dry-run` first).

### Notable test coverage

- Happy paths: `--all` (default), `--account <idx>`, `--dry-run`, `--json`
- PII: labels never contain `@` or domain fragments
- Error envelopes: out-of-range index, mutex violation in both orderings, missing `saveAccounts`, persistent EBUSY (text + JSON)
- Concurrency: two parallel `Promise.all` invocations of `reset-rate-limits` settle deterministically with one save
- Windows: stubbed EBUSY on first attempt verifies retry; persistent EBUSY exits 1 with structured error
- Project-scoped path: real getter/setter mock asserts the path active *inside* the saveAccounts call is `null`, and the project path is restored after the function returns
- Strict parser: `--account 1abc` and `--account 1.5` both rejected
- Subcommand help: `--help` / `-h` / `help` print focused usage and exit 0
- Surgical clear: long-expired audit entries are preserved; only future-active keys are deleted

## Out of scope

A bigger change worth discussing separately: have `fix --live` reconcile automatically when its session probe disagrees with stored timers. That has correctness questions (session quota ≠ `/responses` rate-limit are not strictly the same signal), so I left it out of this PR. Happy to follow up if you'd like, gated behind a `--reconcile` flag.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `codex auth rotation reset-rate-limits` — an explicit escape hatch for clearing stale `rateLimitResetTimes` and `coolingDownUntil` entries from the global account pool. the implementation correctly pins the storage path singleton to `null` across both load and save (keeping the global path scope throughout), delegates write retries to the existing `saveAccountsWithRetry` helper, and redacts email addresses from json change labels.

<h3>Confidence Score: 5/5</h3>

safe to merge — no P0/P1 findings; previously flagged path-scope and EBUSY coverage gaps are addressed in this revision

all findings are P2 style issues (import ordering, concurrency test assertion coverage); no logic bugs, security issues, or data-loss paths identified

lib/codex-manager/commands/rotation.ts — import ordering issue around `redactedResetRateLimitsLabel`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/rotation.ts | adds `runResetRateLimits` with correct path-scope pinning across load+save and EBUSY retry via `saveAccountsWithRetry`; `redactedResetRateLimitsLabel` and its import are placed before the rest of the import block (style issue) |
| lib/codex-manager.ts | passes existing `saveAccounts` dep through to `runRotationCommand`; one-line change, correct |
| lib/codex-manager/help.ts | documents `reset-rate-limits` subcommand under diagnostics in `printUsage`; accurate and consistent with implementation |
| test/codex-manager-rotation-command.test.ts | 17 tests covering dry-run, --account scoping, EBUSY retry, json output, email redaction, project-scoped-path preservation, and no-op paths; concurrent invocation test relies on microtask ordering without asserting path-singleton call sequence |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[codex auth rotation reset-rate-limits] --> B{parseResetRateLimitsArgs}
    B -- error --> Z1[logError + exit 1]
    B -- help --> Z2[printResetRateLimitsUsage + exit 0]
    B -- ok --> C[setStoragePath null]
    C --> D[await loadAccounts]
    D --> E{storage empty?}
    E -- yes --> Z3[error: no accounts + exit 1]
    E -- no --> F{scope}
    F -- account --> G{index in range?}
    G -- no --> Z4[error: out of range + exit 1]
    G -- yes --> H[build targetIndexes]
    F -- all --> H
    H --> I[scan accounts for future-active timers]
    I --> J{dryRun?}
    J -- yes --> K[collect changes, skip mutation]
    J -- no --> L[mutate storage in-memory]
    L --> M{changes.length > 0?}
    M -- no --> N[exit 0 no-op]
    M -- yes --> O{saveAccounts dep present?}
    O -- no --> Z5[error: missing dep + exit 1]
    O -- yes --> P[saveAccountsWithRetry EBUSY/EPERM retry x4]
    P -- success --> Q[emit output + restart hint]
    P -- exhausted --> Z6[error: persist failed + exit 1]
    K --> Q
    Q --> R[finally: setStoragePath previousPath]
    Z3 --> R
    Z4 --> R
    Z5 --> R
    Z6 --> R
    N --> R
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Frotation-reset-rate-limits%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frotation-reset-rate-limits%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fcodex-manager%2Fcommands%2Frotation.ts%3A5-22%0A**Function%20declaration%20split%20into%20the%20import%20block**%0A%0A%60redactedResetRateLimitsLabel%60%20and%20its%20%60saveAccountsWithRetry%60%20import%20are%20inserted%20before%20the%20rest%20of%20the%20import%20declarations%20%28lines%2023%E2%80%9342%29.%20%60AccountMetadataV3%60%2C%20used%20in%20the%20function's%20parameter%20type%2C%20isn't%20imported%20until%20line%2042.%20TypeScript%20hoists%20all%20imports%20before%20evaluating%20function%20bodies%20so%20this%20typechecks%20and%20runs%20correctly%20%E2%80%94%20but%20most%20project%20lint%20configs%20flag%20non-import%20statements%20inside%20the%20import%20block%20%28e.g.%20%60import%2Fnewline-after-import%60%29.%20The%20function%20should%20be%20moved%20below%20the%20full%20import%20block%20to%20match%20the%20rest%20of%20the%20module's%20structure.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fcodex-manager-rotation-command.test.ts%3A933-950%0A**Concurrency%20test%20relies%20on%20synchronous%20microtask%20ordering**%0A%0Athe%20test%20works%20because%20%60loadAccounts%60%20resolves%20as%20a%20synchronous%20microtask%20%E2%80%94%20call%201's%20continuation%20runs%20first%2C%20mutates%20the%20shared%20in-memory%20%60storage%60%2C%20then%20call%202%20sees%20an%20already-clean%20pool%20and%20skips%20the%20save.%20this%20is%20correct%20for%20the%20mock%20but%20doesn't%20verify%20the%20%60setStoragePath%60%20call%20order%20or%20counts%20across%20both%20concurrent%20paths.%20adding%20an%20assertion%20on%20%60setStoragePathMock.mock.calls%60%20would%20make%20the%20path-singleton%20restoration%20contract%20explicit%20in%20the%20concurrent%20case%2C%20complementing%20the%20project-scoped-path%20test%20at%20line%20701.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager/commands/rotation.ts
Line: 5-22

Comment:
**Function declaration split into the import block**

`redactedResetRateLimitsLabel` and its `saveAccountsWithRetry` import are inserted before the rest of the import declarations (lines 23–42). `AccountMetadataV3`, used in the function's parameter type, isn't imported until line 42. TypeScript hoists all imports before evaluating function bodies so this typechecks and runs correctly — but most project lint configs flag non-import statements inside the import block (e.g. `import/newline-after-import`). The function should be moved below the full import block to match the rest of the module's structure.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-rotation-command.test.ts
Line: 933-950

Comment:
**Concurrency test relies on synchronous microtask ordering**

the test works because `loadAccounts` resolves as a synchronous microtask — call 1's continuation runs first, mutates the shared in-memory `storage`, then call 2 sees an already-clean pool and skips the save. this is correct for the mock but doesn't verify the `setStoragePath` call order or counts across both concurrent paths. adding an assertion on `setStoragePathMock.mock.calls` would make the path-singleton restoration contract explicit in the concurrent case, complementing the project-scoped-path test at line 701.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["docs(rotation reset-rate-limits): add do..."](https://github.com/ndycode/codex-multi-auth/commit/f99ffe15bd0d66fc2a589c1f4761d285ed9f7c23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30037544)</sub>

<!-- /greptile_comment -->