### PR TITLE
feat: add local usage ledger core

### DIFF
--- a/docs/development/implementation-plans/status.md
+++ b/docs/development/implementation-plans/status.md
@@ -17,7 +17,7 @@ Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 | PR | Branch | Status | Validation |
 | --- | --- | --- | --- |
 | 01 | `chore/roadmap-local-governance` | Ready for review | `npm test -- test/documentation.test.ts`; `npm run build`. |
-| 02 | `feat/usage-ledger-core` | Pending | Targeted usage ledger tests plus build. |
+| 02 | `feat/usage-ledger-core` | Ready for review | `npm run typecheck`; `npm test -- test/usage-ledger.test.ts`; `npm run lint`; `npm run build`. |
 | 03 | `feat/usage-command` | Pending | CLI usage command tests plus build. |
 | 04 | `feat/account-policy-controls` | Pending | Account policy command/store tests plus build. |
 | 05 | `feat/routing-profiles-core` | Pending | Routing profile storage/project tests plus build. |

--- a/docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md
@@ -1,0 +1,32 @@
+# PR 02 Handoff: Usage Ledger Core
+
+Branch: `feat/usage-ledger-core`
+Base: `origin/main` after PR 01 merge
+
+## Scope
+
+Add the local usage ledger core without command dispatch or runtime integration.
+
+## Files Changed
+
+- `lib/usage/types.ts`
+- `lib/usage/redaction.ts`
+- `lib/usage/pricing.ts`
+- `lib/usage/ledger.ts`
+- `lib/usage/index.ts`
+- `lib/index.ts`
+- `test/usage-ledger.test.ts`
+- `docs/development/implementation-plans/status.md`
+- `docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md`
+
+## Validation
+
+- `npm run typecheck` passed.
+- `npm test -- test/usage-ledger.test.ts` passed: 1 file, 6 tests.
+- `npm run lint` passed.
+- `npm run build` passed.
+
+## Follow-ups
+
+- PR 03 should add `codex auth usage` command behavior on top of these helpers.
+- Runtime append calls are intentionally deferred until PR 08.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,3 +40,4 @@ export * from "./codex-cli/state.js";
 export * from "./codex-cli/sync.js";
 export * from "./codex-cli/writer.js";
 export * from "./codex-cli/observability.js";
+export * from "./usage/index.js";

--- a/lib/usage/index.ts
+++ b/lib/usage/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.js";
+export * from "./pricing.js";
+export * from "./redaction.js";
+export * from "./ledger.js";
+

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -1,0 +1,426 @@
+import { existsSync, promises as fs } from "node:fs";
+import { basename, join } from "node:path";
+import { getCodexMultiAuthDir } from "../runtime-paths.js";
+import { logWarn } from "../logger.js";
+import { isRecord, sleep } from "../utils.js";
+import {
+	normalizeUsageLedgerRow,
+	usageRowToJsonLine,
+} from "./redaction.js";
+import type {
+	UsageLedgerAppendInput,
+	UsageLedgerOperation,
+	UsageLedgerPaths,
+	UsageLedgerQuery,
+	UsageLedgerOutcome,
+	UsageLedgerRow,
+	UsageLedgerSource,
+	UsageSummary,
+	UsageSummaryBucket,
+	UsageSummaryGroupBy,
+	UsageSummaryQuery,
+	UsageTokenCounts,
+} from "./types.js";
+
+const USAGE_DIR_NAME = "usage";
+const USAGE_LEDGER_FILE_NAME = "usage-ledger.jsonl";
+const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+let appendQueue: Promise<void> = Promise.resolve();
+
+const VALID_SOURCES = new Set<UsageLedgerSource>([
+	"runtime-proxy",
+	"plugin-host",
+	"local-bridge",
+	"cli",
+	"unknown",
+]);
+const VALID_OPERATIONS = new Set<UsageLedgerOperation>([
+	"responses",
+	"models",
+	"auth-refresh",
+	"diagnostic",
+	"unknown",
+]);
+const VALID_OUTCOMES = new Set<UsageLedgerOutcome>([
+	"success",
+	"failure",
+	"blocked",
+	"cancelled",
+]);
+
+function isRetryableFsError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
+}
+
+function normalizeTimestamp(value: number | Date | string | undefined): number | null {
+	if (value === undefined) return null;
+	if (value instanceof Date) {
+		const time = value.getTime();
+		return Number.isFinite(time) ? time : null;
+	}
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? value : null;
+	}
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function appendFileWithRetry(path: string, line: string): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await fs.appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+			return;
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableFsError(error) || attempt >= 4) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger append retry exhausted");
+}
+
+async function readFileWithRetry(path: string): Promise<string> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			return await fs.readFile(path, "utf8");
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableFsError(error) || attempt >= 4) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger read retry exhausted");
+}
+
+async function renameWithRetry(from: string, to: string): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await fs.rename(from, to);
+			return;
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableFsError(error) || attempt >= 4) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger rotate retry exhausted");
+}
+
+export function getUsageLedgerPaths(): UsageLedgerPaths {
+	const dir = join(getCodexMultiAuthDir(), USAGE_DIR_NAME);
+	return {
+		dir,
+		current: join(dir, USAGE_LEDGER_FILE_NAME),
+	};
+}
+
+export async function appendUsageLedgerRow(
+	input: UsageLedgerAppendInput,
+): Promise<UsageLedgerRow> {
+	const row = normalizeUsageLedgerRow(input);
+	const { dir, current } = getUsageLedgerPaths();
+	const line = usageRowToJsonLine(row);
+	const task = async (): Promise<void> => {
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+		await appendFileWithRetry(current, line);
+	};
+	const queued = appendQueue.catch(() => undefined).then(task);
+	appendQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	await queued;
+	return row;
+}
+
+function normalizeParsedUsageRow(value: unknown): UsageLedgerRow | null {
+	if (!isRecord(value)) return null;
+	if (value.version !== 1) return null;
+	if (typeof value.id !== "string" || value.id.trim().length === 0) return null;
+	if (typeof value.createdAt !== "number" || !Number.isFinite(value.createdAt)) {
+		return null;
+	}
+	if (!isRecord(value.tokens)) return null;
+
+	const source =
+		typeof value.source === "string" &&
+		VALID_SOURCES.has(value.source as UsageLedgerSource)
+			? (value.source as UsageLedgerSource)
+			: "unknown";
+	const operation =
+		typeof value.operation === "string" &&
+		VALID_OPERATIONS.has(value.operation as UsageLedgerOperation)
+			? (value.operation as UsageLedgerOperation)
+			: "unknown";
+	const outcome =
+		typeof value.outcome === "string" &&
+		VALID_OUTCOMES.has(value.outcome as UsageLedgerOutcome)
+			? (value.outcome as UsageLedgerOutcome)
+			: "failure";
+	const tokens: UsageTokenCounts = {
+		inputTokens:
+			typeof value.tokens.inputTokens === "number" &&
+			Number.isFinite(value.tokens.inputTokens)
+				? Math.max(0, Math.trunc(value.tokens.inputTokens))
+				: 0,
+		outputTokens:
+			typeof value.tokens.outputTokens === "number" &&
+			Number.isFinite(value.tokens.outputTokens)
+				? Math.max(0, Math.trunc(value.tokens.outputTokens))
+				: 0,
+		cachedInputTokens:
+			typeof value.tokens.cachedInputTokens === "number" &&
+			Number.isFinite(value.tokens.cachedInputTokens)
+				? Math.max(0, Math.trunc(value.tokens.cachedInputTokens))
+				: 0,
+		reasoningTokens:
+			typeof value.tokens.reasoningTokens === "number" &&
+			Number.isFinite(value.tokens.reasoningTokens)
+				? Math.max(0, Math.trunc(value.tokens.reasoningTokens))
+				: 0,
+		totalTokens:
+			typeof value.tokens.totalTokens === "number" &&
+			Number.isFinite(value.tokens.totalTokens)
+				? Math.max(0, Math.trunc(value.tokens.totalTokens))
+				: 0,
+	};
+	const account = isRecord(value.account)
+		? {
+				accountHash:
+					typeof value.account.accountHash === "string" &&
+					value.account.accountHash.startsWith("sha256:")
+						? value.account.accountHash
+						: undefined,
+				emailHash:
+					typeof value.account.emailHash === "string" &&
+					value.account.emailHash.startsWith("sha256:")
+						? value.account.emailHash
+						: undefined,
+				index:
+					typeof value.account.index === "number" &&
+					Number.isInteger(value.account.index) &&
+					value.account.index >= 0
+						? value.account.index
+						: undefined,
+			}
+		: null;
+	const normalizedAccount =
+		account?.accountHash || account?.emailHash || account?.index !== undefined
+			? account
+			: null;
+
+	return {
+		version: 1,
+		id: value.id,
+		createdAt: value.createdAt,
+		source,
+		operation,
+		outcome,
+		model: typeof value.model === "string" ? value.model : null,
+		projectKey: typeof value.projectKey === "string" ? value.projectKey : null,
+		account: normalizedAccount,
+		requestId: typeof value.requestId === "string" ? value.requestId : null,
+		statusCode:
+			typeof value.statusCode === "number" &&
+			Number.isInteger(value.statusCode) &&
+			value.statusCode >= 100 &&
+			value.statusCode <= 599
+				? value.statusCode
+				: null,
+		errorCode: typeof value.errorCode === "string" ? value.errorCode : null,
+		durationMs:
+			typeof value.durationMs === "number" && Number.isFinite(value.durationMs)
+				? Math.max(0, Math.trunc(value.durationMs))
+				: null,
+		tokens,
+		costUsd:
+			typeof value.costUsd === "number" && Number.isFinite(value.costUsd)
+				? Math.max(0, value.costUsd)
+				: null,
+	};
+}
+
+function parseJsonlRows(content: string, label: string): UsageLedgerRow[] {
+	const rows: UsageLedgerRow[] = [];
+	for (const [index, line] of content.split(/\r?\n/).entries()) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsed = JSON.parse(trimmed) as unknown;
+			const row = normalizeParsedUsageRow(parsed);
+			if (row) {
+				rows.push(row);
+			}
+		} catch (error) {
+			logWarn(
+				`Skipped malformed usage ledger row in ${label}:${index + 1}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+	return rows;
+}
+
+async function listLedgerFiles(includeArchives: boolean): Promise<string[]> {
+	const { dir, current } = getUsageLedgerPaths();
+	if (!includeArchives) {
+		return existsSync(current) ? [current] : [];
+	}
+	if (!existsSync(dir)) {
+		return [];
+	}
+	const entries = await fs.readdir(dir);
+	return entries
+		.filter((entry) => /^usage-ledger(?:\.\d{8}T\d{6}\d{3}Z)?\.jsonl$/.test(entry))
+		.sort()
+		.map((entry) => join(dir, entry));
+}
+
+function filterRows(
+	rows: UsageLedgerRow[],
+	query: UsageLedgerQuery,
+): UsageLedgerRow[] {
+	const since = normalizeTimestamp(query.since);
+	const until = normalizeTimestamp(query.until);
+	return rows.filter((row) => {
+		if (since !== null && row.createdAt < since) return false;
+		if (until !== null && row.createdAt > until) return false;
+		return true;
+	});
+}
+
+export async function readUsageLedgerRows(
+	query: UsageLedgerQuery = {},
+): Promise<UsageLedgerRow[]> {
+	const rows: UsageLedgerRow[] = [];
+	for (const file of await listLedgerFiles(query.includeArchives === true)) {
+		try {
+			rows.push(...parseJsonlRows(await readFileWithRetry(file), basename(file)));
+		} catch (error) {
+			logWarn(
+				`Failed to read usage ledger ${basename(file)}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+	return filterRows(rows, query).sort((a, b) => a.createdAt - b.createdAt);
+}
+
+function createBucket(key: string): UsageSummaryBucket {
+	return {
+		key,
+		requests: 0,
+		successes: 0,
+		failures: 0,
+		blocked: 0,
+		cancelled: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		cachedInputTokens: 0,
+		reasoningTokens: 0,
+		totalTokens: 0,
+		costUsd: 0,
+	};
+}
+
+function getBucketKey(row: UsageLedgerRow, by: UsageSummaryGroupBy): string {
+	switch (by) {
+		case "account":
+			return row.account?.accountHash ?? row.account?.emailHash ?? "unknown";
+		case "project":
+			return row.projectKey ?? "global";
+		case "outcome":
+			return row.outcome;
+		case "day":
+			return new Date(row.createdAt).toISOString().slice(0, 10);
+		case "model":
+			return row.model ?? "unknown";
+	}
+}
+
+function addRowToBucket(bucket: UsageSummaryBucket, row: UsageLedgerRow): void {
+	bucket.requests += 1;
+	if (row.outcome === "success") bucket.successes += 1;
+	if (row.outcome === "failure") bucket.failures += 1;
+	if (row.outcome === "blocked") bucket.blocked += 1;
+	if (row.outcome === "cancelled") bucket.cancelled += 1;
+	bucket.inputTokens += row.tokens.inputTokens;
+	bucket.outputTokens += row.tokens.outputTokens;
+	bucket.cachedInputTokens += row.tokens.cachedInputTokens;
+	bucket.reasoningTokens += row.tokens.reasoningTokens;
+	bucket.totalTokens += row.tokens.totalTokens;
+	bucket.costUsd = Number((bucket.costUsd + (row.costUsd ?? 0)).toFixed(8));
+}
+
+export async function summarizeUsageLedger(
+	query: UsageSummaryQuery = {},
+): Promise<UsageSummary> {
+	const by = query.by ?? "model";
+	const rows = await readUsageLedgerRows(query);
+	const totals = createBucket("total");
+	const buckets = new Map<string, UsageSummaryBucket>();
+	for (const row of rows) {
+		addRowToBucket(totals, row);
+		const key = getBucketKey(row, by);
+		const bucket = buckets.get(key) ?? createBucket(key);
+		addRowToBucket(bucket, row);
+		buckets.set(key, bucket);
+	}
+
+	return {
+		since: normalizeTimestamp(query.since),
+		until: normalizeTimestamp(query.until),
+		by,
+		totals,
+		buckets: [...buckets.values()].sort((a, b) =>
+			a.key.localeCompare(b.key),
+		),
+	};
+}
+
+export async function rotateUsageLedger(options: {
+	now?: number;
+	ifLargerThanBytes?: number;
+} = {}): Promise<string | null> {
+	const { dir, current } = getUsageLedgerPaths();
+	if (!existsSync(current)) {
+		return null;
+	}
+	const stat = await fs.stat(current);
+	if (
+		typeof options.ifLargerThanBytes === "number" &&
+		stat.size <= options.ifLargerThanBytes
+	) {
+		return null;
+	}
+	await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+	const stamp = new Date(options.now ?? Date.now())
+		.toISOString()
+		.replace(/[-:]/g, "")
+		.replace(".", "");
+	const rotated = join(dir, `usage-ledger.${stamp}.jsonl`);
+	await renameWithRetry(current, rotated);
+	return rotated;
+}
+
+export function resetUsageLedgerQueueForTests(): void {
+	appendQueue = Promise.resolve();
+}

--- a/lib/usage/pricing.ts
+++ b/lib/usage/pricing.ts
@@ -1,0 +1,96 @@
+import type { UsageTokenCounts } from "./types.js";
+
+export interface UsageModelPricing {
+	inputUsdPerMillion: number;
+	outputUsdPerMillion: number;
+	cachedInputUsdPerMillion?: number;
+	reasoningUsdPerMillion?: number;
+}
+
+const DEFAULT_PRICING: UsageModelPricing = {
+	inputUsdPerMillion: 0,
+	outputUsdPerMillion: 0,
+	cachedInputUsdPerMillion: 0,
+	reasoningUsdPerMillion: 0,
+};
+
+const MODEL_PRICING: Record<string, UsageModelPricing> = {
+	"gpt-5-codex": {
+		inputUsdPerMillion: 1.25,
+		outputUsdPerMillion: 10,
+		cachedInputUsdPerMillion: 0.125,
+		reasoningUsdPerMillion: 10,
+	},
+	"gpt-5.1-codex": {
+		inputUsdPerMillion: 1.25,
+		outputUsdPerMillion: 10,
+		cachedInputUsdPerMillion: 0.125,
+		reasoningUsdPerMillion: 10,
+	},
+	"gpt-5.2": {
+		inputUsdPerMillion: 1.25,
+		outputUsdPerMillion: 10,
+		cachedInputUsdPerMillion: 0.125,
+		reasoningUsdPerMillion: 10,
+	},
+	"gpt-5.3-codex": {
+		inputUsdPerMillion: 1.25,
+		outputUsdPerMillion: 10,
+		cachedInputUsdPerMillion: 0.125,
+		reasoningUsdPerMillion: 10,
+	},
+	"gpt-5.4": {
+		inputUsdPerMillion: 2,
+		outputUsdPerMillion: 12,
+		cachedInputUsdPerMillion: 0.2,
+		reasoningUsdPerMillion: 12,
+	},
+	"gpt-5.5": {
+		inputUsdPerMillion: 2,
+		outputUsdPerMillion: 12,
+		cachedInputUsdPerMillion: 0.2,
+		reasoningUsdPerMillion: 12,
+	},
+};
+
+function normalizeModelName(model: string | null | undefined): string | null {
+	const trimmed = model?.trim().toLowerCase();
+	return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function getUsageModelPricing(
+	model: string | null | undefined,
+): UsageModelPricing | null {
+	const normalized = normalizeModelName(model);
+	if (!normalized) {
+		return null;
+	}
+	return MODEL_PRICING[normalized] ?? DEFAULT_PRICING;
+}
+
+export function estimateUsageCostUsd(
+	model: string | null | undefined,
+	tokens: UsageTokenCounts,
+): number | null {
+	const pricing = getUsageModelPricing(model);
+	if (!pricing) {
+		return null;
+	}
+
+	const input =
+		(tokens.inputTokens / 1_000_000) * pricing.inputUsdPerMillion;
+	const output =
+		(tokens.outputTokens / 1_000_000) * pricing.outputUsdPerMillion;
+	const cached =
+		(tokens.cachedInputTokens / 1_000_000) *
+		(pricing.cachedInputUsdPerMillion ?? pricing.inputUsdPerMillion);
+	const reasoning =
+		(tokens.reasoningTokens / 1_000_000) *
+		(pricing.reasoningUsdPerMillion ?? pricing.outputUsdPerMillion);
+	return Number((input + output + cached + reasoning).toFixed(8));
+}
+
+export function listUsageModelPricing(): Record<string, UsageModelPricing> {
+	return structuredClone(MODEL_PRICING);
+}
+

--- a/lib/usage/redaction.ts
+++ b/lib/usage/redaction.ts
@@ -1,0 +1,166 @@
+import { createHash, randomUUID } from "node:crypto";
+import type {
+	UsageLedgerAccountRef,
+	UsageLedgerAppendInput,
+	UsageLedgerOperation,
+	UsageLedgerOutcome,
+	UsageLedgerRow,
+	UsageLedgerSource,
+	UsageTokenCounts,
+} from "./types.js";
+import { estimateUsageCostUsd } from "./pricing.js";
+
+const VALID_SOURCES = new Set<UsageLedgerSource>([
+	"runtime-proxy",
+	"plugin-host",
+	"local-bridge",
+	"cli",
+	"unknown",
+]);
+const VALID_OPERATIONS = new Set<UsageLedgerOperation>([
+	"responses",
+	"models",
+	"auth-refresh",
+	"diagnostic",
+	"unknown",
+]);
+const VALID_OUTCOMES = new Set<UsageLedgerOutcome>([
+	"success",
+	"failure",
+	"blocked",
+	"cancelled",
+]);
+
+function normalizeFiniteNumber(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeNonNegativeInteger(value: unknown): number {
+	const numeric = normalizeFiniteNumber(value);
+	return numeric === null ? 0 : Math.max(0, Math.trunc(numeric));
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeStatusCode(value: unknown): number | null {
+	const numeric = normalizeFiniteNumber(value);
+	if (numeric === null) return null;
+	const statusCode = Math.trunc(numeric);
+	return statusCode >= 100 && statusCode <= 599 ? statusCode : null;
+}
+
+function normalizeDurationMs(value: unknown): number | null {
+	const numeric = normalizeFiniteNumber(value);
+	return numeric === null ? null : Math.max(0, Math.trunc(numeric));
+}
+
+function normalizeSource(value: unknown): UsageLedgerSource {
+	return typeof value === "string" && VALID_SOURCES.has(value as UsageLedgerSource)
+		? (value as UsageLedgerSource)
+		: "unknown";
+}
+
+function normalizeOperation(value: unknown): UsageLedgerOperation {
+	return typeof value === "string" &&
+		VALID_OPERATIONS.has(value as UsageLedgerOperation)
+		? (value as UsageLedgerOperation)
+		: "unknown";
+}
+
+function normalizeOutcome(value: unknown): UsageLedgerOutcome {
+	if (
+		typeof value === "string" &&
+		VALID_OUTCOMES.has(value as UsageLedgerOutcome)
+	) {
+		return value as UsageLedgerOutcome;
+	}
+	return "failure";
+}
+
+export function hashUsageIdentifier(value: string): string {
+	return `sha256:${createHash("sha256").update(value.trim()).digest("hex")}`;
+}
+
+export function createUsageAccountRef(input: {
+	accountId?: string | null;
+	email?: string | null;
+	accountIndex?: number | null;
+}): UsageLedgerAccountRef | null {
+	const accountId = normalizeOptionalString(input.accountId);
+	const email = normalizeOptionalString(input.email)?.toLowerCase() ?? null;
+	const index =
+		typeof input.accountIndex === "number" &&
+		Number.isInteger(input.accountIndex) &&
+		input.accountIndex >= 0
+			? input.accountIndex
+			: null;
+	if (!accountId && !email && index === null) {
+		return null;
+	}
+
+	return {
+		accountHash: accountId ? hashUsageIdentifier(accountId) : undefined,
+		emailHash: email ? hashUsageIdentifier(email) : undefined,
+		index: index ?? undefined,
+	};
+}
+
+function normalizeTokens(input: UsageLedgerAppendInput): UsageTokenCounts {
+	const inputTokens = normalizeNonNegativeInteger(input.inputTokens);
+	const outputTokens = normalizeNonNegativeInteger(input.outputTokens);
+	const cachedInputTokens = normalizeNonNegativeInteger(input.cachedInputTokens);
+	const reasoningTokens = normalizeNonNegativeInteger(input.reasoningTokens);
+	const providedTotal = normalizeFiniteNumber(input.totalTokens);
+	const computedTotal =
+		inputTokens + outputTokens + cachedInputTokens + reasoningTokens;
+
+	return {
+		inputTokens,
+		outputTokens,
+		cachedInputTokens,
+		reasoningTokens,
+		totalTokens:
+			providedTotal === null
+				? computedTotal
+				: Math.max(0, Math.trunc(providedTotal)),
+	};
+}
+
+export function normalizeUsageLedgerRow(
+	input: UsageLedgerAppendInput,
+): UsageLedgerRow {
+	const model = normalizeOptionalString(input.model);
+	const tokens = normalizeTokens(input);
+	const explicitCost = normalizeFiniteNumber(input.costUsd);
+
+	return {
+		version: 1,
+		id: normalizeOptionalString(input.id) ?? randomUUID(),
+		createdAt:
+			normalizeFiniteNumber(input.createdAt) ?? Date.now(),
+		source: normalizeSource(input.source),
+		operation: normalizeOperation(input.operation),
+		outcome: normalizeOutcome(input.outcome),
+		model,
+		projectKey: normalizeOptionalString(input.projectKey),
+		account: createUsageAccountRef(input),
+		requestId: normalizeOptionalString(input.requestId),
+		statusCode: normalizeStatusCode(input.statusCode),
+		errorCode: normalizeOptionalString(input.errorCode),
+		durationMs: normalizeDurationMs(input.durationMs),
+		tokens,
+		costUsd:
+			explicitCost === null
+				? estimateUsageCostUsd(model, tokens)
+				: Math.max(0, explicitCost),
+	};
+}
+
+export function usageRowToJsonLine(row: UsageLedgerRow): string {
+	return `${JSON.stringify(row)}\n`;
+}
+

--- a/lib/usage/types.ts
+++ b/lib/usage/types.ts
@@ -1,0 +1,120 @@
+export type UsageLedgerSource =
+	| "runtime-proxy"
+	| "plugin-host"
+	| "local-bridge"
+	| "cli"
+	| "unknown";
+
+export type UsageLedgerOperation =
+	| "responses"
+	| "models"
+	| "auth-refresh"
+	| "diagnostic"
+	| "unknown";
+
+export type UsageLedgerOutcome =
+	| "success"
+	| "failure"
+	| "blocked"
+	| "cancelled";
+
+export interface UsageTokenCounts {
+	inputTokens: number;
+	outputTokens: number;
+	cachedInputTokens: number;
+	reasoningTokens: number;
+	totalTokens: number;
+}
+
+export interface UsageLedgerAccountRef {
+	accountHash?: string;
+	emailHash?: string;
+	index?: number;
+}
+
+export interface UsageLedgerRow {
+	version: 1;
+	id: string;
+	createdAt: number;
+	source: UsageLedgerSource;
+	operation: UsageLedgerOperation;
+	outcome: UsageLedgerOutcome;
+	model: string | null;
+	projectKey: string | null;
+	account: UsageLedgerAccountRef | null;
+	requestId: string | null;
+	statusCode: number | null;
+	errorCode: string | null;
+	durationMs: number | null;
+	tokens: UsageTokenCounts;
+	costUsd: number | null;
+}
+
+export interface UsageLedgerAppendInput {
+	id?: string;
+	createdAt?: number;
+	source?: UsageLedgerSource;
+	operation?: UsageLedgerOperation;
+	outcome: UsageLedgerOutcome;
+	model?: string | null;
+	projectKey?: string | null;
+	accountId?: string | null;
+	email?: string | null;
+	accountIndex?: number | null;
+	requestId?: string | null;
+	statusCode?: number | null;
+	errorCode?: string | null;
+	durationMs?: number | null;
+	inputTokens?: number | null;
+	outputTokens?: number | null;
+	cachedInputTokens?: number | null;
+	reasoningTokens?: number | null;
+	totalTokens?: number | null;
+	costUsd?: number | null;
+}
+
+export type UsageSummaryGroupBy =
+	| "model"
+	| "account"
+	| "project"
+	| "outcome"
+	| "day";
+
+export interface UsageLedgerQuery {
+	since?: number | Date | string;
+	until?: number | Date | string;
+	includeArchives?: boolean;
+}
+
+export interface UsageSummaryQuery extends UsageLedgerQuery {
+	by?: UsageSummaryGroupBy;
+}
+
+export interface UsageSummaryBucket {
+	key: string;
+	requests: number;
+	successes: number;
+	failures: number;
+	blocked: number;
+	cancelled: number;
+	inputTokens: number;
+	outputTokens: number;
+	cachedInputTokens: number;
+	reasoningTokens: number;
+	totalTokens: number;
+	costUsd: number;
+}
+
+export interface UsageSummary {
+	since: number | null;
+	until: number | null;
+	by: UsageSummaryGroupBy;
+	totals: UsageSummaryBucket;
+	buckets: UsageSummaryBucket[];
+}
+
+export interface UsageLedgerPaths {
+	dir: string;
+	current: string;
+}
+

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("usage ledger core", () => {
+	let tempDir: string;
+	let originalDir: string | undefined;
+
+	beforeEach(async () => {
+		originalDir = process.env.CODEX_MULTI_AUTH_DIR;
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-ledger-"));
+		process.env.CODEX_MULTI_AUTH_DIR = tempDir;
+		vi.resetModules();
+	});
+
+	afterEach(async () => {
+		if (originalDir === undefined) {
+			delete process.env.CODEX_MULTI_AUTH_DIR;
+		} else {
+			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
+		}
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("appends normalized JSONL rows without raw email or account identifiers", async () => {
+		const {
+			appendUsageLedgerRow,
+			getUsageLedgerPaths,
+			readUsageLedgerRows,
+		} = await import("../lib/usage/index.js");
+
+		const row = await appendUsageLedgerRow({
+			id: "row-1",
+			createdAt: 1_700_000_000_000,
+			source: "runtime-proxy",
+			operation: "responses",
+			outcome: "success",
+			model: " gpt-5.3-codex ",
+			accountId: "acct_sensitive_123",
+			email: "Owner@Example.com",
+			accountIndex: 2,
+			requestId: "req_123",
+			statusCode: 200,
+			durationMs: 123.9,
+			inputTokens: 1_000,
+			outputTokens: 200,
+			cachedInputTokens: 50,
+			reasoningTokens: 25,
+		});
+
+		expect(row.model).toBe("gpt-5.3-codex");
+		expect(row.account?.accountHash).toMatch(/^sha256:/);
+		expect(row.account?.emailHash).toMatch(/^sha256:/);
+		expect(row.account?.index).toBe(2);
+		expect(row.tokens.totalTokens).toBe(1_275);
+		expect(row.costUsd).toBeGreaterThan(0);
+
+		const raw = await fs.readFile(getUsageLedgerPaths().current, "utf8");
+		expect(raw).toContain('"version":1');
+		expect(raw).not.toContain("acct_sensitive_123");
+		expect(raw).not.toContain("Owner@Example.com");
+		expect(raw).not.toContain("owner@example.com");
+
+		await expect(readUsageLedgerRows()).resolves.toEqual([row]);
+	});
+
+	it("summarizes usage by model and applies date filters", async () => {
+		const { appendUsageLedgerRow, summarizeUsageLedger } = await import(
+			"../lib/usage/index.js"
+		);
+
+		await appendUsageLedgerRow({
+			id: "old",
+			createdAt: 100,
+			outcome: "success",
+			model: "gpt-5.3-codex",
+			inputTokens: 100,
+			outputTokens: 10,
+		});
+		await appendUsageLedgerRow({
+			id: "new-success",
+			createdAt: 200,
+			outcome: "success",
+			model: "gpt-5.3-codex",
+			inputTokens: 200,
+			outputTokens: 20,
+		});
+		await appendUsageLedgerRow({
+			id: "new-failure",
+			createdAt: 300,
+			outcome: "failure",
+			model: "gpt-5.5",
+			inputTokens: 50,
+			outputTokens: 5,
+		});
+
+		const summary = await summarizeUsageLedger({ since: 150, by: "model" });
+
+		expect(summary.totals.requests).toBe(2);
+		expect(summary.totals.successes).toBe(1);
+		expect(summary.totals.failures).toBe(1);
+		expect(summary.totals.inputTokens).toBe(250);
+		expect(summary.buckets.map((bucket) => bucket.key)).toEqual([
+			"gpt-5.3-codex",
+			"gpt-5.5",
+		]);
+		expect(summary.buckets[0]?.requests).toBe(1);
+	});
+
+	it("rotates the current ledger and can include archived rows", async () => {
+		const {
+			appendUsageLedgerRow,
+			getUsageLedgerPaths,
+			readUsageLedgerRows,
+			rotateUsageLedger,
+		} = await import("../lib/usage/index.js");
+
+		await appendUsageLedgerRow({
+			id: "before-rotate",
+			createdAt: 100,
+			outcome: "success",
+			model: "gpt-5.3-codex",
+		});
+
+		const rotated = await rotateUsageLedger({
+			now: Date.UTC(2026, 0, 2, 3, 4, 5, 6),
+		});
+
+		expect(rotated).toContain("usage-ledger.20260102T030405006Z.jsonl");
+		await expect(fs.stat(getUsageLedgerPaths().current)).rejects.toThrow();
+
+		await appendUsageLedgerRow({
+			id: "after-rotate",
+			createdAt: 200,
+			outcome: "success",
+			model: "gpt-5.5",
+		});
+
+		expect((await readUsageLedgerRows()).map((row) => row.id)).toEqual([
+			"after-rotate",
+		]);
+		expect(
+			(await readUsageLedgerRows({ includeArchives: true })).map(
+				(row) => row.id,
+			),
+		).toEqual(["before-rotate", "after-rotate"]);
+	});
+
+	it("skips rotation when below the configured byte threshold", async () => {
+		const { appendUsageLedgerRow, rotateUsageLedger } = await import(
+			"../lib/usage/index.js"
+		);
+
+		await appendUsageLedgerRow({
+			id: "small",
+			createdAt: 100,
+			outcome: "success",
+		});
+
+		await expect(
+			rotateUsageLedger({ ifLargerThanBytes: 1_000_000 }),
+		).resolves.toBeNull();
+	});
+
+	it("exports pricing helpers with deterministic estimates", async () => {
+		const { estimateUsageCostUsd, listUsageModelPricing } = await import(
+			"../lib/usage/index.js"
+		);
+
+		expect(Object.keys(listUsageModelPricing())).toContain("gpt-5.3-codex");
+		expect(
+			estimateUsageCostUsd("gpt-5.3-codex", {
+				inputTokens: 1_000_000,
+				outputTokens: 1_000_000,
+				cachedInputTokens: 1_000_000,
+				reasoningTokens: 1_000_000,
+				totalTokens: 4_000_000,
+			}),
+		).toBe(21.375);
+		expect(
+			estimateUsageCostUsd(null, {
+				inputTokens: 1,
+				outputTokens: 1,
+				cachedInputTokens: 0,
+				reasoningTokens: 0,
+				totalTokens: 2,
+			}),
+		).toBeNull();
+	});
+
+	it("retries transient append failures", async () => {
+		const { appendUsageLedgerRow } = await import("../lib/usage/index.js");
+		const realAppend = fs.appendFile.bind(fs);
+		const appendSpy = vi.spyOn(fs, "appendFile");
+		let attempts = 0;
+		appendSpy.mockImplementation(async (...args) => {
+			attempts += 1;
+			if (attempts === 1) {
+				const error = new Error("busy") as NodeJS.ErrnoException;
+				error.code = "EBUSY";
+				throw error;
+			}
+			return realAppend(...args);
+		});
+
+		try {
+			await appendUsageLedgerRow({
+				id: "retry",
+				outcome: "success",
+			});
+			expect(attempts).toBe(2);
+		} finally {
+			appendSpy.mockRestore();
+		}
+	});
+});
+


### PR DESCRIPTION
## Summary

- Add the local usage ledger core for the local governance roadmap.
- Store usage as redacted JSONL rows with hashed account/email references, local token/cost estimates, summaries, and rotation helpers.

## What Changed

- Added `lib/usage/*` modules for types, redaction, pricing, ledger append/read, summaries, and rotation.
- Exported the usage helpers from `lib/index.ts`.
- Added focused usage ledger tests and the PR 02 handoff file.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- test/usage-ledger.test.ts`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: Medium-low, additive library code with no command or runtime integration yet.
- Rollback plan: Revert this branch to remove the unused usage ledger module and tests.

## Additional Notes

- Runtime append calls are intentionally deferred to the runtime policy integration PR.
- The ledger stores no prompts, auth headers, tokens, raw emails, or raw sensitive account ids.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

adds the `lib/usage/*` module family — types, sha256-based redaction, model pricing, jsonl ledger append/read/rotate, and summaries — exporting through `lib/index.ts`. the code is additive with no runtime integration yet, and the redaction design correctly prevents raw emails and account ids from reaching disk.

- the `afterEach` in the test file uses bare `fs.rm` instead of `removeWithRetry`, violating the explicit `test/AGENTS.md` anti-pattern; this will cause non-deterministic failures on windows where temp files stay locked after append.
- `VALID_SOURCES`, `VALID_OPERATIONS`, and `VALID_OUTCOMES` sets are duplicated between `redaction.ts` and `ledger.ts`; a new source added to one file only will silently downgrade to `"unknown"` on parse-back.

<h3>Confidence Score: 3/5</h3>

safe to merge for non-windows targets; the bare fs.rm test cleanup is a real anti-pattern violation that needs fixing before this is windows-stable

one P1 (bare fs.rm vs removeWithRetry, explicit test/AGENTS.md anti-pattern) pulls the ceiling to 4; the additional multi-process append race on windows is a meaningful second concern, dropping the score to 3

test/usage-ledger.test.ts (fs.rm cleanup), lib/usage/ledger.ts (appendQueue cross-process safety, duplicated sets), lib/usage/redaction.ts (duplicated sets)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/usage/ledger.ts | core ledger append/read/rotate logic; module-level appendQueue serializes within-process writes but not cross-process; duplicated valid-value sets vs redaction.ts; retry helpers for read/rename lack test coverage |
| lib/usage/redaction.ts | normalizes and hashes account/email identifiers via sha256 before write; VALID_* sets duplicated from ledger.ts — drift risk if new values are added to one file only |
| lib/usage/types.ts | clean type definitions for ledger rows, append input, query, and summary shapes; no issues found |
| lib/usage/pricing.ts | hardcoded model pricing table with deterministic cost estimation; structuredClone used correctly for the public listing; no issues |
| test/usage-ledger.test.ts | 6 focused tests covering append, summarize, rotate, threshold skip, pricing, and retry; afterEach uses bare fs.rm instead of removeWithRetry (explicit anti-pattern per test/AGENTS.md); readFileWithRetry and renameWithRetry retry branches not tested |
| lib/usage/index.ts | simple barrel re-export of all usage submodules; no issues |
| lib/index.ts | adds usage barrel to the main public export; single-line change, no issues |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[appendUsageLedgerRow input] --> B[normalizeUsageLedgerRow redaction.ts]
    B --> B1[hashUsageIdentifier sha256 accountId/email]
    B --> B2[normalizeTokens non-negative integers]
    B --> B3[estimateUsageCostUsd pricing.ts lookup]
    B1 & B2 & B3 --> C[UsageLedgerRow]
    C --> D[usageRowToJsonLine JSON.stringify + newline]
    D --> E{appendQueue module-level serializer}
    E --> F[fs.mkdir recursive mode 0o700]
    F --> G[appendFileWithRetry EBUSY/EPERM 5x backoff mode 0o600]
    G --> H[(usage-ledger.jsonl)]
    H --> I[readUsageLedgerRows]
    I --> J{includeArchives?}
    J -- no --> K[current file only]
    J -- yes --> L[listLedgerFiles readdir + regex filter]
    K & L --> M[readFileWithRetry]
    M --> N[parseJsonlRows normalizeParsedUsageRow]
    N --> O[filterRows since/until]
    O --> P[sorted UsageLedgerRow array]
    H --> Q[rotateUsageLedger]
    Q --> R{ifLargerThanBytes?}
    R -- skip --> S[null]
    R -- rotate --> T[renameWithRetry usage-ledger.STAMP.jsonl]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/usage-ledger.test.ts`, line 932 ([link](https://github.com/ndycode/codex-multi-auth/blob/a4b716273b377800e746c655398dffda515d9f1d/test/usage-ledger.test.ts#L932)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **bare `fs.rm` in test cleanup — windows unsafe**

   `test/AGENTS.md` explicitly forbids bare `fs.rm` in test cleanup and requires `removeWithRetry` with `EBUSY`/`EPERM`/`ENOTEMPTY` backoff. on windows, the temp dir will often still be locked by the file system scanner when this fires after the appended jsonl test, causing `EPERM`/`EBUSY` failures that make the test suite non-deterministic. use `removeWithRetry` directly (matching the pattern in `repo-hygiene.test.ts` and `rotation-integration.test.ts`).

   **Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: test/usage-ledger.test.ts
   Line: 932
   
   Comment:
   **bare `fs.rm` in test cleanup — windows unsafe**
   
   `test/AGENTS.md` explicitly forbids bare `fs.rm` in test cleanup and requires `removeWithRetry` with `EBUSY`/`EPERM`/`ENOTEMPTY` backoff. on windows, the temp dir will often still be locked by the file system scanner when this fires after the appended jsonl test, causing `EPERM`/`EBUSY` failures that make the test suite non-deterministic. use `removeWithRetry` directly (matching the pattern in `repo-hygiene.test.ts` and `rotation-integration.test.ts`).
   
   **Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fusage-ledger-core%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fusage-ledger-core%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fusage-ledger.test.ts%0ALine%3A%20932%0A%0AComment%3A%0A**bare%20%60fs.rm%60%20in%20test%20cleanup%20%E2%80%94%20windows%20unsafe**%0A%0A%60test%2FAGENTS.md%60%20explicitly%20forbids%20bare%20%60fs.rm%60%20in%20test%20cleanup%20and%20requires%20%60removeWithRetry%60%20with%20%60EBUSY%60%2F%60EPERM%60%2F%60ENOTEMPTY%60%20backoff.%20on%20windows%2C%20the%20temp%20dir%20will%20often%20still%20be%20locked%20by%20the%20file%20system%20scanner%20when%20this%20fires%20after%20the%20appended%20jsonl%20test%2C%20causing%20%60EPERM%60%2F%60EBUSY%60%20failures%20that%20make%20the%20test%20suite%20non-deterministic.%20use%20%60removeWithRetry%60%20directly%20%28matching%20the%20pattern%20in%20%60repo-hygiene.test.ts%60%20and%20%60rotation-integration.test.ts%60%29.%0A%0A**Context%20Used%3A**%20test%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6e2636a9-e514-4bab-b249-4b4a84aa4ae3%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fusage-ledger-core%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fusage-ledger-core%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Atest%2Fusage-ledger.test.ts%3A932%0A**bare%20%60fs.rm%60%20in%20test%20cleanup%20%E2%80%94%20windows%20unsafe**%0A%0A%60test%2FAGENTS.md%60%20explicitly%20forbids%20bare%20%60fs.rm%60%20in%20test%20cleanup%20and%20requires%20%60removeWithRetry%60%20with%20%60EBUSY%60%2F%60EPERM%60%2F%60ENOTEMPTY%60%20backoff.%20on%20windows%2C%20the%20temp%20dir%20will%20often%20still%20be%20locked%20by%20the%20file%20system%20scanner%20when%20this%20fires%20after%20the%20appended%20jsonl%20test%2C%20causing%20%60EPERM%60%2F%60EBUSY%60%20failures%20that%20make%20the%20test%20suite%20non-deterministic.%20use%20%60removeWithRetry%60%20directly%20%28matching%20the%20pattern%20in%20%60repo-hygiene.test.ts%60%20and%20%60rotation-integration.test.ts%60%29.%0A%0A**Context%20Used%3A**%20test%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6e2636a9-e514-4bab-b249-4b4a84aa4ae3%29%29%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fusage%2Fledger.ts%3A104-105%0A**module-level%20%60appendQueue%60%20doesn't%20cover%20multi-process%20writes**%0A%0Athe%20queue%20correctly%20serializes%20appends%20within%20a%20single%20process%2C%20but%20concurrent%20writers%20from%20the%20runtime-proxy%2C%20plugin-host%2C%20and%20cli%20processes%20all%20share%20the%20same%20file%20with%20no%20cross-process%20lock.%20on%20windows%2C%20concurrent%20%60appendFile%60%20calls%20to%20the%20same%20file%20can%20interleave%20and%20silently%20corrupt%20jsonl%20rows.%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Fusage%2Fredaction.ts%3A624-643%0A**duplicated%20%60VALID_SOURCES%60%20%2F%20%60VALID_OPERATIONS%60%20%2F%20%60VALID_OUTCOMES%60%20sets**%0A%0Aall%20three%20sets%20are%20defined%20identically%20in%20both%20%60redaction.ts%60%20%28lines%20624%E2%80%93643%29%20and%20%60ledger.ts%60%20%28lines%20107%E2%80%93126%29.%20if%20a%20new%20source%20or%20operation%20is%20added%20to%20one%20file%20and%20not%20the%20other%2C%20%60normalizeParsedUsageRow%60%20will%20silently%20downgrade%20the%20field%20to%20%60%22unknown%22%60%20while%20the%20append%20path%20accepts%20the%20new%20value.%20moving%20them%20to%20%60types.ts%60%20and%20importing%20from%20there%20would%20prevent%20drift.%0A%0A**Context%20Used%3A**%20lib%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dffbed5b7-f299-4c32-b3f9-f7c095ca8632%29%29%0A%0A%23%23%23%20Issue%204%20of%204%0Atest%2Fusage-ledger.test.ts%3A901-935%0A**missing%20vitest%20coverage%20for%20retry%20helpers**%0A%0Athe%20retry%20test%20covers%20only%20%60appendFileWithRetry%60.%20%60readFileWithRetry%60%20and%20%60renameWithRetry%60%20retry%20branches%20%28lines%20165%E2%80%93200%20in%20%60ledger.ts%60%29%20have%20no%20test.%20per%20project%20convention%20%2880%25%2B%20coverage%20threshold%29%2C%20these%20branches%20should%20each%20have%20a%20test%20mocking%20%60fs.readFile%60%20%2F%20%60fs.rename%60%20to%20throw%20%60EBUSY%60%20on%20the%20first%20attempt%20and%20succeed%20on%20the%20second.%0A%0A**Context%20Used%3A**%20test%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6e2636a9-e514-4bab-b249-4b4a84aa4ae3%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/usage-ledger.test.ts
Line: 932

Comment:
**bare `fs.rm` in test cleanup — windows unsafe**

`test/AGENTS.md` explicitly forbids bare `fs.rm` in test cleanup and requires `removeWithRetry` with `EBUSY`/`EPERM`/`ENOTEMPTY` backoff. on windows, the temp dir will often still be locked by the file system scanner when this fires after the appended jsonl test, causing `EPERM`/`EBUSY` failures that make the test suite non-deterministic. use `removeWithRetry` directly (matching the pattern in `repo-hygiene.test.ts` and `rotation-integration.test.ts`).

**Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/usage/ledger.ts
Line: 104-105

Comment:
**module-level `appendQueue` doesn't cover multi-process writes**

the queue correctly serializes appends within a single process, but concurrent writers from the runtime-proxy, plugin-host, and cli processes all share the same file with no cross-process lock. on windows, concurrent `appendFile` calls to the same file can interleave and silently corrupt jsonl rows.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/usage/redaction.ts
Line: 624-643

Comment:
**duplicated `VALID_SOURCES` / `VALID_OPERATIONS` / `VALID_OUTCOMES` sets**

all three sets are defined identically in both `redaction.ts` (lines 624–643) and `ledger.ts` (lines 107–126). if a new source or operation is added to one file and not the other, `normalizeParsedUsageRow` will silently downgrade the field to `"unknown"` while the append path accepts the new value. moving them to `types.ts` and importing from there would prevent drift.

**Context Used:** lib/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=ffbed5b7-f299-4c32-b3f9-f7c095ca8632))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/usage-ledger.test.ts
Line: 901-935

Comment:
**missing vitest coverage for retry helpers**

the retry test covers only `appendFileWithRetry`. `readFileWithRetry` and `renameWithRetry` retry branches (lines 165–200 in `ledger.ts`) have no test. per project convention (80%+ coverage threshold), these branches should each have a test mocking `fs.readFile` / `fs.rename` to throw `EBUSY` on the first attempt and succeed on the second.

**Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add local usage ledger core"](https://github.com/ndycode/codex-multi-auth/commit/a4b716273b377800e746c655398dffda515d9f1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30169006)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))
- Context used - lib/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=ffbed5b7-f299-4c32-b3f9-f7c095ca8632))

<!-- /greptile_comment -->