### PR TITLE
fix(config): handle non-Error throws when loading plugin config

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -287,7 +287,9 @@ export function loadPluginConfig(): PluginConfig {
 	} catch (error) {
 		const configPath = resolvePluginConfigPath() ?? CONFIG_PATH;
 		logConfigWarnOnce(
-			`Failed to load config from ${configPath}: ${(error as Error).message}`,
+			`Failed to load config from ${configPath}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
 		);
 		return { ...DEFAULT_PLUGIN_CONFIG };
 	}

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -694,6 +694,32 @@ describe("Plugin Configuration", () => {
 			expect(mockLogWarn).toHaveBeenCalled();
 		});
 
+		it("should not crash when readFileSync throws a non-Error value", () => {
+			// Regression: the catch branch previously cast `error as Error`, which
+			// would dereference `.message` on a string/object/null and produce
+			// "Cannot read properties of …" if anything other than an Error reached
+			// the handler. Stay defensive about non-standard throws.
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockImplementation(() => {
+				throw "raw string thrown by misbehaving fs shim";
+			});
+
+			const mockLogWarn = vi.mocked(logger.logWarn);
+			mockLogWarn.mockClear();
+
+			const config = loadPluginConfig();
+
+			expect(config.codexMode).toBe(true);
+			expect(mockLogWarn).toHaveBeenCalled();
+			const warnMessages = mockLogWarn.mock.calls
+				.map(([message]) => String(message))
+				.join("\n");
+			expect(warnMessages).toContain("Failed to load config from");
+			expect(warnMessages).toContain(
+				"raw string thrown by misbehaving fs shim",
+			);
+		});
+
 		it("should deduplicate repeated validation warnings across multiple loads", () => {
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue(


### PR DESCRIPTION
## Summary

The catch branch in \`loadPluginConfig\` used \`(error as Error).message\`, which would itself throw if anything other than an \`Error\` instance reached the handler (e.g. a raw string thrown by a misbehaving \`fs\` shim, a plain object, \`null\`, or a non-standard rejection). The fallback path is meant to keep the plugin running on default config — letting that path crash defeats the purpose.

## What changed

- **\`lib/config.ts:290\`** — switch the cast \`(error as Error).message\` to the safer \`error instanceof Error ? error.message : String(error)\` pattern that the same file already uses at lines 458 and 497 for backup-config and last-resort fallbacks.
- **\`test/plugin-config.test.ts\`** — new regression test \"should not crash when readFileSync throws a non-Error value\" that throws a raw string from \`readFileSync\` and asserts the warning message includes the stringified value, locking the safer behavior in.

## Validation

- [x] \`npx vitest run test/plugin-config.test.ts\` — 71/71 pass
- [x] No code-coverage regression: existing invalid-JSON and permission-denied paths still pass through the catch branch
- [x] No other call sites: this is the only \`(error as Error).message\` cast in \`lib/config.ts\`

## Risk / Rollback

Trivially low. The new branch is a strict superset of the old one for the \`error instanceof Error\` case, and adds correct behavior for the non-Error case. Revert is a single 1-line change.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

replaces the unsafe `(error as Error).message` cast in the `loadPluginConfig` catch block with the safer `error instanceof Error ? error.message : String(error)` pattern, consistent with lines 458 and 497 in the same file. a regression test is added for the raw-string-throw case; the fix is correct and the risk is trivially low.

<h3>Confidence Score: 4/5</h3>

safe to merge — the fix is a strict superset of the old behavior and the only finding is a p2 coverage gap

no p0/p1 issues; single p2 noting missing vitest cases for null and plain-object throws that the pr description explicitly mentions as motivating scenarios

test/plugin-config.test.ts — consider broadening the non-Error throw test to cover null and plain objects

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/config.ts | one-line fix: replaces unsafe `(error as Error).message` cast with `error instanceof Error ? error.message : String(error)`, matching the existing pattern at lines 458 and 497; no logic change for the normal Error path |
| test/plugin-config.test.ts | regression test added for raw-string throw; covers the primary motivating case but misses null and plain-object throws cited in the pr description |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[loadPluginConfig called] --> B[read and parse config file]
    B -->|success| C[return merged PluginConfig]
    B -->|throws| D{error instanceof Error?}
    D -->|yes| E[use error.message]
    D -->|no| F[use String error]
    E --> G[logConfigWarnOnce with message]
    F --> G
    G --> H[return DEFAULT_PLUGIN_CONFIG]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fconfig-error-message-cast%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fconfig-error-message-cast%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fplugin-config.test.ts%3A697-721%0A**missing%20coverage%20for%20%60null%60%20and%20plain-object%20throws**%0A%0Athe%20pr%20description%20calls%20out%20%60null%60%2C%20plain%20objects%2C%20and%20non-standard%20rejections%20as%20motivating%20cases%2C%20but%20the%20test%20only%20exercises%20the%20raw-string%20path.%20%60String%28null%29%60%20%E2%86%92%20%60%22null%22%60%20and%20%60String%28%7B%7D%29%60%20%E2%86%92%20%60%22%5Bobject%20Object%5D%22%60%20are%20both%20handled%20by%20the%20same%20branch%2C%20so%20a%20couple%20of%20extra%20sub-cases%20%28or%20a%20%60it.each%60%29%20would%20lock%20that%20in%20and%20prevent%20a%20future%20%60instanceof%60%20guard%20from%20silently%20missing%20those%20types.%0A%0A%60%60%60ts%0Ait.each%28%5B%0A%20%20%5B%22raw%20string%22%2C%20%22raw%20string%20thrown%20by%20misbehaving%20fs%20shim%22%5D%2C%0A%20%20%5B%22null%20throw%22%2C%20%20null%5D%2C%0A%20%20%5B%22plain%20object%22%2C%20%7B%20code%3A%20%22EPERM%22%20%7D%5D%2C%0A%5D%29%28%22should%20not%20crash%20when%20readFileSync%20throws%20a%20non-Error%20value%20%28%25s%29%22%2C%20%28_label%2C%20thrown%29%20%3D%3E%20%7B%0A%20%20mockExistsSync.mockReturnValue%28true%29%3B%0A%20%20mockReadFileSync.mockImplementation%28%28%29%20%3D%3E%20%7B%20throw%20thrown%3B%20%7D%29%3B%0A%20%20const%20config%20%3D%20loadPluginConfig%28%29%3B%0A%20%20expect%28config.codexMode%29.toBe%28true%29%3B%0A%20%20const%20warnMessages%20%3D%20vi.mocked%28logger.logWarn%29.mock.calls.map%28%28%5Bm%5D%29%20%3D%3E%20String%28m%29%29.join%28%22%5Cn%22%29%3B%0A%20%20expect%28warnMessages%29.toContain%28%22Failed%20to%20load%20config%20from%22%29%3B%0A%20%20expect%28warnMessages%29.toContain%28String%28thrown%29%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/plugin-config.test.ts
Line: 697-721

Comment:
**missing coverage for `null` and plain-object throws**

the pr description calls out `null`, plain objects, and non-standard rejections as motivating cases, but the test only exercises the raw-string path. `String(null)` → `"null"` and `String({})` → `"[object Object]"` are both handled by the same branch, so a couple of extra sub-cases (or a `it.each`) would lock that in and prevent a future `instanceof` guard from silently missing those types.

```ts
it.each([
  ["raw string", "raw string thrown by misbehaving fs shim"],
  ["null throw",  null],
  ["plain object", { code: "EPERM" }],
])("should not crash when readFileSync throws a non-Error value (%s)", (_label, thrown) => {
  mockExistsSync.mockReturnValue(true);
  mockReadFileSync.mockImplementation(() => { throw thrown; });
  const config = loadPluginConfig();
  expect(config.codexMode).toBe(true);
  const warnMessages = vi.mocked(logger.logWarn).mock.calls.map(([m]) => String(m)).join("\n");
  expect(warnMessages).toContain("Failed to load config from");
  expect(warnMessages).toContain(String(thrown));
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(config): handle non-Error throws whe..."](https://github.com/ndycode/codex-multi-auth/commit/3913a1030f077c7239ba71a739b9d7d1b3721634) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30145469)</sub>

<!-- /greptile_comment -->