### PR TITLE
feat: add local usage ledger core

### DIFF
--- a/docs/development/implementation-plans/status.md
+++ b/docs/development/implementation-plans/status.md
@@ -17,7 +17,7 @@ Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 | PR | Branch | Status | Validation |
 | --- | --- | --- | --- |
 | 01 | `chore/roadmap-local-governance` | Ready for review | `npm test -- test/documentation.test.ts`; `npm run build`. |
-| 02 | `feat/usage-ledger-core` | Pending | Targeted usage ledger tests plus build. |
+| 02 | `feat/usage-ledger-core` | Ready for review | `npm run typecheck`; `npm test -- test/usage-ledger.test.ts`; `npm run lint`; `npm run build`. |
 | 03 | `feat/usage-command` | Pending | CLI usage command tests plus build. |
 | 04 | `feat/account-policy-controls` | Pending | Account policy command/store tests plus build. |
 | 05 | `feat/routing-profiles-core` | Pending | Routing profile storage/project tests plus build. |

--- a/docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md
@@ -1,0 +1,32 @@
+# PR 02 Handoff: Usage Ledger Core
+
+Branch: `feat/usage-ledger-core`
+Base: `origin/main` after PR 01 merge
+
+## Scope
+
+Add the local usage ledger core without command dispatch or runtime integration.
+
+## Files Changed
+
+- `lib/usage/types.ts`
+- `lib/usage/redaction.ts`
+- `lib/usage/pricing.ts`
+- `lib/usage/ledger.ts`
+- `lib/usage/index.ts`
+- `lib/index.ts`
+- `test/usage-ledger.test.ts`
+- `docs/development/implementation-plans/status.md`
+- `docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md`
+
+## Validation
+
+- `npm run typecheck` passed.
+- `npm test -- test/usage-ledger.test.ts` passed: 1 file, 6 tests.
+- `npm run lint` passed.
+- `npm run build` passed.
+
+## Follow-ups
+
+- PR 03 should add `codex auth usage` command behavior on top of these helpers.
+- Runtime append calls are intentionally deferred until PR 08.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,3 +40,4 @@ export * from "./codex-cli/state.js";
 export * from "./codex-cli/sync.js";
 export * from "./codex-cli/writer.js";
 export * from "./codex-cli/observability.js";
+export * from "./usage/index.js";

--- a/lib/usage/index.ts
+++ b/lib/usage/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.js";
+export * from "./pricing.js";
+export * from "./redaction.js";
+export * from "./ledger.js";
+

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -1,0 +1,426 @@
+import { existsSync, promises as fs } from "node:fs";
+import { basename, join } from "node:path";
+import { getCodexMultiAuthDir } from "../runtime-paths.js";
+import { logWarn } from "../logger.js";
+import { isRecord, sleep } from "../utils.js";
+import {
+	normalizeUsageLedgerRow,
+	usageRowToJsonLine,
+} from "./redaction.js";
+import type {
+	UsageLedgerAppendInput,
+	UsageLedgerOperation,
+	UsageLedgerPaths,
+	UsageLedgerQuery,
+	UsageLedgerOutcome,
+	UsageLedgerRow,
+	UsageLedgerSource,
+	UsageSummary,
+	UsageSummaryBucket,
+	UsageSummaryGroupBy,
+	UsageSummaryQuery,
+	UsageTokenCounts,
+} from "./types.js";
+
+const USAGE_DIR_NAME = "usage";
+const USAGE_LEDGER_FILE_NAME = "usage-ledger.jsonl";
+const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+let appendQueue: Promise<void> = Promise.resolve();
+
+const VALID_SOURCES = new Set<UsageLedgerSource>([
+	"runtime-proxy",
+	"plugin-host",
+	"local-bridge",
+	"cli",
+	"unknown",
+]);
+const VALID_OPERATIONS = new Set<UsageLedgerOperation>([
+	"responses",
+	"models",
+	"auth-refresh",
+	"diagnostic",
+	"unknown",
+]);
+const VALID_OUTCOMES = new Set<UsageLedgerOutcome>([
+	"success",
+	"failure",
+	"blocked",
+	"cancelled",
+]);
+
+function isRetryableFsError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
+}
+
+function normalizeTimestamp(value: number | Date | string | undefined): number | null {
+	if (value === undefined) return null;
+	if (value instanceof Date) {
+		const time = value.getTime();
+		return Number.isFinite(time) ? time : null;
+	}
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? value : null;
+	}
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function appendFileWithRetry(path: string, line: string): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await fs.appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+			return;
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableFsError(error) || attempt >= 4) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger append retry exhausted");
+}
+
+async function readFileWithRetry(path: string): Promise<string> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			return await fs.readFile(path, "utf8");
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableFsError(error) || attempt >= 4) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger read retry exhausted");
+}
+
+async function renameWithRetry(from: string, to: string): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await fs.rename(from, to);
+			return;
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableFsError(error) || attempt >= 4) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger rotate retry exhausted");
+}
+
+export function getUsageLedgerPaths(): UsageLedgerPaths {
+	const dir = join(getCodexMultiAuthDir(), USAGE_DIR_NAME);
+	return {
+		dir,
+		current: join(dir, USAGE_LEDGER_FILE_NAME),
+	};
+}
+
+export async function appendUsageLedgerRow(
+	input: UsageLedgerAppendInput,
+): Promise<UsageLedgerRow> {
+	const row = normalizeUsageLedgerRow(input);
+	const { dir, current } = getUsageLedgerPaths();
+	const line = usageRowToJsonLine(row);
+	const task = async (): Promise<void> => {
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+		await appendFileWithRetry(current, line);
+	};
+	const queued = appendQueue.catch(() => undefined).then(task);
+	appendQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	await queued;
+	return row;
+}
+
+function normalizeParsedUsageRow(value: unknown): UsageLedgerRow | null {
+	if (!isRecord(value)) return null;
+	if (value.version !== 1) return null;
+	if (typeof value.id !== "string" || value.id.trim().length === 0) return null;
+	if (typeof value.createdAt !== "number" || !Number.isFinite(value.createdAt)) {
+		return null;
+	}
+	if (!isRecord(value.tokens)) return null;
+
+	const source =
+		typeof value.source === "string" &&
+		VALID_SOURCES.has(value.source as UsageLedgerSource)
+			? (value.source as UsageLedgerSource)
+			: "unknown";
+	const operation =
+		typeof value.operation === "string" &&
+		VALID_OPERATIONS.has(value.operation as UsageLedgerOperation)
+			? (value.operation as UsageLedgerOperation)
+			: "unknown";
+	const outcome =
+		typeof value.outcome === "string" &&
+		VALID_OUTCOMES.has(value.outcome as UsageLedgerOutcome)
+			? (value.outcome as UsageLedgerOutcome)
+			: "failure";
+	const tokens: UsageTokenCounts = {
+		inputTokens:
+			typeof value.tokens.inputTokens === "number" &&
+			Number.isFinite(value.tokens.inputTokens)
+				? Math.max(0, Math.trunc(value.tokens.inputTokens))
+				: 0,
+		outputTokens:
+			typeof value.tokens.outputTokens === "number" &&
+			Number.isFinite(value.tokens.outputTokens)
+				? Math.max(0, Math.trunc(value.tokens.outputTokens))
+				: 0,
+		cachedInputTokens:
+			typeof value.tokens.cachedInputTokens === "number" &&
+			Number.isFinite(value.tokens.cachedInputTokens)
+				? Math.max(0, Math.trunc(value.tokens.cachedInputTokens))
+				: 0,
+		reasoningTokens:
+			typeof value.tokens.reasoningTokens === "number" &&
+			Number.isFinite(value.tokens.reasoningTokens)
+				? Math.max(0, Math.trunc(value.tokens.reasoningTokens))
+				: 0,
+		totalTokens:
+			typeof value.tokens.totalTokens === "number" &&
+			Number.isFinite(value.tokens.totalTokens)
+				? Math.max(0, Math.trunc(value.tokens.totalTokens))
+				: 0,
+	};
+	const account = isRecord(value.account)
+		? {
+				accountHash:
+					typeof value.account.accountHash === "string" &&
+					value.account.accountHash.startsWith("sha256:")
+						? value.account.accountHash
+						: undefined,
+				emailHash:
+					typeof value.account.emailHash === "string" &&
+					value.account.emailHash.startsWith("sha256:")
+						? value.account.emailHash
+						: undefined,
+				index:
+					typeof value.account.index === "number" &&
+					Number.isInteger(value.account.index) &&
+					value.account.index >= 0
+						? value.account.index
+						: undefined,
+			}
+		: null;
+	const normalizedAccount =
+		account?.accountHash || account?.emailHash || account?.index !== undefined
+			? account
+			: null;
+
+	return {
+		version: 1,
+		id: value.id,
+		createdAt: value.createdAt,
+		source,
+		operation,
+		outcome,
+		model: typeof value.model === "string" ? value.model : null,
+		projectKey: typeof value.projectKey === "string" ? value.projectKey : null,
+		account: normalizedAccount,
+		requestId: typeof value.requestId === "string" ? value.requestId : null,
+		statusCode:
+			typeof value.statusCode === "number" &&
+			Number.isInteger(value.statusCode) &&
+			value.statusCode >= 100 &&
+			value.statusCode <= 599
+				? value.statusCode
+				: null,
+		errorCode: typeof value.errorCode === "string" ? value.errorCode : null,
+		durationMs:
+			typeof value.durationMs === "number" && Number.isFinite(value.durationMs)
+				? Math.max(0, Math.trunc(value.durationMs))
+				: null,
+		tokens,
+		costUsd:
+			typeof value.costUsd === "number" && Number.isFinite(value.costUsd)
+				? Math.max(0, value.costUsd)
+				: null,
+	};
+}
+
+function parseJsonlRows(content: string, label: string): UsageLedgerRow[] {
+	const rows: UsageLedgerRow[] = [];
+	for (const [index, line] of content.split(/\r?\n/).entries()) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsed = JSON.parse(trimmed) as unknown;
+			const row = normalizeParsedUsageRow(parsed);
+			if (row) {
+				rows.push(row);
+			}
+		} catch (error) {
+			logWarn(
+				`Skipped malformed usage ledger row in ${label}:${index + 1}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+	return rows;
+}
+
+async function listLedgerFiles(includeArchives: boolean): Promise<string[]> {
+	const { dir, current } = getUsageLedgerPaths();
+	if (!includeArchives) {
+		return existsSync(current) ? [current] : [];
+	}
+	if (!existsSync(dir)) {
+		return [];
+	}
+	const entries = await fs.readdir(dir);
+	return entries
+		.filter((entry) => /^usage-ledger(?:\.\d{8}T\d{6}\d{3}Z)?\.jsonl$/.test(entry))
+		.sort()
+		.map((entry) => join(dir, entry));
+}
+
+function filterRows(
+	rows: UsageLedgerRow[],
+	query: UsageLedgerQuery,
+): UsageLedgerRow[] {
+	const since = normalizeTimestamp(query.since);
+	const until = normalizeTimestamp(query.until);
+	return rows.filter((row) => {
+		if (since !== null && row.createdAt < since) return false;
+		if (until !== null && row.createdAt > until) return false;
+		return true;
+	});
+}
+
+export async function readUsageLedgerRows(
+	query: UsageLedgerQuery = {},
+): Promise<UsageLedgerRow[]> {
+	const rows: UsageLedgerRow[] = [];
+	for (const file of await listLedgerFiles(query.includeArchives === true)) {
+		try {
+			rows.push(...parseJsonlRows(await readFileWithRetry(file), basename(file)));
+		} catch (error) {
+			logWarn(
+				`Failed to read usage ledger ${basename(file)}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+	return filterRows(rows, query).sort((a, b) => a.createdAt - b.createdAt);
+}
+
+function createBucket(key: string): UsageSummaryBucket {
+	return {
+		key,
+		requests: 0,
+		successes: 0,
+		failures: 0,
+		blocked: 0,
+		cancelled: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		cachedInputTokens: 0,
+		reasoningTokens: 0,
+		totalTokens: 0,
+		costUsd: 0,
+	};
+}
+
+function getBucketKey(row: UsageLedgerRow, by: UsageSummaryGroupBy): string {
+	switch (by) {
+		case "account":
+			return row.account?.accountHash ?? row.account?.emailHash ?? "unknown";
+		case "project":
+			return row.projectKey ?? "global";
+		case "outcome":
+			return row.outcome;
+		case "day":
+			return new Date(row.createdAt).toISOString().slice(0, 10);
+		case "model":
+			return row.model ?? "unknown";
+	}
+}
+
+function addRowToBucket(bucket: UsageSummaryBucket, row: UsageLedgerRow): void {
+	bucket.requests += 1;
+	if (row.outcome === "success") bucket.successes += 1;
+	if (row.outcome === "failure") bucket.failures += 1;
+	if (row.outcome === "blocked") bucket.blocked += 1;
+	if (row.outcome === "cancelled") bucket.cancelled += 1;
+	bucket.inputTokens += row.tokens.inputTokens;
+	bucket.outputTokens += row.tokens.outputTokens;
+	bucket.cachedInputTokens += row.tokens.cachedInputTokens;
+	bucket.reasoningTokens += row.tokens.reasoningTokens;
+	bucket.totalTokens += row.tokens.totalTokens;
+	bucket.costUsd = Number((bucket.costUsd + (row.costUsd ?? 0)).toFixed(8));
+}
+
+export async function summarizeUsageLedger(
+	query: UsageSummaryQuery = {},
+): Promise<UsageSummary> {
+	const by = query.by ?? "model";
+	const rows = await readUsageLedgerRows(query);
+	const totals = createBucket("total");
+	const buckets = new Map<string, UsageSummaryBucket>();
+	for (const row of rows) {
+		addRowToBucket(totals, row);
+		const key = getBucketKey(row, by);
+		const bucket = buckets.get(key) ?? createBucket(key);
+		addRowToBucket(bucket, row);
+		buckets.set(key, bucket);
+	}
+
+	return {
+		since: normalizeTimestamp(query.since),
+		until: normalizeTimestamp(query.until),
+		by,
+		totals,
+		buckets: [...buckets.values()].sort((a, b) =>
+			a.key.localeCompare(b.key),
+		),
+	};
+}
+
+export async function rotateUsageLedger(options: {
+	now?: number;
+	ifLargerThanBytes?: number;
+} = {}): Promise<string | null> {
+	const { dir, current } = getUsageLedgerPaths();
+	if (!existsSync(current)) {
+		return null;
+	}
+	const stat = await fs.stat(current);
+	if (
+		typeof options.ifLargerThanBytes === "number" &&
+		stat.size <= options.ifLargerThanBytes
+	) {
+		return null;
+	}
+	await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+	const stamp = new Date(options.now ?? Date.now())
+		.toISOString()
+		.replace(/[-:]/g, "")
+		.replace(".", "");
+	const rotated = join(dir, `usage-ledger.${stamp}.jsonl`);
+	await renameWithRetry(current, rotated);
+	return rotated;
+}
+
+export function resetUsageLedgerQueueForTests(): void {
+	appendQueue = Promise.resolve();
+}

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -112,6 +112,25 @@ async function removeStaleLockIfNeeded(lockPath: string): Promise<boolean> {
 	}
 }
 
+async function closeLockHandleWithRetry(
+	handle: Awaited<ReturnType<typeof fs.open>>,
+): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await handle.close();
+			return;
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableLockError(error)) throw error;
+			await sleep(Math.min(250, 10 * 2 ** attempt));
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger lock handle close retry exhausted");
+}
+
 async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>> {
 	const started = Date.now();
 	let attempt = 0;
@@ -123,17 +142,24 @@ async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>>
 				JSON.stringify({ pid: process.pid, createdAt: Date.now() }) + "\n",
 				"utf8",
 			);
+			const lockHandle = handle;
 			let released = false;
 			return async () => {
 				if (released) return;
 				released = true;
-				await handle?.close();
+				let closeError: unknown;
+				try {
+					await closeLockHandleWithRetry(lockHandle);
+				} catch (error) {
+					closeError = error;
+				}
 				await unlinkWithRetry(lockPath);
+				if (closeError) throw closeError;
 			};
 		} catch (error) {
 			if (handle) {
 				try {
-					await handle.close();
+					await closeLockHandleWithRetry(handle);
 				} catch {
 					// Best-effort cleanup after a failed lock metadata write.
 				}

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -25,6 +25,9 @@ import type {
 const USAGE_DIR_NAME = "usage";
 const USAGE_LEDGER_FILE_NAME = "usage-ledger.jsonl";
 const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+const LOCK_RETRYABLE_FS_CODES = new Set(["EACCES", "EBUSY", "EEXIST", "EPERM"]);
+const LOCK_STALE_MS = 30_000;
+const LOCK_MAX_WAIT_MS = 10_000;
 let appendQueue: Promise<void> = Promise.resolve();
 
 const VALID_SOURCES = new Set<UsageLedgerSource>([
@@ -53,6 +56,15 @@ function isRetryableFsError(error: unknown): boolean {
 	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
 }
 
+function isRetryableLockError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && LOCK_RETRYABLE_FS_CODES.has(code);
+}
+
+function isMissingFileError(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
 function normalizeTimestamp(value: number | Date | string | undefined): number | null {
 	if (value === undefined) return null;
 	if (value instanceof Date) {
@@ -66,13 +78,14 @@ function normalizeTimestamp(value: number | Date | string | undefined): number |
 	return Number.isFinite(parsed) ? parsed : null;
 }
 
-async function appendFileWithRetry(path: string, line: string): Promise<void> {
+async function unlinkWithRetry(path: string): Promise<void> {
 	let lastError: unknown;
 	for (let attempt = 0; attempt < 5; attempt += 1) {
 		try {
-			await fs.appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+			await fs.unlink(path);
 			return;
 		} catch (error) {
+			if (isMissingFileError(error)) return;
 			lastError = error;
 			if (!isRetryableFsError(error) || attempt >= 4) {
 				throw error;
@@ -82,7 +95,94 @@ async function appendFileWithRetry(path: string, line: string): Promise<void> {
 	}
 	throw lastError instanceof Error
 		? lastError
-		: new Error("usage ledger append retry exhausted");
+		: new Error("usage ledger lock cleanup retry exhausted");
+}
+
+async function removeStaleLockIfNeeded(lockPath: string): Promise<boolean> {
+	try {
+		const stat = await fs.stat(lockPath);
+		if (Date.now() - stat.mtimeMs < LOCK_STALE_MS) {
+			return false;
+		}
+		await unlinkWithRetry(lockPath);
+		return true;
+	} catch (error) {
+		if (isMissingFileError(error)) return true;
+		throw error;
+	}
+}
+
+async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>> {
+	const started = Date.now();
+	let attempt = 0;
+	while (true) {
+		let handle: Awaited<ReturnType<typeof fs.open>> | null = null;
+		try {
+			handle = await fs.open(lockPath, "wx", 0o600);
+			await handle.writeFile(
+				JSON.stringify({ pid: process.pid, createdAt: Date.now() }) + "\n",
+				"utf8",
+			);
+			let released = false;
+			return async () => {
+				if (released) return;
+				released = true;
+				await handle?.close();
+				await unlinkWithRetry(lockPath);
+			};
+		} catch (error) {
+			if (handle) {
+				try {
+					await handle.close();
+				} catch {
+					// Best-effort cleanup after a failed lock metadata write.
+				}
+				await unlinkWithRetry(lockPath);
+			}
+			if (!isRetryableLockError(error)) {
+				throw error;
+			}
+			await removeStaleLockIfNeeded(lockPath);
+			if (Date.now() - started >= LOCK_MAX_WAIT_MS) {
+				throw new Error(`Timed out waiting for usage ledger lock: ${lockPath}`);
+			}
+			await sleep(Math.min(250, 10 * 2 ** Math.min(attempt, 5)));
+			attempt += 1;
+		}
+	}
+}
+
+async function appendFileWithRetry(path: string, line: string): Promise<void> {
+	const release = await acquireAppendLock(`${path}.lock`);
+	let lastError: unknown;
+	try {
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			try {
+				await fs.appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+				return;
+			} catch (error) {
+				lastError = error;
+				if (!isRetryableFsError(error) || attempt >= 4) {
+					throw error;
+				}
+				await sleep(10 * 2 ** attempt);
+			}
+		}
+		throw lastError instanceof Error
+			? lastError
+			: new Error("usage ledger append retry exhausted");
+	} finally {
+		await release();
+	}
+}
+
+async function runWithAppendQueue<T>(task: () => Promise<T>): Promise<T> {
+	const queued = appendQueue.catch(() => undefined).then(task);
+	appendQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	return queued;
 }
 
 async function readFileWithRetry(path: string): Promise<string> {
@@ -136,16 +236,10 @@ export async function appendUsageLedgerRow(
 	const row = normalizeUsageLedgerRow(input);
 	const { dir, current } = getUsageLedgerPaths();
 	const line = usageRowToJsonLine(row);
-	const task = async (): Promise<void> => {
+	await runWithAppendQueue(async () => {
 		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
 		await appendFileWithRetry(current, line);
-	};
-	const queued = appendQueue.catch(() => undefined).then(task);
-	appendQueue = queued.then(
-		() => undefined,
-		() => undefined,
-	);
-	await queued;
+	});
 	return row;
 }
 
@@ -370,14 +464,17 @@ function addRowToBucket(bucket: UsageSummaryBucket, row: UsageLedgerRow): void {
 	bucket.costUsd = Number((bucket.costUsd + (row.costUsd ?? 0)).toFixed(8));
 }
 
-export async function summarizeUsageLedger(
+export function summarizeUsageRows(
+	rows: UsageLedgerRow[],
 	query: UsageSummaryQuery = {},
-): Promise<UsageSummary> {
+): UsageSummary {
 	const by = query.by ?? "model";
-	const rows = await readUsageLedgerRows(query);
+	const filteredRows = filterRows(rows, query).sort(
+		(a, b) => a.createdAt - b.createdAt,
+	);
 	const totals = createBucket("total");
 	const buckets = new Map<string, UsageSummaryBucket>();
-	for (const row of rows) {
+	for (const row of filteredRows) {
 		addRowToBucket(totals, row);
 		const key = getBucketKey(row, by);
 		const bucket = buckets.get(key) ?? createBucket(key);
@@ -396,29 +493,42 @@ export async function summarizeUsageLedger(
 	};
 }
 
+export async function summarizeUsageLedger(
+	query: UsageSummaryQuery = {},
+): Promise<UsageSummary> {
+	return summarizeUsageRows(await readUsageLedgerRows(query), query);
+}
+
 export async function rotateUsageLedger(options: {
 	now?: number;
 	ifLargerThanBytes?: number;
 } = {}): Promise<string | null> {
 	const { dir, current } = getUsageLedgerPaths();
-	if (!existsSync(current)) {
-		return null;
-	}
-	const stat = await fs.stat(current);
-	if (
-		typeof options.ifLargerThanBytes === "number" &&
-		stat.size <= options.ifLargerThanBytes
-	) {
-		return null;
-	}
-	await fs.mkdir(dir, { recursive: true, mode: 0o700 });
-	const stamp = new Date(options.now ?? Date.now())
-		.toISOString()
-		.replace(/[-:]/g, "")
-		.replace(".", "");
-	const rotated = join(dir, `usage-ledger.${stamp}.jsonl`);
-	await renameWithRetry(current, rotated);
-	return rotated;
+	return runWithAppendQueue(async () => {
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+		const release = await acquireAppendLock(`${current}.lock`);
+		try {
+			if (!existsSync(current)) {
+				return null;
+			}
+			const stat = await fs.stat(current);
+			if (
+				typeof options.ifLargerThanBytes === "number" &&
+				stat.size <= options.ifLargerThanBytes
+			) {
+				return null;
+			}
+			const stamp = new Date(options.now ?? Date.now())
+				.toISOString()
+				.replace(/[-:]/g, "")
+				.replace(".", "");
+			const rotated = join(dir, `usage-ledger.${stamp}.jsonl`);
+			await renameWithRetry(current, rotated);
+			return rotated;
+		} finally {
+			await release();
+		}
+	});
 }
 
 export function resetUsageLedgerQueueForTests(): void {

--- a/lib/usage/pricing.ts
+++ b/lib/usage/pricing.ts
@@ -7,13 +7,6 @@ export interface UsageModelPricing {
 	reasoningUsdPerMillion?: number;
 }
 
-const DEFAULT_PRICING: UsageModelPricing = {
-	inputUsdPerMillion: 0,
-	outputUsdPerMillion: 0,
-	cachedInputUsdPerMillion: 0,
-	reasoningUsdPerMillion: 0,
-};
-
 const MODEL_PRICING: Record<string, UsageModelPricing> = {
 	"gpt-5-codex": {
 		inputUsdPerMillion: 1.25,
@@ -65,7 +58,7 @@ export function getUsageModelPricing(
 	if (!normalized) {
 		return null;
 	}
-	return MODEL_PRICING[normalized] ?? DEFAULT_PRICING;
+	return MODEL_PRICING[normalized] ?? null;
 }
 
 export function estimateUsageCostUsd(
@@ -77,8 +70,12 @@ export function estimateUsageCostUsd(
 		return null;
 	}
 
+	const billableInputTokens = Math.max(
+		0,
+		tokens.inputTokens - tokens.cachedInputTokens,
+	);
 	const input =
-		(tokens.inputTokens / 1_000_000) * pricing.inputUsdPerMillion;
+		(billableInputTokens / 1_000_000) * pricing.inputUsdPerMillion;
 	const output =
 		(tokens.outputTokens / 1_000_000) * pricing.outputUsdPerMillion;
 	const cached =

--- a/lib/usage/pricing.ts
+++ b/lib/usage/pricing.ts
@@ -1,0 +1,96 @@
+import type { UsageTokenCounts } from "./types.js";
+
+export interface UsageModelPricing {
+	inputUsdPerMillion: number;
+	outputUsdPerMillion: number;
+	cachedInputUsdPerMillion?: number;
+	reasoningUsdPerMillion?: number;
+}
+
+const DEFAULT_PRICING: UsageModelPricing = {
+	inputUsdPerMillion: 0,
+	outputUsdPerMillion: 0,
+	cachedInputUsdPerMillion: 0,
+	reasoningUsdPerMillion: 0,
+};
+
+const MODEL_PRICING: Record<string, UsageModelPricing> = {
+	"gpt-5-codex": {
+		inputUsdPerMillion: 1.25,
+		outputUsdPerMillion: 10,
+		cachedInputUsdPerMillion: 0.125,
+		reasoningUsdPerMillion: 10,
+	},
+	"gpt-5.1-codex": {
+		inputUsdPerMillion: 1.25,
+		outputUsdPerMillion: 10,
+		cachedInputUsdPerMillion: 0.125,
+		reasoningUsdPerMillion: 10,
+	},
+	"gpt-5.2": {
+		inputUsdPerMillion: 1.25,
+		outputUsdPerMillion: 10,
+		cachedInputUsdPerMillion: 0.125,
+		reasoningUsdPerMillion: 10,
+	},
+	"gpt-5.3-codex": {
+		inputUsdPerMillion: 1.25,
+		outputUsdPerMillion: 10,
+		cachedInputUsdPerMillion: 0.125,
+		reasoningUsdPerMillion: 10,
+	},
+	"gpt-5.4": {
+		inputUsdPerMillion: 2,
+		outputUsdPerMillion: 12,
+		cachedInputUsdPerMillion: 0.2,
+		reasoningUsdPerMillion: 12,
+	},
+	"gpt-5.5": {
+		inputUsdPerMillion: 2,
+		outputUsdPerMillion: 12,
+		cachedInputUsdPerMillion: 0.2,
+		reasoningUsdPerMillion: 12,
+	},
+};
+
+function normalizeModelName(model: string | null | undefined): string | null {
+	const trimmed = model?.trim().toLowerCase();
+	return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function getUsageModelPricing(
+	model: string | null | undefined,
+): UsageModelPricing | null {
+	const normalized = normalizeModelName(model);
+	if (!normalized) {
+		return null;
+	}
+	return MODEL_PRICING[normalized] ?? DEFAULT_PRICING;
+}
+
+export function estimateUsageCostUsd(
+	model: string | null | undefined,
+	tokens: UsageTokenCounts,
+): number | null {
+	const pricing = getUsageModelPricing(model);
+	if (!pricing) {
+		return null;
+	}
+
+	const input =
+		(tokens.inputTokens / 1_000_000) * pricing.inputUsdPerMillion;
+	const output =
+		(tokens.outputTokens / 1_000_000) * pricing.outputUsdPerMillion;
+	const cached =
+		(tokens.cachedInputTokens / 1_000_000) *
+		(pricing.cachedInputUsdPerMillion ?? pricing.inputUsdPerMillion);
+	const reasoning =
+		(tokens.reasoningTokens / 1_000_000) *
+		(pricing.reasoningUsdPerMillion ?? pricing.outputUsdPerMillion);
+	return Number((input + output + cached + reasoning).toFixed(8));
+}
+
+export function listUsageModelPricing(): Record<string, UsageModelPricing> {
+	return structuredClone(MODEL_PRICING);
+}
+

--- a/lib/usage/redaction.ts
+++ b/lib/usage/redaction.ts
@@ -1,0 +1,166 @@
+import { createHash, randomUUID } from "node:crypto";
+import type {
+	UsageLedgerAccountRef,
+	UsageLedgerAppendInput,
+	UsageLedgerOperation,
+	UsageLedgerOutcome,
+	UsageLedgerRow,
+	UsageLedgerSource,
+	UsageTokenCounts,
+} from "./types.js";
+import { estimateUsageCostUsd } from "./pricing.js";
+
+const VALID_SOURCES = new Set<UsageLedgerSource>([
+	"runtime-proxy",
+	"plugin-host",
+	"local-bridge",
+	"cli",
+	"unknown",
+]);
+const VALID_OPERATIONS = new Set<UsageLedgerOperation>([
+	"responses",
+	"models",
+	"auth-refresh",
+	"diagnostic",
+	"unknown",
+]);
+const VALID_OUTCOMES = new Set<UsageLedgerOutcome>([
+	"success",
+	"failure",
+	"blocked",
+	"cancelled",
+]);
+
+function normalizeFiniteNumber(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeNonNegativeInteger(value: unknown): number {
+	const numeric = normalizeFiniteNumber(value);
+	return numeric === null ? 0 : Math.max(0, Math.trunc(numeric));
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeStatusCode(value: unknown): number | null {
+	const numeric = normalizeFiniteNumber(value);
+	if (numeric === null) return null;
+	const statusCode = Math.trunc(numeric);
+	return statusCode >= 100 && statusCode <= 599 ? statusCode : null;
+}
+
+function normalizeDurationMs(value: unknown): number | null {
+	const numeric = normalizeFiniteNumber(value);
+	return numeric === null ? null : Math.max(0, Math.trunc(numeric));
+}
+
+function normalizeSource(value: unknown): UsageLedgerSource {
+	return typeof value === "string" && VALID_SOURCES.has(value as UsageLedgerSource)
+		? (value as UsageLedgerSource)
+		: "unknown";
+}
+
+function normalizeOperation(value: unknown): UsageLedgerOperation {
+	return typeof value === "string" &&
+		VALID_OPERATIONS.has(value as UsageLedgerOperation)
+		? (value as UsageLedgerOperation)
+		: "unknown";
+}
+
+function normalizeOutcome(value: unknown): UsageLedgerOutcome {
+	if (
+		typeof value === "string" &&
+		VALID_OUTCOMES.has(value as UsageLedgerOutcome)
+	) {
+		return value as UsageLedgerOutcome;
+	}
+	return "failure";
+}
+
+export function hashUsageIdentifier(value: string): string {
+	return `sha256:${createHash("sha256").update(value.trim()).digest("hex")}`;
+}
+
+export function createUsageAccountRef(input: {
+	accountId?: string | null;
+	email?: string | null;
+	accountIndex?: number | null;
+}): UsageLedgerAccountRef | null {
+	const accountId = normalizeOptionalString(input.accountId);
+	const email = normalizeOptionalString(input.email)?.toLowerCase() ?? null;
+	const index =
+		typeof input.accountIndex === "number" &&
+		Number.isInteger(input.accountIndex) &&
+		input.accountIndex >= 0
+			? input.accountIndex
+			: null;
+	if (!accountId && !email && index === null) {
+		return null;
+	}
+
+	return {
+		accountHash: accountId ? hashUsageIdentifier(accountId) : undefined,
+		emailHash: email ? hashUsageIdentifier(email) : undefined,
+		index: index ?? undefined,
+	};
+}
+
+function normalizeTokens(input: UsageLedgerAppendInput): UsageTokenCounts {
+	const inputTokens = normalizeNonNegativeInteger(input.inputTokens);
+	const outputTokens = normalizeNonNegativeInteger(input.outputTokens);
+	const cachedInputTokens = normalizeNonNegativeInteger(input.cachedInputTokens);
+	const reasoningTokens = normalizeNonNegativeInteger(input.reasoningTokens);
+	const providedTotal = normalizeFiniteNumber(input.totalTokens);
+	const computedTotal =
+		inputTokens + outputTokens + cachedInputTokens + reasoningTokens;
+
+	return {
+		inputTokens,
+		outputTokens,
+		cachedInputTokens,
+		reasoningTokens,
+		totalTokens:
+			providedTotal === null
+				? computedTotal
+				: Math.max(0, Math.trunc(providedTotal)),
+	};
+}
+
+export function normalizeUsageLedgerRow(
+	input: UsageLedgerAppendInput,
+): UsageLedgerRow {
+	const model = normalizeOptionalString(input.model);
+	const tokens = normalizeTokens(input);
+	const explicitCost = normalizeFiniteNumber(input.costUsd);
+
+	return {
+		version: 1,
+		id: normalizeOptionalString(input.id) ?? randomUUID(),
+		createdAt:
+			normalizeFiniteNumber(input.createdAt) ?? Date.now(),
+		source: normalizeSource(input.source),
+		operation: normalizeOperation(input.operation),
+		outcome: normalizeOutcome(input.outcome),
+		model,
+		projectKey: normalizeOptionalString(input.projectKey),
+		account: createUsageAccountRef(input),
+		requestId: normalizeOptionalString(input.requestId),
+		statusCode: normalizeStatusCode(input.statusCode),
+		errorCode: normalizeOptionalString(input.errorCode),
+		durationMs: normalizeDurationMs(input.durationMs),
+		tokens,
+		costUsd:
+			explicitCost === null
+				? estimateUsageCostUsd(model, tokens)
+				: Math.max(0, explicitCost),
+	};
+}
+
+export function usageRowToJsonLine(row: UsageLedgerRow): string {
+	return `${JSON.stringify(row)}\n`;
+}
+

--- a/lib/usage/redaction.ts
+++ b/lib/usage/redaction.ts
@@ -115,8 +115,7 @@ function normalizeTokens(input: UsageLedgerAppendInput): UsageTokenCounts {
 	const cachedInputTokens = normalizeNonNegativeInteger(input.cachedInputTokens);
 	const reasoningTokens = normalizeNonNegativeInteger(input.reasoningTokens);
 	const providedTotal = normalizeFiniteNumber(input.totalTokens);
-	const computedTotal =
-		inputTokens + outputTokens + cachedInputTokens + reasoningTokens;
+	const computedTotal = inputTokens + outputTokens + reasoningTokens;
 
 	return {
 		inputTokens,

--- a/lib/usage/types.ts
+++ b/lib/usage/types.ts
@@ -1,0 +1,120 @@
+export type UsageLedgerSource =
+	| "runtime-proxy"
+	| "plugin-host"
+	| "local-bridge"
+	| "cli"
+	| "unknown";
+
+export type UsageLedgerOperation =
+	| "responses"
+	| "models"
+	| "auth-refresh"
+	| "diagnostic"
+	| "unknown";
+
+export type UsageLedgerOutcome =
+	| "success"
+	| "failure"
+	| "blocked"
+	| "cancelled";
+
+export interface UsageTokenCounts {
+	inputTokens: number;
+	outputTokens: number;
+	cachedInputTokens: number;
+	reasoningTokens: number;
+	totalTokens: number;
+}
+
+export interface UsageLedgerAccountRef {
+	accountHash?: string;
+	emailHash?: string;
+	index?: number;
+}
+
+export interface UsageLedgerRow {
+	version: 1;
+	id: string;
+	createdAt: number;
+	source: UsageLedgerSource;
+	operation: UsageLedgerOperation;
+	outcome: UsageLedgerOutcome;
+	model: string | null;
+	projectKey: string | null;
+	account: UsageLedgerAccountRef | null;
+	requestId: string | null;
+	statusCode: number | null;
+	errorCode: string | null;
+	durationMs: number | null;
+	tokens: UsageTokenCounts;
+	costUsd: number | null;
+}
+
+export interface UsageLedgerAppendInput {
+	id?: string;
+	createdAt?: number;
+	source?: UsageLedgerSource;
+	operation?: UsageLedgerOperation;
+	outcome: UsageLedgerOutcome;
+	model?: string | null;
+	projectKey?: string | null;
+	accountId?: string | null;
+	email?: string | null;
+	accountIndex?: number | null;
+	requestId?: string | null;
+	statusCode?: number | null;
+	errorCode?: string | null;
+	durationMs?: number | null;
+	inputTokens?: number | null;
+	outputTokens?: number | null;
+	cachedInputTokens?: number | null;
+	reasoningTokens?: number | null;
+	totalTokens?: number | null;
+	costUsd?: number | null;
+}
+
+export type UsageSummaryGroupBy =
+	| "model"
+	| "account"
+	| "project"
+	| "outcome"
+	| "day";
+
+export interface UsageLedgerQuery {
+	since?: number | Date | string;
+	until?: number | Date | string;
+	includeArchives?: boolean;
+}
+
+export interface UsageSummaryQuery extends UsageLedgerQuery {
+	by?: UsageSummaryGroupBy;
+}
+
+export interface UsageSummaryBucket {
+	key: string;
+	requests: number;
+	successes: number;
+	failures: number;
+	blocked: number;
+	cancelled: number;
+	inputTokens: number;
+	outputTokens: number;
+	cachedInputTokens: number;
+	reasoningTokens: number;
+	totalTokens: number;
+	costUsd: number;
+}
+
+export interface UsageSummary {
+	since: number | null;
+	until: number | null;
+	by: UsageSummaryGroupBy;
+	totals: UsageSummaryBucket;
+	buckets: UsageSummaryBucket[];
+}
+
+export interface UsageLedgerPaths {
+	dir: string;
+	current: string;
+}
+

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -122,12 +122,17 @@ describe("usage ledger core", () => {
 			outcome: "success",
 			model: "gpt-5.3-codex",
 		});
+		const lockPath = `${getUsageLedgerPaths().current}.lock`;
+		await fs.writeFile(lockPath, "stale\n", "utf8");
+		const staleDate = new Date(Date.now() - 60_000);
+		await fs.utimes(lockPath, staleDate, staleDate);
 
 		const rotated = await rotateUsageLedger({
 			now: Date.UTC(2026, 0, 2, 3, 4, 5, 6),
 		});
 
 		expect(rotated).toContain("usage-ledger.20260102T030405006Z.jsonl");
+		await expect(fs.stat(lockPath)).rejects.toThrow();
 		await expect(fs.stat(getUsageLedgerPaths().current)).rejects.toThrow();
 
 		await appendUsageLedgerRow({
@@ -177,9 +182,27 @@ describe("usage ledger core", () => {
 				reasoningTokens: 1_000_000,
 				totalTokens: 4_000_000,
 			}),
-		).toBe(21.375);
+		).toBe(20.125);
+		expect(
+			estimateUsageCostUsd("gpt-5.3-codex", {
+				inputTokens: 1_000,
+				outputTokens: 200,
+				cachedInputTokens: 50,
+				reasoningTokens: 25,
+				totalTokens: 1_275,
+			}),
+		).toBe(0.00344375);
 		expect(
 			estimateUsageCostUsd(null, {
+				inputTokens: 1,
+				outputTokens: 1,
+				cachedInputTokens: 0,
+				reasoningTokens: 0,
+				totalTokens: 2,
+			}),
+		).toBeNull();
+		expect(
+			estimateUsageCostUsd("unknown-model", {
 				inputTokens: 1,
 				outputTokens: 1,
 				cachedInputTokens: 0,
@@ -213,6 +236,30 @@ describe("usage ledger core", () => {
 		} finally {
 			appendSpy.mockRestore();
 		}
+	});
+
+	it("removes stale append locks before writing", async () => {
+		const {
+			appendUsageLedgerRow,
+			getUsageLedgerPaths,
+			readUsageLedgerRows,
+		} = await import("../lib/usage/index.js");
+		const { dir, current } = getUsageLedgerPaths();
+		const lockPath = `${current}.lock`;
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(lockPath, "stale\n", "utf8");
+		const staleDate = new Date(Date.now() - 60_000);
+		await fs.utimes(lockPath, staleDate, staleDate);
+
+		await appendUsageLedgerRow({
+			id: "after-stale-lock",
+			outcome: "success",
+		});
+
+		await expect(fs.stat(lockPath)).rejects.toThrow();
+		expect((await readUsageLedgerRows()).map((row) => row.id)).toEqual([
+			"after-stale-lock",
+		]);
 	});
 });
 

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 describe("usage ledger core", () => {
 	let tempDir: string;
@@ -20,7 +21,7 @@ describe("usage ledger core", () => {
 		} else {
 			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
 		}
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetry(tempDir, { recursive: true, force: true });
 	});
 
 	it("appends normalized JSONL rows without raw email or account identifiers", async () => {

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -169,6 +169,39 @@ describe("usage ledger core", () => {
 		).resolves.toBeNull();
 	});
 
+	it("retries transient lock close failures before removing the lock", async () => {
+		const realOpen = fs.open.bind(fs);
+		const openSpy = vi.spyOn(fs, "open");
+		openSpy.mockImplementationOnce(async (...args: Parameters<typeof fs.open>) => {
+			const handle = await realOpen(...args);
+			let closeAttempts = 0;
+			return new Proxy(handle, {
+				get(target, property, receiver) {
+					if (property === "close") {
+						return async () => {
+							closeAttempts += 1;
+							if (closeAttempts === 1) {
+								throw Object.assign(new Error("close busy"), { code: "EBUSY" });
+							}
+							return target.close();
+						};
+					}
+					return Reflect.get(target, property, receiver);
+				},
+			}) as Awaited<ReturnType<typeof fs.open>>;
+		});
+		const { appendUsageLedgerRow, getUsageLedgerPaths } = await import(
+			"../lib/usage/index.js"
+		);
+
+		await appendUsageLedgerRow({ id: "close-retry", outcome: "success" });
+
+		const paths = getUsageLedgerPaths();
+		await expect(fs.access(`${paths.current}.lock`)).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+	});
+
 	it("exports pricing helpers with deterministic estimates", async () => {
 		const { estimateUsageCostUsd, listUsageModelPricing } = await import(
 			"../lib/usage/index.js"

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -53,7 +53,8 @@ describe("usage ledger core", () => {
 		expect(row.account?.accountHash).toMatch(/^sha256:/);
 		expect(row.account?.emailHash).toMatch(/^sha256:/);
 		expect(row.account?.index).toBe(2);
-		expect(row.tokens.totalTokens).toBe(1_275);
+		expect(row.tokens.totalTokens).toBe(1_225);
+		expect(row.tokens.cachedInputTokens).toBe(50);
 		expect(row.costUsd).toBeGreaterThan(0);
 
 		const raw = await fs.readFile(getUsageLedgerPaths().current, "utf8");
@@ -189,7 +190,7 @@ describe("usage ledger core", () => {
 				outputTokens: 200,
 				cachedInputTokens: 50,
 				reasoningTokens: 25,
-				totalTokens: 1_275,
+				totalTokens: 1_225,
 			}),
 		).toBe(0.00344375);
 		expect(

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("usage ledger core", () => {
+	let tempDir: string;
+	let originalDir: string | undefined;
+
+	beforeEach(async () => {
+		originalDir = process.env.CODEX_MULTI_AUTH_DIR;
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-ledger-"));
+		process.env.CODEX_MULTI_AUTH_DIR = tempDir;
+		vi.resetModules();
+	});
+
+	afterEach(async () => {
+		if (originalDir === undefined) {
+			delete process.env.CODEX_MULTI_AUTH_DIR;
+		} else {
+			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
+		}
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("appends normalized JSONL rows without raw email or account identifiers", async () => {
+		const {
+			appendUsageLedgerRow,
+			getUsageLedgerPaths,
+			readUsageLedgerRows,
+		} = await import("../lib/usage/index.js");
+
+		const row = await appendUsageLedgerRow({
+			id: "row-1",
+			createdAt: 1_700_000_000_000,
+			source: "runtime-proxy",
+			operation: "responses",
+			outcome: "success",
+			model: " gpt-5.3-codex ",
+			accountId: "acct_sensitive_123",
+			email: "Owner@Example.com",
+			accountIndex: 2,
+			requestId: "req_123",
+			statusCode: 200,
+			durationMs: 123.9,
+			inputTokens: 1_000,
+			outputTokens: 200,
+			cachedInputTokens: 50,
+			reasoningTokens: 25,
+		});
+
+		expect(row.model).toBe("gpt-5.3-codex");
+		expect(row.account?.accountHash).toMatch(/^sha256:/);
+		expect(row.account?.emailHash).toMatch(/^sha256:/);
+		expect(row.account?.index).toBe(2);
+		expect(row.tokens.totalTokens).toBe(1_275);
+		expect(row.costUsd).toBeGreaterThan(0);
+
+		const raw = await fs.readFile(getUsageLedgerPaths().current, "utf8");
+		expect(raw).toContain('"version":1');
+		expect(raw).not.toContain("acct_sensitive_123");
+		expect(raw).not.toContain("Owner@Example.com");
+		expect(raw).not.toContain("owner@example.com");
+
+		await expect(readUsageLedgerRows()).resolves.toEqual([row]);
+	});
+
+	it("summarizes usage by model and applies date filters", async () => {
+		const { appendUsageLedgerRow, summarizeUsageLedger } = await import(
+			"../lib/usage/index.js"
+		);
+
+		await appendUsageLedgerRow({
+			id: "old",
+			createdAt: 100,
+			outcome: "success",
+			model: "gpt-5.3-codex",
+			inputTokens: 100,
+			outputTokens: 10,
+		});
+		await appendUsageLedgerRow({
+			id: "new-success",
+			createdAt: 200,
+			outcome: "success",
+			model: "gpt-5.3-codex",
+			inputTokens: 200,
+			outputTokens: 20,
+		});
+		await appendUsageLedgerRow({
+			id: "new-failure",
+			createdAt: 300,
+			outcome: "failure",
+			model: "gpt-5.5",
+			inputTokens: 50,
+			outputTokens: 5,
+		});
+
+		const summary = await summarizeUsageLedger({ since: 150, by: "model" });
+
+		expect(summary.totals.requests).toBe(2);
+		expect(summary.totals.successes).toBe(1);
+		expect(summary.totals.failures).toBe(1);
+		expect(summary.totals.inputTokens).toBe(250);
+		expect(summary.buckets.map((bucket) => bucket.key)).toEqual([
+			"gpt-5.3-codex",
+			"gpt-5.5",
+		]);
+		expect(summary.buckets[0]?.requests).toBe(1);
+	});
+
+	it("rotates the current ledger and can include archived rows", async () => {
+		const {
+			appendUsageLedgerRow,
+			getUsageLedgerPaths,
+			readUsageLedgerRows,
+			rotateUsageLedger,
+		} = await import("../lib/usage/index.js");
+
+		await appendUsageLedgerRow({
+			id: "before-rotate",
+			createdAt: 100,
+			outcome: "success",
+			model: "gpt-5.3-codex",
+		});
+
+		const rotated = await rotateUsageLedger({
+			now: Date.UTC(2026, 0, 2, 3, 4, 5, 6),
+		});
+
+		expect(rotated).toContain("usage-ledger.20260102T030405006Z.jsonl");
+		await expect(fs.stat(getUsageLedgerPaths().current)).rejects.toThrow();
+
+		await appendUsageLedgerRow({
+			id: "after-rotate",
+			createdAt: 200,
+			outcome: "success",
+			model: "gpt-5.5",
+		});
+
+		expect((await readUsageLedgerRows()).map((row) => row.id)).toEqual([
+			"after-rotate",
+		]);
+		expect(
+			(await readUsageLedgerRows({ includeArchives: true })).map(
+				(row) => row.id,
+			),
+		).toEqual(["before-rotate", "after-rotate"]);
+	});
+
+	it("skips rotation when below the configured byte threshold", async () => {
+		const { appendUsageLedgerRow, rotateUsageLedger } = await import(
+			"../lib/usage/index.js"
+		);
+
+		await appendUsageLedgerRow({
+			id: "small",
+			createdAt: 100,
+			outcome: "success",
+		});
+
+		await expect(
+			rotateUsageLedger({ ifLargerThanBytes: 1_000_000 }),
+		).resolves.toBeNull();
+	});
+
+	it("exports pricing helpers with deterministic estimates", async () => {
+		const { estimateUsageCostUsd, listUsageModelPricing } = await import(
+			"../lib/usage/index.js"
+		);
+
+		expect(Object.keys(listUsageModelPricing())).toContain("gpt-5.3-codex");
+		expect(
+			estimateUsageCostUsd("gpt-5.3-codex", {
+				inputTokens: 1_000_000,
+				outputTokens: 1_000_000,
+				cachedInputTokens: 1_000_000,
+				reasoningTokens: 1_000_000,
+				totalTokens: 4_000_000,
+			}),
+		).toBe(21.375);
+		expect(
+			estimateUsageCostUsd(null, {
+				inputTokens: 1,
+				outputTokens: 1,
+				cachedInputTokens: 0,
+				reasoningTokens: 0,
+				totalTokens: 2,
+			}),
+		).toBeNull();
+	});
+
+	it("retries transient append failures", async () => {
+		const { appendUsageLedgerRow } = await import("../lib/usage/index.js");
+		const realAppend = fs.appendFile.bind(fs);
+		const appendSpy = vi.spyOn(fs, "appendFile");
+		let attempts = 0;
+		appendSpy.mockImplementation(async (...args) => {
+			attempts += 1;
+			if (attempts === 1) {
+				const error = new Error("busy") as NodeJS.ErrnoException;
+				error.code = "EBUSY";
+				throw error;
+			}
+			return realAppend(...args);
+		});
+
+		try {
+			await appendUsageLedgerRow({
+				id: "retry",
+				outcome: "success",
+			});
+			expect(attempts).toBe(2);
+		} finally {
+			appendSpy.mockRestore();
+		}
+	});
+});
+


### PR DESCRIPTION
Replacement for merged PR #448 after main was reverted for review.\n\nScope:\n- Add local JSONL usage ledger core.\n- Add local pricing, redaction, summaries, and rotation helpers.\n- Avoid storing prompts, auth headers, raw emails, or raw sensitive account ids.\n\nValidation from original slice:\n- Usage ledger focused tests passed before the review stack was opened.\n- Cumulative review branch has passed typecheck, lint, and build through PR 06.\n\nReview note:\n- Base is the replacement roadmap PR branch so this remains a stacked review slice.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

adds the local JSONL usage ledger core: append, read, rotate, pricing estimation, and account/email redaction via sha256 hashing. the three issues flagged in prior review threads (cross-process windows atomicity, rotation not serialized through appendQueue, unknown model silently returning $0) are all addressed — a file-lock sentinel now guards cross-process appends, `rotateUsageLedger` is wrapped in `runWithAppendQueue`, and `getUsageModelPricing` returns `null` for unrecognized models.

<h3>Confidence Score: 5/5</h3>

safe to merge — all prior P1s resolved, remaining findings are P2 quality/maintenance concerns

no P0 or P1 findings; the three previously-flagged critical issues are demonstrably fixed; new P2s (duplicate validation sets, missing EACCES in retryable codes, missing concurrent-write test) do not affect correctness of the shipped path

lib/usage/ledger.ts and lib/usage/redaction.ts for the duplicate validation sets and EACCES gap

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/usage/ledger.ts | Core JSONL ledger: adds file-lock sentinel for cross-process Windows safety and serializes rotation through appendQueue; EACCES missing from RETRYABLE_FS_CODES for append/rename paths |
| lib/usage/redaction.ts | Normalizes and hashes account/email identifiers before storage; duplicates VALID_SOURCES/VALID_OPERATIONS/VALID_OUTCOMES sets that also live in ledger.ts, risking divergence on future type additions |
| lib/usage/pricing.ts | Static model pricing table and cost estimator; correctly returns null for unknown models (prior DEFAULT_PRICING issue resolved) |
| lib/usage/types.ts | Clean type definitions for ledger rows, queries, and summaries; no issues found |
| test/usage-ledger.test.ts | 7 test cases covering append, summarize, rotate, stale-lock cleanup, lock-close retry, and pricing; correctly uses removeWithRetry; missing concurrent-write stress test for the new file-lock path |
| lib/usage/index.ts | Barrel re-export of all usage submodules; no issues |
| lib/index.ts | Adds usage barrel to public lib exports; one-line change, no issues |
| docs/development/implementation-plans/status.md | Updates PR 02 status to Ready for review with validation commands; docs-only change |
| docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md | New subagent handoff doc for PR 02 scope and validation; docs-only |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller (runtime-proxy / plugin-host)
    participant L as ledger.ts
    participant Q as appendQueue
    participant LK as .lock sentinel
    participant FS as JSONL file

    C->>L: appendUsageLedgerRow(input)
    L->>L: normalizeUsageLedgerRow (redaction.ts)
    L->>Q: runWithAppendQueue(task)
    Q->>FS: mkdir (recursive)
    Q->>LK: acquireAppendLock → fs.open(wx)
    LK-->>Q: release fn
    Q->>FS: appendFile (with EBUSY/EPERM retry)
    Q->>LK: release() → close + unlink
    Q-->>L: row written
    L-->>C: UsageLedgerRow

    Note over C,FS: Rotation (same queue slot)
    C->>L: rotateUsageLedger()
    L->>Q: runWithAppendQueue(task)
    Q->>LK: acquireAppendLock
    Q->>FS: stat → rename to usage-ledger.{stamp}.jsonl
    Q->>LK: release()
    Q-->>L: archived path | null
    L-->>C: rotated path
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/usage-ledger.test.ts`, line 1064 ([link](https://github.com/ndycode/codex-multi-auth/blob/810ce6f18a451b87b668b211cb8cce11abc5daa1/test/usage-ledger.test.ts#L1064)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **bare `fs.rm` in `afterEach` — windows cleanup will fail**

   `test/AGENTS.md` explicitly prohibits bare `fs.rm` in test cleanup and requires `removeWithRetry` for Windows safety. on windows, vitest can leave handles open on the temp dir after each test (e.g. the JSONL file, lock file), causing `EBUSY`/`ENOTEMPTY` on recursive delete and flaking the entire suite.

   if `removeWithRetry` isn't exported from `utils`, the existing retry pattern (`sleep` + backoff on `EBUSY`/`EPERM`/`ENOTEMPTY`) used elsewhere (e.g. `rotation-integration.test.ts`) should be applied here too.

   **Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: test/usage-ledger.test.ts
   Line: 1064
   
   Comment:
   **bare `fs.rm` in `afterEach` — windows cleanup will fail**
   
   `test/AGENTS.md` explicitly prohibits bare `fs.rm` in test cleanup and requires `removeWithRetry` for Windows safety. on windows, vitest can leave handles open on the temp dir after each test (e.g. the JSONL file, lock file), causing `EBUSY`/`ENOTEMPTY` on recursive delete and flaking the entire suite.
   
   if `removeWithRetry` isn't exported from `utils`, the existing retry pattern (`sleep` + backoff on `EBUSY`/`EPERM`/`ENOTEMPTY`) used elsewhere (e.g. `rotation-integration.test.ts`) should be applied here too.
   
   **Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22review%2Fpr-448-usage-ledger-core%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22review%2Fpr-448-usage-ledger-core%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fusage-ledger.test.ts%0ALine%3A%201064%0A%0AComment%3A%0A**bare%20%60fs.rm%60%20in%20%60afterEach%60%20%E2%80%94%20windows%20cleanup%20will%20fail**%0A%0A%60test%2FAGENTS.md%60%20explicitly%20prohibits%20bare%20%60fs.rm%60%20in%20test%20cleanup%20and%20requires%20%60removeWithRetry%60%20for%20Windows%20safety.%20on%20windows%2C%20vitest%20can%20leave%20handles%20open%20on%20the%20temp%20dir%20after%20each%20test%20%28e.g.%20the%20JSONL%20file%2C%20lock%20file%29%2C%20causing%20%60EBUSY%60%2F%60ENOTEMPTY%60%20on%20recursive%20delete%20and%20flaking%20the%20entire%20suite.%0A%0Aif%20%60removeWithRetry%60%20isn't%20exported%20from%20%60utils%60%2C%20the%20existing%20retry%20pattern%20%28%60sleep%60%20%2B%20backoff%20on%20%60EBUSY%60%2F%60EPERM%60%2F%60ENOTEMPTY%60%29%20used%20elsewhere%20%28e.g.%20%60rotation-integration.test.ts%60%29%20should%20be%20applied%20here%20too.%0A%0A**Context%20Used%3A**%20test%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6e2636a9-e514-4bab-b249-4b4a84aa4ae3%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22review%2Fpr-448-usage-ledger-core%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22review%2Fpr-448-usage-ledger-core%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fusage%2Fredaction.ts%3A13-32%0A**Duplicate%20validation%20sets%20risk%20silent%20divergence**%0A%0A%60VALID_SOURCES%60%2C%20%60VALID_OPERATIONS%60%2C%20and%20%60VALID_OUTCOMES%60%20are%20defined%20identically%20here%20and%20again%20in%20%60ledger.ts%60%20%28lines%2033%E2%80%9352%29.%20if%20a%20new%20variant%20is%20added%20to%20%60UsageLedgerSource%60%20%2F%20%60UsageLedgerOperation%60%20%2F%20%60UsageLedgerOutcome%60%20in%20%60types.ts%60%20but%20only%20one%20of%20the%20two%20files%20is%20updated%2C%20written%20rows%20will%20be%20accepted%20by%20%60normalizeUsageLedgerRow%60%20but%20then%20silently%20remapped%20to%20%60%22unknown%22%60%20%2F%20%60%22failure%22%60%20by%20%60normalizeParsedUsageRow%60%20on%20read-back%2C%20corrupting%20per-model%20and%20per-source%20summaries.%0A%0Aconsider%20sharing%20the%20sets%20from%20a%20single%20location%20%28e.g.%20as%20%60const%60%20arrays%20exported%20from%20%60types.ts%60%20and%20derived%20into%20%60Set%3C%3E%60%20at%20the%20call%20sites%2C%20or%20a%20thin%20%60validation.ts%60%20module%29%20to%20prevent%20drift.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fusage%2Fledger.ts%3A27%0A**%60EACCES%60%20missing%20from%20retryable%20fs%20codes%20for%20append%20and%20rename**%0A%0A%60RETRYABLE_FS_CODES%20%3D%20%7B%20EBUSY%2C%20EPERM%20%7D%60%20is%20used%20in%20%60appendFileWithRetry%60%2C%20%60readFileWithRetry%60%2C%20and%20%60renameWithRetry%60.%20on%20windows%2C%20%60fs.appendFile%60%20and%20%60fs.rename%60%20can%20return%20%60EACCES%60%20%28not%20%60EPERM%60%29%20when%20another%20process%20holds%20a%20handle%20on%20the%20file.%20this%20means%20a%20transient%20overlap%20%E2%80%94%20e.g.%20%60runtime-proxy%60%20reading%20the%20file%20while%20%60rotateUsageLedger%60%20renames%20it%20%E2%80%94%20could%20throw%20and%20surface%20a%20non-retried%20error%20instead%20of%20backing%20off.%20%60LOCK_RETRYABLE_FS_CODES%60%20already%20includes%20%60EACCES%60%20for%20the%20lock%20path%3B%20the%20same%20code%20should%20be%20added%20here%20for%20consistency%20with%20the%20Windows%20safety%20convention%20used%20elsewhere%20in%20the%20codebase.%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fusage-ledger.test.ts%3A1-25%0A**No%20concurrent-append%20test%20for%20the%20new%20file-lock%20mechanism**%0A%0Athe%20file%20lock%20%28%60acquireAppendLock%60%29%20is%20the%20primary%20safety%20guarantee%20added%20in%20this%20PR%20for%20cross-process%20writes%20on%20windows.%20the%20suite%20currently%20covers%20single-writer%20retry%20behavior%20%28stale%20lock%2C%20transient%20EBUSY%20close%29%2C%20but%20there%20is%20no%20test%20that%20fires%20multiple%20%60appendUsageLedgerRow%60%20calls%20in%20parallel%20and%20asserts%20that%20all%20rows%20land%20intact%20and%20the%20lock%20file%20is%20cleaned%20up.%20given%20that%20the%20locking%20path%20is%20non-trivial%20and%20the%20project's%20convention%20is%20to%20test%20concurrent%2Frace%20behavior%20explicitly%20%28see%20%60unified-settings.test.ts%60%2C%20%60rotation-integration.test.ts%60%29%2C%20a%20parallel-write%20test%20would%20close%20this%20coverage%20gap.%0A%0A**Context%20Used%3A**%20test%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6e2636a9-e514-4bab-b249-4b4a84aa4ae3%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/usage/redaction.ts
Line: 13-32

Comment:
**Duplicate validation sets risk silent divergence**

`VALID_SOURCES`, `VALID_OPERATIONS`, and `VALID_OUTCOMES` are defined identically here and again in `ledger.ts` (lines 33–52). if a new variant is added to `UsageLedgerSource` / `UsageLedgerOperation` / `UsageLedgerOutcome` in `types.ts` but only one of the two files is updated, written rows will be accepted by `normalizeUsageLedgerRow` but then silently remapped to `"unknown"` / `"failure"` by `normalizeParsedUsageRow` on read-back, corrupting per-model and per-source summaries.

consider sharing the sets from a single location (e.g. as `const` arrays exported from `types.ts` and derived into `Set<>` at the call sites, or a thin `validation.ts` module) to prevent drift.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/usage/ledger.ts
Line: 27

Comment:
**`EACCES` missing from retryable fs codes for append and rename**

`RETRYABLE_FS_CODES = { EBUSY, EPERM }` is used in `appendFileWithRetry`, `readFileWithRetry`, and `renameWithRetry`. on windows, `fs.appendFile` and `fs.rename` can return `EACCES` (not `EPERM`) when another process holds a handle on the file. this means a transient overlap — e.g. `runtime-proxy` reading the file while `rotateUsageLedger` renames it — could throw and surface a non-retried error instead of backing off. `LOCK_RETRYABLE_FS_CODES` already includes `EACCES` for the lock path; the same code should be added here for consistency with the Windows safety convention used elsewhere in the codebase.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/usage-ledger.test.ts
Line: 1-25

Comment:
**No concurrent-append test for the new file-lock mechanism**

the file lock (`acquireAppendLock`) is the primary safety guarantee added in this PR for cross-process writes on windows. the suite currently covers single-writer retry behavior (stale lock, transient EBUSY close), but there is no test that fires multiple `appendUsageLedgerRow` calls in parallel and asserts that all rows land intact and the lock file is cleaned up. given that the locking path is non-trivial and the project's convention is to test concurrent/race behavior explicitly (see `unified-settings.test.ts`, `rotation-integration.test.ts`), a parallel-write test would close this coverage gap.

**Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["test: retry usage ledger cleanup"](https://github.com/ndycode/codex-multi-auth/commit/38a2f1bb9c8d111a2bf12a0d30555d0935c9d480) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30171487)</sub>

<!-- /greptile_comment -->