### PR TITLE
feat: add usage summary command

### DIFF
--- a/docs/development/implementation-plans/status.md
+++ b/docs/development/implementation-plans/status.md
@@ -18,7 +18,7 @@ Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 | --- | --- | --- | --- |
 | 01 | `chore/roadmap-local-governance` | Ready for review | `npm test -- test/documentation.test.ts`; `npm run build`. |
 | 02 | `feat/usage-ledger-core` | Ready for review | `npm run typecheck`; `npm test -- test/usage-ledger.test.ts`; `npm run lint`; `npm run build`. |
-| 03 | `feat/usage-command` | Pending | CLI usage command tests plus build. |
+| 03 | `feat/usage-command` | Ready for review | `npm run typecheck`; usage command/core/docs tests; `npm run lint`; `npm run build`. |
 | 04 | `feat/account-policy-controls` | Pending | Account policy command/store tests plus build. |
 | 05 | `feat/routing-profiles-core` | Pending | Routing profile storage/project tests plus build. |
 | 06 | `feat/budget-guard` | Pending | Budget guard command/evaluator tests plus build. |

--- a/docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md
@@ -1,0 +1,29 @@
+# PR 03 Handoff: Usage Command
+
+Branch: `feat/usage-command`
+Base: `origin/main` after PR 02 merge
+
+## Scope
+
+Add `codex auth usage` command behavior on top of the local usage ledger core.
+
+## Files Changed
+
+- `lib/codex-manager/commands/usage.ts`
+- `lib/codex-manager.ts`
+- `lib/codex-manager/help.ts`
+- `docs/reference/commands.md`
+- `docs/development/implementation-plans/status.md`
+- `docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md`
+
+## Validation
+
+- `npm run typecheck` passed.
+- `npm test -- test/codex-manager-usage-command.test.ts test/usage-ledger.test.ts test/documentation.test.ts` passed: 3 files, 36 tests.
+- `npm run lint` passed.
+- `npm run build` passed.
+
+## Follow-ups
+
+- PR 08 should add runtime usage row appends.
+- PR 09 should include usage summaries in `codex auth monitor`.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -57,6 +57,7 @@ Compatibility aliases are supported:
 | --- | --- |
 | `codex auth features` | Print implemented feature summary |
 | `codex auth report` | Generate full health report |
+| `codex auth usage` | Summarize local usage ledger rows |
 | `codex auth why-selected [--now|--last]` | Explain which account the selector picks now or via the last persisted runtime snapshot |
 | `codex auth rotation enable\|disable\|status\|bind-app\|unbind-app` | Manage the default-on runtime Responses proxy for live Codex account rotation |
 
@@ -68,12 +69,15 @@ Compatibility aliases are supported:
 | --- | --- | --- |
 | `--device-auth` | login | Use the OpenAI Codex device-code flow for remote/headless login (mutually exclusive with `--manual` / `--no-browser`) |
 | `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow (mutually exclusive with `--device-auth`) |
-| `--json` | verify-flagged, verify, why-selected, best, forecast, report, fix, doctor, config explain, debug bundle | Print machine-readable output |
+| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, fix, doctor, config explain, debug bundle | Print machine-readable output |
+| `--csv` | usage | Print or write CSV bucket output |
 | `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |
 | `--live` | best, forecast, report, fix | Use live probe before decisions/output |
 | `--dry-run` | verify-flagged, verify (with `--flagged`/`--all`), fix, doctor | Preview without writing storage |
 | `--model <model>` | best, forecast, report, fix | Specify model for live probe paths |
-| `--out <path>` | report | Write report output to file |
+| `--out <path>` | report, usage | Write report output to file |
+| `--since <time>` | usage | Filter local usage rows by timestamp, ISO date, or relative duration |
+| `--by <group>` | usage | Group usage by model, account, project, outcome, or day |
 | `--write <path>` | init-config, config template | Write template output to a file instead of stdout |
 | `--fix` | doctor | Apply safe repairs |
 | `--no-restore` | verify-flagged, verify (with `--flagged`/`--all`) | Verify only; do not restore healthy flagged accounts |
@@ -82,6 +86,37 @@ Compatibility aliases are supported:
 | `--all` | verify | Run both `--paths` and `--flagged` together |
 | `--now`, `-n` | why-selected | Recompute the current selection from live state (default) |
 | `--last`, `-l` | why-selected | Recompute selection from current state and attach the last persisted runtime snapshot |
+
+---
+
+## `codex auth usage`
+
+Summarizes the local usage ledger. Rows are local-only metadata and do not
+contain prompts, tokens, auth headers, raw account emails, or raw sensitive
+account ids.
+
+Usage:
+
+```bash
+codex auth usage [--since <time|duration>] [--by <model|account|project|outcome|day>] [--json|--csv] [--out <path>]
+codex auth usage rotate [--if-larger-than-bytes <bytes>] [--json]
+```
+
+Flags:
+
+- `--since`: filter rows by Unix milliseconds, ISO date, or relative duration
+  such as `24h`, `7d`, or `2w`.
+- `--by`: group summary output by `model`, `account`, `project`, `outcome`, or
+  `day`. Default: `model`.
+- `--json`, `-j`: emit machine-readable JSON including the summary and rows.
+- `--csv`: emit CSV bucket output.
+- `--out`: write the rendered output to a file.
+- `rotate`: move the current ledger to a timestamped archive.
+- `--if-larger-than-bytes`: skip rotation unless the current ledger is larger
+  than the provided byte threshold.
+
+Exit code: `0` for successful summary or rotation, `1` for invalid options or
+write failures.
 
 ---
 

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -80,6 +80,7 @@ import {
 } from "./codex-manager/commands/status.js";
 import { loadPersistedRuntimeObservabilitySnapshot } from "./runtime/runtime-observability.js";
 import { runSwitchCommand } from "./codex-manager/commands/switch.js";
+import { runUsageCommand } from "./codex-manager/commands/usage.js";
 import { parseAuthLoginArgs, printUsage } from "./codex-manager/help.js";
 import {
 	applyUiThemeFromDashboardSettings,
@@ -3470,6 +3471,9 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 			loadRuntimeObservabilitySnapshot:
 				loadPersistedRuntimeObservabilitySnapshot,
 		});
+	}
+	if (command === "usage") {
+		return runUsageCommand(rest);
 	}
 	if (command === "rotation") {
 		return runRotationCommand(rest, {

--- a/lib/codex-manager/commands/usage.ts
+++ b/lib/codex-manager/commands/usage.ts
@@ -1,0 +1,384 @@
+import { promises as fs } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { sleep } from "../../utils.js";
+import {
+	readUsageLedgerRows,
+	rotateUsageLedger,
+	summarizeUsageLedger,
+	type UsageLedgerRow,
+	type UsageSummary,
+	type UsageSummaryBucket,
+	type UsageSummaryGroupBy,
+} from "../../usage/index.js";
+
+interface UsageCliOptions {
+	since?: number | Date | string;
+	by: UsageSummaryGroupBy;
+	json: boolean;
+	csv: boolean;
+	outPath?: string;
+}
+
+interface UsageRotateOptions {
+	json: boolean;
+	ifLargerThanBytes?: number;
+}
+
+type ParsedArgsResult<T> =
+	| { ok: true; options: T }
+	| { ok: false; message: string };
+
+export interface UsageCommandDeps {
+	summarizeUsage?: typeof summarizeUsageLedger;
+	readRows?: typeof readUsageLedgerRows;
+	rotateLedger?: typeof rotateUsageLedger;
+	logInfo?: (message: string) => void;
+	logError?: (message: string) => void;
+	getCwd?: () => string;
+	writeFile?: (path: string, contents: string) => Promise<void>;
+}
+
+const VALID_GROUPS = new Set<UsageSummaryGroupBy>([
+	"model",
+	"account",
+	"project",
+	"outcome",
+	"day",
+]);
+const RETRYABLE_WRITE_CODES = new Set(["EBUSY", "EPERM"]);
+
+function parsePositiveInteger(rawValue: string): number | null {
+	if (!/^\d+$/.test(rawValue.trim())) return null;
+	const parsed = Number.parseInt(rawValue, 10);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseSinceValue(value: string): number | string {
+	const trimmed = value.trim();
+	const relative = /^(\d+)(m|h|d|w)$/i.exec(trimmed);
+	if (relative?.[1] && relative[2]) {
+		const amount = Number.parseInt(relative[1], 10);
+		const unit = relative[2].toLowerCase();
+		const multiplier =
+			unit === "m"
+				? 60_000
+				: unit === "h"
+					? 3_600_000
+					: unit === "d"
+						? 86_400_000
+						: 604_800_000;
+		return Date.now() - amount * multiplier;
+	}
+	if (/^\d+$/.test(trimmed)) {
+		return Number.parseInt(trimmed, 10);
+	}
+	return trimmed;
+}
+
+function printUsageCommandHelp(logInfo: (message: string) => void): void {
+	logInfo(
+		[
+			"Usage:",
+			"  codex auth usage [--since <time|duration>] [--by <model|account|project|outcome|day>] [--json|--csv] [--out <path>]",
+			"  codex auth usage rotate [--if-larger-than-bytes <bytes>] [--json]",
+			"",
+			"Options:",
+			"  --since            Filter rows by timestamp, ISO date, or relative duration like 24h, 7d, 2w",
+			"  --by               Group summary output (default: model)",
+			"  --json, -j         Print machine-readable JSON output",
+			"  --csv              Print or write CSV bucket output",
+			"  --out              Write output to a file path",
+			"",
+			"Notes:",
+			"  - Usage rows contain local metadata only, not prompts, tokens, auth headers, raw emails, or raw account ids.",
+		].join("\n"),
+	);
+}
+
+function parseUsageArgs(args: string[]): ParsedArgsResult<UsageCliOptions> {
+	const options: UsageCliOptions = {
+		by: "model",
+		json: false,
+		csv: false,
+	};
+
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (!arg) continue;
+		if (arg === "--json" || arg === "-j") {
+			options.json = true;
+			continue;
+		}
+		if (arg === "--csv") {
+			options.csv = true;
+			continue;
+		}
+		if (arg === "--since") {
+			const value = args[i + 1];
+			if (!value) return { ok: false, message: "Missing value for --since" };
+			options.since = parseSinceValue(value);
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--since=")) {
+			const value = arg.slice("--since=".length).trim();
+			if (!value) return { ok: false, message: "Missing value for --since" };
+			options.since = parseSinceValue(value);
+			continue;
+		}
+		if (arg === "--by") {
+			const value = args[i + 1];
+			if (!value) return { ok: false, message: "Missing value for --by" };
+			if (!VALID_GROUPS.has(value as UsageSummaryGroupBy)) {
+				return { ok: false, message: `Unknown --by value: ${value}` };
+			}
+			options.by = value as UsageSummaryGroupBy;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--by=")) {
+			const value = arg.slice("--by=".length).trim();
+			if (!VALID_GROUPS.has(value as UsageSummaryGroupBy)) {
+				return { ok: false, message: `Unknown --by value: ${value}` };
+			}
+			options.by = value as UsageSummaryGroupBy;
+			continue;
+		}
+		if (arg === "--out") {
+			const value = args[i + 1];
+			if (!value) return { ok: false, message: "Missing value for --out" };
+			options.outPath = value;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--out=")) {
+			const value = arg.slice("--out=".length).trim();
+			if (!value) return { ok: false, message: "Missing value for --out" };
+			options.outPath = value;
+			continue;
+		}
+		return { ok: false, message: `Unknown usage option: ${arg}` };
+	}
+
+	if (options.json && options.csv) {
+		return { ok: false, message: "Cannot combine --json and --csv" };
+	}
+	return { ok: true, options };
+}
+
+function parseRotateArgs(args: string[]): ParsedArgsResult<UsageRotateOptions> {
+	const options: UsageRotateOptions = { json: false };
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (!arg) continue;
+		if (arg === "--json" || arg === "-j") {
+			options.json = true;
+			continue;
+		}
+		if (arg === "--if-larger-than-bytes") {
+			const value = args[i + 1];
+			if (!value) {
+				return {
+					ok: false,
+					message: "Missing value for --if-larger-than-bytes",
+				};
+			}
+			const parsed = parsePositiveInteger(value);
+			if (parsed === null) {
+				return {
+					ok: false,
+					message: "--if-larger-than-bytes must be a positive integer",
+				};
+			}
+			options.ifLargerThanBytes = parsed;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--if-larger-than-bytes=")) {
+			const parsed = parsePositiveInteger(
+				arg.slice("--if-larger-than-bytes=".length),
+			);
+			if (parsed === null) {
+				return {
+					ok: false,
+					message: "--if-larger-than-bytes must be a positive integer",
+				};
+			}
+			options.ifLargerThanBytes = parsed;
+			continue;
+		}
+		return { ok: false, message: `Unknown usage rotate option: ${arg}` };
+	}
+	return { ok: true, options };
+}
+
+function formatCurrency(value: number): string {
+	return `$${value.toFixed(6)}`;
+}
+
+function formatTextSummary(summary: UsageSummary): string {
+	const lines = [
+		`Usage summary by ${summary.by}`,
+		`Requests: ${summary.totals.requests} (${summary.totals.successes} success, ${summary.totals.failures} failed, ${summary.totals.blocked} blocked, ${summary.totals.cancelled} cancelled)`,
+		`Tokens: ${summary.totals.totalTokens} total (${summary.totals.inputTokens} input, ${summary.totals.outputTokens} output, ${summary.totals.cachedInputTokens} cached, ${summary.totals.reasoningTokens} reasoning)`,
+		`Estimated cost: ${formatCurrency(summary.totals.costUsd)}`,
+	];
+	if (summary.buckets.length === 0) {
+		lines.push("No usage rows found.");
+		return lines.join("\n");
+	}
+	lines.push("");
+	for (const bucket of summary.buckets) {
+		lines.push(
+			`${bucket.key}: ${bucket.requests} request(s), ${bucket.totalTokens} token(s), ${formatCurrency(bucket.costUsd)}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function csvEscape(value: string | number): string {
+	const text = String(value);
+	return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+function bucketToCsvRow(bucket: UsageSummaryBucket): string {
+	return [
+		bucket.key,
+		bucket.requests,
+		bucket.successes,
+		bucket.failures,
+		bucket.blocked,
+		bucket.cancelled,
+		bucket.inputTokens,
+		bucket.outputTokens,
+		bucket.cachedInputTokens,
+		bucket.reasoningTokens,
+		bucket.totalTokens,
+		bucket.costUsd.toFixed(8),
+	]
+		.map(csvEscape)
+		.join(",");
+}
+
+function formatCsvSummary(summary: UsageSummary): string {
+	return [
+		"key,requests,successes,failures,blocked,cancelled,inputTokens,outputTokens,cachedInputTokens,reasoningTokens,totalTokens,costUsd",
+		...summary.buckets.map(bucketToCsvRow),
+		...(summary.buckets.length === 0 ? [bucketToCsvRow(summary.totals)] : []),
+	].join("\n");
+}
+
+function rowsToJsonPayload(summary: UsageSummary, rows: UsageLedgerRow[]): string {
+	return JSON.stringify(
+		{
+			command: "usage",
+			summary,
+			rows,
+		},
+		null,
+		2,
+	);
+}
+
+function isRetryableWriteError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_WRITE_CODES.has(code);
+}
+
+async function defaultWriteFile(path: string, contents: string): Promise<void> {
+	await fs.mkdir(dirname(path), { recursive: true });
+	const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+	let moved = false;
+	try {
+		await fs.writeFile(tempPath, contents, "utf-8");
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			try {
+				await fs.rename(tempPath, path);
+				moved = true;
+				return;
+			} catch (error) {
+				if (!isRetryableWriteError(error) || attempt >= 4) throw error;
+				await sleep(10 * 2 ** attempt);
+			}
+		}
+	} finally {
+		if (!moved) {
+			try {
+				await fs.unlink(tempPath);
+			} catch {
+				// Best-effort temp cleanup.
+			}
+		}
+	}
+}
+
+export async function runUsageCommand(
+	args: string[],
+	deps: UsageCommandDeps = {},
+): Promise<number> {
+	const logInfo = deps.logInfo ?? console.log;
+	const logError = deps.logError ?? console.error;
+	if (args.includes("--help") || args.includes("-h")) {
+		printUsageCommandHelp(logInfo);
+		return 0;
+	}
+
+	const [subcommand, ...rest] = args;
+	if (subcommand === "rotate") {
+		const parsed = parseRotateArgs(rest);
+		if (!parsed.ok) {
+			logError(parsed.message);
+			return 1;
+		}
+		const rotatedPath = await (deps.rotateLedger ?? rotateUsageLedger)({
+			ifLargerThanBytes: parsed.options.ifLargerThanBytes,
+		});
+		if (parsed.options.json) {
+			logInfo(
+				JSON.stringify({
+					command: "usage rotate",
+					rotated: rotatedPath !== null,
+					path: rotatedPath,
+				}),
+			);
+		} else {
+			logInfo(
+				rotatedPath
+					? `Usage ledger rotated: ${rotatedPath}`
+					: "Usage ledger rotation skipped.",
+			);
+		}
+		return 0;
+	}
+
+	const parsed = parseUsageArgs(args);
+	if (!parsed.ok) {
+		logError(parsed.message);
+		printUsageCommandHelp(logInfo);
+		return 1;
+	}
+	const options = parsed.options;
+	const query = { since: options.since, by: options.by };
+	const [summary, rows] = await Promise.all([
+		(deps.summarizeUsage ?? summarizeUsageLedger)(query),
+		(deps.readRows ?? readUsageLedgerRows)(query),
+	]);
+	const rendered = options.json
+		? rowsToJsonPayload(summary, rows)
+		: options.csv
+			? formatCsvSummary(summary)
+			: formatTextSummary(summary);
+
+	if (options.outPath) {
+		const outputPath = resolve(deps.getCwd?.() ?? process.cwd(), options.outPath);
+		await (deps.writeFile ?? defaultWriteFile)(outputPath, `${rendered}\n`);
+		if (!options.json && !options.csv) {
+			logInfo(`Usage report written: ${outputPath}`);
+		}
+		return 0;
+	}
+
+	logInfo(rendered);
+	return 0;
+}
+

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -21,6 +21,7 @@ export function printUsage(): void {
 			"  codex auth doctor [--json] [--fix] [--dry-run]",
 			"",
 			"Diagnostics:",
+			"  codex auth usage [--since <time|duration>] [--by <group>] [--json|--csv] [--out <path>]",
 			"  codex auth rotation <enable|disable|status|bind-app|unbind-app>",
 			"  codex auth rotation reset-rate-limits [--all | --account <idx>] [--dry-run] [--json]",
 			"  codex auth why-selected [--now | --last] [--json]",

--- a/test/codex-manager-usage-command.test.ts
+++ b/test/codex-manager-usage-command.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UsageLedgerRow, UsageSummary } from "../lib/usage/index.js";
+import { runUsageCommand } from "../lib/codex-manager/commands/usage.js";
+
+function makeSummary(overrides: Partial<UsageSummary> = {}): UsageSummary {
+	return {
+		since: null,
+		until: null,
+		by: "model",
+		totals: {
+			key: "total",
+			requests: 2,
+			successes: 1,
+			failures: 1,
+			blocked: 0,
+			cancelled: 0,
+			inputTokens: 100,
+			outputTokens: 50,
+			cachedInputTokens: 25,
+			reasoningTokens: 10,
+			totalTokens: 185,
+			costUsd: 0.01234567,
+		},
+		buckets: [
+			{
+				key: "gpt-5.3-codex",
+				requests: 2,
+				successes: 1,
+				failures: 1,
+				blocked: 0,
+				cancelled: 0,
+				inputTokens: 100,
+				outputTokens: 50,
+				cachedInputTokens: 25,
+				reasoningTokens: 10,
+				totalTokens: 185,
+				costUsd: 0.01234567,
+			},
+		],
+		...overrides,
+	};
+}
+
+const rows: UsageLedgerRow[] = [
+	{
+		version: 1,
+		id: "row-1",
+		createdAt: 100,
+		source: "runtime-proxy",
+		operation: "responses",
+		outcome: "success",
+		model: "gpt-5.3-codex",
+		projectKey: null,
+		account: null,
+		requestId: null,
+		statusCode: 200,
+		errorCode: null,
+		durationMs: 10,
+		tokens: {
+			inputTokens: 100,
+			outputTokens: 50,
+			cachedInputTokens: 25,
+			reasoningTokens: 10,
+			totalTokens: 185,
+		},
+		costUsd: 0.01234567,
+	},
+];
+
+describe("usage command", () => {
+	it("prints text summaries by default", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand([], {
+			logInfo,
+			summarizeUsage: async () => makeSummary(),
+			readRows: async () => rows,
+		});
+
+		expect(exitCode).toBe(0);
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain(
+			"Usage summary by model",
+		);
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain("gpt-5.3-codex");
+	});
+
+	it("prints json payloads with rows", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand(["--json"], {
+			logInfo,
+			summarizeUsage: async () => makeSummary(),
+			readRows: async () => rows,
+		});
+
+		expect(exitCode).toBe(0);
+		const payload = JSON.parse(String(logInfo.mock.calls[0]?.[0])) as {
+			command: string;
+			rows: UsageLedgerRow[];
+			summary: UsageSummary;
+		};
+		expect(payload.command).toBe("usage");
+		expect(payload.rows[0]?.id).toBe("row-1");
+		expect(payload.summary.totals.requests).toBe(2);
+	});
+
+	it("prints csv output", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand(["--csv", "--by", "day"], {
+			logInfo,
+			summarizeUsage: async (query) => makeSummary({ by: query.by }),
+			readRows: async () => rows,
+		});
+
+		expect(exitCode).toBe(0);
+		const output = String(logInfo.mock.calls[0]?.[0]);
+		expect(output).toContain("key,requests,successes");
+		expect(output).toContain("gpt-5.3-codex,2,1,1");
+	});
+
+	it("writes rendered output to a file", async () => {
+		const writeFile = vi.fn(async () => undefined);
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand(["--out", "usage.txt"], {
+			logInfo,
+			writeFile,
+			getCwd: () => "/workspace",
+			summarizeUsage: async () => makeSummary(),
+			readRows: async () => rows,
+		});
+
+		expect(exitCode).toBe(0);
+		expect(writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("usage.txt"),
+			expect.stringContaining("Usage summary by model"),
+		);
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain("Usage report written");
+	});
+
+	it("rotates the ledger", async () => {
+		const logInfo = vi.fn();
+		const rotateLedger = vi.fn(async () => "/usage/usage-ledger.rotated.jsonl");
+		const exitCode = await runUsageCommand(
+			["rotate", "--if-larger-than-bytes", "10", "--json"],
+			{
+				logInfo,
+				rotateLedger,
+			},
+		);
+
+		expect(exitCode).toBe(0);
+		expect(rotateLedger).toHaveBeenCalledWith({ ifLargerThanBytes: 10 });
+		expect(JSON.parse(String(logInfo.mock.calls[0]?.[0]))).toEqual({
+			command: "usage rotate",
+			rotated: true,
+			path: "/usage/usage-ledger.rotated.jsonl",
+		});
+	});
+
+	it("rejects invalid options", async () => {
+		const logError = vi.fn();
+		const exitCode = await runUsageCommand(["--json", "--csv"], {
+			logError,
+			logInfo: vi.fn(),
+		});
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Cannot combine --json and --csv",
+		);
+	});
+});
+

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -328,7 +328,7 @@ describe("Documentation Integrity", () => {
 
 		expect(readme).toContain("codex auth fix --live --model gpt-5.3-codex");
 		expect(commandRef).toContain(
-			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, fix, doctor, config explain, debug bundle |",
+			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, fix, doctor, config explain, debug bundle |",
 		);
 		expect(commandRef).toContain(
 			"| `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |",


### PR DESCRIPTION
## Summary

- Add `codex auth usage` for local usage ledger summaries.
- Support `--since`, `--by`, `--json`, `--csv`, `--out`, and `usage rotate`.

## What Changed

- Added the usage command module and wired it into `runCodexMultiAuthCli`.
- Updated CLI help and command reference docs.
- Added focused command tests and updated documentation parity tests.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- test/codex-manager-usage-command.test.ts test/usage-ledger.test.ts test/documentation.test.ts`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [x] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: Medium-low, additive CLI command on top of local ledger helpers.
- Rollback plan: Revert this branch to remove the command wiring, docs, and tests.

## Additional Notes

- Runtime usage collection remains deferred to the runtime policy integration PR.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `codex auth usage` with `--since`, `--by`, `--json`, `--csv`, `--out`, and `usage rotate` subcommand on top of the existing ledger core. wiring, help text, and docs are accurate.

- **p1**: `Promise.all([summarizeUsage, readRows])` has no try/catch — ledger read errors escape as unhandled exceptions instead of returning exit code `1` as documented.
- **p1**: same gap in the `rotate` branch — a filesystem error (e.g. windows `EBUSY` on the ledger file) throws rather than returning `1`.

<h3>Confidence Score: 3/5</h3>

two p1 error-handling gaps in the new command module need to be fixed before merging.

two p1 findings (missing try/catch on both the summary and rotate paths) pull the score below the p1 ceiling of 4. the rest of the change is additive and low-risk.

lib/codex-manager/commands/usage.ts — error handling on ledger read and rotate paths

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/usage.ts | new usage command module — two P1 issues: no try/catch on ledger reads or rotate, so errors escape as unhandled exceptions instead of returning exit code 1. also missing EAGAIN from retryable write codes (P2). |
| test/codex-manager-usage-command.test.ts | new command test — covers 5 happy paths but missing coverage for --since parsing variants, --help, rotate-skipped path, defaultWriteFile retry, and invalid --by. |
| lib/codex-manager.ts | minimal wiring change — adds the usage command dispatch before the rotation block, looks correct. |
| lib/codex-manager/help.ts | adds usage command line to diagnostics section of help output, matches actual command signature. |
| docs/reference/commands.md | docs updated accurately for --since, --by, --csv, --out, rotate, exit codes, and flag matrix. |
| test/documentation.test.ts | parity test updated to expect 'usage' in --json flag matrix, matches the docs change. |
| docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md | new handoff doc for pr-03, accurate scope and validation steps. |
| docs/development/implementation-plans/status.md | status row for pr-03 updated from pending to ready for review. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runUsageCommand args] --> B{--help / -h?}
    B -- yes --> C[printUsageCommandHelp → exit 0]
    B -- no --> D{subcommand === rotate?}
    D -- yes --> E[parseRotateArgs rest]
    E -- invalid --> F[logError → exit 1]
    E -- ok --> G[rotateLedger ifLargerThanBytes]
    G -- no try/catch --> H[logInfo rotated/skipped → exit 0]
    D -- no --> I[parseUsageArgs args]
    I -- invalid --> J[logError + help → exit 1]
    I -- ok --> K[Promise.all summarizeUsage + readRows]
    K -- no try/catch --> L{outPath set?}
    L -- yes --> M[resolve path → writeFile retries EBUSY/EPERM]
    M --> N[logInfo written → exit 0]
    L -- no --> O[logInfo rendered → exit 0]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fusage-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fusage-command%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Fcodex-manager%2Fcommands%2Fusage.ts%3A362-370%0A**unhandled%20errors%20escape%20instead%20of%20returning%20exit%20code%201**%0A%0A%60Promise.all%28%5BsummarizeUsage%2C%20readRows%5D%29%60%20has%20no%20try%2Fcatch.%20if%20the%20ledger%20file%20is%20missing%2C%20corrupt%2C%20or%20throws%20for%20any%20reason%2C%20the%20error%20propagates%20out%20of%20%60runUsageCommand%60%20as%20an%20unhandled%20exception%20rather%20than%20returning%20%601%60.%20the%20docs%20say%20%22exit%20code%201%20for%20invalid%20options%20or%20write%20failures%22%20%E2%80%94%20ledger%20read%20failures%20should%20be%20treated%20the%20same%20way.%0A%0A%60%60%60suggestion%0A%09let%20summary%3A%20UsageSummary%3B%0A%09let%20rows%3A%20UsageLedgerRow%5B%5D%3B%0A%09try%20%7B%0A%09%09%5Bsummary%2C%20rows%5D%20%3D%20await%20Promise.all%28%5B%0A%09%09%09%28deps.summarizeUsage%20%3F%3F%20summarizeUsageLedger%29%28query%29%2C%0A%09%09%09%28deps.readRows%20%3F%3F%20readUsageLedgerRows%29%28query%29%2C%0A%09%09%5D%29%3B%0A%09%7D%20catch%20%28error%29%20%7B%0A%09%09logError%28%60Failed%20to%20read%20usage%20ledger%3A%20%24%7Berror%20instanceof%20Error%20%3F%20error.message%20%3A%20String%28error%29%7D%60%29%3B%0A%09%09return%201%3B%0A%09%7D%0A%09const%20rendered%20%3D%20options.json%0A%09%09%3F%20rowsToJsonPayload%28summary%2C%20rows%29%0A%09%09%3A%20options.csv%0A%09%09%09%3F%20formatCsvSummary%28summary%29%0A%09%09%09%3A%20formatTextSummary%28summary%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fcodex-manager%2Fcommands%2Fusage.ts%3A333-351%0A**rotate%20path%20also%20has%20no%20error%20handling**%0A%0A%60rotateLedger%28...%29%60%20is%20awaited%20without%20a%20try%2Fcatch.%20a%20filesystem%20error%20%28e.g.%20ledger%20locked%20on%20windows%29%20throws%20instead%20of%20returning%20%601%60.%20same%20fix%20pattern%20as%20the%20summary%20path%20%E2%80%94%20wrap%20in%20try%2Fcatch%20and%20return%20%601%60%20with%20%60logError%60.%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Fcodex-manager%2Fcommands%2Fusage.ts%3A48%0A**%60EAGAIN%60%20missing%20from%20retryable%20write%20codes**%0A%0A%60lib%2FAGENTS.md%60%20lists%20the%20project-standard%20retry%20set%20as%20%60EBUSY%2FEPERM%2FEAGAIN%60%20for%20file%20writes.%20%60EAGAIN%60%20is%20absent%20here%2C%20so%20a%20write%20that%20fails%20with%20%60EAGAIN%60%20%28e.g.%20advisory%20lock%20on%20some%20linux%20filesystems%29%20will%20throw%20instead%20of%20retrying.%0A%0A%60%60%60suggestion%0Aconst%20RETRYABLE_WRITE_CODES%20%3D%20new%20Set%28%5B%22EBUSY%22%2C%20%22EPERM%22%2C%20%22EAGAIN%22%5D%29%3B%0A%60%60%60%0A%0A**Context%20Used%3A**%20lib%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dffbed5b7-f299-4c32-b3f9-f7c095ca8632%29%29%0A%0A%23%23%23%20Issue%204%20of%204%0Atest%2Fcodex-manager-usage-command.test.ts%3A1-10%0A**missing%20vitest%20coverage%20for%20several%20branches**%0A%0Athe%20test%20file%20covers%20the%20happy%20paths%20well%2C%20but%20these%20branches%20have%20no%20coverage%3A%0A%0A-%20%60--since%60%20parsing%3A%20relative%20durations%20%28%6024h%60%2C%20%607d%60%2C%20%602w%60%29%2C%20iso%20date%20string%2C%20raw%20unix%20ms%0A-%20%60--help%60%20%2F%20%60-h%60%20flag%20exits%200%20and%20calls%20%60logInfo%60%0A-%20%60rotate%60%20when%20%60rotateLedger%60%20returns%20%60null%60%20%28threshold%20not%20met%2C%20non-json%20and%20json%20paths%29%0A-%20%60defaultWriteFile%60%20retry%20on%20%60EBUSY%60%2F%60EPERM%60%2F%60EAGAIN%60%0A-%20%60--by%60%20with%20an%20invalid%20group%20name%20returning%20exit%20code%201%0A-%20%60--out%60%20with%20%60--json%60%20or%20%60--csv%60%20%28no%20confirmation%20log%20line%20expected%29%0A%0Aper%20the%20repo's%2080%25%2B%20coverage%20threshold%20and%20test%2FAGENTS.md%20conventions%2C%20these%20are%20expected%20to%20be%20covered.%0A%0A**Context%20Used%3A**%20test%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6e2636a9-e514-4bab-b249-4b4a84aa4ae3%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager/commands/usage.ts
Line: 362-370

Comment:
**unhandled errors escape instead of returning exit code 1**

`Promise.all([summarizeUsage, readRows])` has no try/catch. if the ledger file is missing, corrupt, or throws for any reason, the error propagates out of `runUsageCommand` as an unhandled exception rather than returning `1`. the docs say "exit code 1 for invalid options or write failures" — ledger read failures should be treated the same way.

```suggestion
	let summary: UsageSummary;
	let rows: UsageLedgerRow[];
	try {
		[summary, rows] = await Promise.all([
			(deps.summarizeUsage ?? summarizeUsageLedger)(query),
			(deps.readRows ?? readUsageLedgerRows)(query),
		]);
	} catch (error) {
		logError(`Failed to read usage ledger: ${error instanceof Error ? error.message : String(error)}`);
		return 1;
	}
	const rendered = options.json
		? rowsToJsonPayload(summary, rows)
		: options.csv
			? formatCsvSummary(summary)
			: formatTextSummary(summary);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager/commands/usage.ts
Line: 333-351

Comment:
**rotate path also has no error handling**

`rotateLedger(...)` is awaited without a try/catch. a filesystem error (e.g. ledger locked on windows) throws instead of returning `1`. same fix pattern as the summary path — wrap in try/catch and return `1` with `logError`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/codex-manager/commands/usage.ts
Line: 48

Comment:
**`EAGAIN` missing from retryable write codes**

`lib/AGENTS.md` lists the project-standard retry set as `EBUSY/EPERM/EAGAIN` for file writes. `EAGAIN` is absent here, so a write that fails with `EAGAIN` (e.g. advisory lock on some linux filesystems) will throw instead of retrying.

```suggestion
const RETRYABLE_WRITE_CODES = new Set(["EBUSY", "EPERM", "EAGAIN"]);
```

**Context Used:** lib/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=ffbed5b7-f299-4c32-b3f9-f7c095ca8632))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-usage-command.test.ts
Line: 1-10

Comment:
**missing vitest coverage for several branches**

the test file covers the happy paths well, but these branches have no coverage:

- `--since` parsing: relative durations (`24h`, `7d`, `2w`), iso date string, raw unix ms
- `--help` / `-h` flag exits 0 and calls `logInfo`
- `rotate` when `rotateLedger` returns `null` (threshold not met, non-json and json paths)
- `defaultWriteFile` retry on `EBUSY`/`EPERM`/`EAGAIN`
- `--by` with an invalid group name returning exit code 1
- `--out` with `--json` or `--csv` (no confirmation log line expected)

per the repo's 80%+ coverage threshold and test/AGENTS.md conventions, these are expected to be covered.

**Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add usage summary command"](https://github.com/ndycode/codex-multi-auth/commit/21644210570f454e03ff323e5c9a830fde9fb2a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30169429)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->