### PR TITLE
fix(storage): wrap remaining saveAccounts call sites with retry helper

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,4 +1,5 @@
 import type { Auth } from "@codex-ai/sdk";
+import { saveAccountsWithRetry } from "./codex-manager/forecast-report-shared.js";
 import { createLogger } from "./logger.js";
 import {
 	loadAccounts,
@@ -286,7 +287,7 @@ export class AccountManager {
 		const sourceOfTruthStorage = synced.storage ?? stored;
 		if (synced.changed && sourceOfTruthStorage) {
 			try {
-				await saveAccounts(sourceOfTruthStorage);
+				await saveAccountsWithRetry(sourceOfTruthStorage, saveAccounts);
 			} catch (error) {
 				log.debug("Failed to persist Codex CLI source-of-truth sync", {
 					error: String(error),

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -38,6 +38,7 @@ import {
 } from "./codex-manager/commands/best.js";
 import { runCheckCommand } from "./codex-manager/commands/check.js";
 import { runConfigExplainCommand } from "./codex-manager/commands/config-explain.js";
+import { saveAccountsWithRetry } from "./codex-manager/forecast-report-shared.js";
 import { runDebugBundleCommand } from "./codex-manager/commands/debug-bundle.js";
 import {
 	parseWhySelectedArgs,
@@ -2358,7 +2359,7 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 	}
 
 	if (changed) {
-		await saveAccounts(storage);
+		await saveAccountsWithRetry(storage, saveAccounts);
 	}
 
 	if (
@@ -3207,7 +3208,7 @@ async function persistAndSyncSelectedAccount({
 
 	account.lastUsed = switchNow;
 	account.lastSwitchReason = switchReason;
-	await saveAccounts(storage);
+	await saveAccountsWithRetry(storage, saveAccounts);
 
 	const synced = await setCodexCliActiveSelection({
 		accountId: account.accountId,

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -122,7 +122,30 @@ describe("accounts edge branches", () => {
     const manager = await AccountManager.loadFromDisk();
 
     expect(manager.getAccountCount()).toBe(1);
+    // Non-retryable error (no errno code) → single attempt, then debug-logged.
     expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+  });
+
+  it("loadFromDisk retries source-of-truth persist on transient EBUSY", async () => {
+    const stored = buildStored([
+      buildStoredAccount({ refreshToken: "stored-1" }),
+    ]);
+    mockLoadAccounts.mockResolvedValue(stored);
+    mockSyncAccountStorageFromCodexCli.mockResolvedValue({
+      storage: stored,
+      changed: true,
+    });
+    const ebusy = Object.assign(new Error("file busy"), { code: "EBUSY" });
+    mockSaveAccounts.mockRejectedValueOnce(ebusy);
+    mockSaveAccounts.mockResolvedValueOnce(undefined);
+    mockLoadCodexCliState.mockResolvedValue({ accounts: [] });
+
+    const { AccountManager } = await importAccountsModule();
+    const manager = await AccountManager.loadFromDisk();
+
+    expect(manager.getAccountCount()).toBe(1);
+    // First attempt EBUSY, second succeeds — retry helper should have called twice.
+    expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
   });
 
   it("hydrates from Codex CLI cache and catches save failures", async () => {

--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -148,6 +148,30 @@ describe("accounts edge branches", () => {
     expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
   });
 
+  it("loadFromDisk exhausts retries on persistent EPERM and continues", async () => {
+    const stored = buildStored([
+      buildStoredAccount({ refreshToken: "stored-1" }),
+    ]);
+    mockLoadAccounts.mockResolvedValue(stored);
+    mockSyncAccountStorageFromCodexCli.mockResolvedValue({
+      storage: stored,
+      changed: true,
+    });
+    const eperm = Object.assign(new Error("permission denied"), {
+      code: "EPERM",
+    });
+    mockSaveAccounts.mockRejectedValue(eperm);
+    mockLoadCodexCliState.mockResolvedValue({ accounts: [] });
+
+    const { AccountManager } = await importAccountsModule();
+    const manager = await AccountManager.loadFromDisk();
+
+    expect(manager.getAccountCount()).toBe(1);
+    // Persistent EPERM exhausts the retry budget (initial + 3 retries = 4
+    // attempts) before lib/accounts.ts catches and continues.
+    expect(mockSaveAccounts).toHaveBeenCalledTimes(4);
+  });
+
   it("hydrates from Codex CLI cache and catches save failures", async () => {
     const now = Date.now();
     const stored = buildStored([

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -3215,9 +3215,10 @@ describe("codex manager cli commands", () => {
 			],
 		});
 		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
-		saveAccountsMock.mockRejectedValueOnce(
-			makeErrnoError("save failed", "EBUSY"),
-		);
+		// Use mockRejectedValue (unbounded) so saveAccountsWithRetry's EBUSY retries
+		// also fail; the test asserts the rejection path and that we never silently
+		// drop the error.
+		saveAccountsMock.mockRejectedValue(makeErrnoError("save failed", "EBUSY"));
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		await expect(runCodexMultiAuthCli(["auth", "check"])).rejects.toMatchObject(

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -3545,6 +3545,116 @@ describe("codex manager cli commands", () => {
 		);
 	});
 
+	it("retries saveAccounts on transient EBUSY when persisting best-account switch", async () => {
+		// Regression for the saveAccountsWithRetry call in
+		// persistAndSyncSelectedAccount (lib/codex-manager.ts:3211): a single
+		// EBUSY must NOT abort the switch — the retry helper should recover.
+		const now = Date.now();
+		let storageState = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "current@example.com",
+					accountId: "acc_current",
+					refreshToken: "refresh-current",
+					accessToken: "access-current",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					coolingDownUntil: now + 60_000,
+					enabled: true,
+				},
+				{
+					email: "next@example.com",
+					accountId: "acc_next",
+					refreshToken: "refresh-next",
+					accessToken: "access-next",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		};
+		loadAccountsMock.mockImplementation(async () =>
+			structuredClone(storageState),
+		);
+		// First save attempt rejects with EBUSY; second succeeds. Without the
+		// retry wrapper this collapses to a single attempt and the switch fails.
+		saveAccountsMock.mockRejectedValueOnce(makeErrnoError("busy", "EBUSY"));
+		saveAccountsMock.mockImplementationOnce(async (nextStorage) => {
+			storageState = structuredClone(nextStorage);
+		});
+		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+
+		const exitCode = await runCodexMultiAuthCli(["auth", "best"]);
+
+		expect(exitCode).toBe(0);
+		expect(saveAccountsMock).toHaveBeenCalledTimes(2);
+		expect(storageState.activeIndex).toBe(1);
+		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		expect(logSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Switched to best account 2"),
+		);
+	});
+
+	it("propagates persistent EBUSY from persistAndSyncSelectedAccount after retry exhaustion", async () => {
+		// Regression for the saveAccountsWithRetry call in
+		// persistAndSyncSelectedAccount: when EBUSY persists past the retry
+		// budget (initial + 3 retries = 4 attempts), the error must propagate
+		// rather than be silently swallowed, and codex-cli must not be told
+		// about a switch that did not actually persist.
+		const now = Date.now();
+		const storageState = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "current@example.com",
+					accountId: "acc_current",
+					refreshToken: "refresh-current",
+					accessToken: "access-current",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					coolingDownUntil: now + 60_000,
+					enabled: true,
+				},
+				{
+					email: "next@example.com",
+					accountId: "acc_next",
+					refreshToken: "refresh-next",
+					accessToken: "access-next",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		};
+		loadAccountsMock.mockImplementation(async () =>
+			structuredClone(storageState),
+		);
+		saveAccountsMock.mockRejectedValue(makeErrnoError("busy", "EBUSY"));
+
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+
+		await expect(runCodexMultiAuthCli(["auth", "best"])).rejects.toMatchObject(
+			{
+				code: "EBUSY",
+			},
+		);
+		// Initial attempt + 3 retries = 4 calls before throwing.
+		expect(saveAccountsMock).toHaveBeenCalledTimes(4);
+		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+	});
+
 	it("parses --model=value for live best selection", async () => {
 		const now = Date.now();
 		loadAccountsMock.mockResolvedValueOnce({

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -3227,6 +3227,9 @@ describe("codex manager cli commands", () => {
 				message: "save failed",
 			},
 		);
+		// saveAccountsWithRetry must have retried beyond a single attempt; if a
+		// regression replaces it with a raw saveAccounts call, this drops to 1.
+		expect(saveAccountsMock.mock.calls.length).toBeGreaterThan(1);
 		expect(originalQuotaCache).toEqual({
 			byAccountId: {},
 			byEmail: {},


### PR DESCRIPTION
## Summary

Three production paths still wrote raw `await saveAccounts(storage)` without the EBUSY/EPERM retry helper that every other persistence boundary in this codebase uses. Wraps them in `saveAccountsWithRetry` so a transient Windows file-lock contention no longer silently drops a sync (or, in switch flows, fails the whole operation).

## Why this matters

Per `lib/AGENTS.md` ("focus on auth rotation, windows filesystem io, and concurrency. verify every change … new queues handle ebusy/429 scenarios"), every persistence boundary should be EBUSY-tolerant. The forecast / report / best / rotation-reset / new rotation-reset-rate-limits paths all already use `saveAccountsWithRetry` from `lib/codex-manager/forecast-report-shared.ts`. These three were the holdouts I found while auditing the codebase after #442:

| Site | Function | Failure mode |
| --- | --- | --- |
| `lib/accounts.ts:289` | `AccountManager.loadFromDisk` source-of-truth sync persist | A momentary file lock during startup silently drops the Codex CLI ↔ multi-auth sync. The catch already debug-logs but doesn't retry, so the in-memory state diverges from disk without user visibility. |
| `lib/codex-manager.ts:2362` | `runHealthCheck` post-mutation save | A transient lock during `codex auth check` rejects the whole command instead of riding through. |
| `lib/codex-manager.ts:3211` | `persistAndSyncSelectedAccount` pre-Codex-CLI-sync save | A transient lock during `codex auth switch` aborts the switch and may leave the active account out of sync. |

## Changes

- `lib/accounts.ts` — import `saveAccountsWithRetry`, replace one raw call.
- `lib/codex-manager.ts` — import `saveAccountsWithRetry`, replace two raw calls.
- `test/accounts-edge.test.ts` — new regression: `loadFromDisk retries source-of-truth persist on transient EBUSY`.
- `test/codex-manager-cli.test.ts` — existing `does not mutate loaded quota cache when live check account save fails` updated to use `mockRejectedValue` (unbounded) so the retry exhausts and the test still asserts its intended rejection path.

## Retry policy (unchanged)

Same as the existing `saveAccountsWithRetry` helper:
- Up to 3 retries on EBUSY / EPERM with backoff (`10 * 2 ** attempt` ms).
- Any non-retryable error (no `code`, or a code outside the EBUSY/EPERM set) re-throws on the first attempt.
- The existing test `loadFromDisk tolerates sync persistence failures` keeps its 1-call assertion: that error has no `code`, so it short-circuits as before.

## Test plan

- [x] `npm run typecheck`
- [x] `npx eslint`
- [x] Full suite: **3745 / 3745 pass**
- [x] Targeted: new EBUSY-retry regression in `accounts-edge.test.ts` confirms two attempts on a single transient failure.

## Notes

This is the first follow-up from a broader reliability audit of the codebase that surfaced four PR-sized improvements. Subsequent PRs will cover the path-singleton try/finally hardening, a concurrency regression test for path-singleton races, and cleanup of the unused `lastAccountEmail` field. Submitting them as separate PRs so each can be reviewed in isolation.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

wraps the three remaining raw `saveAccounts` call sites in `saveAccountsWithRetry` so transient windows file-lock errors (EBUSY/EPERM) no longer silently drop a startup sync or abort a switch/health-check command. all three paths now match the retry policy already in place everywhere else in the codebase.

<h3>Confidence Score: 5/5</h3>

safe to merge — only P2 style finding, logic and token safety are correct

all three call sites correctly pass the locally-imported saveAccounts as a callback, matching existing usage; no circular dependency introduced by the accounts.ts → forecast-report-shared import; retry semantics and error propagation are correct; tests cover transient recovery, exhaustion, and the no-codex-cli-sync guarantee; only finding is a cosmetic import ordering issue

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds import of saveAccountsWithRetry and wraps the loadFromDisk source-of-truth persist call; error catch block remains intact so transient windows EBUSY no longer silently drops the sync |
| lib/codex-manager.ts | imports saveAccountsWithRetry and wraps the two raw saveAccounts calls in runHealthCheck and persistAndSyncSelectedAccount; import is placed mid-commands/ block (P2 style only) |
| test/accounts-edge.test.ts | adds two new regression tests covering transient EBUSY recovery (2 calls) and persistent EPERM exhaustion (4 calls); both rely on real timers with small sleep totals (~70ms max), no fake-timer conflict |
| test/codex-manager-cli.test.ts | updates existing EBUSY test to unbounded mockRejectedValue so retries exhaust before asserting rejection; adds two new regression tests for persistAndSyncSelectedAccount (transient recovery and retry exhaustion with no codex-cli sync) |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant saveAccountsWithRetry
    participant saveAccounts (fs)

    Caller->>saveAccountsWithRetry: saveAccountsWithRetry(storage, saveAccounts)
    loop attempt 0..3
        saveAccountsWithRetry->>saveAccounts (fs): saveAccounts(storage)
        alt success
            saveAccounts (fs)-->>saveAccountsWithRetry: resolved
            saveAccountsWithRetry-->>Caller: return
        else EBUSY / EPERM and attempt < 3
            saveAccounts (fs)-->>saveAccountsWithRetry: throw {code: EBUSY|EPERM}
            saveAccountsWithRetry->>saveAccountsWithRetry: sleep(10 * 2^attempt ms)
        else non-retryable OR attempt >= 3
            saveAccounts (fs)-->>saveAccountsWithRetry: throw error
            saveAccountsWithRetry-->>Caller: rethrow
        end
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2FsaveAccounts-retry-windows-resilience%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2FsaveAccounts-retry-windows-resilience%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fcodex-manager.ts%3A41-42%0A**import%20inserted%20mid-%60commands%2F%60%20block**%0A%0A%60forecast-report-shared.js%60%20sorts%20lexically%20after%20%60commands%2F%60%20%28%60f%60%20%3E%20%60c%60%29%2C%20so%20it%20lands%20in%20the%20middle%20of%20the%20alphabetical%20%60commands%2F%60%20import%20group.%20consider%20moving%20it%20after%20the%20last%20%60commands%2F%60%20import%20to%20keep%20the%20block%20sorted%20and%20readable.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20runConfigExplainCommand%20%7D%20from%20%22.%2Fcodex-manager%2Fcommands%2Fconfig-explain.js%22%3B%0Aimport%20%7B%20runDebugBundleCommand%20%7D%20from%20%22.%2Fcodex-manager%2Fcommands%2Fdebug-bundle.js%22%3B%0Aimport%20%7B%20saveAccountsWithRetry%20%7D%20from%20%22.%2Fcodex-manager%2Fforecast-report-shared.js%22%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager.ts
Line: 41-42

Comment:
**import inserted mid-`commands/` block**

`forecast-report-shared.js` sorts lexically after `commands/` (`f` > `c`), so it lands in the middle of the alphabetical `commands/` import group. consider moving it after the last `commands/` import to keep the block sorted and readable.

```suggestion
import { runConfigExplainCommand } from "./codex-manager/commands/config-explain.js";
import { runDebugBundleCommand } from "./codex-manager/commands/debug-bundle.js";
import { saveAccountsWithRetry } from "./codex-manager/forecast-report-shared.js";
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test(codex-manager): cover persistAndSyn..."](https://github.com/ndycode/codex-multi-auth/commit/b42247ac5416cb710922d68de020fa2518631d34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30077170)</sub>

**Context used:**

- Context used - lib/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=ffbed5b7-f299-4c32-b3f9-f7c095ca8632))

<!-- /greptile_comment -->