### PR TITLE
refactor(env): consolidate parseBooleanEnv into one shared helper

### DIFF
--- a/lib/codex-manager/commands/rotation.ts
+++ b/lib/codex-manager/commands/rotation.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { formatAccountLabel, formatCooldown, formatWaitTime } from "../../accounts.js";
+import { parseBooleanEnv } from "../../env-parsing.js";
 import { getCodexMultiAuthDir } from "../../runtime-paths.js";
 import { saveAccountsWithRetry } from "../forecast-report-shared.js";
 
@@ -415,23 +416,11 @@ async function runResetRateLimits(
 	}
 }
 
-function parseBooleanEnv(value: string | undefined): boolean | null {
-	if (value === undefined || value.trim().length === 0) return null;
-	const normalized = value.trim().toLowerCase();
-	if (normalized === "1" || normalized === "true" || normalized === "yes") {
-		return true;
-	}
-	if (normalized === "0" || normalized === "false" || normalized === "no") {
-		return false;
-	}
-	return null;
-}
-
 function formatEnvOverride(): string {
 	const raw = process.env.CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY;
 	if (raw === undefined || raw.trim().length === 0) return "none";
 	const parsed = parseBooleanEnv(raw);
-	if (parsed === null) return `invalid (${raw})`;
+	if (parsed === undefined) return `invalid (${raw})`;
 	return parsed ? "enabled" : "disabled";
 }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, promises as fs, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { parseBooleanEnv } from "./env-parsing.js";
 import { logWarn } from "./logger.js";
 import {
 	getCodexHomeDir,
@@ -670,26 +671,6 @@ export async function savePluginConfig(
 		};
 		await saveUnifiedPluginConfig(merged);
 	});
-}
-
-/**
- * Get the effective CODEX_MODE setting
- * Priority: environment variable > config file > default (true)
- *
- * @param pluginConfig - Plugin configuration from file
- * @returns True if CODEX_MODE should be enabled
- */
-function parseBooleanEnv(value: string | undefined): boolean | undefined {
-	if (value === undefined) return undefined;
-	const normalized = value.trim().toLowerCase();
-	if (normalized.length === 0) return undefined;
-	if (normalized === "1" || normalized === "true" || normalized === "yes") {
-		return true;
-	}
-	if (normalized === "0" || normalized === "false" || normalized === "no") {
-		return false;
-	}
-	return undefined;
 }
 
 function parseNumberEnv(value: string | undefined): number | undefined {

--- a/lib/env-parsing.ts
+++ b/lib/env-parsing.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared helpers for parsing string environment variables.
+ *
+ * Pulled out of three near-identical local copies (lib/config.ts,
+ * lib/refresh-lease.ts, lib/codex-manager/commands/rotation.ts) so every
+ * call site agrees on accepted truthy/falsy literals and on what an
+ * unparseable value returns.
+ */
+
+const TRUE_VALUES = new Set(["1", "true", "yes"]);
+const FALSE_VALUES = new Set(["0", "false", "no"]);
+
+/**
+ * Parses a boolean environment-variable string.
+ *
+ * Accepts (case-insensitive, trimmed): "1"/"0", "true"/"false", "yes"/"no".
+ * Returns `undefined` for `undefined` input, an empty/whitespace-only
+ * string, or any value that doesn't match an accepted literal — letting
+ * callers fall back to nullish coalescing or default-handling logic.
+ *
+ * @param value - Raw env-variable value (or `undefined` when unset).
+ * @returns `true`/`false` for recognised literals, otherwise `undefined`.
+ */
+export function parseBooleanEnv(
+	value: string | undefined,
+): boolean | undefined {
+	if (value === undefined) return undefined;
+	const normalized = value.trim().toLowerCase();
+	if (normalized.length === 0) return undefined;
+	if (TRUE_VALUES.has(normalized)) return true;
+	if (FALSE_VALUES.has(normalized)) return false;
+	return undefined;
+}

--- a/lib/refresh-lease.ts
+++ b/lib/refresh-lease.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, promises as fs } from "node:fs";
 import { join } from "node:path";
+import { parseBooleanEnv } from "./env-parsing.js";
 import { createLogger } from "./logger.js";
 import { getCodexMultiAuthDir } from "./runtime-paths.js";
 import { safeParseTokenResult } from "./schemas.js";
@@ -46,14 +47,6 @@ export interface RefreshLeaseHandle {
 	role: "owner" | "follower" | "bypass";
 	result?: TokenResult;
 	release: (result?: TokenResult) => Promise<void>;
-}
-
-function parseBooleanEnv(value: string | undefined): boolean | undefined {
-	if (value === undefined) return undefined;
-	const normalized = value.trim().toLowerCase();
-	if (normalized === "1" || normalized === "true" || normalized === "yes") return true;
-	if (normalized === "0" || normalized === "false" || normalized === "no") return false;
-	return undefined;
 }
 
 function parseEnvInt(value: string | undefined): number | undefined {

--- a/test/env-parsing.test.ts
+++ b/test/env-parsing.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { parseBooleanEnv } from "../lib/env-parsing.js";
+
+describe("parseBooleanEnv", () => {
+	describe("truthy literals", () => {
+		it.each([
+			["1", true],
+			["0", false],
+			["true", true],
+			["false", false],
+			["yes", true],
+			["no", false],
+		])("parses %s as %s", (input, expected) => {
+			expect(parseBooleanEnv(input)).toBe(expected);
+		});
+	});
+
+	describe("case and whitespace tolerance", () => {
+		it.each([
+			["TRUE", true],
+			["True", true],
+			["FALSE", false],
+			["YES", true],
+			["No", false],
+			["  true  ", true],
+			["\tfalse\n", false],
+			["  1 ", true],
+			["  0 ", false],
+		])("parses %j as %s", (input, expected) => {
+			expect(parseBooleanEnv(input)).toBe(expected);
+		});
+	});
+
+	describe("undefined-returning inputs", () => {
+		it("returns undefined for undefined input", () => {
+			expect(parseBooleanEnv(undefined)).toBeUndefined();
+		});
+
+		it.each([
+			[""],
+			["   "],
+			["\t\n"],
+			["maybe"],
+			["enabled"],
+			["disabled"],
+			["on"],
+			["off"],
+			["2"],
+			["-1"],
+			["null"],
+			["undefined"],
+		])("returns undefined for %j", (input) => {
+			expect(parseBooleanEnv(input)).toBeUndefined();
+		});
+	});
+
+	describe("nullish-coalescing semantics", () => {
+		it("lets callers fall through unrecognised values to a default", () => {
+			const fallback = true;
+			expect(parseBooleanEnv("garbage") ?? fallback).toBe(true);
+			expect(parseBooleanEnv(undefined) ?? fallback).toBe(true);
+			expect(parseBooleanEnv("") ?? fallback).toBe(true);
+		});
+
+		it("respects an explicitly parsed false over the default", () => {
+			const fallback = true;
+			expect(parseBooleanEnv("false") ?? fallback).toBe(false);
+			expect(parseBooleanEnv("0") ?? fallback).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Three files carried near-identical local copies of \`parseBooleanEnv\` with subtly different signatures. The rotation copy returned \`boolean | null\` while \`config.ts\` and \`refresh-lease.ts\` returned \`boolean | undefined\` — a real footgun for any future caller that combines them or assumes a unified signature. Easy for the three to drift apart on accepted literals or bug fixes.

This PR extracts one canonical implementation in \`lib/env-parsing.ts\` and routes the three call sites through it.

## What changed

- **New module \`lib/env-parsing.ts\`** with a single \`parseBooleanEnv(value: string | undefined): boolean | undefined\` (the dominant existing signature; works naturally with \`??\` fallback chains).
- **\`lib/config.ts\`** — drop the local copy, import the shared helper.
- **\`lib/refresh-lease.ts\`** — drop the local copy, import the shared helper.
- **\`lib/codex-manager/commands/rotation.ts\`** — drop the local copy, import the shared helper. \`formatEnvOverride\` now checks \`parsed === undefined\` instead of \`parsed === null\` to match the unified return type. The single existing caller is the only consumer of the strict-equality branch and was verified to behave identically.
- **New test file \`test/env-parsing.test.ts\`** — 30 unit tests covering accepted truthy/falsy literals, case insensitivity, whitespace trimming, unrecognised values, and nullish-coalescing semantics that downstream callers rely on.

## Validation

- [x] \`npx vitest run test/env-parsing.test.ts\` — 30/30 pass
- [x] \`npx vitest run test/plugin-config.test.ts test/codex-manager-rotation-command.test.ts test/codex-manager-cli.test.ts\` — 297/297 pass
- [x] \`npx vitest run test/refresh-lease.test.ts\` — 12/12 pass
- [x] No behavioural change at any call site (verified by passing existing suites unchanged)

## Risk / Rollback

Low risk. Pure refactor with full coverage of the new helper and untouched semantics at every call site. The single behavioural delta — \`=== null\` → \`=== undefined\` in \`formatEnvOverride\` — is mechanical and matches the unified return type. Rollback is straightforward: each file would revert to its previous local copy.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

pure refactor: three near-identical local `parseBooleanEnv` copies (with a footgun `boolean | null` vs `boolean | undefined` type mismatch in `rotation.ts`) are replaced by a single canonical helper in `lib/env-parsing.ts`. the `null → undefined` fix in `formatEnvOverride` is safe because the function's early guard already handles the empty/undefined case before calling the helper, meaning no call-site behaviour changes.

<h3>Confidence Score: 5/5</h3>

safe to merge — pure refactor with no behavioural changes and full vitest coverage.

only finding is a P2 test describe-block label; all call sites are mechanically verified, no windows/token/concurrency risk introduced, 30 new tests pass.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/env-parsing.ts | new canonical shared helper; set-based literal lookup is clean, correct, and fully documented. no filesystem or token exposure concerns. |
| lib/config.ts | drops local copy, imports shared helper — identical semantics to what was removed. |
| lib/refresh-lease.ts | drops local copy, imports shared helper — the old copy's implicit empty-string fallback is preserved by the shared helper. |
| lib/codex-manager/commands/rotation.ts | drops local `boolean | null` copy; `formatEnvOverride` pre-guards empty/undefined before calling the helper, so `null → undefined` swap is purely mechanical and safe. |
| test/env-parsing.test.ts | 30 tests; good coverage of truthy/falsy literals, case/whitespace, unrecognised values, and nullish-coalescing semantics. one describe block name is misleading (P2). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["lib/config.ts\ncalls parseBooleanEnv()"] -->|import| S
    B["lib/refresh-lease.ts\ncalls parseBooleanEnv()"] -->|import| S
    C["lib/codex-manager/commands/rotation.ts\nformatEnvOverride() calls parseBooleanEnv()"] -->|import| S
    S["lib/env-parsing.ts\nexport parseBooleanEnv(value)\n→ true | false | undefined"]
    T["test/env-parsing.test.ts\n30 unit tests"] -.->|tests| S
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Fparse-boolean-env-shared%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fparse-boolean-env-shared%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fenv-parsing.test.ts%3A5%0A**misleading%20describe%20block%20name**%0A%0Athe%20inner%20%60describe%60%20is%20labelled%20%60%22truthy%20literals%22%60%20but%20it%20tests%20both%20truthy%20%28%60%221%22%60%2C%20%60%22true%22%60%2C%20%60%22yes%22%60%29%20and%20falsy%20%28%60%220%22%60%2C%20%60%22false%22%60%2C%20%60%22no%22%60%29%20literals.%20a%20name%20like%20%60%22boolean%20literals%22%60%20or%20%60%22accepted%20literals%22%60%20would%20be%20accurate%20and%20avoid%20confusing%20future%20contributors.%0A%0A%60%60%60suggestion%0A%09describe%28%22accepted%20literals%22%2C%20%28%29%20%3D%3E%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/env-parsing.test.ts
Line: 5

Comment:
**misleading describe block name**

the inner `describe` is labelled `"truthy literals"` but it tests both truthy (`"1"`, `"true"`, `"yes"`) and falsy (`"0"`, `"false"`, `"no"`) literals. a name like `"boolean literals"` or `"accepted literals"` would be accurate and avoid confusing future contributors.

```suggestion
	describe("accepted literals", () => {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(env): consolidate parseBooleanE..."](https://github.com/ndycode/codex-multi-auth/commit/671d11d2eb0755da76702a2ced92c175c7240fbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30146826)</sub>

<!-- /greptile_comment -->