### PR TITLE
Add codex auth pro-advice workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ For remote or headless shells, prefer `codex auth login --device-auth`.
 | `codex auth list` | Which accounts are saved and which one is active? |
 | `codex auth switch <index>` | How do I move to a different saved account? |
 | `codex auth forecast --live` | Which account looks best for the next session? |
+| `codex auth pro-advice` | How do I turn dossier markdown into a GPT-5.5 Pro implementation handoff? |
 
 ### Repair
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -65,7 +65,7 @@ Compatibility aliases are supported:
 | `codex auth integrations` | Generate local bridge client snippets |
 | `codex auth models` | Inspect local model/account capability views |
 | `codex auth monitor` | Aggregate runtime, usage, policy, quota, model, and project state |
-| `codex auth pro-advice [--mode auto|manual]` | Run the Pro-advisor handoff workflow without web-session scraping |
+| `codex auth pro-advice [--mode auto|manual|web]` | Run the Pro-advisor handoff workflow without web-session scraping or private browser polling |
 | `codex auth why-selected [--now|--last]` | Explain which account the selector picks now or via the last persisted runtime snapshot |
 | `codex auth rotation enable\|disable\|status\|bind-app\|unbind-app` | Manage the default-on runtime Responses proxy for live Codex account rotation |
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -35,6 +35,7 @@ Compatibility aliases are supported:
 | `codex auth forecast` | Forecast best account by readiness/risk |
 | `codex auth best` | Pick and optionally sync the best account |
 | `codex auth account ...` | Manage local account policy metadata |
+| `codex auth pro-advice` | Prepare a GPT-5.5 Pro handoff from dossier markdown and save implementation advice |
 
 ---
 
@@ -64,6 +65,7 @@ Compatibility aliases are supported:
 | `codex auth integrations` | Generate local bridge client snippets |
 | `codex auth models` | Inspect local model/account capability views |
 | `codex auth monitor` | Aggregate runtime, usage, policy, quota, model, and project state |
+| `codex auth pro-advice [--mode auto|manual]` | Run the Pro-advisor handoff workflow without web-session scraping |
 | `codex auth why-selected [--now|--last]` | Explain which account the selector picks now or via the last persisted runtime snapshot |
 | `codex auth rotation enable\|disable\|status\|bind-app\|unbind-app` | Manage the default-on runtime Responses proxy for live Codex account rotation |
 
@@ -75,13 +77,17 @@ Compatibility aliases are supported:
 | --- | --- | --- |
 | `--device-auth` | login | Use the OpenAI Codex device-code flow for remote/headless login (mutually exclusive with `--manual` / `--no-browser`) |
 | `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow (mutually exclusive with `--device-auth`) |
-| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle | Print machine-readable output |
+| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, pro-advice, fix, doctor, config explain, debug bundle | Print machine-readable output |
 | `--csv` | usage | Print or write CSV bucket output |
 | `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |
 | `--live` | best, forecast, report, fix | Use live probe before decisions/output |
 | `--dry-run` | verify-flagged, verify (with `--flagged`/`--all`), fix, doctor | Preview without writing storage |
 | `--model <model>` | best, forecast, report, fix | Specify model for live probe paths |
 | `--out <path>` | report, usage | Write report output to file |
+| `--mode auto|manual` | pro-advice | Choose background Responses submission or manual GPT-5.5 Pro handoff |
+| `--handoff <path>` | pro-advice | Write the handoff markdown somewhere other than `PRO_HANDOFF.md` |
+| `--advice <path>` | pro-advice | Read or write advice somewhere other than `PRO_ADVICE.md` |
+| `--no-tui` | pro-advice | Use deterministic non-interactive behavior and print the launch command instead of prompting |
 | `--since <time>` | usage | Filter local usage rows by timestamp, ISO date, or relative duration |
 | `--by <group>` | usage | Group usage by model, account, project, outcome, or day |
 | `--kind <name>` | integrations | Select one snippet kind: opencode, openclaw, python, curl, or env |
@@ -171,6 +177,41 @@ codex auth monitor [--json]
 `monitor` aggregates runtime observability, usage, policy, routing profile,
 budget, model matrix, quota cache, and current project context. `models`
 reports neutral account labels and does not expose raw account emails.
+
+---
+
+## `codex auth pro-advice`
+
+Prepares a Pro-advisor handoff for the current codebase. The command discovers
+root dossier markdown such as `*_DOSSIER.md`, `*_DB_DOSSIER.md`,
+`PRO_HANDOFF.md`, `PRO_ADVICE.md`, and `docs/**/*dossier*.md`, then writes a
+clean `PRO_HANDOFF.md` with frontmatter and a required output contract.
+
+Usage:
+
+```bash
+codex auth pro-advice
+codex auth pro-advice --mode manual --no-tui
+codex auth pro-advice --handoff docs/PRO_HANDOFF.md --advice docs/PRO_ADVICE.md
+```
+
+Behavior:
+
+- Auto mode submits the handoff with `background: true` through the managed
+  Codex account pool when the active account is entitled to `gpt-5.5-pro`.
+- Entitlement, auth, quota, and upstream failures are shown plainly, then the
+  command falls back to the manual handoff path.
+- Manual mode writes the handoff and accepts either pasted Pro output or an
+  already-saved `PRO_ADVICE.md`.
+- If no dossier markdown is found, the command writes `PRO_DOSSIER_PROMPT.md`
+  and `PRO_DOSSIER_DB_PROMPT.md` so the user can run `$dossier` and
+  `$dossier-db` first.
+- The command never automates ChatGPT web sessions, cookies, browser state, or
+  private web UI polling.
+
+After `PRO_ADVICE.md` exists, interactive runs ask before launching a new Codex
+session with a prompt that reads the advice and follows its implementation
+prompt. Non-TTY and `--no-tui` runs print the exact launch command instead.
 
 ---
 

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -44,6 +44,7 @@ import { runIntegrationsCommand } from "./codex-manager/commands/integrations.js
 import { runModelsCommand } from "./codex-manager/commands/models.js";
 import { runMonitorCommand } from "./codex-manager/commands/monitor.js";
 import { runConfigExplainCommand } from "./codex-manager/commands/config-explain.js";
+import { runProAdviceCommand } from "./codex-manager/commands/pro-advice.js";
 import { saveAccountsWithRetry } from "./codex-manager/forecast-report-shared.js";
 import { runDebugBundleCommand } from "./codex-manager/commands/debug-bundle.js";
 import {
@@ -3487,6 +3488,14 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 		return runMonitorCommand(rest, {
 			setStoragePath,
 			loadAccounts,
+		});
+	}
+	if (command === "pro-advice") {
+		return runProAdviceCommand(rest, {
+			loadAccounts,
+			resolveActiveIndex,
+			refreshAccessToken: queuedRefresh,
+			isTty: () => output.isTTY,
 		});
 	}
 	if (command === "report") {

--- a/lib/codex-manager/commands/pro-advice.ts
+++ b/lib/codex-manager/commands/pro-advice.ts
@@ -19,6 +19,7 @@ import type { TokenResult } from "../../types.js";
 const DEFAULT_MODEL = "gpt-5.5-pro";
 const DEFAULT_HANDOFF_FILE = "PRO_HANDOFF.md";
 const DEFAULT_ADVICE_FILE = "PRO_ADVICE.md";
+const DEFAULT_CHATGPT_PROMPT_FILE = "PRO_CHATGPT_PROMPT.md";
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const POLL_INTERVAL_MS = 2_500;
 const MAX_SCAN_DEPTH = 4;
@@ -52,6 +53,7 @@ export interface ProAdviceDeps {
 	createReadline?: () => Interface;
 	spawnCodex?: (command: string, args: string[]) => { pid?: number };
 	openUrl?: (url: string) => void | Promise<void>;
+	writeClipboard?: (text: string) => void | Promise<void>;
 	logInfo?: (message: string) => void;
 	logError?: (message: string) => void;
 }
@@ -505,12 +507,60 @@ function openExternalUrl(url: string, deps: ProAdviceDeps): void | Promise<void>
 	child.unref();
 }
 
+function writeClipboard(text: string, deps: ProAdviceDeps): Promise<boolean> {
+	if (deps.writeClipboard) {
+		return Promise.resolve(deps.writeClipboard(text)).then(
+			() => true,
+			() => false,
+		);
+	}
+	if (process.platform !== "win32") return Promise.resolve(false);
+	return new Promise((resolveCopy) => {
+		const child = spawn(
+			"powershell.exe",
+			["-NoProfile", "-Command", "Set-Clipboard -Value ([Console]::In.ReadToEnd())"],
+			{ stdio: ["pipe", "ignore", "ignore"], windowsHide: true },
+		);
+		child.on("error", () => resolveCopy(false));
+		child.on("exit", (code) => resolveCopy(code === 0));
+		child.stdin.end(text);
+	});
+}
+
 function isCodexChatGptModelUnsupported(error: string): boolean {
 	return (
 		error.includes("gpt-5.5-pro") &&
 		error.includes("not supported") &&
 		error.includes("ChatGPT account")
 	);
+}
+
+function buildChatGptWebPrompt(params: {
+	handoff: string;
+	advicePath: string;
+	activeAccount: string | null;
+}): string {
+	const accountLine = params.activeAccount
+		? `Use the ChatGPT account currently selected in the codex-multi-auth pool: ${params.activeAccount}.`
+		: "Use the intended ChatGPT Pro account for this repository.";
+	return [
+		"Run this as GPT-5.5 Pro Extended.",
+		"",
+		accountLine,
+		"",
+		"Read the handoff below and produce the required output contract exactly.",
+		"Return markdown only, with sections:",
+		"1. Findings",
+		"2. Recommended Plan",
+		"3. Codex Implementation Prompt",
+		"",
+		`After the response is complete, save the markdown output to: ${params.advicePath}`,
+		"",
+		"--- HANDOFF START ---",
+		params.handoff.trimEnd(),
+		"--- HANDOFF END ---",
+		"",
+	].join("\n");
 }
 
 async function submitBackgroundAdvice(params: {
@@ -667,6 +717,7 @@ async function runManualAdvice(params: {
 }
 
 async function runWebAdvice(params: {
+	repoRoot: string;
 	handoffPath: string;
 	advicePath: string;
 	deps: ProAdviceDeps;
@@ -679,6 +730,16 @@ async function runWebAdvice(params: {
 	}
 
 	const activeAccount = await getActiveAccountLabel(params.deps);
+	const handoff = (await readIfExists(params.handoffPath)) ?? "";
+	const promptPath = join(params.repoRoot, DEFAULT_CHATGPT_PROMPT_FILE);
+	const webPrompt = buildChatGptWebPrompt({
+		handoff,
+		advicePath: params.advicePath,
+		activeAccount,
+	});
+	await writeTextFile(promptPath, webPrompt);
+	const copied = await writeClipboard(webPrompt, params.deps);
+	await Promise.resolve(openExternalUrl(CHATGPT_WEB_URL, params.deps)).catch(() => undefined);
 	const accountHint = activeAccount
 		? `Active pool account: ${activeAccount}`
 		: "Active pool account could not be resolved; use the intended ChatGPT Pro account.";
@@ -687,7 +748,11 @@ async function runWebAdvice(params: {
 		accountHint,
 		`Open: ${CHATGPT_WEB_URL}`,
 		"Use GPT-5.5 Pro Extended in ChatGPT web.",
-		`Paste the handoff from: ${params.handoffPath}`,
+		copied
+			? "The Pro prompt was copied to the clipboard."
+			: `Copy the Pro prompt from: ${promptPath}`,
+		`Prompt file: ${promptPath}`,
+		`Handoff file: ${params.handoffPath}`,
 		`Save the Pro output to: ${params.advicePath}`,
 	].join("\n");
 
@@ -699,7 +764,6 @@ async function runWebAdvice(params: {
 		};
 	}
 
-	await Promise.resolve(openExternalUrl(CHATGPT_WEB_URL, params.deps)).catch(() => undefined);
 	const rl =
 		params.deps.createReadline?.() ??
 		createInterface({ input: defaultInput, output: defaultOutput });
@@ -850,6 +914,7 @@ export async function runProAdviceCommand(
 			}
 			result = isCodexChatGptModelUnsupported(result.error)
 				? await runWebAdvice({
+						repoRoot,
 						handoffPath,
 						advicePath,
 						deps,
@@ -864,6 +929,7 @@ export async function runProAdviceCommand(
 		}
 	} else if (options.mode === "web") {
 		result = await runWebAdvice({
+			repoRoot,
 			handoffPath,
 			advicePath,
 			deps,

--- a/lib/codex-manager/commands/pro-advice.ts
+++ b/lib/codex-manager/commands/pro-advice.ts
@@ -1,0 +1,765 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import {
+	mkdir,
+	readFile,
+	readdir,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { stdin as defaultInput, stdout as defaultOutput } from "node:process";
+import { createInterface, type Interface } from "node:readline/promises";
+import { CODEX_BASE_URL } from "../../constants.js";
+import { queuedRefresh } from "../../refresh-queue.js";
+import type { AccountStorageV3 } from "../../storage.js";
+import { createCodexHeaders } from "../../request/fetch-helpers.js";
+import type { TokenResult } from "../../types.js";
+
+const DEFAULT_MODEL = "gpt-5.5-pro";
+const DEFAULT_HANDOFF_FILE = "PRO_HANDOFF.md";
+const DEFAULT_ADVICE_FILE = "PRO_ADVICE.md";
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const POLL_INTERVAL_MS = 2_500;
+const MAX_SCAN_DEPTH = 4;
+
+export interface ProAdviceOptions {
+	mode: "auto" | "manual";
+	handoffPath: string;
+	advicePath: string;
+	noTui: boolean;
+	json: boolean;
+	task?: string;
+	timeoutMs: number;
+}
+
+export interface DossierCandidate {
+	path: string;
+	relativePath: string;
+	priority: number;
+}
+
+export interface ProAdviceDeps {
+	cwd?: () => string;
+	now?: () => Date;
+	isTty?: () => boolean;
+	loadAccounts?: () => Promise<AccountStorageV3 | null>;
+	resolveActiveIndex?: (storage: AccountStorageV3) => number;
+	refreshAccessToken?: (refreshToken: string) => Promise<TokenResult>;
+	fetch?: typeof fetch;
+	createReadline?: () => Interface;
+	spawnCodex?: (command: string, args: string[]) => { pid?: number };
+	logInfo?: (message: string) => void;
+	logError?: (message: string) => void;
+}
+
+type ParseResult =
+	| { ok: true; options: ProAdviceOptions }
+	| { ok: false; reason: "help" }
+	| { ok: false; reason: "error"; message: string };
+
+type AdviceResult =
+	| { ok: true; advicePath: string; responseId?: string; mode: "auto" | "manual" }
+	| { ok: false; error: string; status?: number; responseId?: string };
+
+function printProAdviceUsage(logInfo: (message: string) => void): void {
+	logInfo(
+		[
+			"Usage:",
+			"  codex auth pro-advice [--mode auto|manual] [--handoff <path>] [--advice <path>] [--no-tui] [--json]",
+			"",
+			"Behavior:",
+			"  - Discovers dossier markdown in the current codebase",
+			"  - Writes PRO_HANDOFF.md with a required GPT-5.5 Pro output contract",
+			"  - Auto mode uses official background Responses when an entitled managed account is available",
+			"  - Manual mode saves the handoff and accepts pasted or existing PRO_ADVICE.md output",
+			"  - It does not automate ChatGPT web sessions, cookies, or browser polling",
+		].join("\n"),
+	);
+}
+
+export function parseProAdviceArgs(args: string[]): ParseResult {
+	const options: ProAdviceOptions = {
+		mode: "auto",
+		handoffPath: DEFAULT_HANDOFF_FILE,
+		advicePath: DEFAULT_ADVICE_FILE,
+		noTui: false,
+		json: false,
+		timeoutMs: DEFAULT_TIMEOUT_MS,
+	};
+
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (!arg) continue;
+		if (arg === "--help" || arg === "-h" || arg === "help") {
+			return { ok: false, reason: "help" };
+		}
+		if (arg === "--mode") {
+			const value = args[i + 1];
+			if (value !== "auto" && value !== "manual") {
+				return {
+					ok: false,
+					reason: "error",
+					message: "--mode expects auto or manual",
+				};
+			}
+			options.mode = value;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--mode=")) {
+			const value = arg.slice("--mode=".length);
+			if (value !== "auto" && value !== "manual") {
+				return {
+					ok: false,
+					reason: "error",
+					message: "--mode expects auto or manual",
+				};
+			}
+			options.mode = value;
+			continue;
+		}
+		if (arg === "--handoff") {
+			const value = args[i + 1];
+			if (!value) {
+				return {
+					ok: false,
+					reason: "error",
+					message: "Missing value for --handoff",
+				};
+			}
+			options.handoffPath = value;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--handoff=")) {
+			const value = arg.slice("--handoff=".length).trim();
+			if (!value) {
+				return {
+					ok: false,
+					reason: "error",
+					message: "Missing value for --handoff",
+				};
+			}
+			options.handoffPath = value;
+			continue;
+		}
+		if (arg === "--advice") {
+			const value = args[i + 1];
+			if (!value) {
+				return {
+					ok: false,
+					reason: "error",
+					message: "Missing value for --advice",
+				};
+			}
+			options.advicePath = value;
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("--advice=")) {
+			const value = arg.slice("--advice=".length).trim();
+			if (!value) {
+				return {
+					ok: false,
+					reason: "error",
+					message: "Missing value for --advice",
+				};
+			}
+			options.advicePath = value;
+			continue;
+		}
+		if (arg === "--no-tui") {
+			options.noTui = true;
+			continue;
+		}
+		if (arg === "--json" || arg === "-j") {
+			options.json = true;
+			continue;
+		}
+		return {
+			ok: false,
+			reason: "error",
+			message: `Unknown pro-advice option: ${arg}`,
+		};
+	}
+
+	return { ok: true, options };
+}
+
+function normalizePath(root: string, value: string): string {
+	return resolve(root, value);
+}
+
+function isMarkdownFile(path: string): boolean {
+	return extname(path).toLowerCase() === ".md";
+}
+
+function scoreDossier(relativePath: string): number | null {
+	const normalized = relativePath.replace(/\\/g, "/");
+	const name = basename(normalized).toLowerCase();
+	if (name === "pro_handoff.md") return 10;
+	if (name === "pro_advice.md") return 20;
+	if (/^[a-z0-9._-]+_db_dossier\.md$/i.test(name)) return 30;
+	if (/^[a-z0-9._-]+_dossier\.md$/i.test(name)) return 40;
+	if (/dossier/i.test(name) && !normalized.includes("/")) return 50;
+	if (/^docs\/.*dossier.*\.md$/i.test(normalized)) return 60;
+	return null;
+}
+
+async function scanMarkdown(
+	root: string,
+	dir: string,
+	depth: number,
+	out: DossierCandidate[],
+): Promise<void> {
+	if (depth > MAX_SCAN_DEPTH) return;
+	const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+	for (const entry of entries) {
+		if (entry.name === "node_modules" || entry.name === ".git" || entry.name === "dist") {
+			continue;
+		}
+		const absolute = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			await scanMarkdown(root, absolute, depth + 1, out);
+			continue;
+		}
+		if (!entry.isFile() || !isMarkdownFile(entry.name)) continue;
+		const relativePath = relative(root, absolute);
+		const priority = scoreDossier(relativePath);
+		if (priority === null) continue;
+		out.push({ path: absolute, relativePath, priority });
+	}
+}
+
+export async function discoverDossierCandidates(
+	root: string,
+): Promise<DossierCandidate[]> {
+	const out: DossierCandidate[] = [];
+	await scanMarkdown(root, root, 0, out);
+	return out.sort(
+		(left, right) =>
+			left.priority - right.priority ||
+			left.relativePath.localeCompare(right.relativePath),
+	);
+}
+
+function yamlString(value: string): string {
+	return JSON.stringify(value);
+}
+
+function defaultTask(repoName: string): string {
+	return `Review the selected ${repoName} dossier inputs as GPT-5.5 Pro and produce implementation advice for Codex.`;
+}
+
+export function buildDossierPromptFiles(repoName: string): Record<string, string> {
+	return {
+		"PRO_DOSSIER_PROMPT.md": [
+			"# Dossier Prompt",
+			"",
+			"Run `$dossier` in this repository.",
+			"",
+			"Produce one root markdown artifact based on actual code inspection.",
+			"Cover runtime surfaces, subsystems, data boundaries, developer workflows, risks, drift, and uncertainty.",
+			`Repository: ${repoName}`,
+			"",
+		].join("\n"),
+		"PRO_DOSSIER_DB_PROMPT.md": [
+			"# Database Dossier Prompt",
+			"",
+			"Run `$dossier-db` for this project only if live database MCP access is available.",
+			"",
+			"Inspect the live schema through MCP and produce one root markdown artifact.",
+			"Call out blocked or incomplete MCP access explicitly instead of filling gaps from repo docs.",
+			`Repository: ${repoName}`,
+			"",
+		].join("\n"),
+	};
+}
+
+export function buildProHandoffMarkdown(params: {
+	repoRoot: string;
+	createdAt: Date;
+	selectedInputs: DossierCandidate[];
+	task?: string;
+}): string {
+	const repo = basename(params.repoRoot);
+	const task = params.task ?? defaultTask(repo);
+	const selected = params.selectedInputs.map((candidate) =>
+		candidate.relativePath.replace(/\\/g, "/"),
+	);
+	const frontmatter = [
+		"---",
+		'kind: "codex-pro-advice-handoff"',
+		'version: "1"',
+		`repo: ${yamlString(repo)}`,
+		`created_at: ${yamlString(params.createdAt.toISOString())}`,
+		"selected_inputs:",
+		...(selected.length > 0
+			? selected.map((input) => `  - ${yamlString(input)}`)
+			: ["  - null"]),
+		`task: ${yamlString(task)}`,
+		"required_output:",
+		'  - "findings"',
+		'  - "recommended_plan"',
+		'  - "codex_implementation_prompt"',
+		"---",
+		"",
+	];
+
+	const sections = [
+		"# GPT-5.5 Pro Handoff",
+		"",
+		"## Task",
+		"",
+		task,
+		"",
+		"## Required Output Contract",
+		"",
+		"Return markdown with exactly these sections:",
+		"",
+		"1. Findings",
+		"2. Recommended Plan",
+		"3. Codex Implementation Prompt",
+		"",
+		"The implementation prompt must be copy-pasteable into a fresh Codex session and must include scope, files or areas to inspect, constraints, verification commands, and non-goals.",
+		"",
+		"## Selected Inputs",
+		"",
+	];
+
+	if (params.selectedInputs.length === 0) {
+		sections.push(
+			"No dossier markdown was selected. Use the prompt files generated next to this handoff to create dossier inputs first.",
+			"",
+		);
+	} else {
+		for (const candidate of params.selectedInputs) {
+			sections.push(`### ${candidate.relativePath.replace(/\\/g, "/")}`, "");
+			sections.push(`Source path: \`${candidate.relativePath.replace(/\\/g, "/")}\``, "");
+		}
+	}
+
+	sections.push(
+		"## Pro Instructions",
+		"",
+		"Act as a senior implementation advisor. Ground conclusions in the selected dossier contents. Do not assume access to private browser sessions or ChatGPT web cookies. If a required fact is missing, mark it as an uncertainty and recommend the smallest verification step.",
+		"",
+	);
+
+	return `${frontmatter.join("\n")}${sections.join("\n")}`;
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+	await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function writeTextFile(filePath: string, content: string): Promise<void> {
+	await ensureParentDir(filePath);
+	await writeFile(filePath, content, "utf8");
+}
+
+async function readIfExists(path: string): Promise<string | null> {
+	if (!existsSync(path)) return null;
+	const stats = await stat(path).catch(() => null);
+	if (!stats?.isFile()) return null;
+	return readFile(path, "utf8");
+}
+
+function extractResponseText(payload: unknown): string {
+	if (!payload || typeof payload !== "object") return "";
+	const record = payload as Record<string, unknown>;
+	if (typeof record.output_text === "string") return record.output_text;
+	const output = Array.isArray(record.output) ? record.output : [];
+	const chunks: string[] = [];
+	for (const item of output) {
+		if (!item || typeof item !== "object") continue;
+		const itemRecord = item as Record<string, unknown>;
+		const content = Array.isArray(itemRecord.content) ? itemRecord.content : [];
+		for (const contentItem of content) {
+			if (!contentItem || typeof contentItem !== "object") continue;
+			const contentRecord = contentItem as Record<string, unknown>;
+			if (typeof contentRecord.text === "string") {
+				chunks.push(contentRecord.text);
+			}
+		}
+	}
+	return chunks.join("\n").trim();
+}
+
+function extractError(payload: unknown, fallback: string): string {
+	if (!payload || typeof payload !== "object") return fallback;
+	const record = payload as Record<string, unknown>;
+	const error = record.error;
+	if (error && typeof error === "object") {
+		const nested = error as Record<string, unknown>;
+		if (typeof nested.message === "string") return nested.message;
+		if (typeof nested.code === "string") return nested.code;
+	}
+	if (typeof record.message === "string") return record.message;
+	return fallback;
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+	const text = await response.text().catch(() => "");
+	if (!text) return {};
+	try {
+		return JSON.parse(text) as unknown;
+	} catch {
+		return { error: { message: text } };
+	}
+}
+
+function responseStatus(payload: unknown): string {
+	if (!payload || typeof payload !== "object") return "";
+	const status = (payload as Record<string, unknown>).status;
+	return typeof status === "string" ? status : "";
+}
+
+function responseId(payload: unknown): string | undefined {
+	if (!payload || typeof payload !== "object") return undefined;
+	const id = (payload as Record<string, unknown>).id;
+	return typeof id === "string" ? id : undefined;
+}
+
+async function getManagedAccess(deps: ProAdviceDeps): Promise<{
+	accountId: string;
+	accessToken: string;
+}> {
+	if (!deps.loadAccounts || !deps.resolveActiveIndex) {
+		throw new Error("Auto mode requires account storage dependencies.");
+	}
+	const storage = await deps.loadAccounts();
+	if (!storage || storage.accounts.length === 0) {
+		throw new Error("No managed Codex accounts are configured. Run `codex auth login` or use --mode manual.");
+	}
+	const index = deps.resolveActiveIndex(storage);
+	const account = storage.accounts[index];
+	if (!account) {
+		throw new Error("Active account index is out of range.");
+	}
+	const refresh = deps.refreshAccessToken ?? queuedRefresh;
+	const token = await refresh(account.refreshToken);
+	if (token.type !== "success") {
+		throw new Error(token.message ?? token.reason ?? "Token refresh failed.");
+	}
+	const accountId = account.accountId;
+	if (!accountId) {
+		throw new Error("Active account has no ChatGPT account id. Re-login or use --mode manual.");
+	}
+	return { accountId, accessToken: token.access };
+}
+
+async function submitBackgroundAdvice(params: {
+	handoff: string;
+	advicePath: string;
+	deps: ProAdviceDeps;
+	options: ProAdviceOptions;
+}): Promise<AdviceResult> {
+	const fetchImpl = params.deps.fetch ?? fetch;
+	const startedAt = Date.now();
+	const access = await getManagedAccess(params.deps);
+	const headers = createCodexHeaders(undefined, access.accountId, access.accessToken, {
+		model: DEFAULT_MODEL,
+	});
+	headers.set("content-type", "application/json");
+	headers.set("accept", "application/json");
+	const body = {
+		model: DEFAULT_MODEL,
+		background: true,
+		input: [
+			{
+				role: "user",
+				content: [
+					{
+						type: "input_text",
+						text: params.handoff,
+					},
+				],
+			},
+		],
+	};
+
+	const created = await fetchImpl(`${CODEX_BASE_URL}/codex/responses`, {
+		method: "POST",
+		headers,
+		body: JSON.stringify(body),
+	});
+	const createdPayload = await parseJsonResponse(created);
+	const responseIdValue = responseId(createdPayload);
+	if (!created.ok) {
+		return {
+			ok: false,
+			status: created.status,
+			responseId: responseIdValue,
+			error: extractError(createdPayload, `Background response failed with HTTP ${created.status}`),
+		};
+	}
+
+	let latestPayload = createdPayload;
+	while (Date.now() - startedAt < params.options.timeoutMs) {
+		const status = responseStatus(latestPayload);
+		if (status === "completed" || (!status && extractResponseText(latestPayload))) {
+			const text = extractResponseText(latestPayload);
+			if (!text) {
+				return {
+					ok: false,
+					responseId: responseIdValue,
+					error: "Background response completed without text output.",
+				};
+			}
+			await writeTextFile(params.advicePath, text);
+			return {
+				ok: true,
+				mode: "auto",
+				advicePath: params.advicePath,
+				responseId: responseIdValue,
+			};
+		}
+		if (status === "failed" || status === "cancelled" || status === "expired") {
+			return {
+				ok: false,
+				responseId: responseIdValue,
+				error: extractError(latestPayload, `Background response ${status}.`),
+			};
+		}
+		if (!responseIdValue) {
+			return {
+				ok: false,
+				error: "Background response did not return an id to poll.",
+			};
+		}
+		await new Promise((resolvePoll) => setTimeout(resolvePoll, POLL_INTERVAL_MS));
+		const polled = await fetchImpl(
+			`${CODEX_BASE_URL}/codex/responses/${encodeURIComponent(responseIdValue)}`,
+			{ method: "GET", headers },
+		);
+		latestPayload = await parseJsonResponse(polled);
+		if (!polled.ok) {
+			return {
+				ok: false,
+				status: polled.status,
+				responseId: responseIdValue,
+				error: extractError(latestPayload, `Polling failed with HTTP ${polled.status}`),
+			};
+		}
+	}
+
+	if (responseIdValue) {
+		await fetchImpl(
+			`${CODEX_BASE_URL}/codex/responses/${encodeURIComponent(responseIdValue)}/cancel`,
+			{ method: "POST", headers },
+		).catch(() => undefined);
+	}
+	return {
+		ok: false,
+		responseId: responseIdValue,
+		error: "Timed out waiting for background Pro advice.",
+	};
+}
+
+async function askLine(rl: Interface, question: string): Promise<string> {
+	return (await rl.question(question)).trim();
+}
+
+async function runManualAdvice(params: {
+	advicePath: string;
+	deps: ProAdviceDeps;
+	noTui: boolean;
+}): Promise<AdviceResult> {
+	const existing = await readIfExists(params.advicePath);
+	if (existing?.trim()) {
+		return { ok: true, mode: "manual", advicePath: params.advicePath };
+	}
+	if (params.noTui) {
+		return {
+			ok: false,
+			error: `Manual mode wrote the handoff. Paste GPT-5.5 Pro output into ${params.advicePath}.`,
+		};
+	}
+
+	const rl =
+		params.deps.createReadline?.() ??
+		createInterface({ input: defaultInput, output: defaultOutput });
+	try {
+		const pasted = await askLine(
+			rl,
+			"Paste GPT-5.5 Pro output, or press Enter after saving PRO_ADVICE.md: ",
+		);
+		const latest = await readIfExists(params.advicePath);
+		if (latest?.trim()) {
+			return { ok: true, mode: "manual", advicePath: params.advicePath };
+		}
+		if (!pasted.trim()) {
+			return {
+				ok: false,
+				error: `No advice was provided. Save GPT-5.5 Pro output to ${params.advicePath}.`,
+			};
+		}
+		await writeTextFile(params.advicePath, `${pasted.trim()}\n`);
+		return { ok: true, mode: "manual", advicePath: params.advicePath };
+	} finally {
+		rl.close();
+	}
+}
+
+function buildLaunchCommand(advicePath: string): { command: string; args: string[]; prompt: string } {
+	const prompt = [
+		`Read ${advicePath}.`,
+		"Follow the Codex Implementation Prompt section exactly.",
+		"Verify the resulting change with the commands requested in that advice.",
+	].join(" ");
+	return { command: "codex", args: [prompt], prompt };
+}
+
+async function maybeLaunchCodex(params: {
+	advicePath: string;
+	deps: ProAdviceDeps;
+	noTui: boolean;
+	logInfo: (message: string) => void;
+}): Promise<void> {
+	const command = buildLaunchCommand(params.advicePath);
+	if (params.noTui || params.deps.isTty?.() === false) {
+		params.logInfo(`Launch command: ${command.command} ${JSON.stringify(command.args[0])}`);
+		return;
+	}
+	const rl =
+		params.deps.createReadline?.() ??
+		createInterface({ input: defaultInput, output: defaultOutput });
+	try {
+		const answer = await askLine(rl, "Launch a new Codex session with this plan? [y/N] ");
+		if (!/^y(es)?$/i.test(answer)) return;
+		const launcher =
+			params.deps.spawnCodex ??
+			((cmd: string, args: string[]) =>
+				spawn(cmd, args, { stdio: "inherit", shell: process.platform === "win32" }));
+		launcher(command.command, command.args);
+	} finally {
+		rl.close();
+	}
+}
+
+function jsonLog(logInfo: (message: string) => void, payload: unknown): void {
+	logInfo(JSON.stringify(payload));
+}
+
+export async function runProAdviceCommand(
+	args: string[],
+	deps: ProAdviceDeps = {},
+): Promise<number> {
+	const logInfo = deps.logInfo ?? console.log;
+	const logError = deps.logError ?? console.error;
+	const parsed = parseProAdviceArgs(args);
+	if (!parsed.ok) {
+		if (parsed.reason === "help") {
+			printProAdviceUsage(logInfo);
+			return 0;
+		}
+		logError(parsed.message);
+		return 1;
+	}
+	const options = parsed.options;
+	const repoRoot = deps.cwd?.() ?? process.cwd();
+	const handoffPath = normalizePath(repoRoot, options.handoffPath);
+	const advicePath = normalizePath(repoRoot, options.advicePath);
+	const candidates = await discoverDossierCandidates(repoRoot);
+	const selectedInputs = candidates.filter((candidate) =>
+		!candidate.relativePath.replace(/\\/g, "/").startsWith("docs/releases/"),
+	);
+
+	if (selectedInputs.length === 0) {
+		const prompts = buildDossierPromptFiles(basename(repoRoot));
+		for (const [fileName, content] of Object.entries(prompts)) {
+			await writeTextFile(join(repoRoot, fileName), content);
+		}
+	}
+
+	const handoff = buildProHandoffMarkdown({
+		repoRoot,
+		createdAt: deps.now?.() ?? new Date(),
+		selectedInputs,
+		task: options.task,
+	});
+	await writeTextFile(handoffPath, handoff);
+
+	if (options.json) {
+		jsonLog(logInfo, {
+			command: "pro-advice",
+			event: "handoff-written",
+			handoffPath,
+			advicePath,
+			inputs: selectedInputs.map((candidate) => candidate.relativePath),
+		});
+	} else {
+		logInfo(`Wrote handoff: ${handoffPath}`);
+		if (selectedInputs.length === 0) {
+			logInfo("No dossier inputs found. Wrote PRO_DOSSIER_PROMPT.md and PRO_DOSSIER_DB_PROMPT.md.");
+		}
+	}
+
+	let result: AdviceResult;
+	if (options.mode === "auto") {
+		result = await submitBackgroundAdvice({
+			handoff,
+			advicePath,
+			deps,
+			options,
+		}).catch((error: unknown) => ({
+			ok: false,
+			error: error instanceof Error ? error.message : String(error),
+		}));
+		if (!result.ok) {
+			if (!options.json) {
+				logError(`Auto advice failed: ${result.error}`);
+				logInfo("Falling back to manual GPT-5.5 Pro handoff.");
+			}
+			result = await runManualAdvice({
+				advicePath,
+				deps,
+				noTui: options.noTui || !deps.isTty?.(),
+			});
+		}
+	} else {
+		result = await runManualAdvice({
+			advicePath,
+			deps,
+			noTui: options.noTui || !deps.isTty?.(),
+		});
+	}
+
+	if (!result.ok) {
+		if (options.json) {
+			jsonLog(logInfo, {
+				command: "pro-advice",
+				ok: false,
+				error: result.error,
+				handoffPath,
+				advicePath,
+			});
+		} else {
+			logError(result.error);
+		}
+		return 1;
+	}
+
+	if (options.json) {
+		jsonLog(logInfo, {
+			command: "pro-advice",
+			ok: true,
+			mode: result.mode,
+			handoffPath,
+			advicePath: result.advicePath,
+			responseId: result.responseId,
+		});
+		return 0;
+	}
+
+	logInfo(`Saved Pro advice: ${result.advicePath}`);
+	await maybeLaunchCodex({
+		advicePath: result.advicePath,
+		deps,
+		noTui: options.noTui,
+		logInfo,
+	});
+	return 0;
+}

--- a/lib/codex-manager/commands/pro-advice.ts
+++ b/lib/codex-manager/commands/pro-advice.ts
@@ -37,6 +37,7 @@ export interface DossierCandidate {
 	path: string;
 	relativePath: string;
 	priority: number;
+	content?: string;
 }
 
 export interface ProAdviceDeps {
@@ -191,6 +192,15 @@ function normalizePath(root: string, value: string): string {
 	return resolve(root, value);
 }
 
+function sameResolvedPath(left: string, right: string): boolean {
+	const leftResolved = resolve(left);
+	const rightResolved = resolve(right);
+	if (process.platform === "win32") {
+		return leftResolved.toLowerCase() === rightResolved.toLowerCase();
+	}
+	return leftResolved === rightResolved;
+}
+
 function isMarkdownFile(path: string): boolean {
 	return extname(path).toLowerCase() === ".md";
 }
@@ -337,6 +347,11 @@ export function buildProHandoffMarkdown(params: {
 		for (const candidate of params.selectedInputs) {
 			sections.push(`### ${candidate.relativePath.replace(/\\/g, "/")}`, "");
 			sections.push(`Source path: \`${candidate.relativePath.replace(/\\/g, "/")}\``, "");
+			if (typeof candidate.content === "string" && candidate.content.length > 0) {
+				sections.push("````markdown", candidate.content.trimEnd(), "````", "");
+			} else {
+				sections.push("_Content unavailable in this handoff._", "");
+			}
 		}
 	}
 
@@ -664,7 +679,9 @@ export async function runProAdviceCommand(
 	const advicePath = normalizePath(repoRoot, options.advicePath);
 	const candidates = await discoverDossierCandidates(repoRoot);
 	const selectedInputs = candidates.filter((candidate) =>
-		!candidate.relativePath.replace(/\\/g, "/").startsWith("docs/releases/"),
+		!candidate.relativePath.replace(/\\/g, "/").startsWith("docs/releases/") &&
+		!sameResolvedPath(candidate.path, handoffPath) &&
+		!sameResolvedPath(candidate.path, advicePath),
 	);
 
 	if (selectedInputs.length === 0) {
@@ -674,10 +691,17 @@ export async function runProAdviceCommand(
 		}
 	}
 
+	const selectedInputsWithContent = await Promise.all(
+		selectedInputs.map(async (candidate) => ({
+			...candidate,
+			content: await readFile(candidate.path, "utf8").catch(() => ""),
+		})),
+	);
+
 	const handoff = buildProHandoffMarkdown({
 		repoRoot,
 		createdAt: deps.now?.() ?? new Date(),
-		selectedInputs,
+		selectedInputs: selectedInputsWithContent,
 		task: options.task,
 	});
 	await writeTextFile(handoffPath, handoff);

--- a/lib/codex-manager/commands/pro-advice.ts
+++ b/lib/codex-manager/commands/pro-advice.ts
@@ -22,6 +22,7 @@ const DEFAULT_ADVICE_FILE = "PRO_ADVICE.md";
 const DEFAULT_CHATGPT_PROMPT_FILE = "PRO_CHATGPT_PROMPT.md";
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const POLL_INTERVAL_MS = 2_500;
+const WEB_ADVICE_POLL_INTERVAL_MS = 2_500;
 const MAX_SCAN_DEPTH = 4;
 const CHATGPT_WEB_URL = "https://chatgpt.com/";
 
@@ -54,6 +55,7 @@ export interface ProAdviceDeps {
 	spawnCodex?: (command: string, args: string[]) => { pid?: number };
 	openUrl?: (url: string) => void | Promise<void>;
 	writeClipboard?: (text: string) => void | Promise<void>;
+	sleep?: (ms: number) => Promise<void>;
 	logInfo?: (message: string) => void;
 	logError?: (message: string) => void;
 }
@@ -527,6 +529,30 @@ function writeClipboard(text: string, deps: ProAdviceDeps): Promise<boolean> {
 	});
 }
 
+async function sleep(ms: number, deps: ProAdviceDeps): Promise<void> {
+	if (deps.sleep) {
+		await deps.sleep(ms);
+		return;
+	}
+	await new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+async function waitForAdviceFile(params: {
+	advicePath: string;
+	timeoutMs: number;
+	deps: ProAdviceDeps;
+}): Promise<boolean> {
+	const nowMs = () => params.deps.now?.().getTime() ?? Date.now();
+	const startedAt = nowMs();
+	while (nowMs() - startedAt < params.timeoutMs) {
+		const existing = await readIfExists(params.advicePath);
+		if (existing?.trim()) return true;
+		await sleep(WEB_ADVICE_POLL_INTERVAL_MS, params.deps);
+	}
+	const existing = await readIfExists(params.advicePath);
+	return Boolean(existing?.trim());
+}
+
 function isCodexChatGptModelUnsupported(error: string): boolean {
 	return (
 		error.includes("gpt-5.5-pro") &&
@@ -722,6 +748,7 @@ async function runWebAdvice(params: {
 	advicePath: string;
 	deps: ProAdviceDeps;
 	noTui: boolean;
+	timeoutMs: number;
 	logInfo: (message: string) => void;
 }): Promise<AdviceResult> {
 	const existing = await readIfExists(params.advicePath);
@@ -758,9 +785,17 @@ async function runWebAdvice(params: {
 
 	params.logInfo(instructions);
 	if (params.noTui) {
+		params.logInfo(`Waiting for GPT-5.5 Pro web output at ${params.advicePath}.`);
+		if (await waitForAdviceFile({
+			advicePath: params.advicePath,
+			timeoutMs: params.timeoutMs,
+			deps: params.deps,
+		})) {
+			return { ok: true, mode: "web", advicePath: params.advicePath };
+		}
 		return {
 			ok: false,
-			error: `Web-assisted mode wrote the handoff. Save GPT-5.5 Pro web output to ${params.advicePath}.`,
+			error: `Timed out waiting for GPT-5.5 Pro web output at ${params.advicePath}.`,
 		};
 	}
 
@@ -919,6 +954,7 @@ export async function runProAdviceCommand(
 						advicePath,
 						deps,
 						noTui: options.noTui || !deps.isTty?.(),
+						timeoutMs: options.timeoutMs,
 						logInfo,
 					})
 				: await runManualAdvice({
@@ -934,6 +970,7 @@ export async function runProAdviceCommand(
 			advicePath,
 			deps,
 			noTui: options.noTui || !deps.isTty?.(),
+			timeoutMs: options.timeoutMs,
 			logInfo,
 		});
 	} else {

--- a/lib/codex-manager/commands/pro-advice.ts
+++ b/lib/codex-manager/commands/pro-advice.ts
@@ -412,6 +412,10 @@ function extractError(payload: unknown, fallback: string): string {
 		if (typeof nested.code === "string") return nested.code;
 	}
 	if (typeof record.message === "string") return record.message;
+	const serialized = JSON.stringify(payload);
+	if (serialized && serialized !== "{}") {
+		return `${fallback}: ${serialized}`;
+	}
 	return fallback;
 }
 

--- a/lib/codex-manager/commands/pro-advice.ts
+++ b/lib/codex-manager/commands/pro-advice.ts
@@ -22,9 +22,10 @@ const DEFAULT_ADVICE_FILE = "PRO_ADVICE.md";
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const POLL_INTERVAL_MS = 2_500;
 const MAX_SCAN_DEPTH = 4;
+const CHATGPT_WEB_URL = "https://chatgpt.com/";
 
 export interface ProAdviceOptions {
-	mode: "auto" | "manual";
+	mode: "auto" | "manual" | "web";
 	handoffPath: string;
 	advicePath: string;
 	noTui: boolean;
@@ -50,6 +51,7 @@ export interface ProAdviceDeps {
 	fetch?: typeof fetch;
 	createReadline?: () => Interface;
 	spawnCodex?: (command: string, args: string[]) => { pid?: number };
+	openUrl?: (url: string) => void | Promise<void>;
 	logInfo?: (message: string) => void;
 	logError?: (message: string) => void;
 }
@@ -60,21 +62,22 @@ type ParseResult =
 	| { ok: false; reason: "error"; message: string };
 
 type AdviceResult =
-	| { ok: true; advicePath: string; responseId?: string; mode: "auto" | "manual" }
+	| { ok: true; advicePath: string; responseId?: string; mode: "auto" | "manual" | "web" }
 	| { ok: false; error: string; status?: number; responseId?: string };
 
 function printProAdviceUsage(logInfo: (message: string) => void): void {
 	logInfo(
 		[
 			"Usage:",
-			"  codex auth pro-advice [--mode auto|manual] [--handoff <path>] [--advice <path>] [--no-tui] [--json]",
+			"  codex auth pro-advice [--mode auto|manual|web] [--handoff <path>] [--advice <path>] [--no-tui] [--json]",
 			"",
 			"Behavior:",
 			"  - Discovers dossier markdown in the current codebase",
 			"  - Writes PRO_HANDOFF.md with a required GPT-5.5 Pro output contract",
 			"  - Auto mode uses official background Responses when an entitled managed account is available",
+			"  - Web mode opens ChatGPT and waits for saved GPT-5.5 Pro web output",
 			"  - Manual mode saves the handoff and accepts pasted or existing PRO_ADVICE.md output",
-			"  - It does not automate ChatGPT web sessions, cookies, or browser polling",
+			"  - It does not automate ChatGPT web sessions, cookies, or private browser polling",
 		].join("\n"),
 	);
 }
@@ -97,11 +100,11 @@ export function parseProAdviceArgs(args: string[]): ParseResult {
 		}
 		if (arg === "--mode") {
 			const value = args[i + 1];
-			if (value !== "auto" && value !== "manual") {
+			if (value !== "auto" && value !== "manual" && value !== "web") {
 				return {
 					ok: false,
 					reason: "error",
-					message: "--mode expects auto or manual",
+					message: "--mode expects auto, manual, or web",
 				};
 			}
 			options.mode = value;
@@ -110,11 +113,11 @@ export function parseProAdviceArgs(args: string[]): ParseResult {
 		}
 		if (arg.startsWith("--mode=")) {
 			const value = arg.slice("--mode=".length);
-			if (value !== "auto" && value !== "manual") {
+			if (value !== "auto" && value !== "manual" && value !== "web") {
 				return {
 					ok: false,
 					reason: "error",
-					message: "--mode expects auto or manual",
+					message: "--mode expects auto, manual, or web",
 				};
 			}
 			options.mode = value;
@@ -469,6 +472,47 @@ async function getManagedAccess(deps: ProAdviceDeps): Promise<{
 	return { accountId, accessToken: token.access };
 }
 
+async function getActiveAccountLabel(deps: ProAdviceDeps): Promise<string | null> {
+	if (!deps.loadAccounts || !deps.resolveActiveIndex) return null;
+	const storage = await deps.loadAccounts().catch(() => null);
+	if (!storage || storage.accounts.length === 0) return null;
+	const index = deps.resolveActiveIndex(storage);
+	const account = storage.accounts[index];
+	if (!account) return null;
+	const parts = [account.email, account.accountId].filter(
+		(value): value is string => typeof value === "string" && value.length > 0,
+	);
+	return parts.length > 0 ? parts.join(" / ") : `account index ${index}`;
+}
+
+function openExternalUrl(url: string, deps: ProAdviceDeps): void | Promise<void> {
+	if (deps.openUrl) return deps.openUrl(url);
+	const command =
+		process.platform === "win32"
+			? "cmd"
+			: process.platform === "darwin"
+				? "open"
+				: "xdg-open";
+	const args =
+		process.platform === "win32"
+			? ["/c", "start", "", url]
+			: [url];
+	const child = spawn(command, args, {
+		detached: true,
+		stdio: "ignore",
+		windowsHide: true,
+	});
+	child.unref();
+}
+
+function isCodexChatGptModelUnsupported(error: string): boolean {
+	return (
+		error.includes("gpt-5.5-pro") &&
+		error.includes("not supported") &&
+		error.includes("ChatGPT account")
+	);
+}
+
 async function submitBackgroundAdvice(params: {
 	handoff: string;
 	advicePath: string;
@@ -622,6 +666,65 @@ async function runManualAdvice(params: {
 	}
 }
 
+async function runWebAdvice(params: {
+	handoffPath: string;
+	advicePath: string;
+	deps: ProAdviceDeps;
+	noTui: boolean;
+	logInfo: (message: string) => void;
+}): Promise<AdviceResult> {
+	const existing = await readIfExists(params.advicePath);
+	if (existing?.trim()) {
+		return { ok: true, mode: "web", advicePath: params.advicePath };
+	}
+
+	const activeAccount = await getActiveAccountLabel(params.deps);
+	const accountHint = activeAccount
+		? `Active pool account: ${activeAccount}`
+		: "Active pool account could not be resolved; use the intended ChatGPT Pro account.";
+	const instructions = [
+		"ChatGPT web-assisted Pro handoff is ready.",
+		accountHint,
+		`Open: ${CHATGPT_WEB_URL}`,
+		"Use GPT-5.5 Pro Extended in ChatGPT web.",
+		`Paste the handoff from: ${params.handoffPath}`,
+		`Save the Pro output to: ${params.advicePath}`,
+	].join("\n");
+
+	params.logInfo(instructions);
+	if (params.noTui) {
+		return {
+			ok: false,
+			error: `Web-assisted mode wrote the handoff. Save GPT-5.5 Pro web output to ${params.advicePath}.`,
+		};
+	}
+
+	await Promise.resolve(openExternalUrl(CHATGPT_WEB_URL, params.deps)).catch(() => undefined);
+	const rl =
+		params.deps.createReadline?.() ??
+		createInterface({ input: defaultInput, output: defaultOutput });
+	try {
+		const pasted = await askLine(
+			rl,
+			"Press Enter after saving PRO_ADVICE.md, or paste GPT-5.5 Pro output here: ",
+		);
+		const latest = await readIfExists(params.advicePath);
+		if (latest?.trim()) {
+			return { ok: true, mode: "web", advicePath: params.advicePath };
+		}
+		if (!pasted.trim()) {
+			return {
+				ok: false,
+				error: `No advice was provided. Save GPT-5.5 Pro web output to ${params.advicePath}.`,
+			};
+		}
+		await writeTextFile(params.advicePath, `${pasted.trim()}\n`);
+		return { ok: true, mode: "web", advicePath: params.advicePath };
+	} finally {
+		rl.close();
+	}
+}
+
 function buildLaunchCommand(advicePath: string): { command: string; args: string[]; prompt: string } {
 	const prompt = [
 		`Read ${advicePath}.`,
@@ -739,14 +842,34 @@ export async function runProAdviceCommand(
 		if (!result.ok) {
 			if (!options.json) {
 				logError(`Auto advice failed: ${result.error}`);
-				logInfo("Falling back to manual GPT-5.5 Pro handoff.");
+				logInfo(
+					isCodexChatGptModelUnsupported(result.error)
+						? "Falling back to ChatGPT web-assisted GPT-5.5 Pro handoff."
+						: "Falling back to manual GPT-5.5 Pro handoff.",
+				);
 			}
-			result = await runManualAdvice({
-				advicePath,
-				deps,
-				noTui: options.noTui || !deps.isTty?.(),
-			});
+			result = isCodexChatGptModelUnsupported(result.error)
+				? await runWebAdvice({
+						handoffPath,
+						advicePath,
+						deps,
+						noTui: options.noTui || !deps.isTty?.(),
+						logInfo,
+					})
+				: await runManualAdvice({
+						advicePath,
+						deps,
+						noTui: options.noTui || !deps.isTty?.(),
+					});
 		}
+	} else if (options.mode === "web") {
+		result = await runWebAdvice({
+			handoffPath,
+			advicePath,
+			deps,
+			noTui: options.noTui || !deps.isTty?.(),
+			logInfo,
+		});
 	} else {
 		result = await runManualAdvice({
 			advicePath,

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -14,6 +14,7 @@ export function printUsage(): void {
 			"  codex auth best [--live] [--json] [--model <model>]",
 			"  codex auth forecast [--live] [--json] [--model <model>]",
 			"  codex auth account tag|untag|weight|pause|unpause|drain|undrain|note ...",
+			"  codex auth pro-advice [--mode auto|manual] [--handoff <path>] [--advice <path>] [--no-tui] [--json]",
 			"",
 			"Repair:",
 			"  codex auth verify-flagged [--dry-run] [--json] [--no-restore]",

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -14,7 +14,7 @@ export function printUsage(): void {
 			"  codex auth best [--live] [--json] [--model <model>]",
 			"  codex auth forecast [--live] [--json] [--model <model>]",
 			"  codex auth account tag|untag|weight|pause|unpause|drain|undrain|note ...",
-			"  codex auth pro-advice [--mode auto|manual] [--handoff <path>] [--advice <path>] [--no-tui] [--json]",
+			"  codex auth pro-advice [--mode auto|manual|web] [--handoff <path>] [--advice <path>] [--no-tui] [--json]",
 			"",
 			"Repair:",
 			"  codex auth verify-flagged [--dry-run] [--json] [--no-restore]",

--- a/scripts/codex-routing.js
+++ b/scripts/codex-routing.js
@@ -19,6 +19,7 @@ const AUTH_SUBCOMMANDS = new Set([
 	"integrations",
 	"models",
 	"monitor",
+	"pro-advice",
 	"rotation",
 	"why-selected",
 	"config",

--- a/test/codex-manager-pro-advice-command.test.ts
+++ b/test/codex-manager-pro-advice-command.test.ts
@@ -60,7 +60,7 @@ describe("codex auth pro-advice command", () => {
 		expect(
 			parseProAdviceArgs([
 				"--mode",
-				"manual",
+				"web",
 				"--handoff",
 				"HANDOFF.md",
 				"--advice=ADVICE.md",
@@ -70,7 +70,7 @@ describe("codex auth pro-advice command", () => {
 		).toEqual({
 			ok: true,
 			options: {
-				mode: "manual",
+				mode: "web",
 				handoffPath: "HANDOFF.md",
 				advicePath: "ADVICE.md",
 				noTui: true,
@@ -79,9 +79,15 @@ describe("codex auth pro-advice command", () => {
 			},
 		});
 		expect(parseProAdviceArgs(["--mode", "web"])).toEqual({
-			ok: false,
-			reason: "error",
-			message: "--mode expects auto or manual",
+			ok: true,
+			options: {
+				mode: "web",
+				handoffPath: "PRO_HANDOFF.md",
+				advicePath: "PRO_ADVICE.md",
+				noTui: false,
+				json: false,
+				timeoutMs: 1_800_000,
+			},
 		});
 	});
 
@@ -239,5 +245,68 @@ describe("codex auth pro-advice command", () => {
 		const handoff = await readFile(join(root, "PRO_HANDOFF.md"), "utf8");
 		expect(handoff).toContain("APP_DOSSIER.md");
 		expect(handoff).not.toContain("# Manual");
+	});
+
+	it("guides ChatGPT web handoff with the active pool account", async () => {
+		const root = await createTempRoot();
+		await writeFile(join(root, "APP_DOSSIER.md"), "# dossier\n", "utf8");
+		const infos: string[] = [];
+		const errors: string[] = [];
+
+		await expect(
+			runProAdviceCommand(["--mode", "web", "--no-tui", "--json"], {
+				cwd: () => root,
+				now: () => new Date("2026-04-30T00:00:00.000Z"),
+				isTty: () => false,
+				loadAccounts: async () => createStorage(),
+				resolveActiveIndex: () => 0,
+				logInfo: (message) => infos.push(message),
+				logError: (message) => errors.push(message),
+			}),
+		).resolves.toBe(1);
+
+		expect(errors).toEqual([]);
+		expect(infos.join("\n")).toContain("Active pool account: pro@example.com / acc_pro");
+		expect(infos.join("\n")).toContain("https://chatgpt.com/");
+		const finalPayload = JSON.parse(infos.at(-1) ?? "{}");
+		expect(finalPayload).toMatchObject({
+			command: "pro-advice",
+			ok: false,
+		});
+		expect(finalPayload.error).toContain("Web-assisted mode wrote the handoff");
+	});
+
+	it("falls back to ChatGPT web when Codex account rejects GPT-5.5 Pro", async () => {
+		const root = await createTempRoot();
+		await writeFile(join(root, "APP_DOSSIER.md"), "# dossier\n", "utf8");
+		const infos: string[] = [];
+		const errors: string[] = [];
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					detail:
+						"The 'gpt-5.5-pro' model is not supported when using Codex with a ChatGPT account.",
+				}),
+				{ status: 400 },
+			),
+		);
+
+		await expect(
+			runProAdviceCommand(["--no-tui"], {
+				cwd: () => root,
+				now: () => new Date("2026-04-30T00:00:00.000Z"),
+				isTty: () => false,
+				loadAccounts: async () => createStorage(),
+				resolveActiveIndex: () => 0,
+				refreshAccessToken: async () => tokenSuccess(),
+				fetch: fetchMock,
+				logInfo: (message) => infos.push(message),
+				logError: (message) => errors.push(message),
+			}),
+		).resolves.toBe(1);
+
+		expect(errors.join("\n")).toContain("not supported");
+		expect(infos.join("\n")).toContain("Falling back to ChatGPT web-assisted");
+		expect(infos.join("\n")).toContain("Active pool account: pro@example.com / acc_pro");
 	});
 });

--- a/test/codex-manager-pro-advice-command.test.ts
+++ b/test/codex-manager-pro-advice-command.test.ts
@@ -254,17 +254,21 @@ describe("codex auth pro-advice command", () => {
 		const errors: string[] = [];
 		const opened: string[] = [];
 		let clipboard = "";
+		let nowMs = new Date("2026-04-30T00:00:00.000Z").getTime();
 
 		await expect(
 			runProAdviceCommand(["--mode", "web", "--no-tui", "--json"], {
 				cwd: () => root,
-				now: () => new Date("2026-04-30T00:00:00.000Z"),
+				now: () => new Date(nowMs),
 				isTty: () => false,
 				loadAccounts: async () => createStorage(),
 				resolveActiveIndex: () => 0,
 				openUrl: (url) => opened.push(url),
 				writeClipboard: (text) => {
 					clipboard = text;
+				},
+				sleep: async (ms) => {
+					nowMs += ms;
 				},
 				logInfo: (message) => infos.push(message),
 				logError: (message) => errors.push(message),
@@ -286,7 +290,7 @@ describe("codex auth pro-advice command", () => {
 			command: "pro-advice",
 			ok: false,
 		});
-		expect(finalPayload.error).toContain("Web-assisted mode wrote the handoff");
+		expect(finalPayload.error).toContain("Timed out waiting for GPT-5.5 Pro web output");
 	});
 
 	it("falls back to ChatGPT web when Codex account rejects GPT-5.5 Pro", async () => {
@@ -295,6 +299,7 @@ describe("codex auth pro-advice command", () => {
 		const infos: string[] = [];
 		const errors: string[] = [];
 		const opened: string[] = [];
+		let nowMs = new Date("2026-04-30T00:00:00.000Z").getTime();
 		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
 			new Response(
 				JSON.stringify({
@@ -308,7 +313,7 @@ describe("codex auth pro-advice command", () => {
 		await expect(
 			runProAdviceCommand(["--no-tui"], {
 				cwd: () => root,
-				now: () => new Date("2026-04-30T00:00:00.000Z"),
+				now: () => new Date(nowMs),
 				isTty: () => false,
 				loadAccounts: async () => createStorage(),
 				resolveActiveIndex: () => 0,
@@ -316,14 +321,19 @@ describe("codex auth pro-advice command", () => {
 				fetch: fetchMock,
 				openUrl: (url) => opened.push(url),
 				writeClipboard: vi.fn(),
+				sleep: async (ms) => {
+					await writeFile(join(root, "PRO_ADVICE.md"), "# Findings\n\nweb\n", "utf8");
+					nowMs += ms;
+				},
 				logInfo: (message) => infos.push(message),
 				logError: (message) => errors.push(message),
 			}),
-		).resolves.toBe(1);
+		).resolves.toBe(0);
 
 		expect(errors.join("\n")).toContain("not supported");
 		expect(infos.join("\n")).toContain("Falling back to ChatGPT web-assisted");
 		expect(infos.join("\n")).toContain("Active pool account: pro@example.com / acc_pro");
+		expect(infos.join("\n")).toContain("Saved Pro advice:");
 		expect(opened).toEqual(["https://chatgpt.com/"]);
 	});
 });

--- a/test/codex-manager-pro-advice-command.test.ts
+++ b/test/codex-manager-pro-advice-command.test.ts
@@ -110,6 +110,7 @@ describe("codex auth pro-advice command", () => {
 					path: "/tmp/example/APP_DOSSIER.md",
 					relativePath: "APP_DOSSIER.md",
 					priority: 40,
+					content: "# App Dossier\n\nGrounded repo notes.\n",
 				},
 			],
 		});
@@ -120,6 +121,8 @@ describe("codex auth pro-advice command", () => {
 		expect(markdown).toContain('  - "APP_DOSSIER.md"');
 		expect(markdown).toContain("## Required Output Contract");
 		expect(markdown).toContain("Codex Implementation Prompt");
+		expect(markdown).toContain("# App Dossier");
+		expect(markdown).toContain("Grounded repo notes.");
 	});
 
 	it("writes prompt files and deterministic JSON in manual non-TTY mode when no dossiers exist", async () => {
@@ -233,6 +236,8 @@ describe("codex auth pro-advice command", () => {
 		expect(errors.join("\n")).toContain("model entitlement required");
 		expect(infos.join("\n")).toContain("Falling back to manual GPT-5.5 Pro handoff.");
 		expect(infos.join("\n")).toContain("Saved Pro advice:");
+		const handoff = await readFile(join(root, "PRO_HANDOFF.md"), "utf8");
+		expect(handoff).toContain("APP_DOSSIER.md");
+		expect(handoff).not.toContain("# Manual");
 	});
 });
-

--- a/test/codex-manager-pro-advice-command.test.ts
+++ b/test/codex-manager-pro-advice-command.test.ts
@@ -1,0 +1,238 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	buildProHandoffMarkdown,
+	discoverDossierCandidates,
+	parseProAdviceArgs,
+	runProAdviceCommand,
+} from "../lib/codex-manager/commands/pro-advice.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+import type { TokenResult } from "../lib/types.js";
+import { withFileOperationRetry } from "../scripts/install-codex-auth-utils.js";
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), "codex-pro-advice-"));
+	tempRoots.push(root);
+	return root;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		tempRoots.splice(0).map((root) =>
+			withFileOperationRetry(() => rm(root, { recursive: true, force: true })),
+		),
+	);
+});
+
+function createStorage(): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { codex: 0 },
+		accounts: [
+			{
+				email: "pro@example.com",
+				accountId: "acc_pro",
+				refreshToken: "refresh-pro",
+				addedAt: 1,
+				lastUsed: 1,
+			},
+		],
+	};
+}
+
+function tokenSuccess(): TokenResult {
+	return {
+		type: "success",
+		access: "access-pro",
+		refresh: "refresh-pro",
+		expires: Date.now() + 60_000,
+		multiAccount: true,
+	};
+}
+
+describe("codex auth pro-advice command", () => {
+	it("parses public flags", () => {
+		expect(
+			parseProAdviceArgs([
+				"--mode",
+				"manual",
+				"--handoff",
+				"HANDOFF.md",
+				"--advice=ADVICE.md",
+				"--no-tui",
+				"--json",
+			]),
+		).toEqual({
+			ok: true,
+			options: {
+				mode: "manual",
+				handoffPath: "HANDOFF.md",
+				advicePath: "ADVICE.md",
+				noTui: true,
+				json: true,
+				timeoutMs: 1_800_000,
+			},
+		});
+		expect(parseProAdviceArgs(["--mode", "web"])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "--mode expects auto or manual",
+		});
+	});
+
+	it("discovers dossier candidates by priority", async () => {
+		const root = await createTempRoot();
+		await writeFile(join(root, "PRO_ADVICE.md"), "old\n", "utf8");
+		await writeFile(join(root, "APP_DB_DOSSIER.md"), "db\n", "utf8");
+		await writeFile(join(root, "APP_DOSSIER.md"), "app\n", "utf8");
+		await writeFile(join(root, "README.md"), "readme\n", "utf8");
+
+		const candidates = await discoverDossierCandidates(root);
+
+		expect(candidates.map((candidate) => candidate.relativePath)).toEqual([
+			"PRO_ADVICE.md",
+			"APP_DB_DOSSIER.md",
+			"APP_DOSSIER.md",
+		]);
+	});
+
+	it("generates frontmatter and required output contract", () => {
+		const markdown = buildProHandoffMarkdown({
+			repoRoot: "/tmp/example",
+			createdAt: new Date("2026-04-30T00:00:00.000Z"),
+			selectedInputs: [
+				{
+					path: "/tmp/example/APP_DOSSIER.md",
+					relativePath: "APP_DOSSIER.md",
+					priority: 40,
+				},
+			],
+		});
+
+		expect(markdown).toContain('kind: "codex-pro-advice-handoff"');
+		expect(markdown).toContain('repo: "example"');
+		expect(markdown).toContain('created_at: "2026-04-30T00:00:00.000Z"');
+		expect(markdown).toContain('  - "APP_DOSSIER.md"');
+		expect(markdown).toContain("## Required Output Contract");
+		expect(markdown).toContain("Codex Implementation Prompt");
+	});
+
+	it("writes prompt files and deterministic JSON in manual non-TTY mode when no dossiers exist", async () => {
+		const root = await createTempRoot();
+		const infos: string[] = [];
+		const errors: string[] = [];
+
+		await expect(
+			runProAdviceCommand(["--mode", "manual", "--no-tui", "--json"], {
+				cwd: () => root,
+				now: () => new Date("2026-04-30T00:00:00.000Z"),
+				isTty: () => false,
+				logInfo: (message) => infos.push(message),
+				logError: (message) => errors.push(message),
+			}),
+		).resolves.toBe(1);
+
+		expect(errors).toEqual([]);
+		expect(await readFile(join(root, "PRO_HANDOFF.md"), "utf8")).toContain(
+			"codex-pro-advice-handoff",
+		);
+		expect(await readFile(join(root, "PRO_DOSSIER_PROMPT.md"), "utf8")).toContain(
+			"$dossier",
+		);
+		expect(await readFile(join(root, "PRO_DOSSIER_DB_PROMPT.md"), "utf8")).toContain(
+			"$dossier-db",
+		);
+		const finalPayload = JSON.parse(infos.at(-1) ?? "{}");
+		expect(finalPayload).toMatchObject({
+			command: "pro-advice",
+			ok: false,
+		});
+		expect(finalPayload.error).toContain("Manual mode wrote the handoff");
+	});
+
+	it("submits and polls a background response with a managed account", async () => {
+		const root = await createTempRoot();
+		await writeFile(join(root, "APP_DOSSIER.md"), "# dossier\n", "utf8");
+		const infos: string[] = [];
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ id: "resp_1", status: "queued" }), {
+					status: 200,
+				}),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						id: "resp_1",
+						status: "completed",
+						output_text: "# Findings\n\nok\n",
+					}),
+					{ status: 200 },
+				),
+			);
+
+		await expect(
+			runProAdviceCommand(["--json"], {
+				cwd: () => root,
+				now: () => new Date("2026-04-30T00:00:00.000Z"),
+				isTty: () => false,
+				loadAccounts: async () => createStorage(),
+				resolveActiveIndex: () => 0,
+				refreshAccessToken: async () => tokenSuccess(),
+				fetch: fetchMock,
+				logInfo: (message) => infos.push(message),
+				logError: vi.fn(),
+			}),
+		).resolves.toBe(0);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(await readFile(join(root, "PRO_ADVICE.md"), "utf8")).toContain(
+			"# Findings",
+		);
+		const finalPayload = JSON.parse(infos.at(-1) ?? "{}");
+		expect(finalPayload).toMatchObject({
+			command: "pro-advice",
+			ok: true,
+			mode: "auto",
+			responseId: "resp_1",
+		});
+	});
+
+	it("falls back to manual advice when entitlement fails", async () => {
+		const root = await createTempRoot();
+		await writeFile(join(root, "APP_DOSSIER.md"), "# dossier\n", "utf8");
+		await writeFile(join(root, "PRO_ADVICE.md"), "# Manual\n\nsaved\n", "utf8");
+		const infos: string[] = [];
+		const errors: string[] = [];
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({ error: { message: "model entitlement required" } }),
+				{ status: 403 },
+			),
+		);
+
+		await expect(
+			runProAdviceCommand([], {
+				cwd: () => root,
+				isTty: () => false,
+				loadAccounts: async () => createStorage(),
+				resolveActiveIndex: () => 0,
+				refreshAccessToken: async () => tokenSuccess(),
+				fetch: fetchMock,
+				logInfo: (message) => infos.push(message),
+				logError: (message) => errors.push(message),
+			}),
+		).resolves.toBe(0);
+
+		expect(errors.join("\n")).toContain("model entitlement required");
+		expect(infos.join("\n")).toContain("Falling back to manual GPT-5.5 Pro handoff.");
+		expect(infos.join("\n")).toContain("Saved Pro advice:");
+	});
+});
+

--- a/test/codex-manager-pro-advice-command.test.ts
+++ b/test/codex-manager-pro-advice-command.test.ts
@@ -252,6 +252,8 @@ describe("codex auth pro-advice command", () => {
 		await writeFile(join(root, "APP_DOSSIER.md"), "# dossier\n", "utf8");
 		const infos: string[] = [];
 		const errors: string[] = [];
+		const opened: string[] = [];
+		let clipboard = "";
 
 		await expect(
 			runProAdviceCommand(["--mode", "web", "--no-tui", "--json"], {
@@ -260,6 +262,10 @@ describe("codex auth pro-advice command", () => {
 				isTty: () => false,
 				loadAccounts: async () => createStorage(),
 				resolveActiveIndex: () => 0,
+				openUrl: (url) => opened.push(url),
+				writeClipboard: (text) => {
+					clipboard = text;
+				},
 				logInfo: (message) => infos.push(message),
 				logError: (message) => errors.push(message),
 			}),
@@ -268,6 +274,13 @@ describe("codex auth pro-advice command", () => {
 		expect(errors).toEqual([]);
 		expect(infos.join("\n")).toContain("Active pool account: pro@example.com / acc_pro");
 		expect(infos.join("\n")).toContain("https://chatgpt.com/");
+		expect(infos.join("\n")).toContain("The Pro prompt was copied to the clipboard.");
+		expect(opened).toEqual(["https://chatgpt.com/"]);
+		expect(clipboard).toContain("Run this as GPT-5.5 Pro Extended.");
+		expect(clipboard).toContain("# dossier");
+		expect(await readFile(join(root, "PRO_CHATGPT_PROMPT.md"), "utf8")).toContain(
+			"Run this as GPT-5.5 Pro Extended.",
+		);
 		const finalPayload = JSON.parse(infos.at(-1) ?? "{}");
 		expect(finalPayload).toMatchObject({
 			command: "pro-advice",
@@ -281,6 +294,7 @@ describe("codex auth pro-advice command", () => {
 		await writeFile(join(root, "APP_DOSSIER.md"), "# dossier\n", "utf8");
 		const infos: string[] = [];
 		const errors: string[] = [];
+		const opened: string[] = [];
 		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
 			new Response(
 				JSON.stringify({
@@ -300,6 +314,8 @@ describe("codex auth pro-advice command", () => {
 				resolveActiveIndex: () => 0,
 				refreshAccessToken: async () => tokenSuccess(),
 				fetch: fetchMock,
+				openUrl: (url) => opened.push(url),
+				writeClipboard: vi.fn(),
 				logInfo: (message) => infos.push(message),
 				logError: (message) => errors.push(message),
 			}),
@@ -308,5 +324,6 @@ describe("codex auth pro-advice command", () => {
 		expect(errors.join("\n")).toContain("not supported");
 		expect(infos.join("\n")).toContain("Falling back to ChatGPT web-assisted");
 		expect(infos.join("\n")).toContain("Active pool account: pro@example.com / acc_pro");
+		expect(opened).toEqual(["https://chatgpt.com/"]);
 	});
 });

--- a/test/codex-routing.test.ts
+++ b/test/codex-routing.test.ts
@@ -40,6 +40,7 @@ describe("codex routing helpers", () => {
 			"integrations",
 			"models",
 			"monitor",
+			"pro-advice",
 			"rotation",
 			"why-selected",
 			"verify",

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -332,7 +332,7 @@ describe("Documentation Integrity", () => {
 
 		expect(readme).toContain("codex auth fix --live --model gpt-5.3-codex");
 		expect(commandRef).toContain(
-			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle |",
+			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, pro-advice, fix, doctor, config explain, debug bundle |",
 		);
 		expect(commandRef).toContain(
 			"| `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |",

--- a/test/oc-chatgpt-target-detection.test.ts
+++ b/test/oc-chatgpt-target-detection.test.ts
@@ -30,6 +30,24 @@ async function loadTargetDetectionWithWin32PathMocks(): Promise<{
 			sep: actual.win32.sep,
 		};
 	});
+	vi.doMock("node:fs", async () => {
+		const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+		return {
+			...actual,
+			existsSync: (path: Parameters<typeof actual.existsSync>[0]) => {
+				if (typeof path === "string" && path.startsWith("\\\\")) {
+					return false;
+				}
+				return actual.existsSync(path);
+			},
+			readdirSync: (path: Parameters<typeof actual.readdirSync>[0]) => {
+				if (typeof path === "string" && path.startsWith("\\\\")) {
+					return [];
+				}
+				return actual.readdirSync(path);
+			},
+		};
+	});
 	const targetDetection = await import("../lib/oc-chatgpt-target-detection.js");
 	return {
 		detectOcChatgptMultiAuthTarget:


### PR DESCRIPTION
## Summary
- Add `codex auth pro-advice` as a dossier-to-Pro-advice workflow with auto and manual modes.
- Generate `PRO_HANDOFF.md`, dossier prompt fallback files, and `PRO_ADVICE.md` outputs without ChatGPT web or cookie automation.
- Add focused command, routing, docs, and background/manual tests.
- Harden the oc-chatgpt target detection UNC test helper so full-suite Windows runs do not hit real UNC filesystem probes.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run clean:repo:check`
- `npm run build`
- `npm test -- test/documentation.test.ts test/codex-manager-pro-advice-command.test.ts test/codex-routing.test.ts test/codex-manager-help.test.ts`
- `npm test -- test/oc-chatgpt-target-detection.test.ts`
- `npm test` (258 files, 3861 tests passed)

## Risks
- Auto mode depends on active managed account entitlement and quota for `gpt-5.5-pro`; failures fall back to manual handoff.
- The command intentionally does not automate ChatGPT web sessions, cookies, browser state, or private UI polling.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

adds `codex auth pro-advice` as a new command: discovers dossier markdown, writes `PRO_HANDOFF.md`, and either submits a background Responses API request (auto mode), opens ChatGPT web (web mode), or accepts pasted output (manual mode). routing, docs, help text, and tests are all included.

- **P1** — `selectedInputs` filters by exact resolved path, so when `--handoff docs/PRO_HANDOFF.md` is used, the default root-level `PRO_HANDOFF.md` from a prior run passes the filter and is embedded as stale dossier context in the new handoff.
- **P2** — `submitBackgroundAdvice` poll sleep uses real `setTimeout` (not `deps.sleep`) unlike the parallel `waitForAdviceFile` helper; the cancel-on-timeout branch has no vitest coverage.

<h3>Confidence Score: 3/5</h3>

hold for the dossier candidate filter P1 — non-default paths cause stale artifact injection into the handoff

one P1 (stale artifact included as dossier input when non-default --handoff/--advice paths are used) caps the score at 4; combined with several P1s from prior rounds still open (TOCTOU, UNC write, prompt injection, concurrency, stale token) the score pulls to 3

lib/codex-manager/commands/pro-advice.ts — specifically the selectedInputs filter and the submitBackgroundAdvice poll loop

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/pro-advice.ts | new 1019-line command module; P1 dossier candidate filter misses default artifact files when non-default --handoff/--advice paths are used; P2 poll sleep uses real setTimeout making the cancel-on-timeout branch untestable |
| lib/codex-manager.ts | adds pro-advice routing block with correct deps; no issues |
| test/codex-manager-pro-advice-command.test.ts | good coverage for parse, discovery, handoff build, auto-mode happy path, manual fallback, and web mode; uses withFileOperationRetry correctly; missing: non-default path filter case, timeout/cancel branch |
| test/oc-chatgpt-target-detection.test.ts | adds existsSync and readdirSync UNC guards to win32-path mock; clean targeted fix |
| scripts/codex-routing.js | adds pro-advice to AUTH_SUBCOMMANDS; routing test updated; no issues |
| lib/codex-manager/help.ts | adds pro-advice usage line matching parseProAdviceArgs flag surface; no issues |
| docs/reference/commands.md | adds pro-advice to command table and flag matrix; consistent with implementation |
| README.md | adds pro-advice to quick-reference table; documentation-only change |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([codex auth pro-advice]) --> B[parseProAdviceArgs]
    B --> C[discoverDossierCandidates]
    C --> D[selectedInputs filter]
    D --> F[buildProHandoffMarkdown]
    F --> G[writeTextFile handoffPath]
    G --> H{mode?}
    H -->|auto| I[submitBackgroundAdvice]
    I -->|poll loop - real setTimeout| J{status?}
    J -->|completed| K[writeTextFile advicePath]
    J -->|failed| L[auto failed]
    J -->|timeout| M[cancel + fallback]
    L -->|gpt-5.5-pro unsupported| N[runWebAdvice]
    L -->|other| O[runManualAdvice]
    H -->|web| N
    H -->|manual| O
    K --> T[maybeLaunchCodex]
    N --> T
    O --> T
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/codex-manager/commands/pro-advice.ts`, line 1016-1023 ([link](https://github.com/ndycode/codex-multi-auth/blob/c9087782045d748ff90e6225ffd3d7a4270abf4a/lib/codex-manager/commands/pro-advice.ts#L1016-L1023)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Default artifact files pollute `selectedInputs` when non-default paths are used**

   `selectedInputs` filters out the current run's `handoffPath` and `advicePath` via `sameResolvedPath`, but only those exact paths. when the user passes `--handoff docs/PRO_HANDOFF.md`, `sameResolvedPath` compares `repoRoot/PRO_HANDOFF.md` (a previous run's artifact, scored priority 10 by `scoreDossier`) against `repoRoot/docs/PRO_HANDOFF.md` — they differ, so the stale handoff is embedded as dossier context in the new handoff. same applies to the default `PRO_ADVICE.md` when `--advice docs/PRO_ADVICE.md` is given. no vitest coverage for the non-default path case.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/codex-manager/commands/pro-advice.ts
   Line: 1016-1023

   Comment:
   **Default artifact files pollute `selectedInputs` when non-default paths are used**

   `selectedInputs` filters out the current run's `handoffPath` and `advicePath` via `sameResolvedPath`, but only those exact paths. when the user passes `--handoff docs/PRO_HANDOFF.md`, `sameResolvedPath` compares `repoRoot/PRO_HANDOFF.md` (a previous run's artifact, scored priority 10 by `scoreDossier`) against `repoRoot/docs/PRO_HANDOFF.md` — they differ, so the stale handoff is embedded as dossier context in the new handoff. same applies to the default `PRO_ADVICE.md` when `--advice docs/PRO_ADVICE.md` is given. no vitest coverage for the non-default path case.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fpro-advice-tui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpro-advice-tui%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fcodex-manager%2Fcommands%2Fpro-advice.ts%0ALine%3A%201016-1023%0A%0AComment%3A%0A**Default%20artifact%20files%20pollute%20%60selectedInputs%60%20when%20non-default%20paths%20are%20used**%0A%0A%60selectedInputs%60%20filters%20out%20the%20current%20run's%20%60handoffPath%60%20and%20%60advicePath%60%20via%20%60sameResolvedPath%60%2C%20but%20only%20those%20exact%20paths.%20when%20the%20user%20passes%20%60--handoff%20docs%2FPRO_HANDOFF.md%60%2C%20%60sameResolvedPath%60%20compares%20%60repoRoot%2FPRO_HANDOFF.md%60%20%28a%20previous%20run's%20artifact%2C%20scored%20priority%2010%20by%20%60scoreDossier%60%29%20against%20%60repoRoot%2Fdocs%2FPRO_HANDOFF.md%60%20%E2%80%94%20they%20differ%2C%20so%20the%20stale%20handoff%20is%20embedded%20as%20dossier%20context%20in%20the%20new%20handoff.%20same%20applies%20to%20the%20default%20%60PRO_ADVICE.md%60%20when%20%60--advice%20docs%2FPRO_ADVICE.md%60%20is%20given.%20no%20vitest%20coverage%20for%20the%20non-default%20path%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fpro-advice-tui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpro-advice-tui%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fcodex-manager%2Fcommands%2Fpro-advice.ts%3A1016-1023%0A**Default%20artifact%20files%20pollute%20%60selectedInputs%60%20when%20non-default%20paths%20are%20used**%0A%0A%60selectedInputs%60%20filters%20out%20the%20current%20run's%20%60handoffPath%60%20and%20%60advicePath%60%20via%20%60sameResolvedPath%60%2C%20but%20only%20those%20exact%20paths.%20when%20the%20user%20passes%20%60--handoff%20docs%2FPRO_HANDOFF.md%60%2C%20%60sameResolvedPath%60%20compares%20%60repoRoot%2FPRO_HANDOFF.md%60%20%28a%20previous%20run's%20artifact%2C%20scored%20priority%2010%20by%20%60scoreDossier%60%29%20against%20%60repoRoot%2Fdocs%2FPRO_HANDOFF.md%60%20%E2%80%94%20they%20differ%2C%20so%20the%20stale%20handoff%20is%20embedded%20as%20dossier%20context%20in%20the%20new%20handoff.%20same%20applies%20to%20the%20default%20%60PRO_ADVICE.md%60%20when%20%60--advice%20docs%2FPRO_ADVICE.md%60%20is%20given.%20no%20vitest%20coverage%20for%20the%20non-default%20path%20case.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fcodex-manager%2Fcommands%2Fpro-advice.ts%3A800-806%0A**%60submitBackgroundAdvice%60%20uses%20real%20%60setTimeout%60%20and%20%60Date.now%28%29%60%20instead%20of%20injected%20deps**%0A%0Athe%20poll%20sleep%20at%20line%20803%20uses%20real%20%60setTimeout%60%2C%20and%20the%20timeout%20check%20at%20line%20771%20uses%20%60Date.now%28%29%60%20directly.%20%60waitForAdviceFile%60%20%E2%80%94%20added%20in%20this%20same%20PR%20%E2%80%94%20correctly%20uses%20%60deps.sleep%60%20and%20%60deps.now%3F.%28%29%60.%20each%20poll%20cycle%20in%20tests%20waits%20a%20real%202.5%20s%2C%20and%20the%20cancel-on-timeout%20branch%20%28lines%20819-829%29%20has%20no%20vitest%20coverage%20and%20cannot%20be%20exercised%20deterministically%20without%20real%20timers.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/codex-manager/commands/pro-advice.ts:1016-1023
**Default artifact files pollute `selectedInputs` when non-default paths are used**

`selectedInputs` filters out the current run's `handoffPath` and `advicePath` via `sameResolvedPath`, but only those exact paths. when the user passes `--handoff docs/PRO_HANDOFF.md`, `sameResolvedPath` compares `repoRoot/PRO_HANDOFF.md` (a previous run's artifact, scored priority 10 by `scoreDossier`) against `repoRoot/docs/PRO_HANDOFF.md` — they differ, so the stale handoff is embedded as dossier context in the new handoff. same applies to the default `PRO_ADVICE.md` when `--advice docs/PRO_ADVICE.md` is given. no vitest coverage for the non-default path case.

### Issue 2 of 2
lib/codex-manager/commands/pro-advice.ts:800-806
**`submitBackgroundAdvice` uses real `setTimeout` and `Date.now()` instead of injected deps**

the poll sleep at line 803 uses real `setTimeout`, and the timeout check at line 771 uses `Date.now()` directly. `waitForAdviceFile` — added in this same PR — correctly uses `deps.sleep` and `deps.now?.()`. each poll cycle in tests waits a real 2.5 s, and the cancel-on-timeout branch (lines 819-829) has no vitest coverage and cannot be exercised deterministically without real timers.


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: wait for web pro advice output"](https://github.com/ndycode/codex-multi-auth/commit/c9087782045d748ff90e6225ffd3d7a4270abf4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30283792)</sub>

<!-- /greptile_comment -->