### PR TITLE
feat: add account policy controls

### DIFF
--- a/docs/development/implementation-plans/status.md
+++ b/docs/development/implementation-plans/status.md
@@ -19,7 +19,7 @@ Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 | 01 | `chore/roadmap-local-governance` | Ready for review | `npm test -- test/documentation.test.ts`; `npm run build`. |
 | 02 | `feat/usage-ledger-core` | Ready for review | `npm run typecheck`; `npm test -- test/usage-ledger.test.ts`; `npm run lint`; `npm run build`. |
 | 03 | `feat/usage-command` | Ready for review | `npm run typecheck`; usage command/core/docs tests; `npm run lint`; `npm run build`. |
-| 04 | `feat/account-policy-controls` | Pending | Account policy command/store tests plus build. |
+| 04 | `feat/account-policy-controls` | Ready for review | `npm run typecheck`; account policy command/store/docs tests; `npm run lint`; `npm run build`. |
 | 05 | `feat/routing-profiles-core` | Pending | Routing profile storage/project tests plus build. |
 | 06 | `feat/budget-guard` | Pending | Budget guard command/evaluator tests plus build. |
 | 07 | `feat/model-capability-matrix` | Pending | Model matrix tests plus `npm run test:model-matrix:smoke`. |

--- a/docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md
@@ -1,0 +1,30 @@
+# PR 04 Handoff: Account Policy Controls
+
+Branch: `feat/account-policy-controls`
+Base: `origin/main` after PR 03 merge
+
+## Scope
+
+Add local account policy storage and `codex auth account` policy commands.
+
+## Files Changed
+
+- `lib/account-policy.ts`
+- `lib/codex-manager/commands/account.ts`
+- `lib/codex-manager.ts`
+- `lib/codex-manager/help.ts`
+- `lib/index.ts`
+- `docs/reference/commands.md`
+- `docs/development/implementation-plans/status.md`
+- `docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md`
+
+## Validation
+
+- `npm run typecheck` passed.
+- `npm test -- test/account-policy.test.ts test/codex-manager-account-command.test.ts test/documentation.test.ts` passed: 3 files, 29 tests.
+- `npm run lint` passed.
+- `npm run build` passed.
+
+## Follow-ups
+
+- PR 08 should enforce pause, drain, weight, and tags during runtime selection.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -34,6 +34,7 @@ Compatibility aliases are supported:
 | `codex auth switch <index>` | Set active account by index |
 | `codex auth forecast` | Forecast best account by readiness/risk |
 | `codex auth best` | Pick and optionally sync the best account |
+| `codex auth account ...` | Manage local account policy metadata |
 
 ---
 
@@ -86,6 +87,35 @@ Compatibility aliases are supported:
 | `--all` | verify | Run both `--paths` and `--flagged` together |
 | `--now`, `-n` | why-selected | Recompute the current selection from live state (default) |
 | `--last`, `-l` | why-selected | Recompute selection from current state and attach the last persisted runtime snapshot |
+
+---
+
+## `codex auth account`
+
+Stores local account policy metadata for future routing and budget enforcement.
+Policy keys are hashed from account identity; raw account ids and raw emails are
+not stored in the policy file.
+
+Usage:
+
+```bash
+codex auth account tag <index> <tag>
+codex auth account untag <index> <tag>
+codex auth account weight <index> <0..10>
+codex auth account pause <index>
+codex auth account unpause <index>
+codex auth account drain <index>
+codex auth account undrain <index>
+codex auth account note <index> <text>
+codex auth account policy list [--json]
+```
+
+Notes:
+
+- `pause` and `drain` are stored only. Runtime enforcement is added by the
+  runtime policy integration PR.
+- `weight` accepts values from `0` to `10`; default is `1`.
+- `tag` values are normalized to lowercase filesystem-safe labels.
 
 ---
 

--- a/lib/account-policy.ts
+++ b/lib/account-policy.ts
@@ -1,0 +1,206 @@
+import { createHash } from "node:crypto";
+import { existsSync, promises as fs } from "node:fs";
+import { basename, join } from "node:path";
+import { logWarn } from "./logger.js";
+import { getCodexMultiAuthDir } from "./runtime-paths.js";
+import type { AccountMetadataV3 } from "./storage.js";
+import { isRecord, sleep } from "./utils.js";
+
+export interface AccountPolicy {
+	accountKey: string;
+	tags: string[];
+	weight: number;
+	paused: boolean;
+	drained: boolean;
+	note: string | null;
+	updatedAt: number;
+}
+
+export interface AccountPolicyStore {
+	version: 1;
+	accounts: Record<string, AccountPolicy>;
+}
+
+const ACCOUNT_POLICY_FILE_NAME = "account-policies.json";
+const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+let writeQueue: Promise<void> = Promise.resolve();
+
+function isRetryableFsError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
+}
+
+function normalizeTag(value: string): string | null {
+	const normalized = value.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-");
+	return normalized.length > 0 ? normalized.slice(0, 64) : null;
+}
+
+function normalizeWeight(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value)
+		? Math.max(0, Math.min(10, value))
+		: 1;
+}
+
+function normalizePolicy(key: string, value: unknown): AccountPolicy {
+	const record = isRecord(value) ? value : {};
+	const tags = Array.isArray(record.tags)
+		? [
+				...new Set(
+					record.tags
+						.filter((tag): tag is string => typeof tag === "string")
+						.map((tag) => normalizeTag(tag))
+						.filter((tag): tag is string => tag !== null),
+				),
+			].sort()
+		: [];
+	const note = typeof record.note === "string" ? record.note.trim() : "";
+	return {
+		accountKey: key,
+		tags,
+		weight: normalizeWeight(record.weight),
+		paused: record.paused === true,
+		drained: record.drained === true,
+		note: note.length > 0 ? note.slice(0, 500) : null,
+		updatedAt:
+			typeof record.updatedAt === "number" && Number.isFinite(record.updatedAt)
+				? record.updatedAt
+				: 0,
+	};
+}
+
+function emptyStore(): AccountPolicyStore {
+	return { version: 1, accounts: {} };
+}
+
+function normalizeStore(value: unknown): AccountPolicyStore {
+	if (!isRecord(value) || value.version !== 1) return emptyStore();
+	const accounts: Record<string, AccountPolicy> = {};
+	if (isRecord(value.accounts)) {
+		for (const [key, raw] of Object.entries(value.accounts)) {
+			if (key.startsWith("sha256:")) {
+				accounts[key] = normalizePolicy(key, raw);
+			}
+		}
+	}
+	return { version: 1, accounts };
+}
+
+async function readFileWithRetry(path: string): Promise<string> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			return await fs.readFile(path, "utf8");
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableFsError(error) || attempt >= 4) throw error;
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("account policy read retry exhausted");
+}
+
+export function getAccountPolicyPath(): string {
+	return join(getCodexMultiAuthDir(), ACCOUNT_POLICY_FILE_NAME);
+}
+
+export function getAccountPolicyKey(
+	account: Pick<AccountMetadataV3, "accountId" | "email">,
+	index?: number,
+): string {
+	const identity =
+		account.accountId?.trim() ||
+		account.email?.trim().toLowerCase() ||
+		(typeof index === "number" ? `index:${index}` : "unknown");
+	return `sha256:${createHash("sha256").update(identity).digest("hex")}`;
+}
+
+export async function loadAccountPolicyStore(): Promise<AccountPolicyStore> {
+	const path = getAccountPolicyPath();
+	if (!existsSync(path)) return emptyStore();
+	try {
+		return normalizeStore(JSON.parse(await readFileWithRetry(path)) as unknown);
+	} catch (error) {
+		logWarn(
+			`Failed to load account policies from ${basename(path)}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return emptyStore();
+	}
+}
+
+export async function saveAccountPolicyStore(
+	store: AccountPolicyStore,
+): Promise<void> {
+	const path = getAccountPolicyPath();
+	const payload = normalizeStore(store);
+	const task = async (): Promise<void> => {
+		await fs.mkdir(getCodexMultiAuthDir(), { recursive: true, mode: 0o700 });
+		const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+		let moved = false;
+		try {
+			await fs.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, {
+				encoding: "utf8",
+				mode: 0o600,
+			});
+			for (let attempt = 0; attempt < 5; attempt += 1) {
+				try {
+					await fs.rename(tempPath, path);
+					moved = true;
+					return;
+				} catch (error) {
+					if (!isRetryableFsError(error) || attempt >= 4) throw error;
+					await sleep(10 * 2 ** attempt);
+				}
+			}
+		} finally {
+			if (!moved) {
+				try {
+					await fs.unlink(tempPath);
+				} catch {
+					// Best-effort temp cleanup.
+				}
+			}
+		}
+	};
+	const queued = writeQueue.catch(() => undefined).then(task);
+	writeQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	await queued;
+}
+
+export function upsertAccountPolicy(
+	store: AccountPolicyStore,
+	accountKey: string,
+	mutate: (policy: AccountPolicy) => void,
+	now = Date.now(),
+): AccountPolicy {
+	const next = structuredClone(
+		store.accounts[accountKey] ?? normalizePolicy(accountKey, null),
+	);
+	mutate(next);
+	next.tags = [
+		...new Set(
+			next.tags
+				.map((tag) => normalizeTag(tag))
+				.filter((tag): tag is string => tag !== null),
+		),
+	].sort();
+	next.weight = normalizeWeight(next.weight);
+	next.updatedAt = now;
+	store.accounts[accountKey] = next;
+	return next;
+}
+
+export function normalizeAccountPolicyTag(value: string): string | null {
+	return normalizeTag(value);
+}
+
+export function resetAccountPolicyWriteQueueForTests(): void {
+	writeQueue = Promise.resolve();
+}
+

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -36,6 +36,7 @@ import {
 	type BestCliOptions,
 	runBestCommand,
 } from "./codex-manager/commands/best.js";
+import { runAccountCommand } from "./codex-manager/commands/account.js";
 import { runCheckCommand } from "./codex-manager/commands/check.js";
 import { runConfigExplainCommand } from "./codex-manager/commands/config-explain.js";
 import { saveAccountsWithRetry } from "./codex-manager/forecast-report-shared.js";
@@ -3454,6 +3455,12 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 	}
 	if (command === "best") {
 		return runBest(rest);
+	}
+	if (command === "account") {
+		return runAccountCommand(rest, {
+			setStoragePath,
+			loadAccounts,
+		});
 	}
 	if (command === "report") {
 		return runReportCommand(rest, {

--- a/lib/codex-manager/commands/account.ts
+++ b/lib/codex-manager/commands/account.ts
@@ -1,0 +1,195 @@
+import {
+	getAccountPolicyKey,
+	loadAccountPolicyStore,
+	normalizeAccountPolicyTag,
+	saveAccountPolicyStore,
+	upsertAccountPolicy,
+	type AccountPolicyStore,
+} from "../../account-policy.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../../storage.js";
+
+export interface AccountCommandDeps {
+	setStoragePath: (path: string | null) => void;
+	loadAccounts: () => Promise<AccountStorageV3 | null>;
+	loadPolicyStore?: typeof loadAccountPolicyStore;
+	savePolicyStore?: typeof saveAccountPolicyStore;
+	logInfo?: (message: string) => void;
+	logError?: (message: string) => void;
+	getNow?: () => number;
+}
+
+function printAccountUsage(logInfo: (message: string) => void): void {
+	logInfo(
+		[
+			"Usage:",
+			"  codex auth account tag <index> <tag>",
+			"  codex auth account untag <index> <tag>",
+			"  codex auth account weight <index> <0..10>",
+			"  codex auth account pause|unpause|drain|undrain <index>",
+			"  codex auth account note <index> <text>",
+			"  codex auth account policy list [--json]",
+		].join("\n"),
+	);
+}
+
+function parseAccountIndex(value: string | undefined): number | null {
+	if (!value || !/^\d+$/.test(value)) return null;
+	const parsed = Number.parseInt(value, 10);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed - 1 : null;
+}
+
+function resolveAccount(
+	storage: AccountStorageV3 | null,
+	index: number | null,
+): { account: AccountMetadataV3; index: number } | null {
+	if (!storage || index === null || index < 0 || index >= storage.accounts.length) {
+		return null;
+	}
+	const account = storage.accounts[index];
+	return account ? { account, index } : null;
+}
+
+function policySummary(store: AccountPolicyStore, storage: AccountStorageV3 | null) {
+	return (storage?.accounts ?? []).map((account, index) => {
+		const accountKey = getAccountPolicyKey(account, index);
+		const policy = store.accounts[accountKey];
+		return {
+			index: index + 1,
+			label: `Account ${index + 1}`,
+			accountKey,
+			tags: policy?.tags ?? [],
+			weight: policy?.weight ?? 1,
+			paused: policy?.paused ?? false,
+			drained: policy?.drained ?? false,
+			note: policy?.note ?? null,
+		};
+	});
+}
+
+export async function runAccountCommand(
+	args: string[],
+	deps: AccountCommandDeps,
+): Promise<number> {
+	const logInfo = deps.logInfo ?? console.log;
+	const logError = deps.logError ?? console.error;
+	const [command, ...rest] = args;
+	if (!command || command === "--help" || command === "-h") {
+		printAccountUsage(logInfo);
+		return 0;
+	}
+
+	deps.setStoragePath(null);
+	const storage = await deps.loadAccounts();
+	const loadStore = deps.loadPolicyStore ?? loadAccountPolicyStore;
+	const saveStore = deps.savePolicyStore ?? saveAccountPolicyStore;
+	const store = await loadStore();
+
+	if (command === "policy") {
+		const [subcommand, ...policyArgs] = rest;
+		if (subcommand !== "list") {
+			logError(`Unknown account policy command: ${subcommand ?? "(missing)"}`);
+			return 1;
+		}
+		const unknown = policyArgs.find((arg) => arg !== "--json" && arg !== "-j");
+		if (unknown) {
+			logError(`Unknown account policy list option: ${unknown}`);
+			return 1;
+		}
+		const payload = {
+			command: "account policy list",
+			accounts: policySummary(store, storage),
+		};
+		if (policyArgs.includes("--json") || policyArgs.includes("-j")) {
+			logInfo(JSON.stringify(payload, null, 2));
+			return 0;
+		}
+		if (payload.accounts.length === 0) {
+			logInfo("No accounts configured.");
+			return 0;
+		}
+		for (const entry of payload.accounts) {
+			const markers = [
+				`weight=${entry.weight}`,
+				entry.paused ? "paused" : null,
+				entry.drained ? "drained" : null,
+				entry.tags.length > 0 ? `tags=${entry.tags.join(",")}` : null,
+				entry.note ? "note" : null,
+			].filter((value): value is string => value !== null);
+			logInfo(`${entry.index}. ${entry.label} | ${markers.join(" | ")}`);
+		}
+		return 0;
+	}
+
+	const accountIndex = parseAccountIndex(rest[0]);
+	const resolved = resolveAccount(storage, accountIndex);
+	if (!resolved) {
+		logError("Account index is required and must reference a configured account.");
+		return 1;
+	}
+	const accountKey = getAccountPolicyKey(resolved.account, resolved.index);
+	const now = deps.getNow?.() ?? Date.now();
+
+	if (command === "tag" || command === "untag") {
+		const tag = normalizeAccountPolicyTag(rest[1] ?? "");
+		if (!tag) {
+			logError(`${command} requires a tag value.`);
+			return 1;
+		}
+		const policy = upsertAccountPolicy(
+			store,
+			accountKey,
+			(next) => {
+				if (command === "tag" && !next.tags.includes(tag)) next.tags.push(tag);
+				if (command === "untag") {
+					next.tags = next.tags.filter((existing) => existing !== tag);
+				}
+			},
+			now,
+		);
+		await saveStore(store);
+		logInfo(
+			`${command === "tag" ? "Tagged" : "Removed tag from"} account ${resolved.index + 1}: ${policy.tags.join(",") || "none"}`,
+		);
+		return 0;
+	}
+
+	if (command === "weight") {
+		const weight = rest[1] === undefined ? Number.NaN : Number.parseFloat(rest[1]);
+		if (!Number.isFinite(weight) || weight < 0 || weight > 10) {
+			logError("weight requires a number from 0 to 10.");
+			return 1;
+		}
+		upsertAccountPolicy(store, accountKey, (next) => {
+			next.weight = weight;
+		}, now);
+		await saveStore(store);
+		logInfo(`Set account ${resolved.index + 1} weight to ${weight}.`);
+		return 0;
+	}
+
+	if (["pause", "unpause", "drain", "undrain"].includes(command)) {
+		upsertAccountPolicy(store, accountKey, (next) => {
+			if (command === "pause") next.paused = true;
+			if (command === "unpause") next.paused = false;
+			if (command === "drain") next.drained = true;
+			if (command === "undrain") next.drained = false;
+		}, now);
+		await saveStore(store);
+		logInfo(`Updated account ${resolved.index + 1}: ${command}.`);
+		return 0;
+	}
+
+	if (command === "note") {
+		const note = rest.slice(1).join(" ").trim();
+		upsertAccountPolicy(store, accountKey, (next) => {
+			next.note = note.length > 0 ? note.slice(0, 500) : null;
+		}, now);
+		await saveStore(store);
+		logInfo(`Updated account ${resolved.index + 1} note.`);
+		return 0;
+	}
+
+	logError(`Unknown account command: ${command}`);
+	printAccountUsage(logInfo);
+	return 1;
+}

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -13,6 +13,7 @@ export function printUsage(): void {
 			"  codex auth switch <index>",
 			"  codex auth best [--live] [--json] [--model <model>]",
 			"  codex auth forecast [--live] [--json] [--model <model>]",
+			"  codex auth account tag|untag|weight|pause|unpause|drain|undrain|note ...",
 			"",
 			"Repair:",
 			"  codex auth verify-flagged [--dry-run] [--json] [--no-restore]",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,3 +41,4 @@ export * from "./codex-cli/sync.js";
 export * from "./codex-cli/writer.js";
 export * from "./codex-cli/observability.js";
 export * from "./usage/index.js";
+export * from "./account-policy.js";

--- a/test/account-policy.test.ts
+++ b/test/account-policy.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("account policy store", () => {
+	let tempDir: string;
+	let originalDir: string | undefined;
+
+	beforeEach(async () => {
+		originalDir = process.env.CODEX_MULTI_AUTH_DIR;
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-account-policy-"));
+		process.env.CODEX_MULTI_AUTH_DIR = tempDir;
+	});
+
+	afterEach(async () => {
+		if (originalDir === undefined) {
+			delete process.env.CODEX_MULTI_AUTH_DIR;
+		} else {
+			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
+		}
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("stores policy rows by hashed account identity", async () => {
+		const {
+			getAccountPolicyKey,
+			getAccountPolicyPath,
+			loadAccountPolicyStore,
+			saveAccountPolicyStore,
+			upsertAccountPolicy,
+		} = await import("../lib/account-policy.js");
+		const account = {
+			accountId: "acct_sensitive",
+			email: "owner@example.com",
+		};
+		const accountKey = getAccountPolicyKey(account, 0);
+		const store = await loadAccountPolicyStore();
+		upsertAccountPolicy(store, accountKey, (policy) => {
+			policy.tags.push("Team A");
+			policy.weight = 2;
+			policy.paused = true;
+			policy.note = "local note";
+		}, 123);
+		await saveAccountPolicyStore(store);
+
+		const raw = await fs.readFile(getAccountPolicyPath(), "utf8");
+		expect(raw).toContain("team-a");
+		expect(raw).not.toContain("acct_sensitive");
+		expect(raw).not.toContain("owner@example.com");
+
+		const loaded = await loadAccountPolicyStore();
+		expect(loaded.accounts[accountKey]).toMatchObject({
+			tags: ["team-a"],
+			weight: 2,
+			paused: true,
+			note: "local note",
+			updatedAt: 123,
+		});
+	});
+});
+

--- a/test/codex-manager-account-command.test.ts
+++ b/test/codex-manager-account-command.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { getAccountPolicyKey, type AccountPolicyStore } from "../lib/account-policy.js";
+import { runAccountCommand } from "../lib/codex-manager/commands/account.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+function makeStorage(): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { codex: 0 },
+		accounts: [
+			{
+				email: "owner@example.com",
+				accountId: "acct_1",
+				refreshToken: "refresh",
+				addedAt: 1,
+				lastUsed: 1,
+			},
+		],
+	};
+}
+
+function makeDeps(store: AccountPolicyStore) {
+	return {
+		setStoragePath: vi.fn(),
+		loadAccounts: vi.fn(async () => makeStorage()),
+		loadPolicyStore: vi.fn(async () => store),
+		savePolicyStore: vi.fn(async () => undefined),
+		logInfo: vi.fn(),
+		logError: vi.fn(),
+		getNow: () => 123,
+	};
+}
+
+describe("account command", () => {
+	it("tags and pauses account policies", async () => {
+		const store: AccountPolicyStore = { version: 1, accounts: {} };
+		const deps = makeDeps(store);
+
+		expect(await runAccountCommand(["tag", "1", "Team A"], deps)).toBe(0);
+		expect(await runAccountCommand(["pause", "1"], deps)).toBe(0);
+
+		const key = getAccountPolicyKey(makeStorage().accounts[0]!, 0);
+		expect(store.accounts[key]).toMatchObject({
+			tags: ["team-a"],
+			paused: true,
+			updatedAt: 123,
+		});
+		expect(deps.savePolicyStore).toHaveBeenCalledTimes(2);
+	});
+
+	it("sets weight, drain state, and note", async () => {
+		const store: AccountPolicyStore = { version: 1, accounts: {} };
+		const deps = makeDeps(store);
+
+		expect(await runAccountCommand(["weight", "1", "3.5"], deps)).toBe(0);
+		expect(await runAccountCommand(["drain", "1"], deps)).toBe(0);
+		expect(await runAccountCommand(["note", "1", "batch", "only"], deps)).toBe(0);
+
+		const key = getAccountPolicyKey(makeStorage().accounts[0]!, 0);
+		expect(store.accounts[key]).toMatchObject({
+			weight: 3.5,
+			drained: true,
+			note: "batch only",
+		});
+	});
+
+	it("lists policy state as json", async () => {
+		const storage = makeStorage();
+		const key = getAccountPolicyKey(storage.accounts[0]!, 0);
+		const store: AccountPolicyStore = {
+			version: 1,
+			accounts: {
+				[key]: {
+					accountKey: key,
+					tags: ["team-a"],
+					weight: 2,
+					paused: true,
+					drained: false,
+					note: null,
+					updatedAt: 123,
+				},
+			},
+		};
+		const deps = makeDeps(store);
+
+		expect(await runAccountCommand(["policy", "list", "--json"], deps)).toBe(0);
+		const payload = JSON.parse(String(deps.logInfo.mock.calls[0]?.[0])) as {
+			accounts: Array<{ accountKey: string; tags: string[]; paused: boolean }>;
+		};
+		expect(payload.accounts[0]).toMatchObject({
+			accountKey: key,
+			tags: ["team-a"],
+			paused: true,
+		});
+		expect(JSON.stringify(payload)).not.toContain("acct_1");
+		expect(JSON.stringify(payload)).not.toContain("owner@example.com");
+	});
+
+	it("rejects invalid account indexes", async () => {
+		const deps = makeDeps({ version: 1, accounts: {} });
+		expect(await runAccountCommand(["tag", "2", "team"], deps)).toBe(1);
+		expect(String(deps.logError.mock.calls[0]?.[0])).toContain(
+			"Account index is required",
+		);
+	});
+});
+


### PR DESCRIPTION
## Summary

- Add local account policy storage and `codex auth account` controls.
- Support tag, untag, weight, pause, unpause, drain, undrain, note, and policy list.

## What Changed

- Added `lib/account-policy.ts` with hashed account policy keys and atomic local storage.
- Added `lib/codex-manager/commands/account.ts` and CLI dispatch/help wiring.
- Updated command reference docs and added targeted tests.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`
- [x] `npm test -- test/account-policy.test.ts test/codex-manager-account-command.test.ts test/documentation.test.ts`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [x] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [ ] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: Medium-low, additive local policy metadata with no runtime enforcement yet.
- Rollback plan: Revert this branch to remove policy storage, account command wiring, docs, and tests.

## Additional Notes

- Policy keys are hashed; raw account ids and raw emails are not stored in the policy file or JSON list output.
- Runtime enforcement is intentionally deferred to PR 08.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds local account policy storage (`account-policies.json`) with sha256-hashed keys and a new `codex auth account` command family (tag, weight, pause, drain, note, policy list). policy enforcement is intentionally deferred to pr 08.

- `getAccountPolicyKey` makes `index` optional, creating a silent hash collision (`sha256:hash(\"unknown\")`) when two accounts both lack `accountId` and `email` and the caller omits the index — making the param required is needed before pr 08 wires enforcement.
- `test/account-policy.test.ts` uses bare `fs.rm` in `afterEach`, violating the `test/AGENTS.md` anti-pattern; on windows this leaves temp dirs behind under `EBUSY`/`EPERM`.

<h3>Confidence Score: 3/5</h3>

two p1s need resolution before merge — test anti-pattern and key collision footgun — but the core logic is sound and enforcement is deferred

two p1 findings (bare fs.rm test anti-pattern on windows, optional index creating a silent hash collision in getAccountPolicyKey) pull the score below the p1 ceiling of 4; the rest of the logic is additive and well-structured

lib/account-policy.ts (getAccountPolicyKey optional index, missing EAGAIN), test/account-policy.test.ts (bare fs.rm, thin coverage)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/account-policy.ts | new module: atomic policy store with write-queue serialization and sha256 key hashing; `getAccountPolicyKey` has an optional `index` param that can silently produce a collision key when both accountId and email are absent; missing `EAGAIN` in retryable codes |
| lib/codex-manager/commands/account.ts | new command module wiring tag/untag/weight/pause/unpause/drain/undrain/note/policy-list; index parsing, resolution, and policy upsert logic look correct; no raw identity in output |
| test/account-policy.test.ts | single happy-path test; bare `fs.rm` in afterEach violates test/AGENTS.md Windows safety rule; missing coverage for write-queue concurrency, EBUSY retry, corrupted JSON, and resetAccountPolicyWriteQueueForTests |
| test/codex-manager-account-command.test.ts | 4 test cases covering tag, pause, weight, drain, note, json list, and invalid index; mocked deps keep it fast; no raw identity leaked in json output is verified |
| lib/codex-manager.ts | minimal change: imports and dispatches `runAccountCommand` with existing `setStoragePath`/`loadAccounts` deps; no issues |
| lib/index.ts | re-exports account-policy.ts; barrel export follows project convention |
| lib/codex-manager/help.ts | adds account command line to usage printout; cosmetically correct |
| docs/reference/commands.md | adds `codex auth account` reference section; usage examples match implementation |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as codex auth account
    participant Cmd as commands/account.ts
    participant Store as loadAccountPolicyStore
    participant Policy as account-policy.ts
    participant FS as account-policies.json

    CLI->>Cmd: runAccountCommand(args, deps)
    Cmd->>Store: loadAccounts()
    Store-->>Cmd: AccountStorageV3
    Cmd->>Policy: loadAccountPolicyStore()
    Policy->>FS: readFileWithRetry (EBUSY retry)
    FS-->>Policy: JSON
    Policy-->>Cmd: AccountPolicyStore
    Cmd->>Policy: upsertAccountPolicy(store, key, mutate)
    Note over Policy: structuredClone + normalize tags/weight
    Cmd->>Policy: saveAccountPolicyStore(store)
    Policy->>FS: writeFile(tempPath, mode 0o600)
    Policy->>FS: rename(tempPath → account-policies.json)
    Note over Policy: queued via writeQueue singleton
    FS-->>CLI: exit 0
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Faccount-policy-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Faccount-policy-controls%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Atest%2Faccount-policy.test.ts%3A23%0A**bare%20%60fs.rm%60%20in%20afterEach%20%E2%80%94%20Windows%20safety%20violation**%0A%0A%60test%2FAGENTS.md%60%20explicitly%20prohibits%20this%3A%20%22do%20not%20use%20bare%20%60fs.rm%60%20in%20test%20cleanup%3B%20use%20%60removeWithRetry%60%20for%20Windows%20safety.%22%20on%20Windows%2C%20%60EBUSY%60%2F%60EPERM%60%2F%60ENOTEMPTY%60%20from%20the%20policy%20file%20written%20by%20the%20test%20can%20leave%20the%20temp%20dir%20behind%20and%20cause%20cross-test%20pollution%20or%20CI%20failures%20on%20Windows%20runners.%0A%0Aimport%20%60removeWithRetry%60%20%28or%20the%20equivalent%20helper%20used%20elsewhere%20in%20the%20test%20suite%2C%20e.g.%20%60repo-hygiene.ts%60%29%20instead%20of%20the%20bare%20%60fs.rm%60%20call.%0A%0A%60%60%60suggestion%0A%09%09await%20removeWithRetry%28tempDir%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Faccount-policy.ts%3A108-117%0A**%60%22unknown%22%60%20fallback%20causes%20hash%20collision**%0A%0Awhen%20both%20%60accountId%60%20and%20%60email%60%20are%20absent%20and%20%60index%60%20is%20not%20passed%2C%20every%20such%20account%20hashes%20to%20the%20same%20%60sha256%3A%24%7Bhash%28%22unknown%22%29%7D%60%20key.%20since%20%60index%60%20is%20optional%2C%20callers%20that%20forget%20to%20pass%20it%20on%20a%20sparse%20account%20will%20silently%20overwrite%20a%20different%20account's%20policy.%20making%20%60index%60%20required%20prevents%20this%20before%20pr%2008%20wires%20enforcement.%0A%0A%60%60%60suggestion%0Aexport%20function%20getAccountPolicyKey%28%0A%09account%3A%20Pick%3CAccountMetadataV3%2C%20%22accountId%22%20%7C%20%22email%22%3E%2C%0A%09index%3A%20number%2C%0A%29%3A%20string%20%7B%0A%09const%20identity%20%3D%0A%09%09account.accountId%3F.trim%28%29%20%7C%7C%0A%09%09account.email%3F.trim%28%29.toLowerCase%28%29%20%7C%7C%0A%09%09%60index%3A%24%7Bindex%7D%60%3B%0A%09return%20%60sha256%3A%24%7BcreateHash%28%22sha256%22%29.update%28identity%29.digest%28%22hex%22%29%7D%60%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Faccount-policy.ts%3A25%0A**missing%20%60EAGAIN%60%20in%20retryable%20fs%20error%20codes**%0A%0A%60lib%2FAGENTS.md%60%20says%20%22settings%20writes%20use%20queued%20retry%20for%20%60EBUSY%60%2F%60EPERM%60%2F%60EAGAIN%60%22%2C%20but%20%60EAGAIN%60%20is%20absent%20here.%20a%20transient%20%60EAGAIN%60%20on%20rename%20or%20read%20will%20throw%20immediately%20instead%20of%20retrying.%0A%0A%60%60%60suggestion%0Aconst%20RETRYABLE_FS_CODES%20%3D%20new%20Set%28%5B%22EBUSY%22%2C%20%22EPERM%22%2C%20%22EAGAIN%22%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Atest%2Faccount-policy.test.ts%3A1-62%0A**missing%20vitest%20coverage%20for%20write-queue%20concurrency%20and%20error%20paths**%0A%0Athe%20test%20suite%20has%20only%20one%20test%20case.%20several%20important%20branches%20have%20no%20coverage%3A%20concurrent%20writes%20%28queue%20serialization%29%2C%20%60readFileWithRetry%60%20EBUSY%20retry%20loop%2C%20corrupted%20JSON%20parse%20returning%20%60emptyStore%28%29%60%2C%20and%20%60resetAccountPolicyWriteQueueForTests%60%20not%20called%20in%20%60beforeEach%60.%20the%2080%25%2B%20coverage%20threshold%20is%20enforced%20project-wide%20and%20the%20write-queue%20pattern%20is%20the%20most%20complex%20part%20of%20this%20module.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/account-policy.test.ts
Line: 23

Comment:
**bare `fs.rm` in afterEach — Windows safety violation**

`test/AGENTS.md` explicitly prohibits this: "do not use bare `fs.rm` in test cleanup; use `removeWithRetry` for Windows safety." on Windows, `EBUSY`/`EPERM`/`ENOTEMPTY` from the policy file written by the test can leave the temp dir behind and cause cross-test pollution or CI failures on Windows runners.

import `removeWithRetry` (or the equivalent helper used elsewhere in the test suite, e.g. `repo-hygiene.ts`) instead of the bare `fs.rm` call.

```suggestion
		await removeWithRetry(tempDir);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/account-policy.ts
Line: 108-117

Comment:
**`"unknown"` fallback causes hash collision**

when both `accountId` and `email` are absent and `index` is not passed, every such account hashes to the same `sha256:${hash("unknown")}` key. since `index` is optional, callers that forget to pass it on a sparse account will silently overwrite a different account's policy. making `index` required prevents this before pr 08 wires enforcement.

```suggestion
export function getAccountPolicyKey(
	account: Pick<AccountMetadataV3, "accountId" | "email">,
	index: number,
): string {
	const identity =
		account.accountId?.trim() ||
		account.email?.trim().toLowerCase() ||
		`index:${index}`;
	return `sha256:${createHash("sha256").update(identity).digest("hex")}`;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/account-policy.ts
Line: 25

Comment:
**missing `EAGAIN` in retryable fs error codes**

`lib/AGENTS.md` says "settings writes use queued retry for `EBUSY`/`EPERM`/`EAGAIN`", but `EAGAIN` is absent here. a transient `EAGAIN` on rename or read will throw immediately instead of retrying.

```suggestion
const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM", "EAGAIN"]);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/account-policy.test.ts
Line: 1-62

Comment:
**missing vitest coverage for write-queue concurrency and error paths**

the test suite has only one test case. several important branches have no coverage: concurrent writes (queue serialization), `readFileWithRetry` EBUSY retry loop, corrupted JSON parse returning `emptyStore()`, and `resetAccountPolicyWriteQueueForTests` not called in `beforeEach`. the 80%+ coverage threshold is enforced project-wide and the write-queue pattern is the most complex part of this module.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add account policy controls"](https://github.com/ndycode/codex-multi-auth/commit/731f49a7cc7181ba6d1903ed43526ed17892753f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30170062)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->