### PR TITLE
fix(proactive-refresh): redact account email through maskEmail in log calls

### DIFF
--- a/lib/proactive-refresh.ts
+++ b/lib/proactive-refresh.ts
@@ -11,7 +11,7 @@
  */
 
 import { queuedRefresh } from "./refresh-queue.js";
-import { createLogger } from "./logger.js";
+import { createLogger, maskEmail } from "./logger.js";
 import type { ManagedAccount } from "./accounts.js";
 import type { TokenResult } from "./types.js";
 import {
@@ -110,7 +110,7 @@ export async function proactiveRefreshAccount(
 	const timeUntilExpiry = getTimeUntilExpiry(account);
 	log.info("Proactively refreshing token", {
 		accountIndex: account.index,
-		email: account.email,
+		...(account.email ? { email: maskEmail(account.email) } : {}),
 		expiresInMs: timeUntilExpiry,
 		expiresInMinutes: Math.round(timeUntilExpiry / 60000),
 	});
@@ -124,14 +124,14 @@ export async function proactiveRefreshAccount(
 	if (result.type === "success") {
 		log.info("Proactive refresh succeeded", {
 			accountIndex: account.index,
-			email: account.email,
+			...(account.email ? { email: maskEmail(account.email) } : {}),
 		});
 		return { refreshed: true, tokenResult: result, reason: "success" };
 	}
 
 	log.warn("Proactive refresh failed", {
 		accountIndex: account.index,
-		email: account.email,
+		...(account.email ? { email: maskEmail(account.email) } : {}),
 		failureReason: result.reason,
 	});
 	return { refreshed: true, tokenResult: result, reason: "failed" };

--- a/lib/proactive-refresh.ts
+++ b/lib/proactive-refresh.ts
@@ -110,7 +110,7 @@ export async function proactiveRefreshAccount(
 	const timeUntilExpiry = getTimeUntilExpiry(account);
 	log.info("Proactively refreshing token", {
 		accountIndex: account.index,
-		...(account.email ? { email: maskEmail(account.email) } : {}),
+		...(account.email ? { emailMasked: maskEmail(account.email) } : {}),
 		expiresInMs: timeUntilExpiry,
 		expiresInMinutes: Math.round(timeUntilExpiry / 60000),
 	});
@@ -124,14 +124,14 @@ export async function proactiveRefreshAccount(
 	if (result.type === "success") {
 		log.info("Proactive refresh succeeded", {
 			accountIndex: account.index,
-			...(account.email ? { email: maskEmail(account.email) } : {}),
+			...(account.email ? { emailMasked: maskEmail(account.email) } : {}),
 		});
 		return { refreshed: true, tokenResult: result, reason: "success" };
 	}
 
 	log.warn("Proactive refresh failed", {
 		accountIndex: account.index,
-		...(account.email ? { email: maskEmail(account.email) } : {}),
+		...(account.email ? { emailMasked: maskEmail(account.email) } : {}),
 		failureReason: result.reason,
 	});
 	return { refreshed: true, tokenResult: result, reason: "failed" };

--- a/test/proactive-refresh.test.ts
+++ b/test/proactive-refresh.test.ts
@@ -9,6 +9,7 @@ import {
 	MIN_PROACTIVE_BUFFER_MS,
 } from "../lib/proactive-refresh.js";
 import type { ManagedAccount } from "../lib/accounts.js";
+import * as logger from "../lib/logger.js";
 import * as refreshQueue from "../lib/refresh-queue.js";
 
 vi.mock("../lib/refresh-queue.js", () => ({
@@ -201,6 +202,61 @@ describe("proactive-refresh", () => {
 			expect(result.refreshed).toBe(true);
 			expect(result.reason).toBe("failed");
 			expect(result.tokenResult).toEqual(failResult);
+		});
+
+		it("redacts the account email through maskEmail in every log path", async () => {
+			const account = createMockAccount({
+				access: "old-access",
+				email: "user.example@longdomain.org",
+				expires: Date.now() + 60000,
+			});
+
+			const maskSpy = vi.spyOn(logger, "maskEmail");
+
+			// Success path emits both "Proactively refreshing token" and
+			// "Proactive refresh succeeded" — each masks the email once.
+			vi.mocked(refreshQueue.queuedRefresh).mockResolvedValueOnce({
+				type: "success" as const,
+				access: "new-access",
+				refresh: "new-refresh",
+				expires: Date.now() + 3600000,
+			});
+			await proactiveRefreshAccount(account);
+
+			// Failure path emits "Proactively refreshing token" and
+			// "Proactive refresh failed".
+			vi.mocked(refreshQueue.queuedRefresh).mockResolvedValueOnce({
+				type: "failed" as const,
+				reason: "network_error" as const,
+				message: "Network error",
+			});
+			await proactiveRefreshAccount(account);
+
+			expect(maskSpy).toHaveBeenCalledWith("user.example@longdomain.org");
+			// Two invocations × two log calls per invocation = 4 mask calls.
+			expect(maskSpy.mock.calls.length).toBeGreaterThanOrEqual(4);
+			maskSpy.mockRestore();
+		});
+
+		it("omits the email field entirely when account has no email", async () => {
+			const account = createMockAccount({
+				access: "old-access",
+				email: undefined,
+				expires: Date.now() + 60000,
+			});
+			const maskSpy = vi.spyOn(logger, "maskEmail");
+			vi.mocked(refreshQueue.queuedRefresh).mockResolvedValueOnce({
+				type: "success" as const,
+				access: "new-access",
+				refresh: "new-refresh",
+				expires: Date.now() + 3600000,
+			});
+
+			await proactiveRefreshAccount(account);
+
+			// No email key on the account → maskEmail must not be called.
+			expect(maskSpy).not.toHaveBeenCalled();
+			maskSpy.mockRestore();
 		});
 
 		it("uses custom buffer when specified", async () => {

--- a/test/proactive-refresh.test.ts
+++ b/test/proactive-refresh.test.ts
@@ -245,6 +245,14 @@ describe("proactive-refresh", () => {
 				expires: Date.now() + 60000,
 			});
 			const maskSpy = vi.spyOn(logger, "maskEmail");
+			// Capture the actual log payloads to prove the email key is absent
+			// (not merely emitted as `emailMasked: undefined`).
+			const infoSpy = vi
+				.spyOn(console, "info")
+				.mockImplementation(() => undefined);
+			const warnSpy = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => undefined);
 			vi.mocked(refreshQueue.queuedRefresh).mockResolvedValueOnce({
 				type: "success" as const,
 				access: "new-access",
@@ -256,7 +264,18 @@ describe("proactive-refresh", () => {
 
 			// No email key on the account → maskEmail must not be called.
 			expect(maskSpy).not.toHaveBeenCalled();
+			// And no log payload should carry an email-bearing key, even as undefined.
+			const allCalls = [...infoSpy.mock.calls, ...warnSpy.mock.calls];
+			for (const call of allCalls) {
+				const data = call[1];
+				if (data && typeof data === "object") {
+					expect(data).not.toHaveProperty("email");
+					expect(data).not.toHaveProperty("emailMasked");
+				}
+			}
 			maskSpy.mockRestore();
+			infoSpy.mockRestore();
+			warnSpy.mockRestore();
 		});
 
 		it("uses custom buffer when specified", async () => {


### PR DESCRIPTION
## Summary

Three log calls in `lib/proactive-refresh.ts` emitted `email: account.email` as a raw string:

- `lib/proactive-refresh.ts:113` — "Proactively refreshing token"
- `lib/proactive-refresh.ts:127` — "Proactive refresh succeeded"
- `lib/proactive-refresh.ts:134` — "Proactive refresh failed"

## Why this matters

`lib/AGENTS.md` (`lib/**` section) is explicit:

> focus on auth rotation, windows filesystem io, and concurrency. verify every change cites affected tests (vitest) and that new queues handle EBUSY/429 scenarios. **check for logging that leaks tokens or emails.**

The shared logger in `lib/logger.ts` does auto-redact any key whose normalized name is in `SENSITIVE_KEYS` (`email` is on that list), but it routes through `maskToken`, which produces partial-leak output for emails longer than 12 chars:

| Input | Auto-mask via `maskToken` | Email-aware mask via `maskEmail` |
| --- | --- | --- |
| `user.example@longdomain.org` | `user.e...n.org` | `us***@***.org` |
| `firstname.lastname@gmail.com` | `firstn...l.com` | `fi***@***.com` |

The token-style mask still exposes most of the local part and most of the domain, which makes correlation across logs trivial. The email-aware mask (already used in `lib/audit.ts` and the embedded `EMAIL_PATTERN` in `maskString`) produces a much smaller fingerprint.

## Changes

- `lib/proactive-refresh.ts` — import `maskEmail` from the same logger module; rewrite the three log calls to spread `{ email: maskEmail(account.email) }` only when the field is defined (avoids emitting `email: undefined`).
- `test/proactive-refresh.test.ts` — two new regression tests:
  - `redacts the account email through maskEmail in every log path` spies on `logger.maskEmail` and asserts it is called with the raw email across success and failure paths.
  - `omits the email field entirely when account has no email` guards against accidentally emitting `email: undefined`.

## Test plan

- [x] `npm run typecheck`
- [x] `npx eslint`
- [x] `npx vitest run test/proactive-refresh.test.ts` — 31/31 pass (29 existing + 2 new)
- [x] Full suite — **3746 / 3746 pass**

## Notes

This was found via a deeper PII-redaction sweep of `lib/` after #443. I scanned all `log.{info,debug,warn,error}` calls in `lib/` for raw email/token interpolation. These three were the only sites still using raw `account.email`; everywhere else either uses `accountId`, an account fingerprint helper, a tokenSuffix, or already routes through `maskEmail`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes raw `account.email` leaking into three log calls in `lib/proactive-refresh.ts` by importing `maskEmail` and emitting the field as `emailMasked` (conditional spread) — the key rename also sidesteps the `sanitizeValue` double-mask path since `"emailmasked"` is not in `SENSITIVE_KEYS`.

<h3>Confidence Score: 5/5</h3>

safe to merge — production code change is correct and the single p2 test gap doesn't affect runtime behavior

all three log sites are fixed consistently, key rename correctly avoids double-masking, conditional spread prevents undefined emission; only finding is a vacuous spy in the omit-email test which doesn't affect production correctness

test/proactive-refresh.test.ts — the `console.info` spy in the "omits email" test should be `console.log`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/proactive-refresh.ts | renames `email` key to `emailMasked` and wraps with `maskEmail()` — correctly avoids double-masking via `sanitizeValue` and prevents emitting `emailMasked: undefined` via conditional spread |
| test/proactive-refresh.test.ts | adds two new regression tests; the `maskEmail` spy and the no-call assertion are sound, but the payload-content assertions in the "omits email" test are vacuously true because `console.info` is spied instead of `console.log` |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[proactiveRefreshAccount called] --> B[log.info: Proactively refreshing token]
    B --> C{account.email defined?}
    C -- yes --> D["maskEmail(account.email) → emailMasked: us***@***.org"]
    C -- no --> E[key omitted entirely]
    D --> F[sanitizeValue: key emailMasked not in SENSITIVE_KEYS]
    E --> F
    F --> G[maskString passes masked value unchanged — no double-mask]
    G --> H{queuedRefresh result}
    H -- success --> I[log.info: Proactive refresh succeeded + emailMasked]
    H -- failed --> J[log.warn: Proactive refresh failed + emailMasked]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fproactive-refresh-redact-emails%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fproactive-refresh-redact-emails%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fproactive-refresh.test.ts%3A252-272%0A**%60console.info%60%20spy%20never%20fires%20for%20info-level%20log%20calls**%0A%0A%60logToConsole%60%20in%20%60logger.ts%60%20routes%20info-level%20messages%20through%20%60console.log%60%2C%20not%20%60console.info%60%20%28line%20197%3A%20%60else%20console.log%28...%29%60%29.%20spying%20on%20%60console.info%60%20here%20means%20%60infoSpy.mock.calls%60%20is%20always%20empty%2C%20so%20the%20loop%20that%20asserts%20absence%20of%20%60email%60%2F%60emailMasked%60%20keys%20never%20executes%20and%20the%20payload-content%20checks%20pass%20vacuously.%20swap%20to%20%60console.log%60%20to%20actually%20exercise%20the%20assertion%3A%0A%0A%60%60%60suggestion%0A%09%09%09const%20infoSpy%20%3D%20vi%0A%09%09%09%09.spyOn%28console%2C%20%22log%22%29%0A%09%09%09%09.mockImplementation%28%28%29%20%3D%3E%20undefined%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/proactive-refresh.test.ts
Line: 252-272

Comment:
**`console.info` spy never fires for info-level log calls**

`logToConsole` in `logger.ts` routes info-level messages through `console.log`, not `console.info` (line 197: `else console.log(...)`). spying on `console.info` here means `infoSpy.mock.calls` is always empty, so the loop that asserts absence of `email`/`emailMasked` keys never executes and the payload-content checks pass vacuously. swap to `console.log` to actually exercise the assertion:

```suggestion
			const infoSpy = vi
				.spyOn(console, "log")
				.mockImplementation(() => undefined);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test(proactive-refresh): assert email ke..."](https://github.com/ndycode/codex-multi-auth/commit/9782d1157b455ff340a5deb0d23ac08aa441a56a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30080320)</sub>

**Context used:**

- Context used - lib/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=ffbed5b7-f299-4c32-b3f9-f7c095ca8632))

<!-- /greptile_comment -->