### PR TITLE
Fix npm bin collision with official Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,22 @@
 All notable changes to this project are documented in this file.
 Dates use ISO format (`YYYY-MM-DD`).
 
-This repository's current stable release line is `2.x`.
+This repository's current stable release line is `3.x`.
 Current stable release notes live in `docs/releases/`.
 This top-level changelog preserves the foundational `0.x` milestones and points older iteration history to `docs/releases/legacy-pre-0.1-history.md`.
+
+## [3.0.0] - 2026-04-30
+
+Major release for conflict-free installs alongside the official Codex CLI.
+See [docs/releases/v3.0.0.md](docs/releases/v3.0.0.md) for full details.
+
+### Changed
+
+- removed the published global `codex` executable from `codex-multi-auth`
+  so npm no longer collides with official or Homebrew-owned Codex installs
+- added `codex-multi-auth-codex` as the explicit forwarding wrapper
+  executable for users who still want this package's Codex wrapper
+- kept account-management commands available through `codex-multi-auth ...`
 
 ## [2.1.1] - 2026-04-29
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/codex-multi-auth.svg)](https://www.npmjs.com/package/codex-multi-auth)
 [![npm downloads](https://img.shields.io/npm/dw/codex-multi-auth.svg)](https://www.npmjs.com/package/codex-multi-auth)
 
-Codex CLI-first multi-account OAuth manager for the official Codex CLI. The installed `codex` wrapper handles `codex auth ...` locally, forwards normal Codex commands to the official runtime, and can optionally route live Responses traffic through a localhost account-rotation proxy.
+Codex CLI-first multi-account OAuth manager for the official Codex CLI. The package installs conflict-free alongside official `codex` installs; use `codex-multi-auth ...` for account management or `codex-multi-auth-codex ...` when you explicitly want the forwarding wrapper.
 
 <img width="1270" height="729" alt="2026-02-28 12_54_58-prompt txt ‎- Notepads" src="https://github.com/user-attachments/assets/0cecb77e-a6d3-432a-ba48-3577db0c7093" />
 
@@ -15,7 +15,7 @@ Codex CLI-first multi-account OAuth manager for the official Codex CLI. The inst
 
 ## What You Get
 
-- Canonical `codex auth ...` workflow for account login, switching, checks, and diagnostics
+- Conflict-free `codex-multi-auth ...` workflow for account login, switching, checks, and diagnostics
 - Official Codex CLI forwarding for all non-auth commands
 - Multi-account OAuth pool with health-aware selection and automatic failover
 - Project-scoped account storage under `~/.codex/multi-auth/projects/<project-key>/...`
@@ -23,7 +23,7 @@ Codex CLI-first multi-account OAuth manager for the official Codex CLI. The inst
 - Experimental settings tab for staged sync, backup, and refresh-guard controls
 - Forecast, report, fix, and doctor commands for operational safety
 - Local usage ledger, budgets, account policy controls, routing profiles, and monitor views for local governance
-- Runtime counters, budget/cooldown state, and multi-auth probe visibility in `codex auth status` / `codex auth report`
+- Runtime counters, budget/cooldown state, and multi-auth probe visibility in `codex-multi-auth status` / `codex-multi-auth report`
 - Default-on runtime Responses proxy for live account rotation inside forwarded Codex CLI/app sessions
 - Optional loopback-only local bridge for `/health`, `/v1/models`, and `/v1/responses`, protected by hashed local client tokens
 - Reversible packaged Codex app bind and user-level launcher routing helpers
@@ -70,12 +70,12 @@ npm i -g codex-multi-auth
 
 ### Option C: Verify wiring
 
-`codex --version` confirms the official Codex CLI is reachable. `codex-multi-auth --version` confirms the installed wrapper package version.
+`codex --version` confirms the official Codex CLI is reachable. `codex-multi-auth --version` confirms the installed manager package version. `codex-multi-auth-codex --version` is the optional forwarding wrapper entrypoint.
 
 ```bash
 codex --version
 codex-multi-auth --version
-codex auth status
+codex-multi-auth status
 ```
 
 Any official install path is fine as long as `codex` is on `PATH`: `npm i -g @openai/codex`, `brew install --cask codex`, or an official release binary.
@@ -89,15 +89,15 @@ Any official install path is fine as long as `codex` is on `PATH`: `npm i -g @op
 
 1. Install global package:
    - `npm i -g codex-multi-auth`
-2. Run first login flow with `codex auth login`
-3. Validate state with `codex auth status` and `codex auth check`
-4. Confirm routing with `codex auth forecast --live`
+2. Run first login flow with `codex-multi-auth login`
+3. Validate state with `codex-multi-auth status` and `codex-multi-auth check`
+4. Confirm routing with `codex-multi-auth forecast --live`
 
 ### Verification
 
 ```bash
-codex auth status
-codex auth check
+codex-multi-auth status
+codex-multi-auth check
 ```
 
 </details>
@@ -111,33 +111,33 @@ Install and sign in:
 ```bash
 npm i -g @openai/codex
 npm i -g codex-multi-auth
-codex auth login
+codex-multi-auth login
 ```
 
 If you already installed the official native CLI via Homebrew or a release binary, you only need:
 
 ```bash
 npm i -g codex-multi-auth
-codex auth login
+codex-multi-auth login
 ```
 
-Verify the wrapper and the new account:
+Verify the manager and the new account:
 
 ```bash
-codex auth status
-codex auth check
+codex-multi-auth status
+codex-multi-auth check
 ```
 
 Use these next:
 
 ```bash
-codex auth list
-codex auth switch 2
-codex auth forecast --live
+codex-multi-auth list
+codex-multi-auth switch 2
+codex-multi-auth forecast --live
 ```
 
 If browser launch is blocked, use the alternate login paths in [docs/getting-started.md](docs/getting-started.md#alternate-login-paths).
-For remote or headless shells, prefer `codex auth login --device-auth`.
+For remote or headless shells, prefer `codex-multi-auth login --device-auth`.
 
 ---
 
@@ -147,39 +147,39 @@ For remote or headless shells, prefer `codex auth login --device-auth`.
 
 | Command | What it answers |
 | --- | --- |
-| `codex auth login` | How do I add or re-open the account menu? |
-| `codex auth status` | Is the wrapper active right now? |
-| `codex auth check` | Do my saved accounts look healthy? |
+| `codex-multi-auth login` | How do I add or re-open the account menu? |
+| `codex-multi-auth status` | Is the wrapper active right now? |
+| `codex-multi-auth check` | Do my saved accounts look healthy? |
 
 ### Daily use
 
 | Command | What it answers |
 | --- | --- |
-| `codex auth list` | Which accounts are saved and which one is active? |
-| `codex auth switch <index>` | How do I move to a different saved account? |
-| `codex auth forecast --live` | Which account looks best for the next session? |
+| `codex-multi-auth list` | Which accounts are saved and which one is active? |
+| `codex-multi-auth switch <index>` | How do I move to a different saved account? |
+| `codex-multi-auth forecast --live` | Which account looks best for the next session? |
 
 ### Repair
 
 | Command | What it answers |
 | --- | --- |
-| `codex auth verify-flagged` | Can any previously flagged account be restored? |
-| `codex auth verify --paths` | Do my storage path chain and sandbox probes still pass self-test? |
-| `codex auth fix --dry-run` | What safe storage or account repairs are available? |
-| `codex auth doctor --fix` | Can the CLI diagnose and apply the safest fixes now? |
+| `codex-multi-auth verify-flagged` | Can any previously flagged account be restored? |
+| `codex-multi-auth verify --paths` | Do my storage path chain and sandbox probes still pass self-test? |
+| `codex-multi-auth fix --dry-run` | What safe storage or account repairs are available? |
+| `codex-multi-auth doctor --fix` | Can the CLI diagnose and apply the safest fixes now? |
 
 ### Advanced
 
 | Command | What it answers |
 | --- | --- |
-| `codex auth report --live --json` | How do I get the full machine-readable health report? |
-| `codex auth fix --live --model gpt-5.3-codex` | How do I run live repair probes with a chosen model? |
-| `codex auth why-selected --json` | Which account does the selector pick now, and why? |
-| `codex auth usage --since 24h --by project` | What local usage has been recorded recently? |
-| `codex auth monitor --json` | What is the combined usage, policy, quota, runtime, and project state? |
-| `codex auth bridge token create --label local-client` | How do I create a local bridge bearer token? |
-| `codex auth integrations --kind python` | How do I generate local bridge client snippets? |
-| `codex auth rotation status` | Is live runtime account rotation enabled for forwarded Codex sessions? |
+| `codex-multi-auth report --live --json` | How do I get the full machine-readable health report? |
+| `codex-multi-auth fix --live --model gpt-5.3-codex` | How do I run live repair probes with a chosen model? |
+| `codex-multi-auth why-selected --json` | Which account does the selector pick now, and why? |
+| `codex-multi-auth usage --since 24h --by project` | What local usage has been recorded recently? |
+| `codex-multi-auth monitor --json` | What is the combined usage, policy, quota, runtime, and project state? |
+| `codex-multi-auth bridge token create --label local-client` | How do I create a local bridge bearer token? |
+| `codex-multi-auth integrations --kind python` | How do I generate local bridge client snippets? |
+| `codex-multi-auth rotation status` | Is live runtime account rotation enabled for forwarded Codex sessions? |
 
 ### Reliability behavior
 
@@ -187,7 +187,7 @@ For remote or headless shells, prefer `codex auth login --device-auth`.
 - active requests use a bounded outbound request budget so one prompt cannot walk the full pool indefinitely
 - repeated cross-account 5xx bursts trigger a short cooldown instead of continuing aggressive rotation
 - proactive refresh is staggered to reduce background refresh bursts
-- `codex auth status` surfaces recent runtime request metrics in text output, and `codex auth report --json` exposes the machine-readable cooldown/runtime snapshot
+- `codex-multi-auth status` surfaces recent runtime request metrics in text output, and `codex-multi-auth report --json` exposes the machine-readable cooldown/runtime snapshot
 
 ---
 
@@ -266,14 +266,14 @@ Selected runtime/environment overrides:
 Validate config after changes:
 
 ```bash
-codex auth status
-codex auth check
-codex auth forecast --live
+codex-multi-auth status
+codex-multi-auth check
+codex-multi-auth forecast --live
 ```
 
 Responses background mode stays opt-in. Enable `backgroundResponses` in settings or `CODEX_AUTH_BACKGROUND_RESPONSES=1` only for callers that intentionally send `background: true`, because those requests switch from stateless `store=false` routing to stateful `store=true`. See [docs/upgrade.md](docs/upgrade.md) for rollout guidance.
 
-Runtime rotation is enabled by default for request-bearing wrapper-launched Codex sessions. Global install/update self-heals supported packaged Codex app binds and user-level launcher routing when possible, while `codex auth rotation enable` remains the explicit repair command. `codex auth rotation disable` turns the setting off and removes the persistent app bind. Set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0`, `CODEX_MULTI_AUTH_APP_BIND_INSTALL=0`, `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0`, or `CODEX_MULTI_AUTH_AUTO_UPDATE=0` to opt out of the matching default behavior.
+Runtime rotation is enabled by default for request-bearing wrapper-launched Codex sessions. Global install/update self-heals supported packaged Codex app binds and user-level launcher routing when possible, while `codex-multi-auth rotation enable` remains the explicit repair command. `codex-multi-auth rotation disable` turns the setting off and removes the persistent app bind. Set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0`, `CODEX_MULTI_AUTH_APP_BIND_INSTALL=0`, `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0`, or `CODEX_MULTI_AUTH_AUTO_UPDATE=0` to opt out of the matching default behavior.
 
 ---
 
@@ -295,15 +295,15 @@ These flows are intentionally non-destructive by default: sync previews before a
 <summary><b>60-second recovery</b></summary>
 
 ```bash
-codex auth doctor --fix
-codex auth check
-codex auth forecast --live
+codex-multi-auth doctor --fix
+codex-multi-auth check
+codex-multi-auth forecast --live
 ```
 
 If still broken:
 
 ```bash
-codex auth login
+codex-multi-auth login
 ```
 
 </details>
@@ -312,12 +312,12 @@ codex auth login
 <summary><b>Common symptoms</b></summary>
 
 - `codex auth` unrecognized: run `where codex` or `which codex`, then follow `docs/troubleshooting.md` for routing fallback commands
-- Switch succeeds but wrong account appears active: run `codex auth switch <index>`, then restart session
-- Requests fail fast with a pool cooldown message: wait for the cooldown window or inspect `codex auth status`
-- Requests fail fast after repeated upstream 5xx errors: inspect `codex auth report --json` for runtime traffic and cooldown details
-- Storage cleanup fails with `EBUSY` / `EPERM` (Windows): run `codex auth doctor --fix` to retry, or manually remove `~/.codex/multi-auth/<project-key>/` and re-login
-- OAuth callback on port `1455` fails: free the port and re-run `codex auth login`
-- Browser launch is blocked or you are in a headless shell: prefer `codex auth login --device-auth`; use `codex auth login --manual` or `CODEX_AUTH_NO_BROWSER=1` only when you need the callback-paste fallback
+- Switch succeeds but wrong account appears active: run `codex-multi-auth switch <index>`, then restart session
+- Requests fail fast with a pool cooldown message: wait for the cooldown window or inspect `codex-multi-auth status`
+- Requests fail fast after repeated upstream 5xx errors: inspect `codex-multi-auth report --json` for runtime traffic and cooldown details
+- Storage cleanup fails with `EBUSY` / `EPERM` (Windows): run `codex-multi-auth doctor --fix` to retry, or manually remove `~/.codex/multi-auth/<project-key>/` and re-login
+- OAuth callback on port `1455` fails: free the port and re-run `codex-multi-auth login`
+- Browser launch is blocked or you are in a headless shell: prefer `codex-multi-auth login --device-auth`; use `codex-multi-auth login --manual` or `CODEX_AUTH_NO_BROWSER=1` only when you need the callback-paste fallback
 - `missing field id_token` / `token_expired` / `refresh_token_reused`: re-login affected account
 
 </details>
@@ -326,14 +326,14 @@ codex auth login
 <summary><b>Diagnostics pack</b></summary>
 
 ```bash
-codex auth list
-codex auth status
-codex auth check
-codex auth verify-flagged --json
-codex auth forecast --live
-codex auth fix --dry-run
-codex auth report --live --json
-codex auth doctor --json
+codex-multi-auth list
+codex-multi-auth status
+codex-multi-auth check
+codex-multi-auth verify-flagged --json
+codex-multi-auth forecast --live
+codex-multi-auth fix --dry-run
+codex-multi-auth report --live --json
+codex-multi-auth doctor --json
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -359,9 +359,9 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current stable: [docs/releases/v2.1.1.md](docs/releases/v2.1.1.md)
-- Previous stable: [docs/releases/v2.1.0.md](docs/releases/v2.1.0.md)
-- Earlier stable: [docs/releases/v2.0.2.md](docs/releases/v2.0.2.md)
+- Current stable: [docs/releases/v3.0.0.md](docs/releases/v3.0.0.md)
+- Previous stable: [docs/releases/v2.1.1.md](docs/releases/v2.1.1.md)
+- Earlier stable: [docs/releases/v2.1.0.md](docs/releases/v2.1.0.md)
 - Earlier stable: [docs/releases/v1.3.2.md](docs/releases/v1.3.2.md)
 - Stable archive: [docs/releases/v1.3.1.md](docs/releases/v1.3.1.md)
 - Full release archive: [docs/README.md#release-history](docs/README.md#release-history)

--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ Selected runtime/environment overrides:
 | `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0/1` | Opt out/in of routing supported app shortcuts during install/update or rotation enable |
 | `CODEX_MULTI_AUTH_AUTO_UPDATE=0/1` | Opt out/in of best-effort global package auto-update checks |
 | `CODEX_TUI_V2=0/1` | Disable/enable TUI v2 |
-| `CODEX_TUI_COLOR_PROFILE=truecolor|ansi256|ansi16` | TUI color profile |
-| `CODEX_TUI_GLYPHS=ascii|unicode|auto` | TUI glyph style |
+| `CODEX_TUI_COLOR_PROFILE=truecolor\|ansi256\|ansi16` | TUI color profile |
+| `CODEX_TUI_GLYPHS=ascii\|unicode\|auto` | TUI glyph style |
 | `CODEX_AUTH_BACKGROUND_RESPONSES=0/1` | Opt in/out of stateful Responses `background: true` compatibility |
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=<ms>` | Request timeout override |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=<ms>` | Stream stall timeout override |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ Security updates are provided for the current maintained release line.
 
 | Version line | Status |
 | --- | --- |
-| `2.x` latest | Supported |
+| `3.x` latest | Supported |
+| `2.x` historical releases | Not supported |
 | pre-`1.0` historical releases | Not supported |
 
 ---

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -58,7 +58,7 @@ Canonical governance for repository documentation quality and consistency.
 3. Canonical storage root: `~/.codex/multi-auth` unless explicitly overridden.
 4. Compatibility aliases (`codex multi auth`, `codex multi-auth`, `codex multiauth`) belong only in command reference, troubleshooting, or migration sections.
 5. Legacy paths/flows and scoped package references belong only in migration and compatibility sections.
-6. Current stable release line is `2.x`; foundational `0.x` and pre-`0.1.0` entries stay archived separately.
+6. Current stable release line is `3.x`; foundational `0.x` and pre-`0.1.0` entries stay archived separately.
 7. Runtime rotation is documented as default-on unless a future release intentionally changes that policy.
 8. Audit evidence under `docs/audits/` is historical snapshot material. Do not rewrite captured evidence to look current; add snapshot notes or new audit artifacts instead.
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -54,7 +54,7 @@ Canonical governance for repository documentation quality and consistency.
 ## Canonical Policy
 
 1. Canonical package name: `codex-multi-auth`.
-2. Canonical account command family: `codex auth ...`.
+2. Canonical account command family: `codex-multi-auth ...`.
 3. Canonical storage root: `~/.codex/multi-auth` unless explicitly overridden.
 4. Compatibility aliases (`codex multi auth`, `codex multi-auth`, `codex multiauth`) belong only in command reference, troubleshooting, or migration sections.
 5. Legacy paths/flows and scoped package references belong only in migration and compatibility sections.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Public documentation for `codex-multi-auth`.
 
 | Document | Focus |
 | --- | --- |
-| [Daily-use landing page](index.md) | Common `codex auth ...` workflows and quick-start guidance |
+| [Daily-use landing page](index.md) | Common `codex-multi-auth ...` workflows and quick-start guidance |
 | [faq.md](faq.md) | Short answers to common adoption questions |
 | [features.md](features.md) | User-facing capability map |
 | [configuration.md](configuration.md) | Stable defaults, precedence, and environment overrides |
@@ -103,7 +103,7 @@ Public documentation for `codex-multi-auth`.
 | [development/IA_FINDABILITY_AUDIT_2026-03-01.md](development/IA_FINDABILITY_AUDIT_2026-03-01.md) | IA and findability baseline audit |
 | [development/CONFIG_FIELDS.md](development/CONFIG_FIELDS.md) | Complete field and environment inventory |
 | [development/CONFIG_FLOW.md](development/CONFIG_FLOW.md) | Configuration resolution flow |
-| [development/RUNBOOK_ADD_AUTH_COMMAND.md](development/RUNBOOK_ADD_AUTH_COMMAND.md) | Safe workflow for adding a new `codex auth ...` command |
+| [development/RUNBOOK_ADD_AUTH_COMMAND.md](development/RUNBOOK_ADD_AUTH_COMMAND.md) | Safe workflow for adding a new `codex-multi-auth ...` command |
 | [development/RUNBOOK_ADD_CONFIG_FIELD.md](development/RUNBOOK_ADD_CONFIG_FIELD.md) | Safe workflow for introducing a new config field |
 | [development/RUNBOOK_CHANGE_ROUTING_POLICY.md](development/RUNBOOK_CHANGE_ROUTING_POLICY.md) | Safe workflow for changing routing, retry, or fallback policy |
 | [development/REPOSITORY_SCOPE.md](development/REPOSITORY_SCOPE.md) | Ownership map by repository path |

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,9 @@ Public documentation for `codex-multi-auth`.
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.1.1.md](releases/v2.1.1.md) | Current stable release notes |
-| [releases/v2.1.0.md](releases/v2.1.0.md) | Prior stable release notes |
+| [releases/v3.0.0.md](releases/v3.0.0.md) | Current stable release notes |
+| [releases/v2.1.1.md](releases/v2.1.1.md) | Prior stable release notes |
+| [releases/v2.1.0.md](releases/v2.1.0.md) | Earlier stable release notes |
 | [releases/v2.0.2.md](releases/v2.0.2.md) | Earlier stable release notes |
 | [releases/v2.0.1.md](releases/v2.0.1.md) | Earlier stable release notes |
 | [releases/v2.0.0.md](releases/v2.0.0.md) | Earlier stable release notes |
@@ -82,8 +83,9 @@ Public documentation for `codex-multi-auth`.
 | [reference/storage-paths.md](reference/storage-paths.md) | Canonical and compatibility storage paths |
 | [reference/public-api.md](reference/public-api.md) | Public API stability and semver contract |
 | [reference/error-contracts.md](reference/error-contracts.md) | CLI, JSON, and helper error semantics |
-| [releases/v2.1.1.md](releases/v2.1.1.md) | Current stable release notes |
-| [releases/v2.1.0.md](releases/v2.1.0.md) | Prior stable release notes |
+| [releases/v3.0.0.md](releases/v3.0.0.md) | Current stable release notes |
+| [releases/v2.1.1.md](releases/v2.1.1.md) | Prior stable release notes |
+| [releases/v2.1.0.md](releases/v2.1.0.md) | Earlier stable release notes |
 | [releases/v2.0.2.md](releases/v2.0.2.md) | Earlier stable release notes |
 | [releases/v2.0.1.md](releases/v2.0.1.md) | Earlier stable release notes |
 | [releases/v0.1.0-beta.0.md](releases/v0.1.0-beta.0.md) | Archived prerelease reference |

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ Public documentation for `codex-multi-auth`.
 | [development/RUNBOOK_ADD_CONFIG_FIELD.md](development/RUNBOOK_ADD_CONFIG_FIELD.md) | Safe workflow for introducing a new config field |
 | [development/RUNBOOK_CHANGE_ROUTING_POLICY.md](development/RUNBOOK_CHANGE_ROUTING_POLICY.md) | Safe workflow for changing routing, retry, or fallback policy |
 | [development/REPOSITORY_SCOPE.md](development/REPOSITORY_SCOPE.md) | Ownership map by repository path |
-| [development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md](development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md) | Safe workflow for adding a new `codex auth` command |
+| [development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md](development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md) | Safe workflow for adding a new `codex-multi-auth ...` command |
 | [development/RUNBOOK_ADD_CONFIG_FIELD_SAFELY.md](development/RUNBOOK_ADD_CONFIG_FIELD_SAFELY.md) | Safe workflow for introducing a new config/settings field |
 | [development/RUNBOOK_CHANGE_ROUTING_POLICY_SAFELY.md](development/RUNBOOK_CHANGE_ROUTING_POLICY_SAFELY.md) | Safe workflow for changing routing or account-selection policy |
 | [development/TESTING.md](development/TESTING.md) | Validation gates and test matrix |

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -39,7 +39,7 @@ Use short sections and scan-friendly tables where they improve clarity.
 
 ## Command and Path Rules
 
-1. Canonical command family is `codex auth ...`.
+1. Canonical command family is `codex-multi-auth ...`.
 2. Canonical runtime root is `~/.codex/multi-auth`.
 3. Runtime rotation must be described as default-on unless the release policy changes.
 4. Legacy command/path references belong only in migration contexts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ Public overview of how `codex-multi-auth` fits around the official Codex CLI.
 
 `codex-multi-auth` is a local `codex` wrapper plus a multi-account OAuth manager.
 
-- `codex auth ...` commands are handled locally by the account manager.
+- `codex-multi-auth ...` commands are handled locally by the account manager.
 - All other `codex` commands are forwarded to the official Codex CLI.
 - Account, settings, quota, backup, and diagnostic state lives under `~/.codex/multi-auth`.
 - Runtime rotation is optional and enabled by default.
@@ -25,7 +25,7 @@ Public overview of how `codex-multi-auth` fits around the official Codex CLI.
 
 It decides whether the current command should:
 
-- stay local as `codex auth ...`
+- stay local as `codex-multi-auth ...`
 - forward to the official Codex CLI
 - add runtime-rotation provider settings before forwarding, when rotation is enabled
 
@@ -66,18 +66,18 @@ The proxy:
 - replaces upstream auth headers with the selected managed account
 - rotates accounts on rate limits, auth refresh failures, network errors, and server errors before response bytes are streamed
 - strips hop-by-hop and stale decoded response headers before returning data to the local Codex client
-- records runtime status for `codex auth status`, `codex auth report`, and `codex auth rotation status`
+- records runtime status for `codex-multi-auth status`, `codex-multi-auth report`, and `codex-multi-auth rotation status`
 
 ### 5. Codex desktop app support
 
-`codex auth rotation enable` can bind a packaged Codex desktop app to the same local runtime-rotation path.
+`codex-multi-auth rotation enable` can bind a packaged Codex desktop app to the same local runtime-rotation path.
 
 This is reversible:
 
 - the real Codex `config.toml` is backed up before modification
 - a localhost router is started for the app
 - a user login startup entry keeps the router available
-- `codex auth rotation disable` or `codex auth rotation unbind-app` restores the backup and removes the startup entry
+- `codex-multi-auth rotation disable` or `codex-multi-auth rotation unbind-app` restores the backup and removes the startup entry
 - official app binaries are not patched
 
 `scripts/codex-app-launcher.js` also supports user-level shortcut routing for environments where shortcuts can be retargeted safely.
@@ -95,7 +95,7 @@ That path reuses the same account pool for:
 - live account sync
 - quota-aware selection
 
-Normal `codex auth ...` usage and wrapper forwarding do not require this host mode.
+Normal `codex-multi-auth ...` usage and wrapper forwarding do not require this host mode.
 
 ---
 
@@ -106,7 +106,7 @@ Default CLI path:
 ```text
 Terminal user
   |
-  | codex auth ...
+  | codex-multi-auth ...
   v
 codex-multi-auth wrapper
   |
@@ -162,7 +162,7 @@ Codex or ChatGPT-backed request flow with refresh, retry, and failover
 ## Design Constraints
 
 - The official OAuth flow remains the source of authentication.
-- The canonical command family is `codex auth ...`.
+- The canonical command family is `codex-multi-auth ...`.
 - The OAuth callback port remains `1455`.
 - Runtime rotation is default-on and localhost-only.
 - The desktop app bind is reversible and does not patch official app files.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,13 +108,13 @@ Keep these enabled for most environments:
 
 ## Runtime Rotation Proxy
 
-`codexRuntimeRotationProxy` is enabled by default. When enabled through defaults, settings, `codex auth rotation enable`, or `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=1`, the `codex` wrapper starts a localhost-only Responses proxy for forwarded official Codex sessions, including CLI request commands, `codex app-server`, and `codex app` launches through the wrapper. The wrapper writes a temporary shadow `CODEX_HOME/config.toml` that selects a custom provider named `codex-multi-auth-runtime-proxy`, launches the official Codex surface against that provider, and removes the shadow home after the owning process exits. Set `codexRuntimeRotationProxy=false`, run `codex auth rotation disable`, or set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` to bypass the proxy.
+`codexRuntimeRotationProxy` is enabled by default. When enabled through defaults, settings, `codex-multi-auth rotation enable`, or `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=1`, the `codex` wrapper starts a localhost-only Responses proxy for forwarded official Codex sessions, including CLI request commands, `codex app-server`, and `codex app` launches through the wrapper. The wrapper writes a temporary shadow `CODEX_HOME/config.toml` that selects a custom provider named `codex-multi-auth-runtime-proxy`, launches the official Codex surface against that provider, and removes the shadow home after the owning process exits. Set `codexRuntimeRotationProxy=false`, run `codex-multi-auth rotation disable`, or set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` to bypass the proxy.
 
-The proxy preserves request bodies and streaming responses, replaces outbound auth headers with the selected managed account, and rotates to another account before response bytes are streamed when it sees rate limits, server errors, network failures, or refresh failures. It removes hop-by-hop headers, private account metadata headers, and stale decoded `content-encoding` from client responses. If every account is unavailable, the proxy returns a structured pool-exhaustion error that points to `codex auth rotation status`.
+The proxy preserves request bodies and streaming responses, replaces outbound auth headers with the selected managed account, and rotates to another account before response bytes are streamed when it sees rate limits, server errors, network failures, or refresh failures. It removes hop-by-hop headers, private account metadata headers, and stale decoded `content-encoding` from client responses. If every account is unavailable, the proxy returns a structured pool-exhaustion error that points to `codex-multi-auth rotation status`.
 
 For `codex app` launches that go through the wrapper, the wrapper automatically starts a small internal helper so rotation can keep working if the desktop app launcher detaches. The helper stores only local runtime status, uses the same per-session proxy client key as the CLI path, and exits after an idle timeout.
 
-`codex auth rotation enable` also binds the packaged desktop app to a persistent localhost router. This backs up the real Codex `config.toml`, writes the `codex-multi-auth-runtime-proxy` provider into the real Codex home, starts the router immediately, and installs a user login startup entry: a Startup `.cmd` on Windows or a LaunchAgent on macOS. The persistent provider is marked as not requiring OpenAI auth and uses a local app-bind client token, so the desktop runtime does not display the selected multi-auth account while codex-multi-auth status and quota views still read the router's last-account telemetry. `codex auth rotation disable` and `codex auth rotation unbind-app` stop that router, remove the startup entry, and restore the backed-up Codex config. The official app files are not patched.
+`codex-multi-auth rotation enable` also binds the packaged desktop app to a persistent localhost router. This backs up the real Codex `config.toml`, writes the `codex-multi-auth-runtime-proxy` provider into the real Codex home, starts the router immediately, and installs a user login startup entry: a Startup `.cmd` on Windows or a LaunchAgent on macOS. The persistent provider is marked as not requiring OpenAI auth and uses a local app-bind client token, so the desktop runtime does not display the selected multi-auth account while codex-multi-auth status and quota views still read the router's last-account telemetry. `codex-multi-auth rotation disable` and `codex-multi-auth rotation unbind-app` stop that router, remove the startup entry, and restore the backed-up Codex config. The official app files are not patched.
 
 Package install/update self-heals these defaults when runtime rotation is enabled:
 
@@ -140,10 +140,10 @@ The shipped config templates expose first-class current OpenAI model aliases:
 ## Validate Effective Configuration
 
 ```bash
-codex auth status
-codex auth list
-codex auth check
-codex auth forecast --live
+codex-multi-auth status
+codex-multi-auth list
+codex-multi-auth check
+codex-multi-auth forecast --live
 ```
 
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ Short answers for developers evaluating `codex-multi-auth`.
 
 ## Does this replace `@openai/codex`?
 
-No. `codex-multi-auth` wraps the official `@openai/codex` CLI. It handles `codex auth ...` locally and forwards the rest of the `codex` workflow to the official CLI.
+No. `codex-multi-auth` wraps the official `@openai/codex` CLI. It handles `codex-multi-auth ...` locally and forwards the rest of the `codex` workflow to the official CLI.
 
 ---
 
@@ -24,13 +24,13 @@ Not for the ChatGPT-authenticated multi-account workflow in this repository. If 
 
 ## Is the plugin runtime required?
 
-No. Many users only need the wrapper and `codex auth ...` commands. The plugin-host runtime is optional and uses the same account pool for advanced host request handling.
+No. Many users only need the wrapper and `codex-multi-auth ...` commands. The plugin-host runtime is optional and uses the same account pool for advanced host request handling.
 
 ---
 
 ## Is runtime rotation required?
 
-Runtime rotation is enabled by default for request-bearing forwarded Codex CLI/app sessions. Disable it with `codex auth rotation disable`, `codexRuntimeRotationProxy=false`, or `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` when you need plain official Codex forwarding.
+Runtime rotation is enabled by default for request-bearing forwarded Codex CLI/app sessions. Disable it with `codex-multi-auth rotation disable`, `codexRuntimeRotationProxy=false`, or `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` when you need plain official Codex forwarding.
 
 ---
 
@@ -63,12 +63,12 @@ By default, under `~/.codex/multi-auth`. Project-scoped account pools can also l
 Run:
 
 ```bash
-codex auth doctor --fix
-codex auth check
-codex auth forecast --live
+codex-multi-auth doctor --fix
+codex-multi-auth check
+codex-multi-auth forecast --live
 ```
 
-Then rerun `codex auth login` if the affected account still looks stale.
+Then rerun `codex-multi-auth login` if the affected account still looks stale.
 
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,12 +8,12 @@ User-facing capability map for `codex-multi-auth`.
 
 | Capability | What it gives you | Primary entry |
 | --- | --- | --- |
-| Multi-account dashboard login | Add and manage multiple OAuth identities from one terminal flow | `codex auth login` |
-| Onboarding backup restore | Restores the latest named backup or lets you choose a named backup manually when a fresh install or empty pool needs to recover saved accounts fast | `codex auth login` |
+| Multi-account dashboard login | Add and manage multiple OAuth identities from one terminal flow | `codex-multi-auth login` |
+| Onboarding backup restore | Restores the latest named backup or lets you choose a named backup manually when a fresh install or empty pool needs to recover saved accounts fast | `codex-multi-auth login` |
 | Account dedupe and identity normalization | Avoid duplicate saved account rows | login flow |
-| Explicit active-account switching | Pick the current account by index instead of relying on hidden state | `codex auth switch <index>` |
-| Fast and deep health checks | See whether the current pool is usable before a coding session | `codex auth check` |
-| Flagged-account verification and restore | Recover accounts that were sidelined during prior failures | `codex auth verify-flagged` |
+| Explicit active-account switching | Pick the current account by index instead of relying on hidden state | `codex-multi-auth switch <index>` |
+| Fast and deep health checks | See whether the current pool is usable before a coding session | `codex-multi-auth check` |
+| Flagged-account verification and restore | Recover accounts that were sidelined during prior failures | `codex-multi-auth verify-flagged` |
 
 ---
 
@@ -21,10 +21,10 @@ User-facing capability map for `codex-multi-auth`.
 
 | Capability | What it gives you | Primary entry |
 | --- | --- | --- |
-| Readiness and risk forecast | Suggests the best next account | `codex auth forecast` |
-| Live quota probe mode | Uses live headers for stronger decisions | `codex auth forecast --live` |
-| JSON report output | Lets you inspect account state in automation or support workflows | `codex auth report --live --json` |
-| Runtime rotation proxy (default-on) | Lets forwarded official Codex CLI/app sessions rotate managed accounts between Responses requests without restarting the session. Disable per install when needed. | `codex auth rotation status` |
+| Readiness and risk forecast | Suggests the best next account | `codex-multi-auth forecast` |
+| Live quota probe mode | Uses live headers for stronger decisions | `codex-multi-auth forecast --live` |
+| JSON report output | Lets you inspect account state in automation or support workflows | `codex-multi-auth report --live --json` |
+| Runtime rotation proxy (default-on) | Lets forwarded official Codex CLI/app sessions rotate managed accounts between Responses requests without restarting the session. Disable per install when needed. | `codex-multi-auth rotation status` |
 
 ---
 
@@ -34,11 +34,11 @@ Runtime rotation is the current 2.x architecture addition. It is default-on and 
 
 | Capability | What it gives you | Primary entry |
 | --- | --- | --- |
-| Local Responses proxy | Routes forwarded official Codex Responses/model traffic through a loopback provider named `codex-multi-auth-runtime-proxy` | `codex auth rotation status` |
+| Local Responses proxy | Routes forwarded official Codex Responses/model traffic through a loopback provider named `codex-multi-auth-runtime-proxy` | `codex-multi-auth rotation status` |
 | Per-request account rotation | Moves to another managed account on quota, auth refresh, network, or server failure before streaming response bytes | runtime proxy |
 | Shadow `CODEX_HOME` launch | Keeps temporary provider config isolated from normal official Codex state for wrapper-launched CLI sessions | `codex` wrapper |
-| Runtime status telemetry | Shows setting state, app helper state, app bind state, account waits, cooldowns, and last-account proxy metadata | `codex auth rotation status` |
-| Reversible desktop app bind | Lets packaged Codex app launches use the same local router without patching official app files | `codex auth rotation bind-app` |
+| Runtime status telemetry | Shows setting state, app helper state, app bind state, account waits, cooldowns, and last-account proxy metadata | `codex-multi-auth rotation status` |
+| Reversible desktop app bind | Lets packaged Codex app launches use the same local router without patching official app files | `codex-multi-auth rotation bind-app` |
 | Launcher routing helper | Retargets supported user-level app shortcuts or creates a managed macOS wrapper app | `codex-multi-auth-app-launcher` |
 
 ---
@@ -47,8 +47,8 @@ Runtime rotation is the current 2.x architecture addition. It is default-on and 
 
 | Capability | What it gives you | Primary entry |
 | --- | --- | --- |
-| Safe repair workflow | Detects and repairs known local storage inconsistencies | `codex auth fix` |
-| Diagnostics with optional repair | One command to inspect and optionally fix common failures | `codex auth doctor` |
+| Safe repair workflow | Detects and repairs known local storage inconsistencies | `codex-multi-auth fix` |
+| Diagnostics with optional repair | One command to inspect and optionally fix common failures | `codex-multi-auth doctor` |
 | Backup and WAL recovery | Safer persistence when local writes are interrupted or partially applied | storage runtime |
 
 ---
@@ -72,7 +72,7 @@ Runtime rotation is the current 2.x architecture addition. It is default-on and 
 | Account action hotkeys | Per-account set, refresh, toggle, and delete shortcuts |
 | In-dashboard settings hub | Runtime and display tuning without editing files directly |
 | Experimental settings hotkeys | Keyboard shortcuts for sync preview, backup export, and refresh-guard tuning |
-| Browser-first OAuth with device/manual fallback | `codex auth login` stays browser-first, while `--device-auth` is preferred for remote/headless shells and `--manual`, `--no-browser`, and `CODEX_AUTH_NO_BROWSER=1` remain callback-paste fallbacks |
+| Browser-first OAuth with device/manual fallback | `codex-multi-auth login` stays browser-first, while `--device-auth` is preferred for remote/headless shells and `--manual`, `--no-browser`, and `CODEX_AUTH_NO_BROWSER=1` remain callback-paste fallbacks |
 
 Device auth prints `https://auth.openai.com/codex/device` plus a one-time code and does not rely on a local browser or callback server. Manual/non-TTY login accepts the full callback URL on stdin for environments where device auth is unavailable.
 
@@ -80,7 +80,7 @@ Device auth prints `https://auth.openai.com/codex/device` plus a one-time code a
 
 ## Optional Plugin-Host Runtime
 
-Some users only need the wrapper and `codex auth ...` commands. If you also run the plugin-host path, `codex-multi-auth` can use the same account pool for:
+Some users only need the wrapper and `codex-multi-auth ...` commands. If you also run the plugin-host path, `codex-multi-auth` can use the same account pool for:
 
 - request transformation for Codex or ChatGPT-backed flows
 - token refresh and refresh deduplication

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,7 +30,7 @@ User-facing capability map for `codex-multi-auth`.
 
 ## Rotate Live Codex Runtime Requests
 
-Runtime rotation is the current 2.x architecture addition. It is default-on and local-only.
+Runtime rotation is part of the current architecture. It is default-on and local-only.
 
 | Capability | What it gives you | Primary entry |
 | --- | --- | --- |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Install `codex-multi-auth`, add an account, and confirm that `codex auth ...` is working.
+Install `codex-multi-auth`, add an account, and confirm that `codex-multi-auth ...` is working.
 
 ---
 
@@ -28,13 +28,13 @@ npm i -g codex-multi-auth
 
 Verify both installed surfaces:
 
-- `codex --version` checks the official `@openai/codex` CLI that the wrapper forwards to.
-- `codex-multi-auth --version` checks the installed wrapper package version.
+- `codex --version` checks the official `@openai/codex` CLI that the manager can pair with.
+- `codex-multi-auth --version` checks the installed manager package version.
 
 ```bash
 codex --version
 codex-multi-auth --version
-codex auth status
+codex-multi-auth status
 ```
 
 ---
@@ -42,7 +42,7 @@ codex auth status
 ## First Login
 
 ```bash
-codex auth login
+codex-multi-auth login
 ```
 
 Expected flow:
@@ -55,15 +55,15 @@ Expected flow:
 Verify the new account:
 
 ```bash
-codex auth status
-codex auth list
-codex auth check
+codex-multi-auth status
+codex-multi-auth list
+codex-multi-auth check
 ```
 
 Choose the next account for your next session:
 
 ```bash
-codex auth forecast --live
+codex-multi-auth forecast --live
 ```
 
 ## Alternate Login Paths
@@ -75,29 +75,29 @@ Use these only when the normal browser-first flow is unavailable.
 For remote, SSH, container, or other headless shells, prefer the device-code flow:
 
 ```bash
-codex auth login --device-auth
+codex-multi-auth login --device-auth
 ```
 
-Open `https://auth.openai.com/codex/device` in any browser, enter the printed code, and keep the terminal running until login completes. The code expires after 15 minutes; rerun `codex auth login --device-auth` if it times out. This path does not open a local browser and does not start the local OAuth callback server.
+Open `https://auth.openai.com/codex/device` in any browser, enter the printed code, and keep the terminal running until login completes. The code expires after 15 minutes; rerun `codex-multi-auth login --device-auth` if it times out. This path does not open a local browser and does not start the local OAuth callback server.
 
-`--device-auth` starts a new login directly. If you want to recover a saved backup first, run plain `codex auth login` so the onboarding restore menu can appear.
+`--device-auth` starts a new login directly. If you want to recover a saved backup first, run plain `codex-multi-auth login` so the onboarding restore menu can appear.
 
 ### Manual or no-browser login
 
 If device auth is unavailable or you want to handle the callback manually:
 
 ```bash
-codex auth login --manual
-CODEX_AUTH_NO_BROWSER=1 codex auth login
+codex-multi-auth login --manual
+CODEX_AUTH_NO_BROWSER=1 codex-multi-auth login
 ```
 
 In non-TTY/manual shells, provide the full redirect URL on stdin:
 
 ```bash
-echo "http://127.0.0.1:1455/auth/callback?code=..." | codex auth login --manual
+echo "http://127.0.0.1:1455/auth/callback?code=..." | codex-multi-auth login --manual
 ```
 
-`codex auth login` remains browser-first by default.
+`codex-multi-auth login` remains browser-first by default.
 
 ### Restore a saved backup during onboarding
 
@@ -120,12 +120,12 @@ See upgrade note: [onboarding restore behavior](upgrade.md#onboarding-restore-no
 
 ## Add More Accounts
 
-Repeat `codex auth login` for each account you want to manage.
+Repeat `codex-multi-auth login` for each account you want to manage.
 
 When you are done, choose the best account for the next session:
 
 ```bash
-codex auth forecast --live
+codex-multi-auth forecast --live
 ```
 
 ---
@@ -133,11 +133,11 @@ codex auth forecast --live
 ## Day-1 Command Pack
 
 ```bash
-codex auth status
-codex auth list
-codex auth switch 2
-codex auth check
-codex auth forecast --live
+codex-multi-auth status
+codex-multi-auth list
+codex-multi-auth switch 2
+codex-multi-auth check
+codex-multi-auth forecast --live
 ```
 
 ---
@@ -147,14 +147,14 @@ codex auth forecast --live
 Normal setup does not require runtime rotation. Enable it only when you want forwarded official Codex CLI/app sessions to use the local account-rotation proxy between Responses requests:
 
 ```bash
-codex auth rotation enable
-codex auth rotation status
+codex-multi-auth rotation enable
+codex-multi-auth rotation status
 ```
 
 To turn it off and restore the packaged app bind if one was installed:
 
 ```bash
-codex auth rotation disable
+codex-multi-auth rotation disable
 ```
 
 ---
@@ -184,15 +184,15 @@ Then continue with [troubleshooting.md](troubleshooting.md#verify-install-and-ro
 If the OAuth callback on port `1455` fails:
 
 - stop the process using port `1455`
-- rerun `codex auth login`
-- if browser launch is unavailable, prefer `codex auth login --device-auth`
-- if device auth is unavailable, rerun `codex auth login --manual`
+- rerun `codex-multi-auth login`
+- if browser launch is unavailable, prefer `codex-multi-auth login --device-auth`
+- if device auth is unavailable, rerun `codex-multi-auth login --manual`
 
 If account state looks stale:
 
 ```bash
-codex auth doctor --fix
-codex auth check
+codex-multi-auth doctor --fix
+codex-multi-auth check
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,7 +88,7 @@ If device auth is unavailable or you want to handle the callback manually:
 
 ```bash
 codex-multi-auth login --manual
-CODEX_AUTH_NO_BROWSER=1 codex-multi-auth login
+CODEX_AUTH_NO_BROWSER=1 codex-multi-auth login --manual
 ```
 
 In non-TTY/manual shells, provide the full redirect URL on stdin:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,21 @@
 # codex-multi-auth Docs
 
-Daily-use guide for the `codex auth ...` workflow.
+Daily-use guide for the `codex-multi-auth ...` workflow.
 
 ---
 
 ## 60-Second Path
 
 ```bash
-codex auth login
-codex auth list
-codex auth check
+codex-multi-auth login
+codex-multi-auth list
+codex-multi-auth check
 ```
 
 If you are choosing an account for the next session:
 
 ```bash
-codex auth forecast --live
+codex-multi-auth forecast --live
 ```
 
 ---
@@ -32,11 +32,11 @@ codex auth forecast --live
 ## Common Daily Commands
 
 ```bash
-codex auth status
-codex auth list
-codex auth switch 2
-codex auth report --live --json
-codex auth doctor --fix
+codex-multi-auth status
+codex-multi-auth list
+codex-multi-auth switch 2
+codex-multi-auth report --live --json
+codex-multi-auth doctor --fix
 ```
 
 ---
@@ -44,9 +44,9 @@ codex auth doctor --fix
 ## Canonical Policy
 
 - Canonical package: `codex-multi-auth`
-- Canonical command family: `codex auth ...`
+- Canonical command family: `codex-multi-auth ...`
 - Canonical storage root: `~/.codex/multi-auth`
-- Runtime rotation: default-on, inspect or repair with `codex auth rotation status`
+- Runtime rotation: default-on, inspect or repair with `codex-multi-auth rotation status`
 
 Legacy migration details live in [upgrade.md](upgrade.md).
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -10,15 +10,15 @@ This project uses tiered API stability.
 
 ### Tier A: Stable APIs
 
-Stable APIs are covered by semver compatibility guarantees and must remain backward-compatible inside the current `2.x` line unless explicitly documented.
+Stable APIs are covered by semver compatibility guarantees and must remain backward-compatible inside the current `3.x` line unless explicitly documented.
 
 - Package root plugin entrypoint exports:
   - `OpenAIOAuthPlugin`
   - `OpenAIAuthPlugin`
   - default export (alias of `OpenAIOAuthPlugin`)
 - Installed binaries:
-  - `codex`
   - `codex-multi-auth`
+  - `codex-multi-auth-codex`
   - `codex-multi-auth-app-launcher`
 - Supported package subpath entrypoints:
   - `codex-multi-auth/auth`
@@ -125,7 +125,7 @@ These details are documented for operator expectations. Internal helper process 
 - Tier A bug fix or doc-only clarification: `PATCH`
 - Tier B additive compatibility improvement: usually `PATCH` or `MINOR` depending on caller impact
 
-This repository currently ships on a `2.x` line, and breaking changes still require explicit migration documentation and review sign-off.
+This repository currently ships on a `3.x` line, and breaking changes still require explicit migration documentation and review sign-off.
 
 ---
 

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -1,0 +1,54 @@
+# Release v3.0.0
+
+Release line: `stable`
+
+This major release removes the package-owned global `codex` executable so
+`codex-multi-auth` can install beside official Codex distributions without npm
+bin collisions.
+
+## Scope
+
+- Package version prepared for publish: `3.0.0`
+- Previous stable release: `v2.1.1`
+- Semver rationale: removing a previously published executable name is a
+  breaking CLI contract change.
+
+## Changed
+
+- `codex-multi-auth` no longer publishes a global `codex` bin.
+- `codex-multi-auth-codex` is the explicit forwarding wrapper entrypoint.
+- `codex-multi-auth ...` remains the account-management command family.
+
+## Migration
+
+Use the official Codex install for the `codex` command:
+
+```bash
+npm i -g @openai/codex
+# or install the official native/Homebrew Codex distribution
+```
+
+Use this package for account management:
+
+```bash
+npm i -g codex-multi-auth
+codex-multi-auth status
+codex-multi-auth login
+```
+
+Use the forwarding wrapper only when you explicitly want this package to launch
+Codex through its wrapper:
+
+```bash
+codex-multi-auth-codex --version
+```
+
+## Validation
+
+- `npm test -- test/package-bin.test.ts test/codex-multi-auth-bin-wrapper.test.ts test/documentation.test.ts`
+- `npm run lint:scripts -- --max-warnings=0 scripts/codex-multi-auth.js`
+- packed install smoke with an existing `codex.cmd` in the npm global prefix
+
+## Release Notes
+
+- Previous release notes: `docs/releases/v2.1.1.md`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,6 @@ where codex
 codex --version
 codex-multi-auth --version
 codex-multi-auth status
-codex-multi-auth status
 npm ls -g codex-multi-auth
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,15 +7,15 @@ Recovery guide for install, login, switching, worktree storage, and stale local 
 ## Start Here
 
 ```bash
-codex auth doctor --fix
-codex auth check
-codex auth forecast --live
+codex-multi-auth doctor --fix
+codex-multi-auth check
+codex-multi-auth forecast --live
 ```
 
 If the account pool is still not usable:
 
 ```bash
-codex auth login
+codex-multi-auth login
 ```
 
 ---
@@ -28,8 +28,8 @@ Check which `codex` executable is running:
 where codex
 codex --version
 codex-multi-auth --version
-codex auth status
-codex multi auth status
+codex-multi-auth status
+codex-multi-auth status
 npm ls -g codex-multi-auth
 ```
 
@@ -40,7 +40,7 @@ npm uninstall -g @ndycode/codex-multi-auth
 npm i -g codex-multi-auth
 ```
 
-`codex multi auth status` is a compatibility alias. The canonical command family remains `codex auth ...`.
+`codex-multi-auth status` is a compatibility alias. The canonical command family remains `codex-multi-auth ...`.
 
 ---
 
@@ -49,8 +49,8 @@ npm i -g codex-multi-auth
 | Symptom | Likely cause | Action |
 | --- | --- | --- |
 | Browser opens unexpectedly | Normal browser-first OAuth flow | Complete the auth step and return to the terminal |
-| OAuth callback port `1455` is in use | Another local process owns the port | Stop the conflicting process and rerun `codex auth login` |
-| Browser or callback handoff is unavailable | Remote, SSH, container, or headless shell | Run `codex auth login --device-auth`; use `codex auth login --manual` only if device auth is unavailable |
+| OAuth callback port `1455` is in use | Another local process owns the port | Stop the conflicting process and rerun `codex-multi-auth login` |
+| Browser or callback handoff is unavailable | Remote, SSH, container, or headless shell | Run `codex-multi-auth login --device-auth`; use `codex-multi-auth login --manual` only if device auth is unavailable |
 | `missing field id_token` | Stale or malformed auth payload | Re-login the affected account |
 | `refresh_token_reused` | The token pair rotated in another context | Re-login the affected account |
 | `token_expired` | The refresh token is no longer valid | Re-login the affected account |
@@ -61,9 +61,9 @@ npm i -g codex-multi-auth
 
 | Symptom | Likely cause | Action |
 | --- | --- | --- |
-| Switch succeeds but the wrong account stays active | Stale Codex CLI sync state | Re-run `codex auth switch <index>` and restart the session |
-| All accounts look unhealthy | The entire pool is stale or damaged | Run `codex auth doctor --fix`, then add at least one fresh account |
-| The dashboard shows old account state | Local files were updated outside the current session | Run `codex auth list`, then `codex auth check` |
+| Switch succeeds but the wrong account stays active | Stale Codex CLI sync state | Re-run `codex-multi-auth switch <index>` and restart the session |
+| All accounts look unhealthy | The entire pool is stale or damaged | Run `codex-multi-auth doctor --fix`, then add at least one fresh account |
+| The dashboard shows old account state | Local files were updated outside the current session | Run `codex-multi-auth list`, then `codex-multi-auth check` |
 
 ---
 
@@ -71,11 +71,11 @@ npm i -g codex-multi-auth
 
 | Symptom | Likely cause | Action |
 | --- | --- | --- |
-| `codex auth rotation status` says disabled | Stored setting or env override is off | Run `codex auth rotation enable`, remove `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0`, or set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=1` for one process |
-| Forwarded Codex session does not show the local provider | Command is help/non-requesting, rotation is disabled, or the official CLI was not launched through the wrapper | Check `where codex`, then run `codex auth rotation status` |
-| Pool exhausted error from the proxy | Every managed account is unavailable for that model/family | Run `codex auth rotation status`, then `codex auth forecast --live` |
-| Packaged app still uses normal Codex routing | App bind was not installed or was removed | Run `codex auth rotation bind-app`, then reopen the app |
-| App bind needs to be removed | You want the official app config restored | Run `codex auth rotation unbind-app` or `codex auth rotation disable` |
+| `codex-multi-auth rotation status` says disabled | Stored setting or env override is off | Run `codex-multi-auth rotation enable`, remove `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0`, or set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=1` for one process |
+| Forwarded Codex session does not show the local provider | Command is help/non-requesting, rotation is disabled, or the official CLI was not launched through the wrapper | Check `where codex`, then run `codex-multi-auth rotation status` |
+| Pool exhausted error from the proxy | Every managed account is unavailable for that model/family | Run `codex-multi-auth rotation status`, then `codex-multi-auth forecast --live` |
+| Packaged app still uses normal Codex routing | App bind was not installed or was removed | Run `codex-multi-auth rotation bind-app`, then reopen the app |
+| App bind needs to be removed | You want the official app config restored | Run `codex-multi-auth rotation unbind-app` or `codex-multi-auth rotation disable` |
 
 The runtime proxy is loopback-only and default-on. It routes Responses traffic only for forwarded request-bearing official Codex sessions and supported app launches.
 
@@ -85,7 +85,7 @@ The runtime proxy is loopback-only and default-on. It routes Responses traffic o
 
 | Symptom | Likely cause | Action |
 | --- | --- | --- |
-| A worktree asks for login again | The worktree still points at a legacy path key | Run `codex auth list` once in the worktree to trigger migration into repo-shared storage |
+| A worktree asks for login again | The worktree still points at a legacy path key | Run `codex-multi-auth list` once in the worktree to trigger migration into repo-shared storage |
 | A repo should not share accounts with another repo | Project-scoped storage is not enabled or not in use | Review the project storage rules in [reference/storage-paths.md](reference/storage-paths.md) |
 
 ---
@@ -93,14 +93,14 @@ The runtime proxy is loopback-only and default-on. It routes Responses traffic o
 ## Diagnostics Pack
 
 ```bash
-codex auth list
-codex auth status
-codex auth check
-codex auth verify-flagged --json
-codex auth forecast --live
-codex auth fix --dry-run
-codex auth report --live --json
-codex auth doctor --json
+codex-multi-auth list
+codex-multi-auth status
+codex-multi-auth check
+codex-multi-auth verify-flagged --json
+codex-multi-auth forecast --live
+codex-multi-auth fix --dry-run
+codex-multi-auth report --live --json
+codex-multi-auth doctor --json
 ```
 
 ---
@@ -113,7 +113,7 @@ PowerShell:
 Remove-Item "$HOME\.codex\multi-auth\openai-codex-accounts.json" -Force -ErrorAction SilentlyContinue
 Remove-Item "$HOME\.codex\multi-auth\openai-codex-flagged-accounts.json" -Force -ErrorAction SilentlyContinue
 Remove-Item "$HOME\.codex\multi-auth\settings.json" -Force -ErrorAction SilentlyContinue
-codex auth login
+codex-multi-auth login
 ```
 
 Bash:
@@ -122,7 +122,7 @@ Bash:
 rm -f ~/.codex/multi-auth/openai-codex-accounts.json
 rm -f ~/.codex/multi-auth/openai-codex-flagged-accounts.json
 rm -f ~/.codex/multi-auth/settings.json
-codex auth login
+codex-multi-auth login
 ```
 
 ---
@@ -131,8 +131,8 @@ codex auth login
 
 Attach these outputs when opening a bug report:
 
-- `codex auth report --json`
-- `codex auth doctor --json`
+- `codex-multi-auth report --json`
+- `codex-multi-auth doctor --json`
 - `codex --version`
 - `codex-multi-auth --version`
 - `npm ls -g codex-multi-auth`

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,6 +1,6 @@
 # Upgrade Guide
 
-Migrate legacy installs to the canonical `codex-multi-auth` workflow on the current `2.x` release line.
+Migrate legacy installs to the canonical `codex-multi-auth` workflow on the current `3.x` release line.
 
 ---
 
@@ -9,6 +9,27 @@ Migrate legacy installs to the canonical `codex-multi-auth` workflow on the curr
 - Package: `codex-multi-auth`
 - Command family: `codex-multi-auth ...`
 - Runtime root: `~/.codex/multi-auth`
+
+---
+
+## v3.0.0 Bin Migration
+
+`v3.0.0` intentionally stops publishing a global `codex` executable. That
+name belongs to the official Codex install path and can be owned by npm,
+Homebrew, or an official release binary.
+
+Use these commands after upgrading:
+
+```bash
+codex --version
+codex-multi-auth --version
+codex-multi-auth status
+codex-multi-auth-codex --version
+```
+
+If you previously ran this package through `codex`, switch account-management
+commands to `codex-multi-auth ...`. If you intentionally need the forwarding
+wrapper from this package, use `codex-multi-auth-codex ...`.
 
 ---
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -7,7 +7,7 @@ Migrate legacy installs to the canonical `codex-multi-auth` workflow on the curr
 ## Canonical Targets
 
 - Package: `codex-multi-auth`
-- Command family: `codex auth ...`
+- Command family: `codex-multi-auth ...`
 - Runtime root: `~/.codex/multi-auth`
 
 ---
@@ -37,26 +37,26 @@ npm i -g codex-multi-auth
 ```bash
 codex --version
 codex-multi-auth --version
-codex auth status
+codex-multi-auth status
 ```
 
 1. Rebuild account health baseline:
 
 ```bash
-codex auth login
-codex auth check
-codex auth forecast --live --model gpt-5.3-codex
+codex-multi-auth login
+codex-multi-auth check
+codex-multi-auth forecast --live --model gpt-5.3-codex
 ```
 
 ---
 
 ## Login Flow Upgrade Notes
 
-- `codex auth login` remains the default browser-first path.
-- `codex auth login --device-auth` is the preferred remote/headless path. It prints a verification URL like `https://auth.openai.com/codex/device` and a one-time code, then completes without a local browser or callback server.
-- `codex auth login --manual` and `codex auth login --no-browser` force manual callback handling for browser-restricted shells.
+- `codex-multi-auth login` remains the default browser-first path.
+- `codex-multi-auth login --device-auth` is the preferred remote/headless path. It prints a verification URL like `https://auth.openai.com/codex/device` and a one-time code, then completes without a local browser or callback server.
+- `codex-multi-auth login --manual` and `codex-multi-auth login --no-browser` force manual callback handling for browser-restricted shells.
 - `CODEX_AUTH_NO_BROWSER=1` suppresses browser launch for automation/headless sessions. False-like values such as `0` and `false` no longer force manual mode.
-- In non-TTY/manual shells, provide the full redirect URL on stdin, for example: `echo "http://127.0.0.1:1455/auth/callback?code=..." | codex auth login --manual`.
+- In non-TTY/manual shells, provide the full redirect URL on stdin, for example: `echo "http://127.0.0.1:1455/auth/callback?code=..." | codex-multi-auth login --manual`.
 - No new npm scripts, storage migrations, or extra upgrade steps were introduced for this auth-flow change.
 
 For the full command/behavior reference, see [reference/commands.md](reference/commands.md).
@@ -83,8 +83,8 @@ For maintainer/debug flows, see advanced/internal controls in [development/CONFI
 The 2.0.1 line makes runtime rotation the default for request-bearing wrapper-launched Codex sessions and keeps the packaged app bind reversible.
 
 - Existing installs route request-bearing non-auth `codex` commands through the localhost rotation proxy unless `codexRuntimeRotationProxy=false` or `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` is set.
-- `codex auth rotation enable` persists the setting and repairs supported packaged Codex app binds through a reversible localhost router.
-- `codex auth rotation disable` turns the setting off and removes the persistent app bind.
+- `codex-multi-auth rotation enable` persists the setting and repairs supported packaged Codex app binds through a reversible localhost router.
+- `codex-multi-auth rotation disable` turns the setting off and removes the persistent app bind.
 - Set `CODEX_MULTI_AUTH_APP_BIND_INSTALL=0` before install/update if you only want wrapper-launched CLI/app sessions routed and do not want the packaged app bind installed.
 - Set `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0` before install/update if you do not want supported user-level app launchers routed through the wrapper.
 - Set `CODEX_MULTI_AUTH_AUTO_UPDATE=0` if you do not want installed packages to run the best-effort daily `npm update -g codex-multi-auth` check.
@@ -93,8 +93,8 @@ The 2.0.1 line makes runtime rotation the default for request-bearing wrapper-la
 Validate after enabling:
 
 ```bash
-codex auth rotation status
-codex auth forecast --live
+codex-multi-auth rotation status
+codex-multi-auth forecast --live
 ```
 
 ---
@@ -111,12 +111,12 @@ codex auth forecast --live
 
 ## Onboarding Restore Note
 
-`codex auth login` now opens directly into the sign-in menu when the active pool is empty, instead of opening the account dashboard first.
+`codex-multi-auth login` now opens directly into the sign-in menu when the active pool is empty, instead of opening the account dashboard first.
 
 - `Recover saved accounts` appears only when at least one valid named backup exists.
 - No new CLI flags or npm scripts were added for this flow.
 - The backup root remains `~/.codex/multi-auth/backups` by default, or `%CODEX_MULTI_AUTH_DIR%\backups` when `CODEX_MULTI_AUTH_DIR` is set.
-- `codex auth login --device-auth` starts a new device-code login directly and does not open the restore menu. Use plain `codex auth login` first when you want to recover a saved backup.
+- `codex-multi-auth login --device-auth` starts a new device-code login directly and does not open the restore menu. Use plain `codex-multi-auth login` first when you want to recover a saved backup.
 
 ---
 
@@ -143,7 +143,7 @@ If you used `perProjectAccounts=true` before worktree identity sharing was added
 | --- | --- |
 | `codex auth` not found | Run `where codex` (Windows) or `which codex` (macOS/Linux) |
 | Old package still active | Uninstall scoped package and reinstall unscoped package |
-| Account pool appears stale | Run `codex auth doctor --fix`, then re-login impacted accounts |
+| Account pool appears stale | Run `codex-multi-auth doctor --fix`, then re-login impacted accounts |
 | Mixed path confusion | Check [reference/storage-paths.md](reference/storage-paths.md) |
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.1",
+	"version": "3.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.1.1",
+			"version": "3.0.0",
 			"bundleDependencies": [
 				"@codex-ai/plugin"
 			],

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
 				"zod": "^4.3.6"
 			},
 			"bin": {
-				"codex": "scripts/codex.js",
 				"codex-multi-auth": "scripts/codex-multi-auth.js",
-				"codex-multi-auth-app-launcher": "scripts/codex-app-launcher.js"
+				"codex-multi-auth-app-launcher": "scripts/codex-app-launcher.js",
+				"codex-multi-auth-codex": "scripts/codex.js"
 			},
 			"devDependencies": {
 				"@codex-ai/sdk": "file:vendor/codex-ai-sdk",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"prepare": "husky"
 	},
 	"bin": {
-		"codex": "scripts/codex.js",
+		"codex-multi-auth-codex": "scripts/codex.js",
 		"codex-multi-auth-app-launcher": "scripts/codex-app-launcher.js",
 		"codex-multi-auth": "scripts/codex-multi-auth.js"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.1",
+	"version": "3.0.0",
 	"description": "Multi-account OAuth manager and codex auth wrapper for the official @openai/codex CLI, with switching, health checks, and recovery tools",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/scripts/codex-multi-auth.js
+++ b/scripts/codex-multi-auth.js
@@ -3,6 +3,7 @@
 // @ts-check
 
 import { createRequire } from "node:module";
+import { AUTH_SUBCOMMANDS } from "./codex-routing.js";
 
 const versionFlags = new Set(["--version", "-v"]);
 
@@ -20,7 +21,16 @@ function resolveCliVersion() {
 	return "";
 }
 
-const args = process.argv.slice(2);
+function normalizeStandaloneArgs(args) {
+	if (args[0] === "auth") return args;
+	const firstArg = args[0] ?? "";
+	if (AUTH_SUBCOMMANDS.has(firstArg)) {
+		return ["auth", ...args];
+	}
+	return args;
+}
+
+const args = normalizeStandaloneArgs(process.argv.slice(2));
 const version = resolveCliVersion();
 
 if (version.length > 0) {

--- a/scripts/codex-multi-auth.js
+++ b/scripts/codex-multi-auth.js
@@ -25,6 +25,7 @@ function normalizeStandaloneArgs(args) {
 	if (args[0] === "auth") return args;
 	const firstArg = args[0] ?? "";
 	if (AUTH_SUBCOMMANDS.has(firstArg)) {
+		// Keep this exhaustive: generic names here are reserved for auth routing.
 		return ["auth", ...args];
 	}
 	return args;

--- a/test/codex-multi-auth-bin-wrapper.test.ts
+++ b/test/codex-multi-auth-bin-wrapper.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import process from "node:process";
@@ -68,6 +68,39 @@ function createChildEnv(): NodeJS.ProcessEnv {
 		}
 	}
 	return env;
+}
+
+function writeRuntimeArgAssertion(fixtureRoot: string, expectedArgs: string[], exitCode = 0): void {
+	const distLibDir = join(fixtureRoot, "dist", "lib");
+	mkdirSync(distLibDir, { recursive: true });
+	writeFileSync(
+		join(distLibDir, "codex-manager.js"),
+		[
+			"export async function runCodexMultiAuthCli(args) {",
+			`\tconst expected = ${JSON.stringify(expectedArgs)};`,
+			'\tif (JSON.stringify(args) !== JSON.stringify(expected)) throw new Error(`bad args: ${JSON.stringify(args)}`);',
+			`\treturn ${exitCode};`,
+			"}",
+		].join("\n"),
+		"utf8",
+	);
+}
+
+function readPackageBinMap(): Record<string, string> {
+	const pkg = JSON.parse(readFileSync(join(repoRootDir, "package.json"), "utf8")) as {
+		bin?: Record<string, string>;
+	};
+	return pkg.bin ?? {};
+}
+
+function emitWindowsNpmShim(prefixDir: string, binName: string, target: string): void {
+	writeFileSync(join(prefixDir, `${binName}.cmd`), `@echo ${binName} -> ${target}\r\n`, "utf8");
+}
+
+function simulateWindowsNpmShimInstall(prefixDir: string, binMap: Record<string, string>): void {
+	for (const [binName, target] of Object.entries(binMap)) {
+		emitWindowsNpmShim(prefixDir, binName, target);
+	}
 }
 
 function runWrapper(fixtureRoot: string, args: string[] = []) {
@@ -148,22 +181,49 @@ describe("codex-multi-auth bin wrapper", () => {
 
 	it("lets the standalone bin omit the auth root for auth subcommands", () => {
 		const fixtureRoot = createWrapperFixture();
-		const distLibDir = join(fixtureRoot, "dist", "lib");
-		mkdirSync(distLibDir, { recursive: true });
-		writeFileSync(
-			join(distLibDir, "codex-manager.js"),
-			[
-				"export async function runCodexMultiAuthCli(args) {",
-				'\tif (!Array.isArray(args) || args[0] !== "auth" || args[1] !== "status") throw new Error("bad args");',
-				"\treturn 0;",
-				"}",
-			].join("\n"),
-			"utf8",
-		);
+		writeRuntimeArgAssertion(fixtureRoot, ["auth", "status"]);
 
 		const result = runWrapper(fixtureRoot, ["status"]);
 
 		expect(result.status).toBe(0);
+	});
+
+	it("lets login use the standalone auth shortcut", () => {
+		const fixtureRoot = createWrapperFixture();
+		writeRuntimeArgAssertion(fixtureRoot, ["auth", "login", "--manual"]);
+
+		const result = runWrapper(fixtureRoot, ["login", "--manual"]);
+
+		expect(result.status).toBe(0);
+		expect(result.stderr).toBe("");
+	});
+
+	it.each([
+		["unrecognized command", ["foobar"]],
+		["empty argv", []],
+	])("passes %s through without adding auth", (_label, args) => {
+		const fixtureRoot = createWrapperFixture();
+		writeRuntimeArgAssertion(fixtureRoot, args, 7);
+
+		const result = runWrapper(fixtureRoot, args);
+
+		expect(result.status).toBe(7);
+		expect(result.stderr).toBe("");
+	});
+
+	it("does not overwrite an existing codex Windows shim when emitting package bins", () => {
+		const fixtureRoot = createWrapperFixture();
+		const prefixDir = join(fixtureRoot, "prefix");
+		mkdirSync(prefixDir, { recursive: true });
+		const existingCodexShim = "@echo official codex\r\n";
+		writeFileSync(join(prefixDir, "codex.cmd"), existingCodexShim, "utf8");
+
+		simulateWindowsNpmShimInstall(prefixDir, readPackageBinMap());
+
+		expect(readFileSync(join(prefixDir, "codex.cmd"), "utf8")).toBe(existingCodexShim);
+		expect(readFileSync(join(prefixDir, "codex-multi-auth-codex.cmd"), "utf8")).toContain(
+			"codex-multi-auth-codex -> scripts/codex.js",
+		);
 	});
 
 	it("propagates integer exit codes", () => {

--- a/test/codex-multi-auth-bin-wrapper.test.ts
+++ b/test/codex-multi-auth-bin-wrapper.test.ts
@@ -52,6 +52,10 @@ function createWrapperFixture(): string {
 		join(repoRootDir, "scripts", "codex-multi-auth.js"),
 		join(scriptDir, "codex-multi-auth.js"),
 	);
+	copyFileSync(
+		join(repoRootDir, "scripts", "codex-routing.js"),
+		join(scriptDir, "codex-routing.js"),
+	);
 	return fixtureRoot;
 }
 
@@ -140,6 +144,26 @@ describe("codex-multi-auth bin wrapper", () => {
 		expect(result.status).toBe(6);
 		expect(result.stdout).toBe("");
 		expect(result.stderr).toBe("");
+	});
+
+	it("lets the standalone bin omit the auth root for auth subcommands", () => {
+		const fixtureRoot = createWrapperFixture();
+		const distLibDir = join(fixtureRoot, "dist", "lib");
+		mkdirSync(distLibDir, { recursive: true });
+		writeFileSync(
+			join(distLibDir, "codex-manager.js"),
+			[
+				"export async function runCodexMultiAuthCli(args) {",
+				'\tif (!Array.isArray(args) || args[0] !== "auth" || args[1] !== "status") throw new Error("bad args");',
+				"\treturn 0;",
+				"}",
+			].join("\n"),
+			"utf8",
+		);
+
+		const result = runWrapper(fixtureRoot, ["status"]);
+
+		expect(result.status).toBe(0);
 	});
 
 	it("propagates integer exit codes", () => {

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -266,7 +266,7 @@ describe("Documentation Integrity", () => {
 		}
 	});
 
-	it("keeps codex auth as the command standard in key docs", () => {
+	it("keeps codex-multi-auth as the command standard in key docs", () => {
 		const keyDocs = [
 			"README.md",
 			"docs/index.md",
@@ -279,8 +279,8 @@ describe("Documentation Integrity", () => {
 		for (const filePath of keyDocs) {
 			expect(
 				read(filePath),
-				`${filePath} must include codex auth command examples`,
-			).toContain("codex auth");
+				`${filePath} must include codex-multi-auth command examples`,
+			).toContain("codex-multi-auth");
 		}
 	});
 
@@ -330,7 +330,7 @@ describe("Documentation Integrity", () => {
 		const help = read(helpPath);
 		const switchCommand = read(switchPath);
 
-		expect(readme).toContain("codex auth fix --live --model gpt-5.3-codex");
+		expect(readme).toContain("codex-multi-auth fix --live --model gpt-5.3-codex");
 		expect(commandRef).toContain(
 			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle |",
 		);
@@ -554,8 +554,8 @@ describe("Documentation Integrity", () => {
 			url: "https://github.com/ndycode/codex-multi-auth/issues",
 		});
 		expect(packageJson.bin).toEqual({
-			codex: "scripts/codex.js",
 			"codex-multi-auth-app-launcher": "scripts/codex-app-launcher.js",
+			"codex-multi-auth-codex": "scripts/codex.js",
 			"codex-multi-auth": "scripts/codex-multi-auth.js",
 		});
 	});

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -37,9 +37,14 @@ function readPackageVersion(): string {
 let packageVersion = "";
 let currentStableReleaseDoc = "";
 // These stay manual so the docs portal keeps an intentional short stable-history window.
-const previousStableReleaseDoc = "docs/releases/v1.3.2.md";
-const earlierStableReleaseDoc = "docs/releases/v1.3.1.md";
+const previousStableReleaseDoc = "docs/releases/v2.1.1.md";
+const earlierStableReleaseDoc = "docs/releases/v2.1.0.md";
 const stableArchiveReleaseDocs = [
+	"docs/releases/v2.0.2.md",
+	"docs/releases/v2.0.1.md",
+	"docs/releases/v2.0.0.md",
+	"docs/releases/v1.3.2.md",
+	"docs/releases/v1.3.1.md",
 	"docs/releases/v1.3.0.md",
 	"docs/releases/v1.2.7.md",
 	"docs/releases/v1.2.6.md",
@@ -443,21 +448,21 @@ describe("Documentation Integrity", () => {
 		expect(settingsRef).toContain("- `menuStatuslineFields`");
 	});
 
-	it("keeps release-line docs aligned with the current 2.x policy", () => {
+	it("keeps release-line docs aligned with the current 3.x policy", () => {
 		const changelog = read("CHANGELOG.md");
 		const security = read("SECURITY.md");
 		const docsGovernance = read("docs/DOCUMENTATION.md");
 		const upgradeGuide = read("docs/upgrade.md");
 		const publicApi = read("docs/reference/public-api.md");
 
-		expect(changelog).toContain("current stable release line is `2.x`");
+		expect(changelog).toContain("current stable release line is `3.x`");
 		expect(changelog).toContain("docs/releases/");
-		expect(security).toContain("`2.x` latest");
+		expect(security).toContain("`3.x` latest");
 		expect(security).toContain("pre-`1.0` historical releases");
-		expect(docsGovernance).toContain("Current stable release line is `2.x`");
-		expect(upgradeGuide).toContain("current `2.x` release line");
-		expect(publicApi).toContain("inside the current `2.x` line");
-		expect(publicApi).toContain("currently ships on a `2.x` line");
+		expect(docsGovernance).toContain("Current stable release line is `3.x`");
+		expect(upgradeGuide).toContain("current `3.x` release line");
+		expect(publicApi).toContain("inside the current `3.x` line");
+		expect(publicApi).toContain("currently ships on a `3.x` line");
 	});
 
 	it("keeps the historical changelog aligned with the archived 0.x release set", () => {

--- a/test/package-bin.test.ts
+++ b/test/package-bin.test.ts
@@ -9,7 +9,8 @@ describe("package bin entries", () => {
 			bundleDependencies?: string[];
 		};
 		expect(pkg.bin).toBeDefined();
-		expect(pkg.bin?.codex).toBe("scripts/codex.js");
+		expect(pkg.bin?.codex).toBeUndefined();
+		expect(pkg.bin?.["codex-multi-auth-codex"]).toBe("scripts/codex.js");
 		expect(pkg.bin?.["codex-multi-auth-app-launcher"]).toBe("scripts/codex-app-launcher.js");
 		expect(pkg.bin?.["codex-multi-auth"]).toBe("scripts/codex-multi-auth.js");
 		expect(pkg.bin?.["codex-multi-auth-opencode-install"]).toBeUndefined();


### PR DESCRIPTION
## Summary
- Remove the published global `codex` bin so npm no longer collides with an existing official/Homebrew Codex install.
- Bump the package to `3.0.0` because removing a published executable name is a breaking CLI contract change.
- Add `codex-multi-auth-codex` as the explicit forwarding wrapper entrypoint.
- Allow `codex-multi-auth status`, `login`, and other auth subcommands without requiring the `auth` root.
- Add regression coverage for Windows shim collision behavior, auth shortcut normalization, and fallback argument paths.
- Update upgrade, release, security, and docs integrity metadata for the new major release line.

## Risk
- Users who intentionally invoked this package through the global `codex` shim must switch to `codex-multi-auth-codex` for the forwarding wrapper.
- The official `codex` command remains owned by the official install path.

## Verification
- `git fetch origin main --prune`
- `npm.cmd install`
- `npm.cmd test -- test/package-bin.test.ts test/codex-multi-auth-bin-wrapper.test.ts test/documentation.test.ts`
- `npm.cmd run lint:scripts -- --max-warnings=0 scripts/codex-multi-auth.js`
- `npx.cmd eslint test/codex-multi-auth-bin-wrapper.test.ts test/documentation.test.ts --max-warnings=0`
- `git diff --check HEAD~1..HEAD`
- `npm.cmd pack --json`
- Simulated global install into a temp npm prefix that already contained `codex.cmd`; install succeeded and produced only `codex-multi-auth.cmd`, `codex-multi-auth-app-launcher.cmd`, and `codex-multi-auth-codex.cmd` in addition to the existing `codex.cmd`.

Closes #457

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

removes the `codex` global bin and adds `codex-multi-auth-codex` as the explicit forwarding wrapper entrypoint, eliminating npm collision with official/Homebrew Codex installs. also adds `normalizeStandaloneArgs` so users can run `codex-multi-auth status` without the `auth` root prefix, backed by new regression tests for Windows shim collision and auth shortcut normalization.

note: `AGENTS.md` (not in this changeset) still documents `codex auth ...` as the canonical command family and package version 2.0.1 — worth regenerating before the next contributor session to avoid misleading guidance.

<h3>Confidence Score: 5/5</h3>

safe to merge — core bin rename is clean, tests cover the regression path, no token/auth logic changed

no P0 or P1 findings; only two P2 style notes: a doc example that conflates two opt-out modes, and a missing removeWithRetry cleanup pattern in the new shim test — neither blocks correctness

docs/getting-started.md (--manual flag in env-var example), test/codex-multi-auth-bin-wrapper.test.ts (no removeWithRetry cleanup on new Windows shim test)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | removes `codex` bin entry, adds `codex-multi-auth-codex` → scripts/codex.js; version bump to 3.0.0 — looks correct |
| scripts/codex-multi-auth.js | adds `normalizeStandaloneArgs` to allow `codex-multi-auth status` without the `auth` prefix; imports AUTH_SUBCOMMANDS from codex-routing.js; logic and edge cases (empty args, unknown command, existing `auth` prefix) are all handled and tested |
| test/codex-multi-auth-bin-wrapper.test.ts | adds Windows shim collision regression test and auth-shortcut normalization tests; shim test is a simulation (not real npm install) and lacks removeWithRetry cleanup for the new temp dir writes |
| test/package-bin.test.ts | updated assertions: `codex` bin must be undefined, `codex-multi-auth-codex` must map to scripts/codex.js — matches package.json change exactly |
| test/documentation.test.ts | updates docs integrity assertions to match new 3.x line, codex-multi-auth command family, and new bin map — clean and consistent |
| docs/getting-started.md | comprehensive command rename; the no-browser env var example gained --manual flag, conflating browser-suppression-only mode with stdin callback-paste mode |
| docs/releases/v3.0.0.md | new release notes file; clearly documents the bin rename rationale, migration path, and semver reasoning |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[codex-multi-auth ...] --> B[normalizeStandaloneArgs]
    B --> C{first arg is auth?}
    C -- yes --> E[pass through unchanged]
    C -- no --> D{AUTH_SUBCOMMANDS match?}
    D -- yes --> F[prepend auth prefix]
    D -- no --> G[pass through unchanged]
    E --> H[runCodexMultiAuthCli]
    F --> H
    G --> H

    I[npm install codex-multi-auth v3] --> J[writes codex-multi-auth-codex.cmd]
    J --> K[official codex bin untouched]
    L[npm install codex-multi-auth v2] --> M[wrote codex.cmd - collision]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fissue-457-brew-install-conflict%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fissue-457-brew-install-conflict%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fcodex-multi-auth-bin-wrapper.test.ts%3A1997-2010%0A**no%20%60removeWithRetry%60%20cleanup%20for%20shim%20temp%20dir%20on%20Windows**%0A%0Athe%20new%20test%20creates%20%60prefixDir%60%20inside%20%60fixtureRoot%60%20%28a%20%60mkdtempSync%60%20temp%20dir%29%20and%20writes%20%60.cmd%60%20shim%20files%20there%2C%20but%20leaves%20no%20cleanup%20at%20the%20end.%20per%20%60test%2FAGENTS.md%60%3A%20%22do%20not%20use%20bare%20%60fs.rm%60%20in%20test%20cleanup%3B%20use%20%60removeWithRetry%60%20for%20Windows%20safety.%22%20if%20ci%20teardown%20or%20a%20future%20%60afterEach%60%20hook%20ever%20tries%20to%20%60rmSync%60%20%60fixtureRoot%60%2C%20it%20may%20hit%20%60EBUSY%60%2F%60EPERM%60%20on%20Windows%20from%20the%20just-written%20%60.cmd%60%20files.%20add%20a%20cleanup%20block%20using%20%60removeWithRetry%60%20%28or%20the%20existing%20helper%20pattern%29%20after%20assertions.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fgetting-started.md%3A1308-1309%0A**%60--manual%60%20added%20to%20env-var-only%20example%20changes%20documented%20behavior**%0A%0Athe%20old%20form%20suppressed%20browser%20launch%20without%20forcing%20stdin%20callback-paste%20mode.%20the%20new%20form%20adds%20%60--manual%60%2C%20which%20is%20a%20distinct%20behavior%20per%20the%20upgrade%20guide%3A%20the%20env%20var%20alone%20covers%20headless%20automation%2C%20while%20%60--manual%60%20specifically%20requires%20pasting%20the%20full%20redirect%20URL%20on%20stdin.%20combining%20both%20in%20one%20example%20conflates%20the%20two%20modes.%20users%20wanting%20only%20browser%20suppression%20for%20automation%20may%20add%20an%20unneeded%20manual-paste%20step.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/codex-multi-auth-bin-wrapper.test.ts:1997-2010
**no `removeWithRetry` cleanup for shim temp dir on Windows**

the new test creates `prefixDir` inside `fixtureRoot` (a `mkdtempSync` temp dir) and writes `.cmd` shim files there, but leaves no cleanup at the end. per `test/AGENTS.md`: "do not use bare `fs.rm` in test cleanup; use `removeWithRetry` for Windows safety." if ci teardown or a future `afterEach` hook ever tries to `rmSync` `fixtureRoot`, it may hit `EBUSY`/`EPERM` on Windows from the just-written `.cmd` files. add a cleanup block using `removeWithRetry` (or the existing helper pattern) after assertions.

### Issue 2 of 2
docs/getting-started.md:1308-1309
**`--manual` added to env-var-only example changes documented behavior**

the old form suppressed browser launch without forcing stdin callback-paste mode. the new form adds `--manual`, which is a distinct behavior per the upgrade guide: the env var alone covers headless automation, while `--manual` specifically requires pasting the full redirect URL on stdin. combining both in one example conflates the two modes. users wanting only browser suppression for automation may add an unneeded manual-paste step.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: mark bin rename as major release"](https://github.com/ndycode/codex-multi-auth/commit/1d3090f7cb2caf860d4cf033248f99772bc09c5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30302146)</sub>

<!-- /greptile_comment -->