### PR TITLE
feat: add account policy controls

### DIFF
--- a/docs/development/implementation-plans/status.md
+++ b/docs/development/implementation-plans/status.md
@@ -19,7 +19,7 @@ Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 | 01 | `chore/roadmap-local-governance` | Ready for review | `npm test -- test/documentation.test.ts`; `npm run build`. |
 | 02 | `feat/usage-ledger-core` | Ready for review | `npm run typecheck`; `npm test -- test/usage-ledger.test.ts`; `npm run lint`; `npm run build`. |
 | 03 | `feat/usage-command` | Ready for review | `npm run typecheck`; usage command/core/docs tests; `npm run lint`; `npm run build`. |
-| 04 | `feat/account-policy-controls` | Pending | Account policy command/store tests plus build. |
+| 04 | `feat/account-policy-controls` | Ready for review | `npm run typecheck`; account policy command/store/docs tests; `npm run lint`; `npm run build`. |
 | 05 | `feat/routing-profiles-core` | Pending | Routing profile storage/project tests plus build. |
 | 06 | `feat/budget-guard` | Pending | Budget guard command/evaluator tests plus build. |
 | 07 | `feat/model-capability-matrix` | Pending | Model matrix tests plus `npm run test:model-matrix:smoke`. |

--- a/docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md
@@ -1,0 +1,30 @@
+# PR 04 Handoff: Account Policy Controls
+
+Branch: `feat/account-policy-controls`
+Base: `origin/main` after PR 03 merge
+
+## Scope
+
+Add local account policy storage and `codex auth account` policy commands.
+
+## Files Changed
+
+- `lib/account-policy.ts`
+- `lib/codex-manager/commands/account.ts`
+- `lib/codex-manager.ts`
+- `lib/codex-manager/help.ts`
+- `lib/index.ts`
+- `docs/reference/commands.md`
+- `docs/development/implementation-plans/status.md`
+- `docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md`
+
+## Validation
+
+- `npm run typecheck` passed.
+- `npm test -- test/account-policy.test.ts test/codex-manager-account-command.test.ts test/documentation.test.ts` passed: 3 files, 29 tests.
+- `npm run lint` passed.
+- `npm run build` passed.
+
+## Follow-ups
+
+- PR 08 should enforce pause, drain, weight, and tags during runtime selection.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -34,6 +34,7 @@ Compatibility aliases are supported:
 | `codex auth switch <index>` | Set active account by index |
 | `codex auth forecast` | Forecast best account by readiness/risk |
 | `codex auth best` | Pick and optionally sync the best account |
+| `codex auth account ...` | Manage local account policy metadata |
 
 ---
 
@@ -86,6 +87,35 @@ Compatibility aliases are supported:
 | `--all` | verify | Run both `--paths` and `--flagged` together |
 | `--now`, `-n` | why-selected | Recompute the current selection from live state (default) |
 | `--last`, `-l` | why-selected | Recompute selection from current state and attach the last persisted runtime snapshot |
+
+---
+
+## `codex auth account`
+
+Stores local account policy metadata for future routing and budget enforcement.
+Policy keys are hashed from account identity; raw account ids and raw emails are
+not stored in the policy file.
+
+Usage:
+
+```bash
+codex auth account tag <index> <tag>
+codex auth account untag <index> <tag>
+codex auth account weight <index> <0..10>
+codex auth account pause <index>
+codex auth account unpause <index>
+codex auth account drain <index>
+codex auth account undrain <index>
+codex auth account note <index> <text>
+codex auth account policy list [--json]
+```
+
+Notes:
+
+- `pause` and `drain` are stored only. Runtime enforcement is added by the
+  runtime policy integration PR.
+- `weight` accepts values from `0` to `10`; default is `1`.
+- `tag` values are normalized to lowercase filesystem-safe labels.
 
 ---
 

--- a/lib/account-policy.ts
+++ b/lib/account-policy.ts
@@ -1,0 +1,206 @@
+import { createHash } from "node:crypto";
+import { existsSync, promises as fs } from "node:fs";
+import { basename, join } from "node:path";
+import { logWarn } from "./logger.js";
+import { getCodexMultiAuthDir } from "./runtime-paths.js";
+import type { AccountMetadataV3 } from "./storage.js";
+import { isRecord, sleep } from "./utils.js";
+
+export interface AccountPolicy {
+	accountKey: string;
+	tags: string[];
+	weight: number;
+	paused: boolean;
+	drained: boolean;
+	note: string | null;
+	updatedAt: number;
+}
+
+export interface AccountPolicyStore {
+	version: 1;
+	accounts: Record<string, AccountPolicy>;
+}
+
+const ACCOUNT_POLICY_FILE_NAME = "account-policies.json";
+const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+let writeQueue: Promise<void> = Promise.resolve();
+
+function isRetryableFsError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
+}
+
+function normalizeTag(value: string): string | null {
+	const normalized = value.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-");
+	return normalized.length > 0 ? normalized.slice(0, 64) : null;
+}
+
+function normalizeWeight(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value)
+		? Math.max(0, Math.min(10, value))
+		: 1;
+}
+
+function normalizePolicy(key: string, value: unknown): AccountPolicy {
+	const record = isRecord(value) ? value : {};
+	const tags = Array.isArray(record.tags)
+		? [
+				...new Set(
+					record.tags
+						.filter((tag): tag is string => typeof tag === "string")
+						.map((tag) => normalizeTag(tag))
+						.filter((tag): tag is string => tag !== null),
+				),
+			].sort()
+		: [];
+	const note = typeof record.note === "string" ? record.note.trim() : "";
+	return {
+		accountKey: key,
+		tags,
+		weight: normalizeWeight(record.weight),
+		paused: record.paused === true,
+		drained: record.drained === true,
+		note: note.length > 0 ? note.slice(0, 500) : null,
+		updatedAt:
+			typeof record.updatedAt === "number" && Number.isFinite(record.updatedAt)
+				? record.updatedAt
+				: 0,
+	};
+}
+
+function emptyStore(): AccountPolicyStore {
+	return { version: 1, accounts: {} };
+}
+
+function normalizeStore(value: unknown): AccountPolicyStore {
+	if (!isRecord(value) || value.version !== 1) return emptyStore();
+	const accounts: Record<string, AccountPolicy> = {};
+	if (isRecord(value.accounts)) {
+		for (const [key, raw] of Object.entries(value.accounts)) {
+			if (key.startsWith("sha256:")) {
+				accounts[key] = normalizePolicy(key, raw);
+			}
+		}
+	}
+	return { version: 1, accounts };
+}
+
+async function readFileWithRetry(path: string): Promise<string> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			return await fs.readFile(path, "utf8");
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableFsError(error) || attempt >= 4) throw error;
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("account policy read retry exhausted");
+}
+
+export function getAccountPolicyPath(): string {
+	return join(getCodexMultiAuthDir(), ACCOUNT_POLICY_FILE_NAME);
+}
+
+export function getAccountPolicyKey(
+	account: Pick<AccountMetadataV3, "accountId" | "email">,
+	index?: number,
+): string {
+	const identity =
+		account.accountId?.trim() ||
+		account.email?.trim().toLowerCase() ||
+		(typeof index === "number" ? `index:${index}` : "unknown");
+	return `sha256:${createHash("sha256").update(identity).digest("hex")}`;
+}
+
+export async function loadAccountPolicyStore(): Promise<AccountPolicyStore> {
+	const path = getAccountPolicyPath();
+	if (!existsSync(path)) return emptyStore();
+	try {
+		return normalizeStore(JSON.parse(await readFileWithRetry(path)) as unknown);
+	} catch (error) {
+		logWarn(
+			`Failed to load account policies from ${basename(path)}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return emptyStore();
+	}
+}
+
+export async function saveAccountPolicyStore(
+	store: AccountPolicyStore,
+): Promise<void> {
+	const path = getAccountPolicyPath();
+	const payload = normalizeStore(store);
+	const task = async (): Promise<void> => {
+		await fs.mkdir(getCodexMultiAuthDir(), { recursive: true, mode: 0o700 });
+		const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+		let moved = false;
+		try {
+			await fs.writeFile(tempPath, `${JSON.stringify(payload, null, 2)}\n`, {
+				encoding: "utf8",
+				mode: 0o600,
+			});
+			for (let attempt = 0; attempt < 5; attempt += 1) {
+				try {
+					await fs.rename(tempPath, path);
+					moved = true;
+					return;
+				} catch (error) {
+					if (!isRetryableFsError(error) || attempt >= 4) throw error;
+					await sleep(10 * 2 ** attempt);
+				}
+			}
+		} finally {
+			if (!moved) {
+				try {
+					await fs.unlink(tempPath);
+				} catch {
+					// Best-effort temp cleanup.
+				}
+			}
+		}
+	};
+	const queued = writeQueue.catch(() => undefined).then(task);
+	writeQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	await queued;
+}
+
+export function upsertAccountPolicy(
+	store: AccountPolicyStore,
+	accountKey: string,
+	mutate: (policy: AccountPolicy) => void,
+	now = Date.now(),
+): AccountPolicy {
+	const next = structuredClone(
+		store.accounts[accountKey] ?? normalizePolicy(accountKey, null),
+	);
+	mutate(next);
+	next.tags = [
+		...new Set(
+			next.tags
+				.map((tag) => normalizeTag(tag))
+				.filter((tag): tag is string => tag !== null),
+		),
+	].sort();
+	next.weight = normalizeWeight(next.weight);
+	next.updatedAt = now;
+	store.accounts[accountKey] = next;
+	return next;
+}
+
+export function normalizeAccountPolicyTag(value: string): string | null {
+	return normalizeTag(value);
+}
+
+export function resetAccountPolicyWriteQueueForTests(): void {
+	writeQueue = Promise.resolve();
+}
+

--- a/lib/account-policy.ts
+++ b/lib/account-policy.ts
@@ -107,12 +107,12 @@ export function getAccountPolicyPath(): string {
 
 export function getAccountPolicyKey(
 	account: Pick<AccountMetadataV3, "accountId" | "email">,
-	index?: number,
+	_index?: number,
 ): string {
 	const identity =
 		account.accountId?.trim() ||
 		account.email?.trim().toLowerCase() ||
-		(typeof index === "number" ? `index:${index}` : "unknown");
+		"unknown";
 	return `sha256:${createHash("sha256").update(identity).digest("hex")}`;
 }
 

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -36,6 +36,7 @@ import {
 	type BestCliOptions,
 	runBestCommand,
 } from "./codex-manager/commands/best.js";
+import { runAccountCommand } from "./codex-manager/commands/account.js";
 import { runCheckCommand } from "./codex-manager/commands/check.js";
 import { runConfigExplainCommand } from "./codex-manager/commands/config-explain.js";
 import { saveAccountsWithRetry } from "./codex-manager/forecast-report-shared.js";
@@ -3454,6 +3455,12 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 	}
 	if (command === "best") {
 		return runBest(rest);
+	}
+	if (command === "account") {
+		return runAccountCommand(rest, {
+			setStoragePath,
+			loadAccounts,
+		});
 	}
 	if (command === "report") {
 		return runReportCommand(rest, {

--- a/lib/codex-manager/commands/account.ts
+++ b/lib/codex-manager/commands/account.ts
@@ -1,0 +1,195 @@
+import {
+	getAccountPolicyKey,
+	loadAccountPolicyStore,
+	normalizeAccountPolicyTag,
+	saveAccountPolicyStore,
+	upsertAccountPolicy,
+	type AccountPolicyStore,
+} from "../../account-policy.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../../storage.js";
+
+export interface AccountCommandDeps {
+	setStoragePath: (path: string | null) => void;
+	loadAccounts: () => Promise<AccountStorageV3 | null>;
+	loadPolicyStore?: typeof loadAccountPolicyStore;
+	savePolicyStore?: typeof saveAccountPolicyStore;
+	logInfo?: (message: string) => void;
+	logError?: (message: string) => void;
+	getNow?: () => number;
+}
+
+function printAccountUsage(logInfo: (message: string) => void): void {
+	logInfo(
+		[
+			"Usage:",
+			"  codex auth account tag <index> <tag>",
+			"  codex auth account untag <index> <tag>",
+			"  codex auth account weight <index> <0..10>",
+			"  codex auth account pause|unpause|drain|undrain <index>",
+			"  codex auth account note <index> <text>",
+			"  codex auth account policy list [--json]",
+		].join("\n"),
+	);
+}
+
+function parseAccountIndex(value: string | undefined): number | null {
+	if (!value || !/^\d+$/.test(value)) return null;
+	const parsed = Number.parseInt(value, 10);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed - 1 : null;
+}
+
+function resolveAccount(
+	storage: AccountStorageV3 | null,
+	index: number | null,
+): { account: AccountMetadataV3; index: number } | null {
+	if (!storage || index === null || index < 0 || index >= storage.accounts.length) {
+		return null;
+	}
+	const account = storage.accounts[index];
+	return account ? { account, index } : null;
+}
+
+function policySummary(store: AccountPolicyStore, storage: AccountStorageV3 | null) {
+	return (storage?.accounts ?? []).map((account, index) => {
+		const accountKey = getAccountPolicyKey(account, index);
+		const policy = store.accounts[accountKey];
+		return {
+			index: index + 1,
+			label: `Account ${index + 1}`,
+			accountKey,
+			tags: policy?.tags ?? [],
+			weight: policy?.weight ?? 1,
+			paused: policy?.paused ?? false,
+			drained: policy?.drained ?? false,
+			note: policy?.note ?? null,
+		};
+	});
+}
+
+export async function runAccountCommand(
+	args: string[],
+	deps: AccountCommandDeps,
+): Promise<number> {
+	const logInfo = deps.logInfo ?? console.log;
+	const logError = deps.logError ?? console.error;
+	const [command, ...rest] = args;
+	if (!command || command === "--help" || command === "-h") {
+		printAccountUsage(logInfo);
+		return 0;
+	}
+
+	deps.setStoragePath(null);
+	const storage = await deps.loadAccounts();
+	const loadStore = deps.loadPolicyStore ?? loadAccountPolicyStore;
+	const saveStore = deps.savePolicyStore ?? saveAccountPolicyStore;
+	const store = await loadStore();
+
+	if (command === "policy") {
+		const [subcommand, ...policyArgs] = rest;
+		if (subcommand !== "list") {
+			logError(`Unknown account policy command: ${subcommand ?? "(missing)"}`);
+			return 1;
+		}
+		const unknown = policyArgs.find((arg) => arg !== "--json" && arg !== "-j");
+		if (unknown) {
+			logError(`Unknown account policy list option: ${unknown}`);
+			return 1;
+		}
+		const payload = {
+			command: "account policy list",
+			accounts: policySummary(store, storage),
+		};
+		if (policyArgs.includes("--json") || policyArgs.includes("-j")) {
+			logInfo(JSON.stringify(payload, null, 2));
+			return 0;
+		}
+		if (payload.accounts.length === 0) {
+			logInfo("No accounts configured.");
+			return 0;
+		}
+		for (const entry of payload.accounts) {
+			const markers = [
+				`weight=${entry.weight}`,
+				entry.paused ? "paused" : null,
+				entry.drained ? "drained" : null,
+				entry.tags.length > 0 ? `tags=${entry.tags.join(",")}` : null,
+				entry.note ? "note" : null,
+			].filter((value): value is string => value !== null);
+			logInfo(`${entry.index}. ${entry.label} | ${markers.join(" | ")}`);
+		}
+		return 0;
+	}
+
+	const accountIndex = parseAccountIndex(rest[0]);
+	const resolved = resolveAccount(storage, accountIndex);
+	if (!resolved) {
+		logError("Account index is required and must reference a configured account.");
+		return 1;
+	}
+	const accountKey = getAccountPolicyKey(resolved.account, resolved.index);
+	const now = deps.getNow?.() ?? Date.now();
+
+	if (command === "tag" || command === "untag") {
+		const tag = normalizeAccountPolicyTag(rest[1] ?? "");
+		if (!tag) {
+			logError(`${command} requires a tag value.`);
+			return 1;
+		}
+		const policy = upsertAccountPolicy(
+			store,
+			accountKey,
+			(next) => {
+				if (command === "tag" && !next.tags.includes(tag)) next.tags.push(tag);
+				if (command === "untag") {
+					next.tags = next.tags.filter((existing) => existing !== tag);
+				}
+			},
+			now,
+		);
+		await saveStore(store);
+		logInfo(
+			`${command === "tag" ? "Tagged" : "Removed tag from"} account ${resolved.index + 1}: ${policy.tags.join(",") || "none"}`,
+		);
+		return 0;
+	}
+
+	if (command === "weight") {
+		const weight = rest[1] === undefined ? Number.NaN : Number.parseFloat(rest[1]);
+		if (!Number.isFinite(weight) || weight < 0 || weight > 10) {
+			logError("weight requires a number from 0 to 10.");
+			return 1;
+		}
+		upsertAccountPolicy(store, accountKey, (next) => {
+			next.weight = weight;
+		}, now);
+		await saveStore(store);
+		logInfo(`Set account ${resolved.index + 1} weight to ${weight}.`);
+		return 0;
+	}
+
+	if (["pause", "unpause", "drain", "undrain"].includes(command)) {
+		upsertAccountPolicy(store, accountKey, (next) => {
+			if (command === "pause") next.paused = true;
+			if (command === "unpause") next.paused = false;
+			if (command === "drain") next.drained = true;
+			if (command === "undrain") next.drained = false;
+		}, now);
+		await saveStore(store);
+		logInfo(`Updated account ${resolved.index + 1}: ${command}.`);
+		return 0;
+	}
+
+	if (command === "note") {
+		const note = rest.slice(1).join(" ").trim();
+		upsertAccountPolicy(store, accountKey, (next) => {
+			next.note = note.length > 0 ? note.slice(0, 500) : null;
+		}, now);
+		await saveStore(store);
+		logInfo(`Updated account ${resolved.index + 1} note.`);
+		return 0;
+	}
+
+	logError(`Unknown account command: ${command}`);
+	printAccountUsage(logInfo);
+	return 1;
+}

--- a/lib/codex-manager/commands/usage.ts
+++ b/lib/codex-manager/commands/usage.ts
@@ -4,6 +4,7 @@ import { sleep } from "../../utils.js";
 import {
 	readUsageLedgerRows,
 	rotateUsageLedger,
+	summarizeUsageRows,
 	summarizeUsageLedger,
 	type UsageLedgerRow,
 	type UsageSummary,
@@ -30,6 +31,7 @@ type ParsedArgsResult<T> =
 
 export interface UsageCommandDeps {
 	summarizeUsage?: typeof summarizeUsageLedger;
+	summarizeRows?: typeof summarizeUsageRows;
 	readRows?: typeof readUsageLedgerRows;
 	rotateLedger?: typeof rotateUsageLedger;
 	logInfo?: (message: string) => void;
@@ -359,10 +361,23 @@ export async function runUsageCommand(
 	}
 	const options = parsed.options;
 	const query = { since: options.since, by: options.by };
-	const [summary, rows] = await Promise.all([
-		(deps.summarizeUsage ?? summarizeUsageLedger)(query),
-		(deps.readRows ?? readUsageLedgerRows)(query),
-	]);
+	let summary: UsageSummary;
+	let rows: UsageLedgerRow[] = [];
+	try {
+		if (options.json) {
+			rows = await (deps.readRows ?? readUsageLedgerRows)(query);
+			summary = (deps.summarizeRows ?? summarizeUsageRows)(rows, query);
+		} else {
+			summary = await (deps.summarizeUsage ?? summarizeUsageLedger)(query);
+		}
+	} catch (error) {
+		logError(
+			`Failed to read usage ledger: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return 1;
+	}
 	const rendered = options.json
 		? rowsToJsonPayload(summary, rows)
 		: options.csv

--- a/lib/codex-manager/commands/usage.ts
+++ b/lib/codex-manager/commands/usage.ts
@@ -332,9 +332,19 @@ export async function runUsageCommand(
 			logError(parsed.message);
 			return 1;
 		}
-		const rotatedPath = await (deps.rotateLedger ?? rotateUsageLedger)({
-			ifLargerThanBytes: parsed.options.ifLargerThanBytes,
-		});
+		let rotatedPath: string | null;
+		try {
+			rotatedPath = await (deps.rotateLedger ?? rotateUsageLedger)({
+				ifLargerThanBytes: parsed.options.ifLargerThanBytes,
+			});
+		} catch (error) {
+			logError(
+				`Failed to rotate usage ledger: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			return 1;
+		}
 		if (parsed.options.json) {
 			logInfo(
 				JSON.stringify({
@@ -386,7 +396,16 @@ export async function runUsageCommand(
 
 	if (options.outPath) {
 		const outputPath = resolve(deps.getCwd?.() ?? process.cwd(), options.outPath);
-		await (deps.writeFile ?? defaultWriteFile)(outputPath, `${rendered}\n`);
+		try {
+			await (deps.writeFile ?? defaultWriteFile)(outputPath, `${rendered}\n`);
+		} catch (error) {
+			logError(
+				`Failed to write usage report: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			return 1;
+		}
 		if (!options.json && !options.csv) {
 			logInfo(`Usage report written: ${outputPath}`);
 		}

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -13,6 +13,7 @@ export function printUsage(): void {
 			"  codex auth switch <index>",
 			"  codex auth best [--live] [--json] [--model <model>]",
 			"  codex auth forecast [--live] [--json] [--model <model>]",
+			"  codex auth account tag|untag|weight|pause|unpause|drain|undrain|note ...",
 			"",
 			"Repair:",
 			"  codex auth verify-flagged [--dry-run] [--json] [--no-restore]",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,3 +41,4 @@ export * from "./codex-cli/sync.js";
 export * from "./codex-cli/writer.js";
 export * from "./codex-cli/observability.js";
 export * from "./usage/index.js";
+export * from "./account-policy.js";

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -112,6 +112,25 @@ async function removeStaleLockIfNeeded(lockPath: string): Promise<boolean> {
 	}
 }
 
+async function closeLockHandleWithRetry(
+	handle: Awaited<ReturnType<typeof fs.open>>,
+): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 5; attempt += 1) {
+		try {
+			await handle.close();
+			return;
+		} catch (error) {
+			lastError = error;
+			if (!isRetryableLockError(error)) throw error;
+			await sleep(Math.min(250, 10 * 2 ** attempt));
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("usage ledger lock handle close retry exhausted");
+}
+
 async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>> {
 	const started = Date.now();
 	let attempt = 0;
@@ -123,17 +142,24 @@ async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>>
 				JSON.stringify({ pid: process.pid, createdAt: Date.now() }) + "\n",
 				"utf8",
 			);
+			const lockHandle = handle;
 			let released = false;
 			return async () => {
 				if (released) return;
 				released = true;
-				await handle?.close();
+				let closeError: unknown;
+				try {
+					await closeLockHandleWithRetry(lockHandle);
+				} catch (error) {
+					closeError = error;
+				}
 				await unlinkWithRetry(lockPath);
+				if (closeError) throw closeError;
 			};
 		} catch (error) {
 			if (handle) {
 				try {
-					await handle.close();
+					await closeLockHandleWithRetry(handle);
 				} catch {
 					// Best-effort cleanup after a failed lock metadata write.
 				}

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -25,6 +25,9 @@ import type {
 const USAGE_DIR_NAME = "usage";
 const USAGE_LEDGER_FILE_NAME = "usage-ledger.jsonl";
 const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM"]);
+const LOCK_RETRYABLE_FS_CODES = new Set(["EACCES", "EBUSY", "EEXIST", "EPERM"]);
+const LOCK_STALE_MS = 30_000;
+const LOCK_MAX_WAIT_MS = 10_000;
 let appendQueue: Promise<void> = Promise.resolve();
 
 const VALID_SOURCES = new Set<UsageLedgerSource>([
@@ -53,6 +56,15 @@ function isRetryableFsError(error: unknown): boolean {
 	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
 }
 
+function isRetryableLockError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && LOCK_RETRYABLE_FS_CODES.has(code);
+}
+
+function isMissingFileError(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
 function normalizeTimestamp(value: number | Date | string | undefined): number | null {
 	if (value === undefined) return null;
 	if (value instanceof Date) {
@@ -66,13 +78,14 @@ function normalizeTimestamp(value: number | Date | string | undefined): number |
 	return Number.isFinite(parsed) ? parsed : null;
 }
 
-async function appendFileWithRetry(path: string, line: string): Promise<void> {
+async function unlinkWithRetry(path: string): Promise<void> {
 	let lastError: unknown;
 	for (let attempt = 0; attempt < 5; attempt += 1) {
 		try {
-			await fs.appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+			await fs.unlink(path);
 			return;
 		} catch (error) {
+			if (isMissingFileError(error)) return;
 			lastError = error;
 			if (!isRetryableFsError(error) || attempt >= 4) {
 				throw error;
@@ -82,7 +95,94 @@ async function appendFileWithRetry(path: string, line: string): Promise<void> {
 	}
 	throw lastError instanceof Error
 		? lastError
-		: new Error("usage ledger append retry exhausted");
+		: new Error("usage ledger lock cleanup retry exhausted");
+}
+
+async function removeStaleLockIfNeeded(lockPath: string): Promise<boolean> {
+	try {
+		const stat = await fs.stat(lockPath);
+		if (Date.now() - stat.mtimeMs < LOCK_STALE_MS) {
+			return false;
+		}
+		await unlinkWithRetry(lockPath);
+		return true;
+	} catch (error) {
+		if (isMissingFileError(error)) return true;
+		throw error;
+	}
+}
+
+async function acquireAppendLock(lockPath: string): Promise<() => Promise<void>> {
+	const started = Date.now();
+	let attempt = 0;
+	while (true) {
+		let handle: Awaited<ReturnType<typeof fs.open>> | null = null;
+		try {
+			handle = await fs.open(lockPath, "wx", 0o600);
+			await handle.writeFile(
+				JSON.stringify({ pid: process.pid, createdAt: Date.now() }) + "\n",
+				"utf8",
+			);
+			let released = false;
+			return async () => {
+				if (released) return;
+				released = true;
+				await handle?.close();
+				await unlinkWithRetry(lockPath);
+			};
+		} catch (error) {
+			if (handle) {
+				try {
+					await handle.close();
+				} catch {
+					// Best-effort cleanup after a failed lock metadata write.
+				}
+				await unlinkWithRetry(lockPath);
+			}
+			if (!isRetryableLockError(error)) {
+				throw error;
+			}
+			await removeStaleLockIfNeeded(lockPath);
+			if (Date.now() - started >= LOCK_MAX_WAIT_MS) {
+				throw new Error(`Timed out waiting for usage ledger lock: ${lockPath}`);
+			}
+			await sleep(Math.min(250, 10 * 2 ** Math.min(attempt, 5)));
+			attempt += 1;
+		}
+	}
+}
+
+async function appendFileWithRetry(path: string, line: string): Promise<void> {
+	const release = await acquireAppendLock(`${path}.lock`);
+	let lastError: unknown;
+	try {
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			try {
+				await fs.appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+				return;
+			} catch (error) {
+				lastError = error;
+				if (!isRetryableFsError(error) || attempt >= 4) {
+					throw error;
+				}
+				await sleep(10 * 2 ** attempt);
+			}
+		}
+		throw lastError instanceof Error
+			? lastError
+			: new Error("usage ledger append retry exhausted");
+	} finally {
+		await release();
+	}
+}
+
+async function runWithAppendQueue<T>(task: () => Promise<T>): Promise<T> {
+	const queued = appendQueue.catch(() => undefined).then(task);
+	appendQueue = queued.then(
+		() => undefined,
+		() => undefined,
+	);
+	return queued;
 }
 
 async function readFileWithRetry(path: string): Promise<string> {
@@ -136,16 +236,10 @@ export async function appendUsageLedgerRow(
 	const row = normalizeUsageLedgerRow(input);
 	const { dir, current } = getUsageLedgerPaths();
 	const line = usageRowToJsonLine(row);
-	const task = async (): Promise<void> => {
+	await runWithAppendQueue(async () => {
 		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
 		await appendFileWithRetry(current, line);
-	};
-	const queued = appendQueue.catch(() => undefined).then(task);
-	appendQueue = queued.then(
-		() => undefined,
-		() => undefined,
-	);
-	await queued;
+	});
 	return row;
 }
 
@@ -370,14 +464,17 @@ function addRowToBucket(bucket: UsageSummaryBucket, row: UsageLedgerRow): void {
 	bucket.costUsd = Number((bucket.costUsd + (row.costUsd ?? 0)).toFixed(8));
 }
 
-export async function summarizeUsageLedger(
+export function summarizeUsageRows(
+	rows: UsageLedgerRow[],
 	query: UsageSummaryQuery = {},
-): Promise<UsageSummary> {
+): UsageSummary {
 	const by = query.by ?? "model";
-	const rows = await readUsageLedgerRows(query);
+	const filteredRows = filterRows(rows, query).sort(
+		(a, b) => a.createdAt - b.createdAt,
+	);
 	const totals = createBucket("total");
 	const buckets = new Map<string, UsageSummaryBucket>();
-	for (const row of rows) {
+	for (const row of filteredRows) {
 		addRowToBucket(totals, row);
 		const key = getBucketKey(row, by);
 		const bucket = buckets.get(key) ?? createBucket(key);
@@ -396,29 +493,42 @@ export async function summarizeUsageLedger(
 	};
 }
 
+export async function summarizeUsageLedger(
+	query: UsageSummaryQuery = {},
+): Promise<UsageSummary> {
+	return summarizeUsageRows(await readUsageLedgerRows(query), query);
+}
+
 export async function rotateUsageLedger(options: {
 	now?: number;
 	ifLargerThanBytes?: number;
 } = {}): Promise<string | null> {
 	const { dir, current } = getUsageLedgerPaths();
-	if (!existsSync(current)) {
-		return null;
-	}
-	const stat = await fs.stat(current);
-	if (
-		typeof options.ifLargerThanBytes === "number" &&
-		stat.size <= options.ifLargerThanBytes
-	) {
-		return null;
-	}
-	await fs.mkdir(dir, { recursive: true, mode: 0o700 });
-	const stamp = new Date(options.now ?? Date.now())
-		.toISOString()
-		.replace(/[-:]/g, "")
-		.replace(".", "");
-	const rotated = join(dir, `usage-ledger.${stamp}.jsonl`);
-	await renameWithRetry(current, rotated);
-	return rotated;
+	return runWithAppendQueue(async () => {
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+		const release = await acquireAppendLock(`${current}.lock`);
+		try {
+			if (!existsSync(current)) {
+				return null;
+			}
+			const stat = await fs.stat(current);
+			if (
+				typeof options.ifLargerThanBytes === "number" &&
+				stat.size <= options.ifLargerThanBytes
+			) {
+				return null;
+			}
+			const stamp = new Date(options.now ?? Date.now())
+				.toISOString()
+				.replace(/[-:]/g, "")
+				.replace(".", "");
+			const rotated = join(dir, `usage-ledger.${stamp}.jsonl`);
+			await renameWithRetry(current, rotated);
+			return rotated;
+		} finally {
+			await release();
+		}
+	});
 }
 
 export function resetUsageLedgerQueueForTests(): void {

--- a/lib/usage/pricing.ts
+++ b/lib/usage/pricing.ts
@@ -7,13 +7,6 @@ export interface UsageModelPricing {
 	reasoningUsdPerMillion?: number;
 }
 
-const DEFAULT_PRICING: UsageModelPricing = {
-	inputUsdPerMillion: 0,
-	outputUsdPerMillion: 0,
-	cachedInputUsdPerMillion: 0,
-	reasoningUsdPerMillion: 0,
-};
-
 const MODEL_PRICING: Record<string, UsageModelPricing> = {
 	"gpt-5-codex": {
 		inputUsdPerMillion: 1.25,
@@ -65,7 +58,7 @@ export function getUsageModelPricing(
 	if (!normalized) {
 		return null;
 	}
-	return MODEL_PRICING[normalized] ?? DEFAULT_PRICING;
+	return MODEL_PRICING[normalized] ?? null;
 }
 
 export function estimateUsageCostUsd(
@@ -77,8 +70,12 @@ export function estimateUsageCostUsd(
 		return null;
 	}
 
+	const billableInputTokens = Math.max(
+		0,
+		tokens.inputTokens - tokens.cachedInputTokens,
+	);
 	const input =
-		(tokens.inputTokens / 1_000_000) * pricing.inputUsdPerMillion;
+		(billableInputTokens / 1_000_000) * pricing.inputUsdPerMillion;
 	const output =
 		(tokens.outputTokens / 1_000_000) * pricing.outputUsdPerMillion;
 	const cached =

--- a/lib/usage/redaction.ts
+++ b/lib/usage/redaction.ts
@@ -115,8 +115,7 @@ function normalizeTokens(input: UsageLedgerAppendInput): UsageTokenCounts {
 	const cachedInputTokens = normalizeNonNegativeInteger(input.cachedInputTokens);
 	const reasoningTokens = normalizeNonNegativeInteger(input.reasoningTokens);
 	const providedTotal = normalizeFiniteNumber(input.totalTokens);
-	const computedTotal =
-		inputTokens + outputTokens + cachedInputTokens + reasoningTokens;
+	const computedTotal = inputTokens + outputTokens + reasoningTokens;
 
 	return {
 		inputTokens,

--- a/test/account-policy.test.ts
+++ b/test/account-policy.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 describe("account policy store", () => {
 	let tempDir: string;
@@ -11,15 +12,20 @@ describe("account policy store", () => {
 		originalDir = process.env.CODEX_MULTI_AUTH_DIR;
 		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-account-policy-"));
 		process.env.CODEX_MULTI_AUTH_DIR = tempDir;
+		vi.resetModules();
 	});
 
 	afterEach(async () => {
+		const { resetAccountPolicyWriteQueueForTests } = await import(
+			"../lib/account-policy.js"
+		);
+		resetAccountPolicyWriteQueueForTests();
 		if (originalDir === undefined) {
 			delete process.env.CODEX_MULTI_AUTH_DIR;
 		} else {
 			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
 		}
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetry(tempDir, { recursive: true, force: true });
 	});
 
 	it("stores policy rows by hashed account identity", async () => {

--- a/test/account-policy.test.ts
+++ b/test/account-policy.test.ts
@@ -8,18 +8,23 @@ describe("account policy store", () => {
 	let tempDir: string;
 	let originalDir: string | undefined;
 
+	async function resetAccountPolicyQueue(): Promise<void> {
+		const { resetAccountPolicyWriteQueueForTests } = await import(
+			"../lib/account-policy.js"
+		);
+		resetAccountPolicyWriteQueueForTests();
+	}
+
 	beforeEach(async () => {
 		originalDir = process.env.CODEX_MULTI_AUTH_DIR;
 		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-account-policy-"));
 		process.env.CODEX_MULTI_AUTH_DIR = tempDir;
 		vi.resetModules();
+		await resetAccountPolicyQueue();
 	});
 
 	afterEach(async () => {
-		const { resetAccountPolicyWriteQueueForTests } = await import(
-			"../lib/account-policy.js"
-		);
-		resetAccountPolicyWriteQueueForTests();
+		await resetAccountPolicyQueue();
 		if (originalDir === undefined) {
 			delete process.env.CODEX_MULTI_AUTH_DIR;
 		} else {

--- a/test/account-policy.test.ts
+++ b/test/account-policy.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("account policy store", () => {
+	let tempDir: string;
+	let originalDir: string | undefined;
+
+	beforeEach(async () => {
+		originalDir = process.env.CODEX_MULTI_AUTH_DIR;
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-account-policy-"));
+		process.env.CODEX_MULTI_AUTH_DIR = tempDir;
+	});
+
+	afterEach(async () => {
+		if (originalDir === undefined) {
+			delete process.env.CODEX_MULTI_AUTH_DIR;
+		} else {
+			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
+		}
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("stores policy rows by hashed account identity", async () => {
+		const {
+			getAccountPolicyKey,
+			getAccountPolicyPath,
+			loadAccountPolicyStore,
+			saveAccountPolicyStore,
+			upsertAccountPolicy,
+		} = await import("../lib/account-policy.js");
+		const account = {
+			accountId: "acct_sensitive",
+			email: "owner@example.com",
+		};
+		const accountKey = getAccountPolicyKey(account, 0);
+		const store = await loadAccountPolicyStore();
+		upsertAccountPolicy(store, accountKey, (policy) => {
+			policy.tags.push("Team A");
+			policy.weight = 2;
+			policy.paused = true;
+			policy.note = "local note";
+		}, 123);
+		await saveAccountPolicyStore(store);
+
+		const raw = await fs.readFile(getAccountPolicyPath(), "utf8");
+		expect(raw).toContain("team-a");
+		expect(raw).not.toContain("acct_sensitive");
+		expect(raw).not.toContain("owner@example.com");
+
+		const loaded = await loadAccountPolicyStore();
+		expect(loaded.accounts[accountKey]).toMatchObject({
+			tags: ["team-a"],
+			weight: 2,
+			paused: true,
+			note: "local note",
+			updatedAt: 123,
+		});
+	});
+});
+

--- a/test/account-policy.test.ts
+++ b/test/account-policy.test.ts
@@ -69,5 +69,17 @@ describe("account policy store", () => {
 			updatedAt: 123,
 		});
 	});
+
+	it("does not use mutable account indexes as policy identity", async () => {
+		const { getAccountPolicyKey } = await import("../lib/account-policy.js");
+		const unidentified = {
+			accountId: undefined,
+			email: undefined,
+		};
+
+		expect(getAccountPolicyKey(unidentified, 0)).toBe(
+			getAccountPolicyKey(unidentified, 4),
+		);
+	});
 });
 

--- a/test/codex-manager-account-command.test.ts
+++ b/test/codex-manager-account-command.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { getAccountPolicyKey, type AccountPolicyStore } from "../lib/account-policy.js";
+import { runAccountCommand } from "../lib/codex-manager/commands/account.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+function makeStorage(): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { codex: 0 },
+		accounts: [
+			{
+				email: "owner@example.com",
+				accountId: "acct_1",
+				refreshToken: "refresh",
+				addedAt: 1,
+				lastUsed: 1,
+			},
+		],
+	};
+}
+
+function makeDeps(store: AccountPolicyStore) {
+	return {
+		setStoragePath: vi.fn(),
+		loadAccounts: vi.fn(async () => makeStorage()),
+		loadPolicyStore: vi.fn(async () => store),
+		savePolicyStore: vi.fn(async () => undefined),
+		logInfo: vi.fn(),
+		logError: vi.fn(),
+		getNow: () => 123,
+	};
+}
+
+describe("account command", () => {
+	it("tags and pauses account policies", async () => {
+		const store: AccountPolicyStore = { version: 1, accounts: {} };
+		const deps = makeDeps(store);
+
+		expect(await runAccountCommand(["tag", "1", "Team A"], deps)).toBe(0);
+		expect(await runAccountCommand(["pause", "1"], deps)).toBe(0);
+
+		const key = getAccountPolicyKey(makeStorage().accounts[0]!, 0);
+		expect(store.accounts[key]).toMatchObject({
+			tags: ["team-a"],
+			paused: true,
+			updatedAt: 123,
+		});
+		expect(deps.savePolicyStore).toHaveBeenCalledTimes(2);
+	});
+
+	it("sets weight, drain state, and note", async () => {
+		const store: AccountPolicyStore = { version: 1, accounts: {} };
+		const deps = makeDeps(store);
+
+		expect(await runAccountCommand(["weight", "1", "3.5"], deps)).toBe(0);
+		expect(await runAccountCommand(["drain", "1"], deps)).toBe(0);
+		expect(await runAccountCommand(["note", "1", "batch", "only"], deps)).toBe(0);
+
+		const key = getAccountPolicyKey(makeStorage().accounts[0]!, 0);
+		expect(store.accounts[key]).toMatchObject({
+			weight: 3.5,
+			drained: true,
+			note: "batch only",
+		});
+	});
+
+	it("lists policy state as json", async () => {
+		const storage = makeStorage();
+		const key = getAccountPolicyKey(storage.accounts[0]!, 0);
+		const store: AccountPolicyStore = {
+			version: 1,
+			accounts: {
+				[key]: {
+					accountKey: key,
+					tags: ["team-a"],
+					weight: 2,
+					paused: true,
+					drained: false,
+					note: null,
+					updatedAt: 123,
+				},
+			},
+		};
+		const deps = makeDeps(store);
+
+		expect(await runAccountCommand(["policy", "list", "--json"], deps)).toBe(0);
+		const payload = JSON.parse(String(deps.logInfo.mock.calls[0]?.[0])) as {
+			accounts: Array<{ accountKey: string; tags: string[]; paused: boolean }>;
+		};
+		expect(payload.accounts[0]).toMatchObject({
+			accountKey: key,
+			tags: ["team-a"],
+			paused: true,
+		});
+		expect(JSON.stringify(payload)).not.toContain("acct_1");
+		expect(JSON.stringify(payload)).not.toContain("owner@example.com");
+	});
+
+	it("rejects invalid account indexes", async () => {
+		const deps = makeDeps({ version: 1, accounts: {} });
+		expect(await runAccountCommand(["tag", "2", "team"], deps)).toBe(1);
+		expect(String(deps.logError.mock.calls[0]?.[0])).toContain(
+			"Account index is required",
+		);
+	});
+});
+

--- a/test/codex-manager-usage-command.test.ts
+++ b/test/codex-manager-usage-command.test.ts
@@ -70,13 +70,15 @@ const rows: UsageLedgerRow[] = [
 describe("usage command", () => {
 	it("prints text summaries by default", async () => {
 		const logInfo = vi.fn();
+		const readRows = vi.fn(async () => rows);
 		const exitCode = await runUsageCommand([], {
 			logInfo,
 			summarizeUsage: async () => makeSummary(),
-			readRows: async () => rows,
+			readRows,
 		});
 
 		expect(exitCode).toBe(0);
+		expect(readRows).not.toHaveBeenCalled();
 		expect(String(logInfo.mock.calls[0]?.[0])).toContain(
 			"Usage summary by model",
 		);
@@ -99,18 +101,21 @@ describe("usage command", () => {
 		};
 		expect(payload.command).toBe("usage");
 		expect(payload.rows[0]?.id).toBe("row-1");
-		expect(payload.summary.totals.requests).toBe(2);
+		expect(payload.summary.totals.requests).toBe(1);
+		expect(payload.summary.totals.totalTokens).toBe(rows[0]?.tokens.totalTokens);
 	});
 
 	it("prints csv output", async () => {
 		const logInfo = vi.fn();
+		const readRows = vi.fn(async () => rows);
 		const exitCode = await runUsageCommand(["--csv", "--by", "day"], {
 			logInfo,
 			summarizeUsage: async (query) => makeSummary({ by: query.by }),
-			readRows: async () => rows,
+			readRows,
 		});
 
 		expect(exitCode).toBe(0);
+		expect(readRows).not.toHaveBeenCalled();
 		const output = String(logInfo.mock.calls[0]?.[0]);
 		expect(output).toContain("key,requests,successes");
 		expect(output).toContain("gpt-5.3-codex,2,1,1");
@@ -119,15 +124,17 @@ describe("usage command", () => {
 	it("writes rendered output to a file", async () => {
 		const writeFile = vi.fn(async () => undefined);
 		const logInfo = vi.fn();
+		const readRows = vi.fn(async () => rows);
 		const exitCode = await runUsageCommand(["--out", "usage.txt"], {
 			logInfo,
 			writeFile,
 			getCwd: () => "/workspace",
 			summarizeUsage: async () => makeSummary(),
-			readRows: async () => rows,
+			readRows,
 		});
 
 		expect(exitCode).toBe(0);
+		expect(readRows).not.toHaveBeenCalled();
 		expect(writeFile).toHaveBeenCalledWith(
 			expect.stringContaining("usage.txt"),
 			expect.stringContaining("Usage summary by model"),
@@ -165,6 +172,22 @@ describe("usage command", () => {
 		expect(exitCode).toBe(1);
 		expect(String(logError.mock.calls[0]?.[0])).toContain(
 			"Cannot combine --json and --csv",
+		);
+	});
+
+	it("reports ledger read failures without uncaught rejections", async () => {
+		const logError = vi.fn();
+		const exitCode = await runUsageCommand(["--json"], {
+			logError,
+			logInfo: vi.fn(),
+			readRows: async () => {
+				throw new Error("read failed");
+			},
+		});
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Failed to read usage ledger: read failed",
 		);
 	});
 });

--- a/test/codex-manager-usage-command.test.ts
+++ b/test/codex-manager-usage-command.test.ts
@@ -162,6 +162,23 @@ describe("usage command", () => {
 		});
 	});
 
+	it("reports rotate failures without uncaught rejections", async () => {
+		const logError = vi.fn();
+		const rotateLedger = vi.fn(async () => {
+			throw new Error("rename denied");
+		});
+		const exitCode = await runUsageCommand(["rotate"], {
+			logError,
+			logInfo: vi.fn(),
+			rotateLedger,
+		});
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Failed to rotate usage ledger: rename denied",
+		);
+	});
+
 	it("rejects invalid options", async () => {
 		const logError = vi.fn();
 		const exitCode = await runUsageCommand(["--json", "--csv"], {
@@ -188,6 +205,25 @@ describe("usage command", () => {
 		expect(exitCode).toBe(1);
 		expect(String(logError.mock.calls[0]?.[0])).toContain(
 			"Failed to read usage ledger: read failed",
+		);
+	});
+
+	it("reports output write failures without uncaught rejections", async () => {
+		const logError = vi.fn();
+		const writeFile = vi.fn(async () => {
+			throw new Error("disk full");
+		});
+		const exitCode = await runUsageCommand(["--out", "usage.txt"], {
+			logError,
+			logInfo: vi.fn(),
+			writeFile,
+			getCwd: () => "/workspace",
+			summarizeUsage: async () => makeSummary(),
+		});
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Failed to write usage report: disk full",
 		);
 	});
 });

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -122,12 +122,17 @@ describe("usage ledger core", () => {
 			outcome: "success",
 			model: "gpt-5.3-codex",
 		});
+		const lockPath = `${getUsageLedgerPaths().current}.lock`;
+		await fs.writeFile(lockPath, "stale\n", "utf8");
+		const staleDate = new Date(Date.now() - 60_000);
+		await fs.utimes(lockPath, staleDate, staleDate);
 
 		const rotated = await rotateUsageLedger({
 			now: Date.UTC(2026, 0, 2, 3, 4, 5, 6),
 		});
 
 		expect(rotated).toContain("usage-ledger.20260102T030405006Z.jsonl");
+		await expect(fs.stat(lockPath)).rejects.toThrow();
 		await expect(fs.stat(getUsageLedgerPaths().current)).rejects.toThrow();
 
 		await appendUsageLedgerRow({
@@ -177,9 +182,27 @@ describe("usage ledger core", () => {
 				reasoningTokens: 1_000_000,
 				totalTokens: 4_000_000,
 			}),
-		).toBe(21.375);
+		).toBe(20.125);
+		expect(
+			estimateUsageCostUsd("gpt-5.3-codex", {
+				inputTokens: 1_000,
+				outputTokens: 200,
+				cachedInputTokens: 50,
+				reasoningTokens: 25,
+				totalTokens: 1_275,
+			}),
+		).toBe(0.00344375);
 		expect(
 			estimateUsageCostUsd(null, {
+				inputTokens: 1,
+				outputTokens: 1,
+				cachedInputTokens: 0,
+				reasoningTokens: 0,
+				totalTokens: 2,
+			}),
+		).toBeNull();
+		expect(
+			estimateUsageCostUsd("unknown-model", {
 				inputTokens: 1,
 				outputTokens: 1,
 				cachedInputTokens: 0,
@@ -213,6 +236,30 @@ describe("usage ledger core", () => {
 		} finally {
 			appendSpy.mockRestore();
 		}
+	});
+
+	it("removes stale append locks before writing", async () => {
+		const {
+			appendUsageLedgerRow,
+			getUsageLedgerPaths,
+			readUsageLedgerRows,
+		} = await import("../lib/usage/index.js");
+		const { dir, current } = getUsageLedgerPaths();
+		const lockPath = `${current}.lock`;
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(lockPath, "stale\n", "utf8");
+		const staleDate = new Date(Date.now() - 60_000);
+		await fs.utimes(lockPath, staleDate, staleDate);
+
+		await appendUsageLedgerRow({
+			id: "after-stale-lock",
+			outcome: "success",
+		});
+
+		await expect(fs.stat(lockPath)).rejects.toThrow();
+		expect((await readUsageLedgerRows()).map((row) => row.id)).toEqual([
+			"after-stale-lock",
+		]);
 	});
 });
 

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 describe("usage ledger core", () => {
 	let tempDir: string;
@@ -20,7 +21,7 @@ describe("usage ledger core", () => {
 		} else {
 			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
 		}
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await removeWithRetry(tempDir, { recursive: true, force: true });
 	});
 
 	it("appends normalized JSONL rows without raw email or account identifiers", async () => {

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -169,6 +169,39 @@ describe("usage ledger core", () => {
 		).resolves.toBeNull();
 	});
 
+	it("retries transient lock close failures before removing the lock", async () => {
+		const realOpen = fs.open.bind(fs);
+		const openSpy = vi.spyOn(fs, "open");
+		openSpy.mockImplementationOnce(async (...args: Parameters<typeof fs.open>) => {
+			const handle = await realOpen(...args);
+			let closeAttempts = 0;
+			return new Proxy(handle, {
+				get(target, property, receiver) {
+					if (property === "close") {
+						return async () => {
+							closeAttempts += 1;
+							if (closeAttempts === 1) {
+								throw Object.assign(new Error("close busy"), { code: "EBUSY" });
+							}
+							return target.close();
+						};
+					}
+					return Reflect.get(target, property, receiver);
+				},
+			}) as Awaited<ReturnType<typeof fs.open>>;
+		});
+		const { appendUsageLedgerRow, getUsageLedgerPaths } = await import(
+			"../lib/usage/index.js"
+		);
+
+		await appendUsageLedgerRow({ id: "close-retry", outcome: "success" });
+
+		const paths = getUsageLedgerPaths();
+		await expect(fs.access(`${paths.current}.lock`)).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+	});
+
 	it("exports pricing helpers with deterministic estimates", async () => {
 		const { estimateUsageCostUsd, listUsageModelPricing } = await import(
 			"../lib/usage/index.js"

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -53,7 +53,8 @@ describe("usage ledger core", () => {
 		expect(row.account?.accountHash).toMatch(/^sha256:/);
 		expect(row.account?.emailHash).toMatch(/^sha256:/);
 		expect(row.account?.index).toBe(2);
-		expect(row.tokens.totalTokens).toBe(1_275);
+		expect(row.tokens.totalTokens).toBe(1_225);
+		expect(row.tokens.cachedInputTokens).toBe(50);
 		expect(row.costUsd).toBeGreaterThan(0);
 
 		const raw = await fs.readFile(getUsageLedgerPaths().current, "utf8");
@@ -189,7 +190,7 @@ describe("usage ledger core", () => {
 				outputTokens: 200,
 				cachedInputTokens: 50,
 				reasoningTokens: 25,
-				totalTokens: 1_275,
+				totalTokens: 1_225,
 			}),
 		).toBe(0.00344375);
 		expect(


### PR DESCRIPTION
Replacement for merged PR #450 after main was reverted for review.\n\nScope:\n- Add local account policy store.\n- Add codex auth account tag|untag|weight|pause|unpause|drain|undrain|note|policy list.\n- Keep account labels neutral in JSON output.\n\nValidation from original slice:\n- Account policy focused tests passed before the review stack was opened.\n- Cumulative review branch has passed typecheck, lint, and build through PR 06.\n\nReview note:\n- Base is the replacement usage-command PR branch so the local governance stack remains reviewable in order.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

adds local account policy store (`account-policies.json`) with sha256-hashed identity keys and `codex auth account tag|untag|weight|pause|unpause|drain|undrain|note|policy list` commands. also fixes the usage cost calculation in `pricing.ts` to subtract cached tokens from billable input (avoiding double-counting) and removes the zero-rate `DEFAULT_PRICING` fallback so unknown models return `null` instead of `$0`.

<h3>Confidence Score: 5/5</h3>

safe to merge — only p2 findings (test helper in public barrel, minor coverage gaps)

no p0 or p1 issues found; atomic writes, write-queue serialization, windows-safe retry, and hashed identity are all correct; previous p1 comments about bare fs.rm and missing write-queue reset are addressed in this revision

lib/index.ts — test-only reset helper leaks into public barrel

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/account-policy.ts | new account policy store — atomic temp-file+rename writes, write-queue serialization, EBUSY/EPERM retry, sha256-hashed identity keys; no raw emails or account ids persisted |
| lib/codex-manager/commands/account.ts | account command dispatcher — all mutations go through upsertAccountPolicy + saveAccountPolicyStore; policy list output uses neutral "Account N" labels; arg parsing and index validation are solid |
| lib/index.ts | adds `export * from "./account-policy.js"` — leaks `resetAccountPolicyWriteQueueForTests` test helper into the public barrel |
| lib/usage/pricing.ts | removes zero-rate DEFAULT_PRICING fallback (unknown models now return null), fixes cost calculation to subtract cached tokens from billable input to avoid double-counting |
| lib/usage/ledger.ts | no substantive changes from base — lock release correctly catches close error, stores it, then still calls unlinkWithRetry before rethrowing; windows safety intact |
| test/account-policy.test.ts | uses removeWithRetry for cleanup and calls resetAccountPolicyWriteQueueForTests in both beforeEach and afterEach — windows-safe and properly isolated |
| test/usage-ledger.test.ts | uses removeWithRetry for cleanup and vi.resetModules() per-test to get a fresh appendQueue; windows-safe; updated expected cost values align with the billing fix in pricing.ts |
| test/codex-manager-account-command.test.ts | covers tag/pause/weight/drain/note and json output; untag/unpause/undrain paths are not tested |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CLI["codex auth account <cmd>"] --> RC[runAccountCommand]
    RC --> LA[loadAccounts]
    RC --> LP[loadAccountPolicyStore]
    LA --> ST[(account storage)]
    LP --> PS[(account-policies.json)]

    RC --> B{command}

    B -->|tag / untag| TAG[normalizeAccountPolicyTag\nupsertAccountPolicy]
    B -->|weight| WGT[upsertAccountPolicy]
    B -->|pause / unpause\ndrain / undrain| FLG[upsertAccountPolicy]
    B -->|note| NOTE[upsertAccountPolicy]
    B -->|policy list| LIST[policySummary → logInfo]

    TAG --> SV[saveAccountPolicyStore]
    WGT --> SV
    FLG --> SV
    NOTE --> SV

    SV --> WQ[writeQueue\nserial promises]
    WQ --> TF[write .tmp file\nmode 0o600]
    TF --> RN[atomic rename\n+ EBUSY retry]
    RN --> PS
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/usage-ledger.test.ts`, line 23-24 ([link](https://github.com/ndycode/codex-multi-auth/blob/cfae507a48913646a3d9051f2559ca0fd9dbf04b/test/usage-ledger.test.ts#L23-L24)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **bare `fs.rm` in afterEach — windows safety violation**

   `test/AGENTS.md` explicitly forbids bare `fs.rm` in test cleanup: use `removeWithRetry` with `EBUSY`/`EPERM`/`ENOTEMPTY` backoff. the temp dir cleanup can race the `appendFile` or `.lock` unlink on windows, leaving the dir behind and polluting subsequent runs. `account-policy.test.ts` in this same PR uses `removeWithRetry` correctly — apply the same pattern here.

   

   you'll also need to import `removeWithRetry` at the top of the file:
   ```ts
   import { removeWithRetry } from "./helpers/remove-with-retry.js";
   ```

   **Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: test/usage-ledger.test.ts
   Line: 23-24
   
   Comment:
   **bare `fs.rm` in afterEach — windows safety violation**
   
   `test/AGENTS.md` explicitly forbids bare `fs.rm` in test cleanup: use `removeWithRetry` with `EBUSY`/`EPERM`/`ENOTEMPTY` backoff. the temp dir cleanup can race the `appendFile` or `.lock` unlink on windows, leaving the dir behind and polluting subsequent runs. `account-policy.test.ts` in this same PR uses `removeWithRetry` correctly — apply the same pattern here.
   
   
   
   you'll also need to import `removeWithRetry` at the top of the file:
   ```ts
   import { removeWithRetry } from "./helpers/remove-with-retry.js";
   ```
   
   **Context Used:** test/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22review%2Fpr-450-account-policy-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22review%2Fpr-450-account-policy-controls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fusage-ledger.test.ts%0ALine%3A%2023-24%0A%0AComment%3A%0A**bare%20%60fs.rm%60%20in%20afterEach%20%E2%80%94%20windows%20safety%20violation**%0A%0A%60test%2FAGENTS.md%60%20explicitly%20forbids%20bare%20%60fs.rm%60%20in%20test%20cleanup%3A%20use%20%60removeWithRetry%60%20with%20%60EBUSY%60%2F%60EPERM%60%2F%60ENOTEMPTY%60%20backoff.%20the%20temp%20dir%20cleanup%20can%20race%20the%20%60appendFile%60%20or%20%60.lock%60%20unlink%20on%20windows%2C%20leaving%20the%20dir%20behind%20and%20polluting%20subsequent%20runs.%20%60account-policy.test.ts%60%20in%20this%20same%20PR%20uses%20%60removeWithRetry%60%20correctly%20%E2%80%94%20apply%20the%20same%20pattern%20here.%0A%0A%60%60%60suggestion%0A%09%09await%20removeWithRetry%28tempDir%2C%20%7B%20recursive%3A%20true%2C%20force%3A%20true%20%7D%29%3B%0A%60%60%60%0A%0Ayou'll%20also%20need%20to%20import%20%60removeWithRetry%60%20at%20the%20top%20of%20the%20file%3A%0A%60%60%60ts%0Aimport%20%7B%20removeWithRetry%20%7D%20from%20%22.%2Fhelpers%2Fremove-with-retry.js%22%3B%0A%60%60%60%0A%0A**Context%20Used%3A**%20test%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D6e2636a9-e514-4bab-b249-4b4a84aa4ae3%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22review%2Fpr-450-account-policy-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22review%2Fpr-450-account-policy-controls%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Findex.ts%3A44%0A**test-only%20reset%20helper%20in%20public%20barrel**%0A%0A%60export%20*%20from%20%22.%2Faccount-policy.js%22%60%20re-exports%20%60resetAccountPolicyWriteQueueForTests%60%20into%20the%20package's%20public%20API.%20the%20%60ForTests%60%20suffix%20clearly%20marks%20intent%2C%20but%20the%20function%20still%20shows%20up%20in%20%60lib%2Findex.ts%60%20for%20all%20consumers.%20%60resetUsageLedgerQueueForTests%60%20from%20%60lib%2Fusage%2Fledger.ts%60%20has%20the%20same%20exposure%20via%20%60lib%2Fusage%2Findex.ts%60.%0A%0Aconsider%20gating%20each%20reset%20export%20behind%20a%20%60%2F%2F%20%40internal%60%20annotation%20or%20a%20separate%20test-helper%20subpath%2C%20or%20exporting%20them%20only%20through%20the%20test%20files%20themselves%20via%20a%20dedicated%20%60lib%2Ftesting.ts%60%20barrel.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fcodex-manager-account-command.test.ts%3A35-107%0A**missing%20coverage%20for%20%60untag%60%2C%20%60unpause%60%2C%20and%20%60undrain%60%20subcommands**%0A%0Athe%20four%20mutation%20tests%20cover%20%60tag%60%2C%20%60pause%60%2C%20%60weight%60%2C%20%60drain%60%2C%20and%20%60note%60%2C%20but%20%60untag%60%2C%20%60unpause%60%2C%20and%20%60undrain%60%20are%20never%20exercised.%20while%20the%20implementation%20is%20symmetric%20%28same%20code%20path%29%2C%20edge%20cases%20like%20%60untag%60%20on%20a%20tag%20that%20doesn't%20exist%20or%20%60unpause%60%20when%20already%20unpaused%20are%20not%20validated.%20recommend%20adding%20at%20least%20one%20round-trip%20test%20%28tag%20then%20untag%2C%20pause%20then%20unpause%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/index.ts
Line: 44

Comment:
**test-only reset helper in public barrel**

`export * from "./account-policy.js"` re-exports `resetAccountPolicyWriteQueueForTests` into the package's public API. the `ForTests` suffix clearly marks intent, but the function still shows up in `lib/index.ts` for all consumers. `resetUsageLedgerQueueForTests` from `lib/usage/ledger.ts` has the same exposure via `lib/usage/index.ts`.

consider gating each reset export behind a `// @internal` annotation or a separate test-helper subpath, or exporting them only through the test files themselves via a dedicated `lib/testing.ts` barrel.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/codex-manager-account-command.test.ts
Line: 35-107

Comment:
**missing coverage for `untag`, `unpause`, and `undrain` subcommands**

the four mutation tests cover `tag`, `pause`, `weight`, `drain`, and `note`, but `untag`, `unpause`, and `undrain` are never exercised. while the implementation is symmetric (same code path), edge cases like `untag` on a tag that doesn't exist or `unpause` when already unpaused are not validated. recommend adding at least one round-trip test (tag then untag, pause then unpause).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["test: retry usage ledger cleanup"](https://github.com/ndycode/codex-multi-auth/commit/8a6663965f0c45b40d8c6e314bab97f20cbf22d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30171595)</sub>

<!-- /greptile_comment -->