### PR TITLE
feat: add usage summary command

### DIFF
--- a/docs/development/implementation-plans/status.md
+++ b/docs/development/implementation-plans/status.md
@@ -18,7 +18,7 @@ Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 | --- | --- | --- | --- |
 | 01 | `chore/roadmap-local-governance` | Ready for review | `npm test -- test/documentation.test.ts`; `npm run build`. |
 | 02 | `feat/usage-ledger-core` | Ready for review | `npm run typecheck`; `npm test -- test/usage-ledger.test.ts`; `npm run lint`; `npm run build`. |
-| 03 | `feat/usage-command` | Pending | CLI usage command tests plus build. |
+| 03 | `feat/usage-command` | Ready for review | `npm run typecheck`; usage command/core/docs tests; `npm run lint`; `npm run build`. |
 | 04 | `feat/account-policy-controls` | Pending | Account policy command/store tests plus build. |
 | 05 | `feat/routing-profiles-core` | Pending | Routing profile storage/project tests plus build. |
 | 06 | `feat/budget-guard` | Pending | Budget guard command/evaluator tests plus build. |

--- a/docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md
@@ -1,0 +1,29 @@
+# PR 03 Handoff: Usage Command
+
+Branch: `feat/usage-command`
+Base: `origin/main` after PR 02 merge
+
+## Scope
+
+Add `codex auth usage` command behavior on top of the local usage ledger core.
+
+## Files Changed
+
+- `lib/codex-manager/commands/usage.ts`
+- `lib/codex-manager.ts`
+- `lib/codex-manager/help.ts`
+- `docs/reference/commands.md`
+- `docs/development/implementation-plans/status.md`
+- `docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md`
+
+## Validation
+
+- `npm run typecheck` passed.
+- `npm test -- test/codex-manager-usage-command.test.ts test/usage-ledger.test.ts test/documentation.test.ts` passed: 3 files, 36 tests.
+- `npm run lint` passed.
+- `npm run build` passed.
+
+## Follow-ups
+
+- PR 08 should add runtime usage row appends.
+- PR 09 should include usage summaries in `codex auth monitor`.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -57,6 +57,7 @@ Compatibility aliases are supported:
 | --- | --- |
 | `codex auth features` | Print implemented feature summary |
 | `codex auth report` | Generate full health report |
+| `codex auth usage` | Summarize local usage ledger rows |
 | `codex auth why-selected [--now|--last]` | Explain which account the selector picks now or via the last persisted runtime snapshot |
 | `codex auth rotation enable\|disable\|status\|bind-app\|unbind-app` | Manage the default-on runtime Responses proxy for live Codex account rotation |
 
@@ -68,12 +69,15 @@ Compatibility aliases are supported:
 | --- | --- | --- |
 | `--device-auth` | login | Use the OpenAI Codex device-code flow for remote/headless login (mutually exclusive with `--manual` / `--no-browser`) |
 | `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow (mutually exclusive with `--device-auth`) |
-| `--json` | verify-flagged, verify, why-selected, best, forecast, report, fix, doctor, config explain, debug bundle | Print machine-readable output |
+| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, fix, doctor, config explain, debug bundle | Print machine-readable output |
+| `--csv` | usage | Print or write CSV bucket output |
 | `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |
 | `--live` | best, forecast, report, fix | Use live probe before decisions/output |
 | `--dry-run` | verify-flagged, verify (with `--flagged`/`--all`), fix, doctor | Preview without writing storage |
 | `--model <model>` | best, forecast, report, fix | Specify model for live probe paths |
-| `--out <path>` | report | Write report output to file |
+| `--out <path>` | report, usage | Write report output to file |
+| `--since <time>` | usage | Filter local usage rows by timestamp, ISO date, or relative duration |
+| `--by <group>` | usage | Group usage by model, account, project, outcome, or day |
 | `--write <path>` | init-config, config template | Write template output to a file instead of stdout |
 | `--fix` | doctor | Apply safe repairs |
 | `--no-restore` | verify-flagged, verify (with `--flagged`/`--all`) | Verify only; do not restore healthy flagged accounts |
@@ -82,6 +86,37 @@ Compatibility aliases are supported:
 | `--all` | verify | Run both `--paths` and `--flagged` together |
 | `--now`, `-n` | why-selected | Recompute the current selection from live state (default) |
 | `--last`, `-l` | why-selected | Recompute selection from current state and attach the last persisted runtime snapshot |
+
+---
+
+## `codex auth usage`
+
+Summarizes the local usage ledger. Rows are local-only metadata and do not
+contain prompts, tokens, auth headers, raw account emails, or raw sensitive
+account ids.
+
+Usage:
+
+```bash
+codex auth usage [--since <time|duration>] [--by <model|account|project|outcome|day>] [--json|--csv] [--out <path>]
+codex auth usage rotate [--if-larger-than-bytes <bytes>] [--json]
+```
+
+Flags:
+
+- `--since`: filter rows by Unix milliseconds, ISO date, or relative duration
+  such as `24h`, `7d`, or `2w`.
+- `--by`: group summary output by `model`, `account`, `project`, `outcome`, or
+  `day`. Default: `model`.
+- `--json`, `-j`: emit machine-readable JSON including the summary and rows.
+- `--csv`: emit CSV bucket output.
+- `--out`: write the rendered output to a file.
+- `rotate`: move the current ledger to a timestamped archive.
+- `--if-larger-than-bytes`: skip rotation unless the current ledger is larger
+  than the provided byte threshold.
+
+Exit code: `0` for successful summary or rotation, `1` for invalid options or
+write failures.
 
 ---
 

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -80,6 +80,7 @@ import {
 } from "./codex-manager/commands/status.js";
 import { loadPersistedRuntimeObservabilitySnapshot } from "./runtime/runtime-observability.js";
 import { runSwitchCommand } from "./codex-manager/commands/switch.js";
+import { runUsageCommand } from "./codex-manager/commands/usage.js";
 import { parseAuthLoginArgs, printUsage } from "./codex-manager/help.js";
 import {
 	applyUiThemeFromDashboardSettings,
@@ -3470,6 +3471,9 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 			loadRuntimeObservabilitySnapshot:
 				loadPersistedRuntimeObservabilitySnapshot,
 		});
+	}
+	if (command === "usage") {
+		return runUsageCommand(rest);
 	}
 	if (command === "rotation") {
 		return runRotationCommand(rest, {

--- a/lib/codex-manager/commands/usage.ts
+++ b/lib/codex-manager/commands/usage.ts
@@ -4,6 +4,7 @@ import { sleep } from "../../utils.js";
 import {
 	readUsageLedgerRows,
 	rotateUsageLedger,
+	summarizeUsageRows,
 	summarizeUsageLedger,
 	type UsageLedgerRow,
 	type UsageSummary,
@@ -30,6 +31,7 @@ type ParsedArgsResult<T> =
 
 export interface UsageCommandDeps {
 	summarizeUsage?: typeof summarizeUsageLedger;
+	summarizeRows?: typeof summarizeUsageRows;
 	readRows?: typeof readUsageLedgerRows;
 	rotateLedger?: typeof rotateUsageLedger;
 	logInfo?: (message: string) => void;
@@ -359,10 +361,23 @@ export async function runUsageCommand(
 	}
 	const options = parsed.options;
 	const query = { since: options.since, by: options.by };
-	const [summary, rows] = await Promise.all([
-		(deps.summarizeUsage ?? summarizeUsageLedger)(query),
-		(deps.readRows ?? readUsageLedgerRows)(query),
-	]);
+	let summary: UsageSummary;
+	let rows: UsageLedgerRow[] = [];
+	try {
+		if (options.json) {
+			rows = await (deps.readRows ?? readUsageLedgerRows)(query);
+			summary = (deps.summarizeRows ?? summarizeUsageRows)(rows, query);
+		} else {
+			summary = await (deps.summarizeUsage ?? summarizeUsageLedger)(query);
+		}
+	} catch (error) {
+		logError(
+			`Failed to read usage ledger: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return 1;
+	}
 	const rendered = options.json
 		? rowsToJsonPayload(summary, rows)
 		: options.csv

--- a/lib/codex-manager/commands/usage.ts
+++ b/lib/codex-manager/commands/usage.ts
@@ -1,0 +1,384 @@
+import { promises as fs } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { sleep } from "../../utils.js";
+import {
+	readUsageLedgerRows,
+	rotateUsageLedger,
+	summarizeUsageLedger,
+	type UsageLedgerRow,
+	type UsageSummary,
+	type UsageSummaryBucket,
+	type UsageSummaryGroupBy,
+} from "../../usage/index.js";
+
+interface UsageCliOptions {
+	since?: number | Date | string;
+	by: UsageSummaryGroupBy;
+	json: boolean;
+	csv: boolean;
+	outPath?: string;
+}
+
+interface UsageRotateOptions {
+	json: boolean;
+	ifLargerThanBytes?: number;
+}
+
+type ParsedArgsResult<T> =
+	| { ok: true; options: T }
+	| { ok: false; message: string };
+
+export interface UsageCommandDeps {
+	summarizeUsage?: typeof summarizeUsageLedger;
+	readRows?: typeof readUsageLedgerRows;
+	rotateLedger?: typeof rotateUsageLedger;
+	logInfo?: (message: string) => void;
+	logError?: (message: string) => void;
+	getCwd?: () => string;
+	writeFile?: (path: string, contents: string) => Promise<void>;
+}
+
+const VALID_GROUPS = new Set<UsageSummaryGroupBy>([
+	"model",
+	"account",
+	"project",
+	"outcome",
+	"day",
+]);
+const RETRYABLE_WRITE_CODES = new Set(["EBUSY", "EPERM"]);
+
+function parsePositiveInteger(rawValue: string): number | null {
+	if (!/^\d+$/.test(rawValue.trim())) return null;
+	const parsed = Number.parseInt(rawValue, 10);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseSinceValue(value: string): number | string {
+	const trimmed = value.trim();
+	const relative = /^(\d+)(m|h|d|w)$/i.exec(trimmed);
+	if (relative?.[1] && relative[2]) {
+		const amount = Number.parseInt(relative[1], 10);
+		const unit = relative[2].toLowerCase();
+		const multiplier =
+			unit === "m"
+				? 60_000
+				: unit === "h"
+					? 3_600_000
+					: unit === "d"
+						? 86_400_000
+						: 604_800_000;
+		return Date.now() - amount * multiplier;
+	}
+	if (/^\d+$/.test(trimmed)) {
+		return Number.parseInt(trimmed, 10);
+	}
+	return trimmed;
+}
+
+function printUsageCommandHelp(logInfo: (message: string) => void): void {
+	logInfo(
+		[
+			"Usage:",
+			"  codex auth usage [--since <time|duration>] [--by <model|account|project|outcome|day>] [--json|--csv] [--out <path>]",
+			"  codex auth usage rotate [--if-larger-than-bytes <bytes>] [--json]",
+			"",
+			"Options:",
+			"  --since            Filter rows by timestamp, ISO date, or relative duration like 24h, 7d, 2w",
+			"  --by               Group summary output (default: model)",
+			"  --json, -j         Print machine-readable JSON output",
+			"  --csv              Print or write CSV bucket output",
+			"  --out              Write output to a file path",
+			"",
+			"Notes:",
+			"  - Usage rows contain local metadata only, not prompts, tokens, auth headers, raw emails, or raw account ids.",
+		].join("\n"),
+	);
+}
+
+function parseUsageArgs(args: string[]): ParsedArgsResult<UsageCliOptions> {
+	const options: UsageCliOptions = {
+		by: "model",
+		json: false,
+		csv: false,
+	};
+
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (!arg) continue;
+		if (arg === "--json" || arg === "-j") {
+			options.json = true;
+			continue;
+		}
+		if (arg === "--csv") {
+			options.csv = true;
+			continue;
+		}
+		if (arg === "--since") {
+			const value = args[i + 1];
+			if (!value) return { ok: false, message: "Missing value for --since" };
+			options.since = parseSinceValue(value);
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--since=")) {
+			const value = arg.slice("--since=".length).trim();
+			if (!value) return { ok: false, message: "Missing value for --since" };
+			options.since = parseSinceValue(value);
+			continue;
+		}
+		if (arg === "--by") {
+			const value = args[i + 1];
+			if (!value) return { ok: false, message: "Missing value for --by" };
+			if (!VALID_GROUPS.has(value as UsageSummaryGroupBy)) {
+				return { ok: false, message: `Unknown --by value: ${value}` };
+			}
+			options.by = value as UsageSummaryGroupBy;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--by=")) {
+			const value = arg.slice("--by=".length).trim();
+			if (!VALID_GROUPS.has(value as UsageSummaryGroupBy)) {
+				return { ok: false, message: `Unknown --by value: ${value}` };
+			}
+			options.by = value as UsageSummaryGroupBy;
+			continue;
+		}
+		if (arg === "--out") {
+			const value = args[i + 1];
+			if (!value) return { ok: false, message: "Missing value for --out" };
+			options.outPath = value;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--out=")) {
+			const value = arg.slice("--out=".length).trim();
+			if (!value) return { ok: false, message: "Missing value for --out" };
+			options.outPath = value;
+			continue;
+		}
+		return { ok: false, message: `Unknown usage option: ${arg}` };
+	}
+
+	if (options.json && options.csv) {
+		return { ok: false, message: "Cannot combine --json and --csv" };
+	}
+	return { ok: true, options };
+}
+
+function parseRotateArgs(args: string[]): ParsedArgsResult<UsageRotateOptions> {
+	const options: UsageRotateOptions = { json: false };
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (!arg) continue;
+		if (arg === "--json" || arg === "-j") {
+			options.json = true;
+			continue;
+		}
+		if (arg === "--if-larger-than-bytes") {
+			const value = args[i + 1];
+			if (!value) {
+				return {
+					ok: false,
+					message: "Missing value for --if-larger-than-bytes",
+				};
+			}
+			const parsed = parsePositiveInteger(value);
+			if (parsed === null) {
+				return {
+					ok: false,
+					message: "--if-larger-than-bytes must be a positive integer",
+				};
+			}
+			options.ifLargerThanBytes = parsed;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--if-larger-than-bytes=")) {
+			const parsed = parsePositiveInteger(
+				arg.slice("--if-larger-than-bytes=".length),
+			);
+			if (parsed === null) {
+				return {
+					ok: false,
+					message: "--if-larger-than-bytes must be a positive integer",
+				};
+			}
+			options.ifLargerThanBytes = parsed;
+			continue;
+		}
+		return { ok: false, message: `Unknown usage rotate option: ${arg}` };
+	}
+	return { ok: true, options };
+}
+
+function formatCurrency(value: number): string {
+	return `$${value.toFixed(6)}`;
+}
+
+function formatTextSummary(summary: UsageSummary): string {
+	const lines = [
+		`Usage summary by ${summary.by}`,
+		`Requests: ${summary.totals.requests} (${summary.totals.successes} success, ${summary.totals.failures} failed, ${summary.totals.blocked} blocked, ${summary.totals.cancelled} cancelled)`,
+		`Tokens: ${summary.totals.totalTokens} total (${summary.totals.inputTokens} input, ${summary.totals.outputTokens} output, ${summary.totals.cachedInputTokens} cached, ${summary.totals.reasoningTokens} reasoning)`,
+		`Estimated cost: ${formatCurrency(summary.totals.costUsd)}`,
+	];
+	if (summary.buckets.length === 0) {
+		lines.push("No usage rows found.");
+		return lines.join("\n");
+	}
+	lines.push("");
+	for (const bucket of summary.buckets) {
+		lines.push(
+			`${bucket.key}: ${bucket.requests} request(s), ${bucket.totalTokens} token(s), ${formatCurrency(bucket.costUsd)}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function csvEscape(value: string | number): string {
+	const text = String(value);
+	return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+function bucketToCsvRow(bucket: UsageSummaryBucket): string {
+	return [
+		bucket.key,
+		bucket.requests,
+		bucket.successes,
+		bucket.failures,
+		bucket.blocked,
+		bucket.cancelled,
+		bucket.inputTokens,
+		bucket.outputTokens,
+		bucket.cachedInputTokens,
+		bucket.reasoningTokens,
+		bucket.totalTokens,
+		bucket.costUsd.toFixed(8),
+	]
+		.map(csvEscape)
+		.join(",");
+}
+
+function formatCsvSummary(summary: UsageSummary): string {
+	return [
+		"key,requests,successes,failures,blocked,cancelled,inputTokens,outputTokens,cachedInputTokens,reasoningTokens,totalTokens,costUsd",
+		...summary.buckets.map(bucketToCsvRow),
+		...(summary.buckets.length === 0 ? [bucketToCsvRow(summary.totals)] : []),
+	].join("\n");
+}
+
+function rowsToJsonPayload(summary: UsageSummary, rows: UsageLedgerRow[]): string {
+	return JSON.stringify(
+		{
+			command: "usage",
+			summary,
+			rows,
+		},
+		null,
+		2,
+	);
+}
+
+function isRetryableWriteError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_WRITE_CODES.has(code);
+}
+
+async function defaultWriteFile(path: string, contents: string): Promise<void> {
+	await fs.mkdir(dirname(path), { recursive: true });
+	const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+	let moved = false;
+	try {
+		await fs.writeFile(tempPath, contents, "utf-8");
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			try {
+				await fs.rename(tempPath, path);
+				moved = true;
+				return;
+			} catch (error) {
+				if (!isRetryableWriteError(error) || attempt >= 4) throw error;
+				await sleep(10 * 2 ** attempt);
+			}
+		}
+	} finally {
+		if (!moved) {
+			try {
+				await fs.unlink(tempPath);
+			} catch {
+				// Best-effort temp cleanup.
+			}
+		}
+	}
+}
+
+export async function runUsageCommand(
+	args: string[],
+	deps: UsageCommandDeps = {},
+): Promise<number> {
+	const logInfo = deps.logInfo ?? console.log;
+	const logError = deps.logError ?? console.error;
+	if (args.includes("--help") || args.includes("-h")) {
+		printUsageCommandHelp(logInfo);
+		return 0;
+	}
+
+	const [subcommand, ...rest] = args;
+	if (subcommand === "rotate") {
+		const parsed = parseRotateArgs(rest);
+		if (!parsed.ok) {
+			logError(parsed.message);
+			return 1;
+		}
+		const rotatedPath = await (deps.rotateLedger ?? rotateUsageLedger)({
+			ifLargerThanBytes: parsed.options.ifLargerThanBytes,
+		});
+		if (parsed.options.json) {
+			logInfo(
+				JSON.stringify({
+					command: "usage rotate",
+					rotated: rotatedPath !== null,
+					path: rotatedPath,
+				}),
+			);
+		} else {
+			logInfo(
+				rotatedPath
+					? `Usage ledger rotated: ${rotatedPath}`
+					: "Usage ledger rotation skipped.",
+			);
+		}
+		return 0;
+	}
+
+	const parsed = parseUsageArgs(args);
+	if (!parsed.ok) {
+		logError(parsed.message);
+		printUsageCommandHelp(logInfo);
+		return 1;
+	}
+	const options = parsed.options;
+	const query = { since: options.since, by: options.by };
+	const [summary, rows] = await Promise.all([
+		(deps.summarizeUsage ?? summarizeUsageLedger)(query),
+		(deps.readRows ?? readUsageLedgerRows)(query),
+	]);
+	const rendered = options.json
+		? rowsToJsonPayload(summary, rows)
+		: options.csv
+			? formatCsvSummary(summary)
+			: formatTextSummary(summary);
+
+	if (options.outPath) {
+		const outputPath = resolve(deps.getCwd?.() ?? process.cwd(), options.outPath);
+		await (deps.writeFile ?? defaultWriteFile)(outputPath, `${rendered}\n`);
+		if (!options.json && !options.csv) {
+			logInfo(`Usage report written: ${outputPath}`);
+		}
+		return 0;
+	}
+
+	logInfo(rendered);
+	return 0;
+}
+

--- a/lib/codex-manager/commands/usage.ts
+++ b/lib/codex-manager/commands/usage.ts
@@ -332,9 +332,19 @@ export async function runUsageCommand(
 			logError(parsed.message);
 			return 1;
 		}
-		const rotatedPath = await (deps.rotateLedger ?? rotateUsageLedger)({
-			ifLargerThanBytes: parsed.options.ifLargerThanBytes,
-		});
+		let rotatedPath: string | null;
+		try {
+			rotatedPath = await (deps.rotateLedger ?? rotateUsageLedger)({
+				ifLargerThanBytes: parsed.options.ifLargerThanBytes,
+			});
+		} catch (error) {
+			logError(
+				`Failed to rotate usage ledger: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			return 1;
+		}
 		if (parsed.options.json) {
 			logInfo(
 				JSON.stringify({
@@ -386,7 +396,16 @@ export async function runUsageCommand(
 
 	if (options.outPath) {
 		const outputPath = resolve(deps.getCwd?.() ?? process.cwd(), options.outPath);
-		await (deps.writeFile ?? defaultWriteFile)(outputPath, `${rendered}\n`);
+		try {
+			await (deps.writeFile ?? defaultWriteFile)(outputPath, `${rendered}\n`);
+		} catch (error) {
+			logError(
+				`Failed to write usage report: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			return 1;
+		}
 		if (!options.json && !options.csv) {
 			logInfo(`Usage report written: ${outputPath}`);
 		}

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -21,6 +21,7 @@ export function printUsage(): void {
 			"  codex auth doctor [--json] [--fix] [--dry-run]",
 			"",
 			"Diagnostics:",
+			"  codex auth usage [--since <time|duration>] [--by <group>] [--json|--csv] [--out <path>]",
 			"  codex auth rotation <enable|disable|status|bind-app|unbind-app>",
 			"  codex auth rotation reset-rate-limits [--all | --account <idx>] [--dry-run] [--json]",
 			"  codex auth why-selected [--now | --last] [--json]",

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -112,6 +112,25 @@ async function removeStaleLockIfNeeded(lockPath: string): Promise<boolean> {
 	}
 }
 
+async function closeLockHandleWithRetry(
+	handle: Awaited<ReturnType<typeof fs.open>>,
+): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await handle.close();
+			return;
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableLockError(error)) throw error;
+			await sleep(Math.min(250, 10 * 2 ** attempt));
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger lock handle close retry exhausted");
+}
+
 async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>> {
 	const started = Date.now();
 	let attempt = 0;
@@ -123,17 +142,24 @@ async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>>
 				JSON.stringify({ pid: process.pid, createdAt: Date.now() }) + "\n",
 				"utf8",
 			);
+			const lockHandle = handle;
 			let released = false;
 			return async () => {
 				if (released) return;
 				released = true;
-				await handle?.close();
+				let closeError: unknown;
+				try {
+					await closeLockHandleWithRetry(lockHandle);
+				} catch (error) {
+					closeError = error;
+				}
 				await unlinkWithRetry(lockPath);
+				if (closeError) throw closeError;
 			};
 		} catch (error) {
 			if (handle) {
 				try {
-					await handle.close();
+					await closeLockHandleWithRetry(handle);
 				} catch {
 					// Best-effort cleanup after a failed lock metadata write.
 				}

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -25,6 +25,9 @@ import type {
 const USAGE_DIR_NAME = "usage";
 const USAGE_LEDGER_FILE_NAME = "usage-ledger.jsonl";
 const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+const LOCK_RETRYABLE_FS_CODES = new Set(["EACCES", "EBUSY", "EEXIST", "EPERM"]);
+const LOCK_STALE_MS = 30_000;
+const LOCK_MAX_WAIT_MS = 10_000;
 let appendQueue: Promise<void> = Promise.resolve();
 
 const VALID_SOURCES = new Set<UsageLedgerSource>([
@@ -53,6 +56,15 @@ function isRetryableFsError(error: unknown): boolean {
 	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
 }
 
+function isRetryableLockError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && LOCK_RETRYABLE_FS_CODES.has(code);
+}
+
+function isMissingFileError(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
 function normalizeTimestamp(value: number | Date | string | undefined): number | null {
 	if (value === undefined) return null;
 	if (value instanceof Date) {
@@ -66,13 +78,14 @@ function normalizeTimestamp(value: number | Date | string | undefined): number |
 	return Number.isFinite(parsed) ? parsed : null;
 }
 
-async function appendFileWithRetry(path: string, line: string): Promise<void> {
+async function unlinkWithRetry(path: string): Promise<void> {
 	let lastError: unknown;
 	for (let attempt = 0; attempt < 5; attempt += 1) {
 		try {
-			await fs.appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+			await fs.unlink(path);
 			return;
 		} catch (error) {
+			if (isMissingFileError(error)) return;
 			lastError = error;
 			if (!isRetryableFsError(error) || attempt >= 4) {
 				throw error;
@@ -82,7 +95,94 @@ async function appendFileWithRetry(path: string, line: string): Promise<void> {
 	}
 	throw lastError instanceof Error
 		? lastError
-		: new Error("usage ledger append retry exhausted");
+		: new Error("usage ledger lock cleanup retry exhausted");
+}
+
+async function removeStaleLockIfNeeded(lockPath: string): Promise<boolean> {
+	try {
+		const stat = await fs.stat(lockPath);
+		if (Date.now() - stat.mtimeMs < LOCK_STALE_MS) {
+			return false;
+		}
+		await unlinkWithRetry(lockPath);
+		return true;
+	} catch (error) {
+		if (isMissingFileError(error)) return true;
+		throw error;
+	}
+}
+
+async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>> {
+	const started = Date.now();
+	let attempt = 0;
+	while (true) {
+		let handle: Awaited<ReturnType<typeof fs.open>> | null = null;
+		try {
+			handle = await fs.open(lockPath, "wx", 0o600);
+			await handle.writeFile(
+				JSON.stringify({ pid: process.pid, createdAt: Date.now() }) + "\n",
+				"utf8",
+			);
+			let released = false;
+			return async () => {
+				if (released) return;
+				released = true;
+				await handle?.close();
+				await unlinkWithRetry(lockPath);
+			};
+		} catch (error) {
+			if (handle) {
+				try {
+					await handle.close();
+				} catch {
+					// Best-effort cleanup after a failed lock metadata write.
+				}
+				await unlinkWithRetry(lockPath);
+			}
+			if (!isRetryableLockError(error)) {
+				throw error;
+			}
+			await removeStaleLockIfNeeded(lockPath);
+			if (Date.now() - started >= LOCK_MAX_WAIT_MS) {
+				throw new Error(`Timed out waiting for usage ledger lock: ${lockPath}`);
+			}
+			await sleep(Math.min(250, 10 * 2 ** Math.min(attempt, 5)));
+			attempt += 1;
+		}
+	}
+}
+
+async function appendFileWithRetry(path: string, line: string): Promise<void> {
+	const release = await acquireAppendLock(`${path}.lock`);
+	let lastError: unknown;
+	try {
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			try {
+				await fs.appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+				return;
+			} catch (error) {
+				lastError = error;
+				if (!isRetryableFsError(error) || attempt >= 4) {
+					throw error;
+				}
+				await sleep(10 * 2 ** attempt);
+			}
+		}
+		throw lastError instanceof Error
+			? lastError
+			: new Error("usage ledger append retry exhausted");
+	} finally {
+		await release();
+	}
+}
+
+async function runWithAppendQueue<T>(task: () => Promise<T>): Promise<T> {
+	const queued = appendQueue.catch(() => undefined).then(task);
+	appendQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	return queued;
 }
 
 async function readFileWithRetry(path: string): Promise<string> {
@@ -136,16 +236,10 @@ export async function appendUsageLedgerRow(
 	const row = normalizeUsageLedgerRow(input);
 	const { dir, current } = getUsageLedgerPaths();
 	const line = usageRowToJsonLine(row);
-	const task = async (): Promise<void> => {
+	await runWithAppendQueue(async () => {
 		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
 		await appendFileWithRetry(current, line);
-	};
-	const queued = appendQueue.catch(() => undefined).then(task);
-	appendQueue = queued.then(
-		() => undefined,
-		() => undefined,
-	);
-	await queued;
+	});
 	return row;
 }
 
@@ -370,14 +464,17 @@ function addRowToBucket(bucket: UsageSummaryBucket, row: UsageLedgerRow): void {
 	bucket.costUsd = Number((bucket.costUsd + (row.costUsd ?? 0)).toFixed(8));
 }
 
-export async function summarizeUsageLedger(
+export function summarizeUsageRows(
+	rows: UsageLedgerRow[],
 	query: UsageSummaryQuery = {},
-): Promise<UsageSummary> {
+): UsageSummary {
 	const by = query.by ?? "model";
-	const rows = await readUsageLedgerRows(query);
+	const filteredRows = filterRows(rows, query).sort(
+		(a, b) => a.createdAt - b.createdAt,
+	);
 	const totals = createBucket("total");
 	const buckets = new Map<string, UsageSummaryBucket>();
-	for (const row of rows) {
+	for (const row of filteredRows) {
 		addRowToBucket(totals, row);
 		const key = getBucketKey(row, by);
 		const bucket = buckets.get(key) ?? createBucket(key);
@@ -396,29 +493,42 @@ export async function summarizeUsageLedger(
 	};
 }
 
+export async function summarizeUsageLedger(
+	query: UsageSummaryQuery = {},
+): Promise<UsageSummary> {
+	return summarizeUsageRows(await readUsageLedgerRows(query), query);
+}
+
 export async function rotateUsageLedger(options: {
 	now?: number;
 	ifLargerThanBytes?: number;
 } = {}): Promise<string | null> {
 	const { dir, current } = getUsageLedgerPaths();
-	if (!existsSync(current)) {
-		return null;
-	}
-	const stat = await fs.stat(current);
-	if (
-		typeof options.ifLargerThanBytes === "number" &&
-		stat.size <= options.ifLargerThanBytes
-	) {
-		return null;
-	}
-	await fs.mkdir(dir, { recursive: true, mode: 0o700 });
-	const stamp = new Date(options.now ?? Date.now())
-		.toISOString()
-		.replace(/[-:]/g, "")
-		.replace(".", "");
-	const rotated = join(dir, `usage-ledger.${stamp}.jsonl`);
-	await renameWithRetry(current, rotated);
-	return rotated;
+	return runWithAppendQueue(async () => {
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+		const release = await acquireAppendLock(`${current}.lock`);
+		try {
+			if (!existsSync(current)) {
+				return null;
+			}
+			const stat = await fs.stat(current);
+			if (
+				typeof options.ifLargerThanBytes === "number" &&
+				stat.size <= options.ifLargerThanBytes
+			) {
+				return null;
+			}
+			const stamp = new Date(options.now ?? Date.now())
+				.toISOString()
+				.replace(/[-:]/g, "")
+				.replace(".", "");
+			const rotated = join(dir, `usage-ledger.${stamp}.jsonl`);
+			await renameWithRetry(current, rotated);
+			return rotated;
+		} finally {
+			await release();
+		}
+	});
 }
 
 export function resetUsageLedgerQueueForTests(): void {

--- a/lib/usage/pricing.ts
+++ b/lib/usage/pricing.ts
@@ -7,13 +7,6 @@ export interface UsageModelPricing {
 	reasoningUsdPerMillion?: number;
 }
 
-const DEFAULT_PRICING: UsageModelPricing = {
-	inputUsdPerMillion: 0,
-	outputUsdPerMillion: 0,
-	cachedInputUsdPerMillion: 0,
-	reasoningUsdPerMillion: 0,
-};
-
 const MODEL_PRICING: Record<string, UsageModelPricing> = {
 	"gpt-5-codex": {
 		inputUsdPerMillion: 1.25,
@@ -65,7 +58,7 @@ export function getUsageModelPricing(
 	if (!normalized) {
 		return null;
 	}
-	return MODEL_PRICING[normalized] ?? DEFAULT_PRICING;
+	return MODEL_PRICING[normalized] ?? null;
 }
 
 export function estimateUsageCostUsd(
@@ -77,8 +70,12 @@ export function estimateUsageCostUsd(
 		return null;
 	}
 
+	const billableInputTokens = Math.max(
+		0,
+		tokens.inputTokens - tokens.cachedInputTokens,
+	);
 	const input =
-		(tokens.inputTokens / 1_000_000) * pricing.inputUsdPerMillion;
+		(billableInputTokens / 1_000_000) * pricing.inputUsdPerMillion;
 	const output =
 		(tokens.outputTokens / 1_000_000) * pricing.outputUsdPerMillion;
 	const cached =

--- a/lib/usage/redaction.ts
+++ b/lib/usage/redaction.ts
@@ -115,8 +115,7 @@ function normalizeTokens(input: UsageLedgerAppendInput): UsageTokenCounts {
 	const cachedInputTokens = normalizeNonNegativeInteger(input.cachedInputTokens);
 	const reasoningTokens = normalizeNonNegativeInteger(input.reasoningTokens);
 	const providedTotal = normalizeFiniteNumber(input.totalTokens);
-	const computedTotal =
-		inputTokens + outputTokens + cachedInputTokens + reasoningTokens;
+	const computedTotal = inputTokens + outputTokens + reasoningTokens;
 
 	return {
 		inputTokens,

--- a/test/codex-manager-usage-command.test.ts
+++ b/test/codex-manager-usage-command.test.ts
@@ -70,13 +70,15 @@ const rows: UsageLedgerRow[] = [
 describe("usage command", () => {
 	it("prints text summaries by default", async () => {
 		const logInfo = vi.fn();
+		const readRows = vi.fn(async () => rows);
 		const exitCode = await runUsageCommand([], {
 			logInfo,
 			summarizeUsage: async () => makeSummary(),
-			readRows: async () => rows,
+			readRows,
 		});
 
 		expect(exitCode).toBe(0);
+		expect(readRows).not.toHaveBeenCalled();
 		expect(String(logInfo.mock.calls[0]?.[0])).toContain(
 			"Usage summary by model",
 		);
@@ -99,18 +101,21 @@ describe("usage command", () => {
 		};
 		expect(payload.command).toBe("usage");
 		expect(payload.rows[0]?.id).toBe("row-1");
-		expect(payload.summary.totals.requests).toBe(2);
+		expect(payload.summary.totals.requests).toBe(1);
+		expect(payload.summary.totals.totalTokens).toBe(rows[0]?.tokens.totalTokens);
 	});
 
 	it("prints csv output", async () => {
 		const logInfo = vi.fn();
+		const readRows = vi.fn(async () => rows);
 		const exitCode = await runUsageCommand(["--csv", "--by", "day"], {
 			logInfo,
 			summarizeUsage: async (query) => makeSummary({ by: query.by }),
-			readRows: async () => rows,
+			readRows,
 		});
 
 		expect(exitCode).toBe(0);
+		expect(readRows).not.toHaveBeenCalled();
 		const output = String(logInfo.mock.calls[0]?.[0]);
 		expect(output).toContain("key,requests,successes");
 		expect(output).toContain("gpt-5.3-codex,2,1,1");
@@ -119,15 +124,17 @@ describe("usage command", () => {
 	it("writes rendered output to a file", async () => {
 		const writeFile = vi.fn(async () => undefined);
 		const logInfo = vi.fn();
+		const readRows = vi.fn(async () => rows);
 		const exitCode = await runUsageCommand(["--out", "usage.txt"], {
 			logInfo,
 			writeFile,
 			getCwd: () => "/workspace",
 			summarizeUsage: async () => makeSummary(),
-			readRows: async () => rows,
+			readRows,
 		});
 
 		expect(exitCode).toBe(0);
+		expect(readRows).not.toHaveBeenCalled();
 		expect(writeFile).toHaveBeenCalledWith(
 			expect.stringContaining("usage.txt"),
 			expect.stringContaining("Usage summary by model"),
@@ -165,6 +172,22 @@ describe("usage command", () => {
 		expect(exitCode).toBe(1);
 		expect(String(logError.mock.calls[0]?.[0])).toContain(
 			"Cannot combine --json and --csv",
+		);
+	});
+
+	it("reports ledger read failures without uncaught rejections", async () => {
+		const logError = vi.fn();
+		const exitCode = await runUsageCommand(["--json"], {
+			logError,
+			logInfo: vi.fn(),
+			readRows: async () => {
+				throw new Error("read failed");
+			},
+		});
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Failed to read usage ledger: read failed",
 		);
 	});
 });

--- a/test/codex-manager-usage-command.test.ts
+++ b/test/codex-manager-usage-command.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UsageLedgerRow, UsageSummary } from "../lib/usage/index.js";
+import { runUsageCommand } from "../lib/codex-manager/commands/usage.js";
+
+function makeSummary(overrides: Partial<UsageSummary> = {}): UsageSummary {
+	return {
+		since: null,
+		until: null,
+		by: "model",
+		totals: {
+			key: "total",
+			requests: 2,
+			successes: 1,
+			failures: 1,
+			blocked: 0,
+			cancelled: 0,
+			inputTokens: 100,
+			outputTokens: 50,
+			cachedInputTokens: 25,
+			reasoningTokens: 10,
+			totalTokens: 185,
+			costUsd: 0.01234567,
+		},
+		buckets: [
+			{
+				key: "gpt-5.3-codex",
+				requests: 2,
+				successes: 1,
+				failures: 1,
+				blocked: 0,
+				cancelled: 0,
+				inputTokens: 100,
+				outputTokens: 50,
+				cachedInputTokens: 25,
+				reasoningTokens: 10,
+				totalTokens: 185,
+				costUsd: 0.01234567,
+			},
+		],
+		...overrides,
+	};
+}
+
+const rows: UsageLedgerRow[] = [
+	{
+		version: 1,
+		id: "row-1",
+		createdAt: 100,
+		source: "runtime-proxy",
+		operation: "responses",
+		outcome: "success",
+		model: "gpt-5.3-codex",
+		projectKey: null,
+		account: null,
+		requestId: null,
+		statusCode: 200,
+		errorCode: null,
+		durationMs: 10,
+		tokens: {
+			inputTokens: 100,
+			outputTokens: 50,
+			cachedInputTokens: 25,
+			reasoningTokens: 10,
+			totalTokens: 185,
+		},
+		costUsd: 0.01234567,
+	},
+];
+
+describe("usage command", () => {
+	it("prints text summaries by default", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand([], {
+			logInfo,
+			summarizeUsage: async () => makeSummary(),
+			readRows: async () => rows,
+		});
+
+		expect(exitCode).toBe(0);
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain(
+			"Usage summary by model",
+		);
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain("gpt-5.3-codex");
+	});
+
+	it("prints json payloads with rows", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand(["--json"], {
+			logInfo,
+			summarizeUsage: async () => makeSummary(),
+			readRows: async () => rows,
+		});
+
+		expect(exitCode).toBe(0);
+		const payload = JSON.parse(String(logInfo.mock.calls[0]?.[0])) as {
+			command: string;
+			rows: UsageLedgerRow[];
+			summary: UsageSummary;
+		};
+		expect(payload.command).toBe("usage");
+		expect(payload.rows[0]?.id).toBe("row-1");
+		expect(payload.summary.totals.requests).toBe(2);
+	});
+
+	it("prints csv output", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand(["--csv", "--by", "day"], {
+			logInfo,
+			summarizeUsage: async (query) => makeSummary({ by: query.by }),
+			readRows: async () => rows,
+		});
+
+		expect(exitCode).toBe(0);
+		const output = String(logInfo.mock.calls[0]?.[0]);
+		expect(output).toContain("key,requests,successes");
+		expect(output).toContain("gpt-5.3-codex,2,1,1");
+	});
+
+	it("writes rendered output to a file", async () => {
+		const writeFile = vi.fn(async () => undefined);
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand(["--out", "usage.txt"], {
+			logInfo,
+			writeFile,
+			getCwd: () => "/workspace",
+			summarizeUsage: async () => makeSummary(),
+			readRows: async () => rows,
+		});
+
+		expect(exitCode).toBe(0);
+		expect(writeFile).toHaveBeenCalledWith(
+			expect.stringContaining("usage.txt"),
+			expect.stringContaining("Usage summary by model"),
+		);
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain("Usage report written");
+	});
+
+	it("rotates the ledger", async () => {
+		const logInfo = vi.fn();
+		const rotateLedger = vi.fn(async () => "/usage/usage-ledger.rotated.jsonl");
+		const exitCode = await runUsageCommand(
+			["rotate", "--if-larger-than-bytes", "10", "--json"],
+			{
+				logInfo,
+				rotateLedger,
+			},
+		);
+
+		expect(exitCode).toBe(0);
+		expect(rotateLedger).toHaveBeenCalledWith({ ifLargerThanBytes: 10 });
+		expect(JSON.parse(String(logInfo.mock.calls[0]?.[0]))).toEqual({
+			command: "usage rotate",
+			rotated: true,
+			path: "/usage/usage-ledger.rotated.jsonl",
+		});
+	});
+
+	it("rejects invalid options", async () => {
+		const logError = vi.fn();
+		const exitCode = await runUsageCommand(["--json", "--csv"], {
+			logError,
+			logInfo: vi.fn(),
+		});
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Cannot combine --json and --csv",
+		);
+	});
+});
+

--- a/test/codex-manager-usage-command.test.ts
+++ b/test/codex-manager-usage-command.test.ts
@@ -162,6 +162,23 @@ describe("usage command", () => {
 		});
 	});
 
+	it("reports rotate failures without uncaught rejections", async () => {
+		const logError = vi.fn();
+		const rotateLedger = vi.fn(async () => {
+			throw new Error("rename denied");
+		});
+		const exitCode = await runUsageCommand(["rotate"], {
+			logError,
+			logInfo: vi.fn(),
+			rotateLedger,
+		});
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Failed to rotate usage ledger: rename denied",
+		);
+	});
+
 	it("rejects invalid options", async () => {
 		const logError = vi.fn();
 		const exitCode = await runUsageCommand(["--json", "--csv"], {
@@ -188,6 +205,25 @@ describe("usage command", () => {
 		expect(exitCode).toBe(1);
 		expect(String(logError.mock.calls[0]?.[0])).toContain(
 			"Failed to read usage ledger: read failed",
+		);
+	});
+
+	it("reports output write failures without uncaught rejections", async () => {
+		const logError = vi.fn();
+		const writeFile = vi.fn(async () => {
+			throw new Error("disk full");
+		});
+		const exitCode = await runUsageCommand(["--out", "usage.txt"], {
+			logError,
+			logInfo: vi.fn(),
+			writeFile,
+			getCwd: () => "/workspace",
+			summarizeUsage: async () => makeSummary(),
+		});
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Failed to write usage report: disk full",
 		);
 	});
 });

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -328,7 +328,7 @@ describe("Documentation Integrity", () => {
 
 		expect(readme).toContain("codex auth fix --live --model gpt-5.3-codex");
 		expect(commandRef).toContain(
-			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, fix, doctor, config explain, debug bundle |",
+			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, fix, doctor, config explain, debug bundle |",
 		);
 		expect(commandRef).toContain(
 			"| `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |",

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -122,12 +122,17 @@ describe("usage ledger core", () => {
 			outcome: "success",
 			model: "gpt-5.3-codex",
 		});
+		const lockPath = `${getUsageLedgerPaths().current}.lock`;
+		await fs.writeFile(lockPath, "stale\n", "utf8");
+		const staleDate = new Date(Date.now() - 60_000);
+		await fs.utimes(lockPath, staleDate, staleDate);
 
 		const rotated = await rotateUsageLedger({
 			now: Date.UTC(2026, 0, 2, 3, 4, 5, 6),
 		});
 
 		expect(rotated).toContain("usage-ledger.20260102T030405006Z.jsonl");
+		await expect(fs.stat(lockPath)).rejects.toThrow();
 		await expect(fs.stat(getUsageLedgerPaths().current)).rejects.toThrow();
 
 		await appendUsageLedgerRow({
@@ -177,9 +182,27 @@ describe("usage ledger core", () => {
 				reasoningTokens: 1_000_000,
 				totalTokens: 4_000_000,
 			}),
-		).toBe(21.375);
+		).toBe(20.125);
+		expect(
+			estimateUsageCostUsd("gpt-5.3-codex", {
+				inputTokens: 1_000,
+				outputTokens: 200,
+				cachedInputTokens: 50,
+				reasoningTokens: 25,
+				totalTokens: 1_275,
+			}),
+		).toBe(0.00344375);
 		expect(
 			estimateUsageCostUsd(null, {
+				inputTokens: 1,
+				outputTokens: 1,
+				cachedInputTokens: 0,
+				reasoningTokens: 0,
+				totalTokens: 2,
+			}),
+		).toBeNull();
+		expect(
+			estimateUsageCostUsd("unknown-model", {
 				inputTokens: 1,
 				outputTokens: 1,
 				cachedInputTokens: 0,
@@ -213,6 +236,30 @@ describe("usage ledger core", () => {
 		} finally {
 			appendSpy.mockRestore();
 		}
+	});
+
+	it("removes stale append locks before writing", async () => {
+		const {
+			appendUsageLedgerRow,
+			getUsageLedgerPaths,
+			readUsageLedgerRows,
+		} = await import("../lib/usage/index.js");
+		const { dir, current } = getUsageLedgerPaths();
+		const lockPath = `${current}.lock`;
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(lockPath, "stale\n", "utf8");
+		const staleDate = new Date(Date.now() - 60_000);
+		await fs.utimes(lockPath, staleDate, staleDate);
+
+		await appendUsageLedgerRow({
+			id: "after-stale-lock",
+			outcome: "success",
+		});
+
+		await expect(fs.stat(lockPath)).rejects.toThrow();
+		expect((await readUsageLedgerRows()).map((row) => row.id)).toEqual([
+			"after-stale-lock",
+		]);
 	});
 });
 

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 describe("usage ledger core", () => {
 	let tempDir: string;
@@ -20,7 +21,7 @@ describe("usage ledger core", () => {
 		} else {
 			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
 		}
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetry(tempDir, { recursive: true, force: true });
 	});
 
 	it("appends normalized JSONL rows without raw email or account identifiers", async () => {

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -169,6 +169,39 @@ describe("usage ledger core", () => {
 		).resolves.toBeNull();
 	});
 
+	it("retries transient lock close failures before removing the lock", async () => {
+		const realOpen = fs.open.bind(fs);
+		const openSpy = vi.spyOn(fs, "open");
+		openSpy.mockImplementationOnce(async (...args: Parameters<typeof fs.open>) => {
+			const handle = await realOpen(...args);
+			let closeAttempts = 0;
+			return new Proxy(handle, {
+				get(target, property, receiver) {
+					if (property === "close") {
+						return async () => {
+							closeAttempts += 1;
+							if (closeAttempts === 1) {
+								throw Object.assign(new Error("close busy"), { code: "EBUSY" });
+							}
+							return target.close();
+						};
+					}
+					return Reflect.get(target, property, receiver);
+				},
+			}) as Awaited<ReturnType<typeof fs.open>>;
+		});
+		const { appendUsageLedgerRow, getUsageLedgerPaths } = await import(
+			"../lib/usage/index.js"
+		);
+
+		await appendUsageLedgerRow({ id: "close-retry", outcome: "success" });
+
+		const paths = getUsageLedgerPaths();
+		await expect(fs.access(`${paths.current}.lock`)).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+	});
+
 	it("exports pricing helpers with deterministic estimates", async () => {
 		const { estimateUsageCostUsd, listUsageModelPricing } = await import(
 			"../lib/usage/index.js"

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -53,7 +53,8 @@ describe("usage ledger core", () => {
 		expect(row.account?.accountHash).toMatch(/^sha256:/);
 		expect(row.account?.emailHash).toMatch(/^sha256:/);
 		expect(row.account?.index).toBe(2);
-		expect(row.tokens.totalTokens).toBe(1_275);
+		expect(row.tokens.totalTokens).toBe(1_225);
+		expect(row.tokens.cachedInputTokens).toBe(50);
 		expect(row.costUsd).toBeGreaterThan(0);
 
 		const raw = await fs.readFile(getUsageLedgerPaths().current, "utf8");
@@ -189,7 +190,7 @@ describe("usage ledger core", () => {
 				outputTokens: 200,
 				cachedInputTokens: 50,
 				reasoningTokens: 25,
-				totalTokens: 1_275,
+				totalTokens: 1_225,
 			}),
 		).toBe(0.00344375);
 		expect(


### PR DESCRIPTION
Replacement for merged PR #449 after main was reverted for review.\n\nScope:\n- Add codex auth usage.\n- Support --since, --by, --json, --csv, --out, and rotation dispatch.\n- Wire command help and dispatcher.\n\nValidation from original slice:\n- Usage command focused tests passed before the review stack was opened.\n- Cumulative review branch has passed typecheck, lint, and build through PR 06.\n\nReview note:\n- Base is the replacement usage-ledger PR branch because this command depends on the ledger core.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

adds `codex auth usage` with `--since`, `--by`, `--json`, `--csv`, `--out`, and `rotate` subcommand, wired into the dispatcher and top-level help. the three error paths flagged in the previous review (rotate throw, ledger read throw, `--out` write throw) are all now wrapped in try/catch returning exit code 1, and the test file covers each one. `defaultWriteFile` uses atomic temp-rename with EPERM/EBUSY retry, consistent with the rest of the codebase's Windows-safe write conventions.

<h3>Confidence Score: 4/5</h3>

safe to merge; only P2 findings remain

all P1 error-handling gaps from the prior review are addressed. the remaining finding is a P2 UX issue: invalid --since strings silently no-op instead of returning an error, plus missing vitest coverage for the --since parsing paths and the defaultWriteFile retry loop.

lib/codex-manager/commands/usage.ts (parseSinceValue string validation) and test/codex-manager-usage-command.test.ts (--since and EPERM retry coverage)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/usage.ts | core usage command: all three error paths (rotate, ledger read, --out write) are now wrapped in try/catch and return exit code 1; defaultWriteFile uses atomic temp-rename with EBUSY/EPERM retry; invalid --since string values silently fall through to no-filter |
| lib/usage/ledger.ts | ledger core: read/rotate/append helpers look correct; stale-lock cleanup confirmed in test; no new issues introduced |
| lib/usage/redaction.ts | hashes account IDs and emails before writing to ledger; no raw PII persisted; looks correct |
| lib/usage/pricing.ts | model pricing table and estimation helpers; no issues |
| test/codex-manager-usage-command.test.ts | covers happy-path (text, json, csv, --out, rotate) and all three error paths; missing coverage for --since parsing, defaultWriteFile EPERM retry |
| test/usage-ledger.test.ts | upgraded bare fs.rm to removeWithRetry for Windows safety; added stale-lock cleanup and close-retry test; token count expectation corrected |
| lib/codex-manager.ts | wires usage command dispatch; bare return runUsageCommand(rest) is safe because runUsageCommand catches all errors internally |
| lib/codex-manager/help.ts | adds codex auth usage to the diagnostics section of top-level help text; no issues |
| test/documentation.test.ts | single-line addition of usage to the --json flag assertion; no issues |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runUsageCommand args] --> B{--help?}
    B -- yes --> C[printUsageCommandHelp exit 0]
    B -- no --> D{subcommand = rotate?}
    D -- yes --> E[parseRotateArgs]
    E --> F{parse ok?}
    F -- no --> G[logError exit 1]
    F -- yes --> H[rotateLedger try/catch]
    H -- throw --> I[logError exit 1]
    H -- ok --> J[log JSON or text exit 0]
    D -- no --> K[parseUsageArgs args]
    K --> L{parse ok?}
    L -- no --> M[logError + help exit 1]
    L -- yes --> N{--json?}
    N -- yes --> O[readRows try/catch]
    N -- no --> P[summarizeUsage try/catch]
    O -- throw --> Q[logError exit 1]
    P -- throw --> Q
    O -- ok --> R[summarizeRows]
    P -- ok --> R
    R --> S{--out path?}
    S -- yes --> T[defaultWriteFile try/catch]
    T -- throw --> U[logError exit 1]
    T -- ok --> V[optional confirmation log exit 0]
    S -- no --> W[logInfo rendered exit 0]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `lib/codex-manager/commands/usage.ts`, line 479-497 ([link](https://github.com/ndycode/codex-multi-auth/blob/c5b078c485a4dc2475f8ae1e5fb405ded9c42b1c/lib/codex-manager/commands/usage.ts#L479-L497)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **rotate path: uncaught errors become unhandled rejections**

   `rotateUsageLedger` can throw (`EACCES`/`ENOSPC` on the rename, lock timeout, etc.) and there's no try/catch here. the caller in `codex-manager.ts` does a bare `return runUsageCommand(rest)` with no catch, so the process exits with an unhandled rejection instead of exit code `1`. the docs explicitly promise exit code `1` for write failures.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/codex-manager/commands/usage.ts
   Line: 479-497

   Comment:
   **rotate path: uncaught errors become unhandled rejections**

   `rotateUsageLedger` can throw (`EACCES`/`ENOSPC` on the rename, lock timeout, etc.) and there's no try/catch here. the caller in `codex-manager.ts` does a bare `return runUsageCommand(rest)` with no catch, so the process exits with an unhandled rejection instead of exit code `1`. the docs explicitly promise exit code `1` for write failures.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22review%2Fpr-449-usage-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22review%2Fpr-449-usage-command%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fcodex-manager%2Fcommands%2Fusage.ts%0ALine%3A%20479-497%0A%0AComment%3A%0A**rotate%20path%3A%20uncaught%20errors%20become%20unhandled%20rejections**%0A%0A%60rotateUsageLedger%60%20can%20throw%20%28%60EACCES%60%2F%60ENOSPC%60%20on%20the%20rename%2C%20lock%20timeout%2C%20etc.%29%20and%20there's%20no%20try%2Fcatch%20here.%20the%20caller%20in%20%60codex-manager.ts%60%20does%20a%20bare%20%60return%20runUsageCommand%28rest%29%60%20with%20no%20catch%2C%20so%20the%20process%20exits%20with%20an%20unhandled%20rejection%20instead%20of%20exit%20code%20%601%60.%20the%20docs%20explicitly%20promise%20exit%20code%20%601%60%20for%20write%20failures.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `lib/codex-manager/commands/usage.ts`, line 531-538 ([link](https://github.com/ndycode/codex-multi-auth/blob/c5b078c485a4dc2475f8ae1e5fb405ded9c42b1c/lib/codex-manager/commands/usage.ts#L531-L538)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`--out` write errors escape as unhandled rejections**

   `writeFile` / `defaultWriteFile` can throw (`EACCES`, `EPERM` on windows, disk full, etc.) and there's no try/catch around this block. the process terminates with an unhandled rejection instead of the documented exit code `1`. the docs section says exit `1` covers "write failures".

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/codex-manager/commands/usage.ts
   Line: 531-538

   Comment:
   **`--out` write errors escape as unhandled rejections**

   `writeFile` / `defaultWriteFile` can throw (`EACCES`, `EPERM` on windows, disk full, etc.) and there's no try/catch around this block. the process terminates with an unhandled rejection instead of the documented exit code `1`. the docs section says exit `1` covers "write failures".

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22review%2Fpr-449-usage-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22review%2Fpr-449-usage-command%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fcodex-manager%2Fcommands%2Fusage.ts%0ALine%3A%20531-538%0A%0AComment%3A%0A**%60--out%60%20write%20errors%20escape%20as%20unhandled%20rejections**%0A%0A%60writeFile%60%20%2F%20%60defaultWriteFile%60%20can%20throw%20%28%60EACCES%60%2C%20%60EPERM%60%20on%20windows%2C%20disk%20full%2C%20etc.%29%20and%20there's%20no%20try%2Fcatch%20around%20this%20block.%20the%20process%20terminates%20with%20an%20unhandled%20rejection%20instead%20of%20the%20documented%20exit%20code%20%601%60.%20the%20docs%20section%20says%20exit%20%601%60%20covers%20%22write%20failures%22.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22review%2Fpr-449-usage-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22review%2Fpr-449-usage-command%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fcodex-manager%2Fcommands%2Fusage.ts%3A58-78%0A**invalid%20%60--since%60%20strings%20silently%20disable%20the%20filter**%0A%0Aif%20a%20user%20provides%20a%20value%20that%20isn't%20a%20relative%20duration%20or%20pure%20integer%20%28e.g.%20%60--since%20not-a-date%60%29%2C%20%60parseSinceValue%60%20returns%20the%20raw%20string.%20%60normalizeTimestamp%60%20in%20the%20ledger%20layer%20calls%20%60Date.parse%28%22not-a-date%22%29%60%20%E2%86%92%20%60NaN%60%20%E2%86%92%20returns%20%60null%60%2C%20so%20%60filterRows%60%20applies%20no%20time%20filter%20at%20all.%20the%20user%20gets%20all%20rows%20with%20no%20warning%2C%20which%20is%20the%20opposite%20of%20what%20they%20asked%20for.%20%60--by%60%20validates%20against%20%60VALID_GROUPS%60%20and%20returns%20an%20error%20%E2%80%94%20%60--since%60%20should%20do%20the%20same%20for%20unrecognised%20strings.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fcodex-manager-usage-command.test.ts%3A70-229%0A**missing%20vitest%20coverage%20for%20%60--since%60%20parsing%20and%20%60defaultWriteFile%60%20retry**%0A%0Athe%20test%20file%20covers%20all%20the%20happy-path%20formats%20and%20the%20three%20error%20paths%20from%20the%20previous%20review%2C%20but%20no%20test%20exercises%20%60parseSinceValue%60%20relative-duration%20formats%20%28%6024h%60%2C%20%607d%60%29%2C%20ISO%20date%20strings%2C%20or%20the%20invalid-string%20case%20noted%20above.%20%60defaultWriteFile%60's%20EPERM%2FEBUSY%20rename-retry%20loop%20is%20also%20untested%20%E2%80%94%20on%20Windows%20this%20path%20is%20the%20one%20most%20likely%20to%20trigger%20during%20concurrent%20CLI%20invocations.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/codex-manager/commands/usage.ts
Line: 58-78

Comment:
**invalid `--since` strings silently disable the filter**

if a user provides a value that isn't a relative duration or pure integer (e.g. `--since not-a-date`), `parseSinceValue` returns the raw string. `normalizeTimestamp` in the ledger layer calls `Date.parse("not-a-date")` → `NaN` → returns `null`, so `filterRows` applies no time filter at all. the user gets all rows with no warning, which is the opposite of what they asked for. `--by` validates against `VALID_GROUPS` and returns an error — `--since` should do the same for unrecognised strings.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-usage-command.test.ts
Line: 70-229

Comment:
**missing vitest coverage for `--since` parsing and `defaultWriteFile` retry**

the test file covers all the happy-path formats and the three error paths from the previous review, but no test exercises `parseSinceValue` relative-duration formats (`24h`, `7d`), ISO date strings, or the invalid-string case noted above. `defaultWriteFile`'s EPERM/EBUSY rename-retry loop is also untested — on Windows this path is the one most likely to trigger during concurrent CLI invocations.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["test: retry usage ledger cleanup"](https://github.com/ndycode/codex-multi-auth/commit/791b16bab71e5beefeb55554eb1c6a4b80082509) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30171531)</sub>

<!-- /greptile_comment -->