### PR TITLE
Fix Codex TUI goal proxy handling

### DIFF
--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -336,6 +336,11 @@ function readStringRecordValue(record: Record<string, unknown>, key: string): st
 		: null;
 }
 
+function readStringSearchParam(searchParams: URLSearchParams, key: string): string | null {
+	const value = searchParams.get(key);
+	return value && value.trim().length > 0 ? value.trim() : null;
+}
+
 function resolveSessionKey(headers: Headers, parsedBody: RequestBody | null): string | null {
 	const headerKey =
 		headers.get(OPENAI_HEADERS.SESSION_ID) ??
@@ -404,11 +409,15 @@ function buildThreadGoalRequestContext(
 ): RequestContext {
 	const headers = headersFromIncoming(req);
 	const parsedBody = parseRequestBody(body);
-	const sessionKey = parsedBody
+	const searchParams = new URL(req.url ?? "/", "http://127.0.0.1").searchParams;
+	const queryThreadKey =
+		readStringSearchParam(searchParams, "thread_id") ??
+		readStringSearchParam(searchParams, "threadId");
+	const bodyThreadKey = parsedBody
 		? (readStringRecordValue(parsedBody, "thread_id") ??
-			readStringRecordValue(parsedBody, "threadId") ??
-			resolveSessionKey(headers, parsedBody))
-		: resolveSessionKey(headers, null);
+			readStringRecordValue(parsedBody, "threadId"))
+		: null;
+	const sessionKey = bodyThreadKey ?? queryThreadKey ?? resolveSessionKey(headers, parsedBody);
 	return {
 		body,
 		headers,

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -109,6 +109,7 @@ const DEFAULT_QUOTA_REMAINING_THRESHOLD = 10;
 const DEFAULT_AUTH_FAILURE_COOLDOWN_MS = 30_000;
 const DEFAULT_MAX_RUNTIME_ACCOUNT_ATTEMPTS = 4;
 const MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024;
+const MAX_THREAD_GOAL_FALLBACKS = 512;
 const HOP_BY_HOP_HEADERS = new Set([
 	"connection",
 	"content-length",
@@ -343,6 +344,33 @@ function readStringSearchParam(searchParams: URLSearchParams, key: string): stri
 
 function isThreadGoalFallbackStatus(status: number): boolean {
 	return status === HTTP_STATUS.FORBIDDEN;
+}
+
+function setThreadGoalFallback(
+	fallbacks: Map<string, string | null>,
+	key: string,
+	goal: string | null,
+): void {
+	if (fallbacks.has(key)) {
+		fallbacks.delete(key);
+	}
+	fallbacks.set(key, goal);
+	while (fallbacks.size > MAX_THREAD_GOAL_FALLBACKS) {
+		const oldestKey = fallbacks.keys().next().value;
+		if (typeof oldestKey !== "string") break;
+		fallbacks.delete(oldestKey);
+	}
+}
+
+function getThreadGoalFallback(
+	fallbacks: Map<string, string | null>,
+	key: string,
+): string | null {
+	if (!fallbacks.has(key)) return null;
+	const goal = fallbacks.get(key) ?? null;
+	fallbacks.delete(key);
+	fallbacks.set(key, goal);
+	return goal;
 }
 
 function resolveSessionKey(headers: Headers, parsedBody: RequestBody | null): string | null {
@@ -942,7 +970,7 @@ export async function startRuntimeRotationProxy(
 				operation: isModelsRequest
 					? "models"
 					: isThreadGoalRequest
-						? "responses"
+						? "thread-goal"
 						: "responses",
 				model: context.model,
 				projectKey,
@@ -1169,12 +1197,12 @@ export async function startRuntimeRotationProxy(
 						account: refreshed.account,
 					});
 					if (context.upstreamPath.endsWith("/set")) {
-						threadGoalFallbacks.set(fallbackKey, goal);
+						setThreadGoalFallback(threadGoalFallbacks, fallbackKey, goal);
 						writeJson(res, HTTP_STATUS.OK, { ok: true, goal });
 						return;
 					}
 					writeJson(res, HTTP_STATUS.OK, {
-						goal: threadGoalFallbacks.get(fallbackKey) ?? null,
+						goal: getThreadGoalFallback(threadGoalFallbacks, fallbackKey),
 					});
 					return;
 				}

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -341,6 +341,10 @@ function readStringSearchParam(searchParams: URLSearchParams, key: string): stri
 	return value && value.trim().length > 0 ? value.trim() : null;
 }
 
+function isThreadGoalFallbackStatus(status: number): boolean {
+	return status === HTTP_STATUS.FORBIDDEN;
+}
+
 function resolveSessionKey(headers: Headers, parsedBody: RequestBody | null): string | null {
 	const headerKey =
 		headers.get(OPENAI_HEADERS.SESSION_ID) ??
@@ -938,7 +942,7 @@ export async function startRuntimeRotationProxy(
 				operation: isModelsRequest
 					? "models"
 					: isThreadGoalRequest
-						? "diagnostic"
+						? "responses"
 						: "responses",
 				model: context.model,
 				projectKey,
@@ -1136,21 +1140,32 @@ export async function startRuntimeRotationProxy(
 					continue;
 				}
 
-				if (isThreadGoalRequest && upstream.status >= 400) {
+				if (isThreadGoalRequest && isThreadGoalFallbackStatus(upstream.status)) {
 					await readErrorBody(upstream);
 					const parsedGoalBody = parseRequestBody(context.body);
-					const fallbackKey = context.sessionKey ?? "default";
+					const fallbackKey = context.sessionKey;
 					const goal =
 						typeof parsedGoalBody?.goal === "string" ? parsedGoalBody.goal : null;
-					accountManager.recordSuccess(refreshed.account, context.family, context.model);
-					await persistRuntimeActiveAccount(
-						accountManager,
-						refreshed.account,
-						context.family,
-					);
+					if (!fallbackKey) {
+						await usageRecorder.record({
+							outcome: "failure",
+							statusCode: HTTP_STATUS.BAD_REQUEST,
+							errorCode: "thread_goal_session_key_required",
+							account: refreshed.account,
+						});
+						writeJson(res, HTTP_STATUS.BAD_REQUEST, {
+							error: {
+								message:
+									"Thread goal fallback requires a thread_id, threadId, or session header.",
+								code: "thread_goal_session_key_required",
+							},
+						});
+						return;
+					}
 					await usageRecorder.record({
-						outcome: "success",
-						statusCode: HTTP_STATUS.OK,
+						outcome: "failure",
+						statusCode: upstream.status,
+						errorCode: "thread_goal_upstream_blocked",
 						account: refreshed.account,
 					});
 					if (context.upstreamPath.endsWith("/set")) {
@@ -1160,6 +1175,23 @@ export async function startRuntimeRotationProxy(
 					}
 					writeJson(res, HTTP_STATUS.OK, {
 						goal: threadGoalFallbacks.get(fallbackKey) ?? null,
+					});
+					return;
+				}
+
+				if (isThreadGoalRequest && upstream.status >= 400) {
+					const forwarded = await forwardStreamingResponse(
+						upstream,
+						res,
+						status,
+						() => undefined,
+						streamStallTimeoutMs,
+					);
+					await usageRecorder.record({
+						outcome: "failure",
+						statusCode: upstream.status,
+						errorCode: forwarded ? "thread_goal_upstream_error" : "stream_forward_failed",
+						account: refreshed.account,
 					});
 					return;
 				}

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -141,6 +141,12 @@ const ALLOWED_MODELS_PATHS = new Set([
 	URL_PATHS.MODELS,
 	`/v1${URL_PATHS.MODELS}`,
 ]);
+const ALLOWED_THREAD_GOAL_PATHS = new Set([
+	"/thread/goal/get",
+	"/thread/goal/set",
+	"/codex/thread/goal/get",
+	"/codex/thread/goal/set",
+]);
 
 function isResponsesPath(pathname: string): boolean {
 	return ALLOWED_RESPONSES_PATHS.has(pathname);
@@ -148,6 +154,14 @@ function isResponsesPath(pathname: string): boolean {
 
 function isModelsPath(pathname: string): boolean {
 	return ALLOWED_MODELS_PATHS.has(pathname);
+}
+
+function isThreadGoalPath(pathname: string): boolean {
+	return ALLOWED_THREAD_GOAL_PATHS.has(pathname);
+}
+
+function normalizeThreadGoalUpstreamPath(pathname: string): string {
+	return pathname.startsWith("/codex/") ? pathname : `/codex${pathname}`;
 }
 
 function headersFromIncoming(req: IncomingMessage): Headers {
@@ -380,6 +394,30 @@ function buildModelsRequestContext(req: IncomingMessage): RequestContext {
 		family: "codex",
 		stream: false,
 		sessionKey: null,
+	};
+}
+
+function buildThreadGoalRequestContext(
+	req: IncomingMessage,
+	body: Buffer,
+	pathname: string,
+): RequestContext {
+	const headers = headersFromIncoming(req);
+	const parsedBody = parseRequestBody(body);
+	const sessionKey = parsedBody
+		? (readStringRecordValue(parsedBody, "thread_id") ??
+			readStringRecordValue(parsedBody, "threadId") ??
+			resolveSessionKey(headers, parsedBody))
+		: resolveSessionKey(headers, null);
+	return {
+		body,
+		headers,
+		method: req.method === "GET" ? "GET" : "POST",
+		upstreamPath: normalizeThreadGoalUpstreamPath(pathname),
+		model: null,
+		family: "codex",
+		stream: false,
+		sessionKey,
 	};
 }
 
@@ -668,7 +706,7 @@ function writeMethodOrPathError(res: ServerResponse): void {
 	writeJson(res, 404, {
 		error: {
 			message:
-				"Runtime rotation proxy only accepts Responses API and model discovery requests.",
+				"Runtime rotation proxy only accepts Responses API, model discovery, and Codex thread goal requests.",
 			code: "runtime_rotation_proxy_not_found",
 		},
 	});
@@ -832,6 +870,7 @@ export async function startRuntimeRotationProxy(
 		lastAccountId: null,
 		lastAccountUpdatedAt: null,
 	};
+	const threadGoalFallbacks = new Map<string, string | null>();
 
 	const handleRequest = async (
 		req: IncomingMessage,
@@ -844,7 +883,10 @@ export async function startRuntimeRotationProxy(
 				req.method === "POST" && isResponsesPath(incomingUrl.pathname);
 			const isModelsRequest =
 				req.method === "GET" && isModelsPath(incomingUrl.pathname);
-			if (!isResponsesRequest && !isModelsRequest) {
+			const isThreadGoalRequest =
+				(req.method === "GET" || req.method === "POST") &&
+				isThreadGoalPath(incomingUrl.pathname);
+			if (!isResponsesRequest && !isModelsRequest && !isThreadGoalRequest) {
 				writeMethodOrPathError(res);
 				return;
 			}
@@ -856,12 +898,15 @@ export async function startRuntimeRotationProxy(
 			}
 
 			status.totalRequests += 1;
+			const requestBody =
+				isResponsesRequest || (isThreadGoalRequest && req.method === "POST")
+					? await readRequestBody(req, maxRequestBodyBytes)
+					: Buffer.alloc(0);
 			const context = isModelsRequest
 				? buildModelsRequestContext(req)
-				: buildResponsesRequestContext(
-						req,
-						await readRequestBody(req, maxRequestBodyBytes),
-					);
+				: isThreadGoalRequest
+					? buildThreadGoalRequestContext(req, requestBody, incomingUrl.pathname)
+					: buildResponsesRequestContext(req, requestBody);
 			const requestStartedAt = now();
 			let policyDecision: RuntimePolicyDecision | null = null;
 			let projectKey: string | null = null;
@@ -881,7 +926,11 @@ export async function startRuntimeRotationProxy(
 			}
 			usageRecorder = createRuntimeUsageRecorder({
 				source: "runtime-proxy",
-				operation: isModelsRequest ? "models" : "responses",
+				operation: isModelsRequest
+					? "models"
+					: isThreadGoalRequest
+						? "diagnostic"
+						: "responses",
 				model: context.model,
 				projectKey,
 				requestId: context.sessionKey,
@@ -1076,6 +1125,34 @@ export async function startRuntimeRotationProxy(
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
+				}
+
+				if (isThreadGoalRequest && upstream.status >= 400) {
+					await readErrorBody(upstream);
+					const parsedGoalBody = parseRequestBody(context.body);
+					const fallbackKey = context.sessionKey ?? "default";
+					const goal =
+						typeof parsedGoalBody?.goal === "string" ? parsedGoalBody.goal : null;
+					accountManager.recordSuccess(refreshed.account, context.family, context.model);
+					await persistRuntimeActiveAccount(
+						accountManager,
+						refreshed.account,
+						context.family,
+					);
+					await usageRecorder.record({
+						outcome: "success",
+						statusCode: HTTP_STATUS.OK,
+						account: refreshed.account,
+					});
+					if (context.upstreamPath.endsWith("/set")) {
+						threadGoalFallbacks.set(fallbackKey, goal);
+						writeJson(res, HTTP_STATUS.OK, { ok: true, goal });
+						return;
+					}
+					writeJson(res, HTTP_STATUS.OK, {
+						goal: threadGoalFallbacks.get(fallbackKey) ?? null,
+					});
+					return;
 				}
 
 				accountManager.recordSuccess(refreshed.account, context.family, context.model);

--- a/lib/runtime/config-toml.ts
+++ b/lib/runtime/config-toml.ts
@@ -75,12 +75,42 @@ export function rewriteTopLevelModelProvider(rawConfig: string): string {
 	return output.join(lineEnding);
 }
 
-function extractTopLevelModelProviderLine(rawConfig: string): string | null {
+export function enableTopLevelResponseStorage(rawConfig: string): string {
+	const lineEnding = rawConfig.includes("\r\n") ? "\r\n" : "\n";
+	const lines = rawConfig.length > 0 ? rawConfig.split(/\r?\n/) : [];
+	const output: string[] = [];
+	let inTopLevel = true;
+
+	for (const line of lines) {
+		if (readTomlTableName(line) !== null) {
+			inTopLevel = false;
+			output.push(line);
+			continue;
+		}
+		if (
+			inTopLevel &&
+			/^\s*disable_response_storage\s*=\s*true\s*(?:#.*)?$/i.test(line)
+		) {
+			output.push("disable_response_storage = false");
+			continue;
+		}
+		output.push(line);
+	}
+
+	return output.join(lineEnding);
+}
+
+function extractTopLevelLine(rawConfig: string, key: string): string | null {
+	const pattern = new RegExp(`^\\s*${key}\\s*=`);
 	for (const line of rawConfig.split(/\r?\n/)) {
 		if (readTomlTableName(line) !== null) return null;
-		if (/^\s*model_provider\s*=/.test(line)) return line;
+		if (pattern.test(line)) return line;
 	}
 	return null;
+}
+
+function extractTopLevelModelProviderLine(rawConfig: string): string | null {
+	return extractTopLevelLine(rawConfig, "model_provider");
 }
 
 export function restoreTopLevelModelProvider(
@@ -99,6 +129,43 @@ export function restoreTopLevelModelProvider(
 			line.includes(RUNTIME_ROTATION_PROXY_PROVIDER_ID);
 		if (isRuntimeProviderLine && !handled) {
 			if (originalLine) output.push(originalLine);
+			handled = true;
+			continue;
+		}
+		output.push(line);
+	}
+
+	return output.join(lineEnding);
+}
+
+export function restoreTopLevelResponseStorage(
+	currentConfig: string,
+	originalConfig: string,
+): string {
+	const lineEnding = currentConfig.includes("\r\n") ? "\r\n" : "\n";
+	const originalLine = extractTopLevelLine(
+		originalConfig,
+		"disable_response_storage",
+	);
+	if (!originalLine) return currentConfig;
+	const lines = currentConfig.length > 0 ? currentConfig.split(/\r?\n/) : [];
+	const output: string[] = [];
+	let handled = false;
+	let inTopLevel = true;
+
+	for (const line of lines) {
+		if (readTomlTableName(line) !== null) {
+			inTopLevel = false;
+			output.push(line);
+			continue;
+		}
+		if (
+			!handled &&
+			inTopLevel &&
+			/^\s*disable_response_storage\s*=/.test(line) &&
+			readTomlTableName(line) === null
+		) {
+			output.push(originalLine);
 			handled = true;
 			continue;
 		}
@@ -147,11 +214,14 @@ export function rewriteConfigTomlForRuntimeRotationProvider(
 		/[\r\n]*$/,
 		"",
 	);
+	const withResponseStorage = enableTopLevelResponseStorage(
+		withModelProvider,
+	).replace(/[\r\n]*$/, "");
 	const providerBlock = createRuntimeRotationProviderBlock(
 		baseUrl,
 		clientApiKey,
 	).join(lineEnding);
-	return `${withModelProvider}${lineEnding}${lineEnding}${providerBlock}${lineEnding}`;
+	return `${withResponseStorage}${lineEnding}${lineEnding}${providerBlock}${lineEnding}`;
 }
 
 export function restoreConfigTomlFromRuntimeRotationProvider(
@@ -159,8 +229,12 @@ export function restoreConfigTomlFromRuntimeRotationProvider(
 	originalConfig: string,
 ): string {
 	const withoutProvider = removeRuntimeRotationProviderBlock(currentConfig);
+	const withResponseStorage = restoreTopLevelResponseStorage(
+		withoutProvider,
+		originalConfig,
+	);
 	return ensureTomlTrailingNewline(
-		restoreTopLevelModelProvider(withoutProvider, originalConfig).replace(
+		restoreTopLevelModelProvider(withResponseStorage, originalConfig).replace(
 			/[\r\n]*$/,
 			"",
 		),

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -40,6 +40,7 @@ const VALID_SOURCES = new Set<UsageLedgerSource>([
 const VALID_OPERATIONS = new Set<UsageLedgerOperation>([
 	"responses",
 	"models",
+	"thread-goal",
 	"auth-refresh",
 	"diagnostic",
 	"unknown",

--- a/lib/usage/redaction.ts
+++ b/lib/usage/redaction.ts
@@ -20,6 +20,7 @@ const VALID_SOURCES = new Set<UsageLedgerSource>([
 const VALID_OPERATIONS = new Set<UsageLedgerOperation>([
 	"responses",
 	"models",
+	"thread-goal",
 	"auth-refresh",
 	"diagnostic",
 	"unknown",

--- a/lib/usage/types.ts
+++ b/lib/usage/types.ts
@@ -8,6 +8,7 @@ export type UsageLedgerSource =
 export type UsageLedgerOperation =
 	| "responses"
 	| "models"
+	| "thread-goal"
 	| "auth-refresh"
 	| "diagnostic"
 	| "unknown";

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -2886,8 +2886,7 @@ async function createRuntimeRotationAppHelperContext(
 
 	const cleanup = async ({ exitCode } = {}) => {
 		const livedMs = Date.now() - startedAt;
-		const exitedSuccessfully = exitCode === 0 || exitCode === null || exitCode === undefined;
-		if (exitedSuccessfully && (options.detachOnExit === true || livedMs < detachGraceMs)) {
+		if (exitCode === 0 && (options.detachOnExit === true || livedMs < detachGraceMs)) {
 			helper.stdout?.destroy();
 			helper.stderr?.destroy();
 			helper.unref();

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1902,6 +1902,21 @@ function mirrorFileIntoShadowHome(sourcePath, destinationPath, tightenFile) {
 	tightenFile(destinationPath);
 }
 
+function shouldMaterializeFileIntoShadowHome(name) {
+	return /\.sqlite(?:-(?:shm|wal))?$/i.test(name);
+}
+
+function materializeFileIntoShadowHome(sourcePath, destinationPath, tightenFile) {
+	try {
+		linkSync(sourcePath, destinationPath);
+		return;
+	} catch {
+		// Hard links make SQLite roots look local without copying an active DB.
+	}
+	copyFileSync(sourcePath, destinationPath);
+	tightenFile(destinationPath);
+}
+
 function collectShadowHomeSyncFileNames(shadowCodexHome, syncFileNames) {
 	try {
 		for (const entry of readdirSync(shadowCodexHome, { withFileTypes: true })) {
@@ -2075,6 +2090,7 @@ function createShadowHomeMirror(
 				continue;
 			}
 			const isKnownStateFile = SHADOW_HOME_STATE_FILE_SET.has(name);
+			const shouldMaterializeFile = shouldMaterializeFileIntoShadowHome(name);
 			const sourcePath = join(originalCodexHome, name);
 			const destinationPath = join(shadowCodexHome, name);
 			if (existsSync(destinationPath)) {
@@ -2103,6 +2119,8 @@ function createShadowHomeMirror(
 					if (isKnownStateFile) {
 						copyFileSync(sourcePath, destinationPath);
 						tightenFile(destinationPath);
+					} else if (shouldMaterializeFile) {
+						materializeFileIntoShadowHome(sourcePath, destinationPath, tightenFile);
 					} else {
 						mirrorFileIntoShadowHome(sourcePath, destinationPath, tightenFile);
 					}
@@ -2266,6 +2284,16 @@ function resolveRuntimeRotationProxyOriginalCodexHome(baseEnv) {
 	return override || resolveCodexHomeDir(baseEnv);
 }
 
+function createRuntimeRotationShadowHome(originalCodexHome) {
+	const shadowRoot = join(
+		originalCodexHome,
+		"multi-auth",
+		"runtime-shadow-homes",
+	);
+	mkdirSync(shadowRoot, { recursive: true });
+	return mkdtempSync(join(shadowRoot, "codex-multi-auth-runtime-home-"));
+}
+
 function createRuntimeRotationProxyCodexHome(
 	baseEnv,
 	proxyBaseUrl,
@@ -2273,7 +2301,7 @@ function createRuntimeRotationProxyCodexHome(
 	configTomlModule,
 ) {
 	const originalCodexHome = resolveRuntimeRotationProxyOriginalCodexHome(baseEnv);
-	const shadowCodexHome = mkdtempSync(join(tmpdir(), "codex-multi-auth-runtime-home-"));
+	const shadowCodexHome = createRuntimeRotationShadowHome(originalCodexHome);
 	let syncShadowHomeStateBack = () => {};
 	const cleanup = () => {
 		try {
@@ -2841,7 +2869,11 @@ function startRuntimeRotationAppHelper(baseContext) {
 	});
 }
 
-async function createRuntimeRotationAppHelperContext(baseContext, configTomlModule) {
+async function createRuntimeRotationAppHelperContext(
+	baseContext,
+	configTomlModule,
+	options = {},
+) {
 	const startedAt = Date.now();
 	const { helper, message } = await startRuntimeRotationAppHelper(baseContext);
 	const helperEnv = message.env ?? {};
@@ -2849,7 +2881,10 @@ async function createRuntimeRotationAppHelperContext(baseContext, configTomlModu
 
 	const cleanup = async ({ exitCode } = {}) => {
 		const livedMs = Date.now() - startedAt;
-		if (exitCode === 0 && livedMs < detachGraceMs) {
+		if (
+			options.detachOnExit === true ||
+			(exitCode === 0 && livedMs < detachGraceMs)
+		) {
 			helper.stdout?.destroy();
 			helper.stderr?.destroy();
 			helper.unref();
@@ -2897,6 +2932,11 @@ async function createRuntimeRotationProxyContextIfEnabled(
 
 	if (isCodexAppCommand(rawArgs)) {
 		return createRuntimeRotationAppHelperContext(baseContext, configTomlModule);
+	}
+	if (isCodexInteractiveTuiCommand(rawArgs)) {
+		return createRuntimeRotationAppHelperContext(baseContext, configTomlModule, {
+			detachOnExit: true,
+		});
 	}
 
 	const proxyModule = await loadRuntimeRotationProxyModule();
@@ -3090,6 +3130,10 @@ function isCodexAppCommand(rawArgs) {
 
 function isCodexAppServerCommand(rawArgs) {
 	return findForwardedCommand(rawArgs)?.command === "app-server";
+}
+
+function isCodexInteractiveTuiCommand(rawArgs) {
+	return findForwardedCommand(rawArgs) === null;
 }
 
 function shouldUseRuntimeRoutingForForwardedArgs(rawArgs) {

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -89,6 +89,7 @@ const shadowHomeCleanupRetryMarkerDir =
 	(process.env.CODEX_MULTI_AUTH_TEST_SHADOW_RETRY_MARKER_DIR ?? "").trim();
 let warnedInvalidRuntimeRotationProxyEnv = false;
 let warnedPendingAccountReadIdOverflow = false;
+let warnedShadowHomeSqliteLinkFailure = false;
 
 async function loadRuntimeConstants() {
 	const fallback = {
@@ -1906,15 +1907,19 @@ function shouldMaterializeFileIntoShadowHome(name) {
 	return /\.sqlite(?:-(?:shm|wal))?$/i.test(name);
 }
 
-function materializeFileIntoShadowHome(sourcePath, destinationPath, tightenFile) {
+function materializeFileIntoShadowHome(sourcePath, destinationPath) {
 	try {
 		linkSync(sourcePath, destinationPath);
-		return;
+		return true;
 	} catch {
-		// Hard links make SQLite roots look local without copying an active DB.
+		if (!warnedShadowHomeSqliteLinkFailure) {
+			warnedShadowHomeSqliteLinkFailure = true;
+			console.error(
+				"codex-multi-auth: skipped SQLite shadow-home materialization because hard-linking failed; refusing to copy active SQLite state.",
+			);
+		}
 	}
-	copyFileSync(sourcePath, destinationPath);
-	tightenFile(destinationPath);
+	return false;
 }
 
 function collectShadowHomeSyncFileNames(shadowCodexHome, syncFileNames) {
@@ -2120,7 +2125,7 @@ function createShadowHomeMirror(
 						copyFileSync(sourcePath, destinationPath);
 						tightenFile(destinationPath);
 					} else if (shouldMaterializeFile) {
-						materializeFileIntoShadowHome(sourcePath, destinationPath, tightenFile);
+						materializeFileIntoShadowHome(sourcePath, destinationPath);
 					} else {
 						mirrorFileIntoShadowHome(sourcePath, destinationPath, tightenFile);
 					}
@@ -2881,10 +2886,8 @@ async function createRuntimeRotationAppHelperContext(
 
 	const cleanup = async ({ exitCode } = {}) => {
 		const livedMs = Date.now() - startedAt;
-		if (
-			options.detachOnExit === true ||
-			(exitCode === 0 && livedMs < detachGraceMs)
-		) {
+		const exitedSuccessfully = exitCode === 0 || exitCode === null || exitCode === undefined;
+		if (exitedSuccessfully && (options.detachOnExit === true || livedMs < detachGraceMs)) {
 			helper.stdout?.destroy();
 			helper.stderr?.destroy();
 			helper.unref();

--- a/test/app-bind.test.ts
+++ b/test/app-bind.test.ts
@@ -127,9 +127,11 @@ describe("Codex app runtime rotation bind", () => {
 		const original = [
 			'model_provider = "openai"',
 			'model = "gpt-5.4"',
+			"disable_response_storage = true",
 			"",
 			"[profiles.default]",
 			'model = "gpt-5.4"',
+			"disable_response_storage = true",
 			"",
 		].join("\n");
 
@@ -149,6 +151,8 @@ describe("Codex app runtime rotation bind", () => {
 		expect(bound).toContain("requires_openai_auth = false");
 		expect(bound).toContain('experimental_bearer_token = "app-secret"');
 		expect(bound).toContain('wire_api = "responses"');
+		expect(bound).toContain("disable_response_storage = false");
+		expect(bound).toContain("[profiles.default]\nmodel = \"gpt-5.4\"\ndisable_response_storage = true");
 		expect(bound).not.toContain("env_key");
 		expect(bound).toContain("[profiles.default]");
 

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -938,6 +938,7 @@ describe("codex bin wrapper", () => {
 			'console.log(`MEMORY_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "memories", "user.md"))}`);',
 			'console.log(`INSTRUCTION_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "instructions", "profile.md"))}`);',
 			'const statePath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite");',
+			'console.log(`ROOT_STATE_SYMLINK:${fs.lstatSync(statePath).isSymbolicLink()}`);',
 			'fs.appendFileSync(statePath, "shadow\\n", "utf8");',
 			'console.log(`ROOT_STATE_REALTIME:${fs.readFileSync(path.join(process.env.ORIGINAL_CODEX_HOME ?? "", "state_5.sqlite"), "utf8").includes("shadow")}`);',
 			'fs.writeFileSync(path.join(process.env.CODEX_HOME ?? "", "new-root-state.json"), "new\\n", "utf8");',
@@ -1018,6 +1019,7 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("SKILL_EXISTS:true");
 		expect(output).toContain("MEMORY_EXISTS:true");
 		expect(output).toContain("INSTRUCTION_EXISTS:true");
+		expect(output).toContain("ROOT_STATE_SYMLINK:false");
 		expect(output).toContain("ROOT_STATE_REALTIME:true");
 		const apiKeyMatch = output.match(/^OPENAI_API_KEY:([0-9a-f]{64})$/m);
 		expect(apiKeyMatch?.[1]).toBeTruthy();
@@ -1041,6 +1043,9 @@ describe("codex bin wrapper", () => {
 		const shadowHomeMatch = output.match(/^CODEX_HOME:(.+)$/m);
 		expect(shadowHomeMatch?.[1]).toBeTruthy();
 		if (shadowHomeMatch?.[1]) {
+			expect(shadowHomeMatch[1]).toContain(
+				join(originalHome, "multi-auth", "runtime-shadow-homes"),
+			);
 			expect(existsSync(shadowHomeMatch[1])).toBe(false);
 		}
 		expect(readFileSync(markerPath, "utf8")).toBe(

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -14,7 +14,14 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import {
+	delimiter,
+	dirname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+} from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -1043,9 +1050,11 @@ describe("codex bin wrapper", () => {
 		const shadowHomeMatch = output.match(/^CODEX_HOME:(.+)$/m);
 		expect(shadowHomeMatch?.[1]).toBeTruthy();
 		if (shadowHomeMatch?.[1]) {
-			expect(shadowHomeMatch[1]).toContain(
-				join(originalHome, "multi-auth", "runtime-shadow-homes"),
-			);
+			const expectedRoot = resolve(originalHome, "multi-auth", "runtime-shadow-homes");
+			const actual = resolve(shadowHomeMatch[1]);
+			const shadowRelativePath = relative(expectedRoot, actual);
+			expect(shadowRelativePath).not.toMatch(/^\.\.(?:[\\/]|$)/);
+			expect(isAbsolute(shadowRelativePath)).toBe(false);
 			expect(existsSync(shadowHomeMatch[1])).toBe(false);
 		}
 		expect(readFileSync(markerPath, "utf8")).toBe(
@@ -1803,6 +1812,42 @@ describe("codex bin wrapper", () => {
 		expect(compatibilityHomeMatch?.[1]).toBeTruthy();
 		expect(compatibilityHomeMatch?.[1]).not.toBe(originalHome);
 		expect(marker).toContain("close\n");
+	});
+
+	it("stops detached TUI app helpers after failed launches", async () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'console.error("tui failed");',
+			"process.exit(1);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const markerPath = join(fixtureRoot, "proxy-marker.txt");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			'model_provider = "openai"\n',
+			"utf8",
+		);
+
+		const result = runWrapper(fixtureRoot, [], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_HOME: originalHome,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+			CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "10000",
+			CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+			CODEX_MULTI_AUTH_TEST_PROXY_MARKER_PID: "1",
+			OPENAI_API_KEY: undefined,
+		});
+
+		expect(result.status).toBe(1);
+		const marker = readFileSync(markerPath, "utf8");
+		const helperPid = Number(
+			marker.match(/^start:http:\/\/127\.0\.0\.1:4567:pid=(\d+)$/m)?.[1] ?? NaN,
+		);
+		expect(Number.isFinite(helperPid)).toBe(true);
+		expect(isProcessAlive(helperPid)).toBe(false);
 	});
 
 	it("writes app router status files with owner-only permissions", async () => {

--- a/test/runtime-policy.test.ts
+++ b/test/runtime-policy.test.ts
@@ -165,4 +165,54 @@ describe("runtime policy", () => {
 		});
 		expect(recorder.hasRecorded()).toBe(true);
 	});
+
+	it("records thread goal usage as a distinct operation", async () => {
+		const append = vi.fn<typeof appendUsageLedgerRow>().mockResolvedValue({
+			version: 1,
+			id: "row-1",
+			createdAt: 100,
+			source: "runtime-proxy",
+			operation: "thread-goal",
+			outcome: "failure",
+			model: null,
+			projectKey: "project-a",
+			account: null,
+			requestId: "thread-1",
+			statusCode: 403,
+			errorCode: "thread_goal_upstream_blocked",
+			durationMs: 0,
+			tokens: {
+				inputTokens: 0,
+				outputTokens: 0,
+				cachedInputTokens: 0,
+				reasoningTokens: 0,
+				totalTokens: 0,
+			},
+			costUsd: 0,
+		});
+		const recorder = createRuntimeUsageRecorder({
+			source: "runtime-proxy",
+			operation: "thread-goal",
+			model: null,
+			projectKey: "project-a",
+			requestId: "thread-1",
+			startedAt: 100,
+			append,
+		});
+
+		await recorder.record({
+			outcome: "failure",
+			statusCode: 403,
+			errorCode: "thread_goal_upstream_blocked",
+		});
+
+		expect(append.mock.calls[0]?.[0]).toMatchObject({
+			source: "runtime-proxy",
+			operation: "thread-goal",
+			outcome: "failure",
+			requestId: "thread-1",
+			statusCode: 403,
+			errorCode: "thread_goal_upstream_blocked",
+		});
+	});
 });

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -167,6 +167,21 @@ async function postThreadGoal(
 	});
 }
 
+async function getThreadGoal(
+	proxy: RuntimeRotationProxyServer,
+	path = "/thread/goal/get",
+	headers: Record<string, string> = {},
+): Promise<Response> {
+	return fetch(`${proxy.baseUrl}${path}`, {
+		method: "GET",
+		headers: {
+			authorization: `Bearer ${DEFAULT_CLIENT_API_KEY}`,
+			"x-api-key": "caller-key",
+			...headers,
+		},
+	});
+}
+
 async function postRawResponses(
 	proxy: RuntimeRotationProxyServer,
 	body: string,
@@ -614,6 +629,33 @@ describe("runtime rotation proxy", () => {
 		expect(calls.map((call) => call.url)).toEqual([
 			"https://example.test/backend-api/codex/thread/goal/set",
 			"https://example.test/backend-api/codex/thread/goal/get",
+		]);
+	});
+
+	it("keys blocked GET thread goal fallbacks by query thread id", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const { calls, fetchImpl } = createRecordingFetch(
+			() =>
+				new Response("<html>blocked</html>", {
+					status: HTTP_STATUS.FORBIDDEN,
+					headers: { "content-type": "text/html" },
+				}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		await postThreadGoal(
+			proxy,
+			{ threadId: "thread-1", goal: "ship it" },
+			"/thread/goal/set",
+		);
+		const response = await getThreadGoal(proxy, "/thread/goal/get?thread_id=thread-1");
+
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		expect(await response.json()).toEqual({ goal: "ship it" });
+		expect(calls.map((call) => call.url)).toEqual([
+			"https://example.test/backend-api/codex/thread/goal/set",
+			"https://example.test/backend-api/codex/thread/goal/get?thread_id=thread-1",
 		]);
 	});
 

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -765,6 +765,42 @@ describe("runtime rotation proxy", () => {
 		).toHaveLength(2);
 	});
 
+	it("evicts oldest local thread goal fallbacks when capacity is exceeded", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 600));
+		const { fetchImpl } = createRecordingFetch(
+			() =>
+				new Response("<html>blocked</html>", {
+					status: HTTP_STATUS.FORBIDDEN,
+					headers: { "content-type": "text/html" },
+				}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		for (let index = 0; index < 513; index += 1) {
+			const response = await postThreadGoal(
+				proxy,
+				{ threadId: `thread-${index}`, goal: `goal-${index}` },
+				"/thread/goal/set",
+			);
+			expect(response.status).toBe(HTTP_STATUS.OK);
+		}
+
+		const evicted = await postThreadGoal(
+			proxy,
+			{ threadId: "thread-0" },
+			"/thread/goal/get",
+		);
+		const retained = await postThreadGoal(
+			proxy,
+			{ threadId: "thread-512" },
+			"/thread/goal/get",
+		);
+
+		expect(await evicted.json()).toEqual({ goal: null });
+		expect(await retained.json()).toEqual({ goal: "goal-512" });
+	});
+
 	it("rejects unauthenticated model discovery requests", async () => {
 		const now = Date.now();
 		const accountManager = new AccountManager(undefined, createStorage(now));

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -149,6 +149,24 @@ async function getModels(
 	});
 }
 
+async function postThreadGoal(
+	proxy: RuntimeRotationProxyServer,
+	body: Record<string, unknown>,
+	path = "/thread/goal/get",
+	headers: Record<string, string> = {},
+): Promise<Response> {
+	return fetch(`${proxy.baseUrl}${path}`, {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${DEFAULT_CLIENT_API_KEY}`,
+			"content-type": "application/json",
+			"x-api-key": "caller-key",
+			...headers,
+		},
+		body: JSON.stringify(body),
+	});
+}
+
 async function postRawResponses(
 	proxy: RuntimeRotationProxyServer,
 	body: string,
@@ -504,6 +522,99 @@ describe("runtime rotation proxy", () => {
 			lastAccountLabel: "Account 1",
 			lastAccountId: "acc_1",
 		});
+	});
+
+	it("forwards TUI thread goal requests through managed account auth", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const { calls, fetchImpl } = createRecordingFetch(
+			() =>
+				new Response('{"goal":"ship it"}\n', {
+					status: HTTP_STATUS.OK,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postThreadGoal(proxy, {
+			threadId: "thread-1",
+			turnId: "turn-1",
+		});
+
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		expect(await response.text()).toBe('{"goal":"ship it"}\n');
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(
+			"https://example.test/backend-api/codex/thread/goal/get",
+		);
+		expect(calls[0]?.headers.get("authorization")).toBe("Bearer access-1");
+		expect(calls[0]?.headers.get("x-api-key")).toBeNull();
+		expect(calls[0]?.headers.get(OPENAI_HEADERS.ACCOUNT_ID)).toBe("acc_1");
+		expect(JSON.parse(calls[0]?.bodyText ?? "{}")).toEqual({
+			threadId: "thread-1",
+			turnId: "turn-1",
+		});
+	});
+
+	it("forwards TUI thread goal set requests without duplicating codex path", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const { calls, fetchImpl } = createRecordingFetch(
+			() =>
+				new Response('{"ok":true}\n', {
+					status: HTTP_STATUS.OK,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postThreadGoal(
+			proxy,
+			{ threadId: "thread-1", turnId: "turn-1", goal: "ship it" },
+			"/codex/thread/goal/set?source=tui",
+		);
+
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(
+			"https://example.test/backend-api/codex/thread/goal/set?source=tui",
+		);
+		expect(calls[0]?.headers.get("authorization")).toBe("Bearer access-1");
+		expect(calls[0]?.headers.get("x-api-key")).toBeNull();
+	});
+
+	it("falls back locally when upstream blocks TUI thread goal requests", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const { calls, fetchImpl } = createRecordingFetch(
+			() =>
+				new Response("<html>blocked</html>", {
+					status: HTTP_STATUS.FORBIDDEN,
+					headers: { "content-type": "text/html" },
+				}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const setResponse = await postThreadGoal(
+			proxy,
+			{ threadId: "thread-1", goal: "ship it" },
+			"/thread/goal/set",
+		);
+		const getResponse = await postThreadGoal(
+			proxy,
+			{ threadId: "thread-1" },
+			"/thread/goal/get",
+		);
+
+		expect(setResponse.status).toBe(HTTP_STATUS.OK);
+		expect(await setResponse.json()).toEqual({ ok: true, goal: "ship it" });
+		expect(getResponse.status).toBe(HTTP_STATUS.OK);
+		expect(await getResponse.json()).toEqual({ goal: "ship it" });
+		expect(calls).toHaveLength(2);
+		expect(calls.map((call) => call.url)).toEqual([
+			"https://example.test/backend-api/codex/thread/goal/set",
+			"https://example.test/backend-api/codex/thread/goal/get",
+		]);
 	});
 
 	it("rejects unauthenticated model discovery requests", async () => {

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -632,6 +632,30 @@ describe("runtime rotation proxy", () => {
 		]);
 	});
 
+	it("rejects anonymous blocked thread goal fallbacks instead of sharing state", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const { calls, fetchImpl } = createRecordingFetch(
+			() =>
+				new Response("<html>blocked</html>", {
+					status: HTTP_STATUS.FORBIDDEN,
+					headers: { "content-type": "text/html" },
+				}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postThreadGoal(proxy, { goal: "ship it" }, "/thread/goal/set");
+
+		expect(response.status).toBe(HTTP_STATUS.BAD_REQUEST);
+		expect(await response.json()).toEqual({
+			error: {
+				message: "Thread goal fallback requires a thread_id, threadId, or session header.",
+				code: "thread_goal_session_key_required",
+			},
+		});
+		expect(calls).toHaveLength(1);
+	});
+
 	it("keys blocked GET thread goal fallbacks by query thread id", async () => {
 		const now = Date.now();
 		const accountManager = new AccountManager(undefined, createStorage(now));
@@ -657,6 +681,88 @@ describe("runtime rotation proxy", () => {
 			"https://example.test/backend-api/codex/thread/goal/set",
 			"https://example.test/backend-api/codex/thread/goal/get?thread_id=thread-1",
 		]);
+	});
+
+	it("passes through non-fallback thread goal client errors", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const recordSuccessSpy = vi.spyOn(accountManager, "recordSuccess");
+		const { calls, fetchImpl } = createRecordingFetch(
+			() =>
+				new Response('{"error":{"code":"bad_goal"}}\n', {
+					status: HTTP_STATUS.BAD_REQUEST,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postThreadGoal(
+			proxy,
+			{ threadId: "thread-1", goal: "" },
+			"/thread/goal/set",
+		);
+
+		expect(response.status).toBe(HTTP_STATUS.BAD_REQUEST);
+		expect(await response.text()).toBe('{"error":{"code":"bad_goal"}}\n');
+		expect(calls).toHaveLength(1);
+		expect(recordSuccessSpy).not.toHaveBeenCalled();
+	});
+
+	it("rejects unauthenticated thread goal requests", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const { calls, fetchImpl } = createRecordingFetch(
+			() => new Response('{"ok":true}', { status: HTTP_STATUS.OK }),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postThreadGoal(
+			proxy,
+			{ threadId: "thread-1" },
+			"/thread/goal/get",
+			{ authorization: "Bearer caller-token", "x-api-key": "caller-key" },
+		);
+
+		expect(response.status).toBe(HTTP_STATUS.UNAUTHORIZED);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("isolates local thread goal fallback state across concurrent threads", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const { calls, fetchImpl } = createRecordingFetch(
+			() =>
+				new Response("<html>blocked</html>", {
+					status: HTTP_STATUS.FORBIDDEN,
+					headers: { "content-type": "text/html" },
+				}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const [setA, setB] = await Promise.all([
+			postThreadGoal(proxy, { threadId: "thread-a", goal: "goal-a" }, "/thread/goal/set"),
+			postThreadGoal(proxy, { threadId: "thread-b", goal: "goal-b" }, "/thread/goal/set"),
+		]);
+		const [getA, getB] = await Promise.all([
+			postThreadGoal(proxy, { threadId: "thread-a" }, "/thread/goal/get"),
+			postThreadGoal(proxy, { threadId: "thread-b" }, "/thread/goal/get"),
+		]);
+
+		expect(setA.status).toBe(HTTP_STATUS.OK);
+		expect(setB.status).toBe(HTTP_STATUS.OK);
+		expect(await getA.json()).toEqual({ goal: "goal-a" });
+		expect(await getB.json()).toEqual({ goal: "goal-b" });
+		expect(calls).toHaveLength(4);
+		expect(
+			calls.filter(
+				(call) => call.url === "https://example.test/backend-api/codex/thread/goal/set",
+			),
+		).toHaveLength(2);
+		expect(
+			calls.filter(
+				(call) => call.url === "https://example.test/backend-api/codex/thread/goal/get",
+			),
+		).toHaveLength(2);
 	});
 
 	it("rejects unauthenticated model discovery requests", async () => {


### PR DESCRIPTION
Summary:
- Proxy Codex thread goal get/set requests through runtime rotation with managed account auth.
- Provide a bounded local thread-goal fallback for upstream 403 storage blocks, keyed by thread/session identity and rejecting anonymous fallback state.
- Keep response storage enabled in runtime shadow config so the TUI can read thread goals.
- Move runtime shadow homes under the real Codex home and hard-link SQLite state files instead of copying active DB files.
- Keep failed TUI/app helper cleanup strict so helpers are not detached after non-zero or signal exits.

Risk notes:
- Runtime rotation now accepts Codex thread goal routes in addition to responses and model discovery.
- Thread-goal fallback state is in-memory, bounded, and scoped to the proxy process.
- SQLite shadow-home materialization now refuses copy fallback if hard-linking fails, avoiding inconsistent active DB snapshots at the cost of skipping that optional live state file.

Verification:
- `npm test -- runtime-rotation-proxy`
- `npm test -- codex-bin-wrapper`
- `npm test -- runtime-policy`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check` (only Windows line-ending warnings)

Docs and Governance Checklist:
- [x] README update not required; behavior is internal runtime proxy compatibility for Codex TUI goal routes.
- [x] Getting started / feature docs update not required; no new user-facing command or setting.
- [x] Reference / upgrade docs update not required; no public API or migration step changed.
- [x] SECURITY / CONTRIBUTING update not required; no policy or disclosure process changed.
- [x] Regression tests cover thread-goal forwarding, query-keyed GET fallback, anonymous fallback rejection, 4xx pass-through, concurrent fallback isolation, fallback eviction, SQLite hard-link behavior, and failed TUI helper cleanup.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

proxies codex TUI thread goal `get`/`set` routes through the runtime rotation proxy with a 403-triggered LRU in-process fallback (512-entry, keyed by `thread_id`/session header); shadow homes are relocated under the real codex home to guarantee same-volume hard links for sqlite state files, and `disable_response_storage = false` is force-written into the shadow config so the TUI can read thread goals. TUI invocations now use `detachOnExit: true` to keep the app helper alive across the TUI session.

<h3>Confidence Score: 5/5</h3>

safe to merge; all findings are p2 style/coverage gaps with no runtime impact on the happy path

prior p1 findings (session-key collision, recordSuccess on 4xx) are addressed in this revision. remaining findings are a missing restore-path test and no EBUSY retry on Windows hard-link creation — neither causes data loss or incorrect behavior on supported platforms.

lib/runtime/config-toml.ts restore path and scripts/codex.js materializeFileIntoShadowHome

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime-rotation-proxy.ts | adds thread goal proxy routes with LRU in-process fallback for 403; session-key null guard returns 400 addressing the prior 'default' collision finding; recordSuccess is skipped for all 4xx goal paths; looks correct |
| lib/runtime/config-toml.ts | adds enableTopLevelResponseStorage and restoreTopLevelResponseStorage; logic is correct for the forward and restore paths, but no test covers the restore direction for the new key |
| scripts/codex.js | moves shadow homes under real Codex home for same-volume hard links; materializeFileIntoShadowHome has no EBUSY/EPERM retry inconsistent with codebase convention; TUI detachOnExit path and isCodexInteractiveTuiCommand look correct |
| test/runtime-rotation-proxy.test.ts | comprehensive new tests: forwarding, codex-path dedup, 403 fallback, anonymous rejection, GET keying, concurrency isolation, capacity eviction, auth rejection — good coverage |
| test/app-bind.test.ts | validates forward path for disable_response_storage; missing restore-path assertion for the new key |
| lib/usage/types.ts | adds 'thread-goal' to UsageLedgerOperation union type; mirrored correctly in ledger.ts and redaction.ts |
| test/codex-bin-wrapper.test.ts | adds shadow-home root path assertion, ROOT_STATE_SYMLINK:false check, and TUI detach-on-failed-launch test; all look correct |
| test/runtime-policy.test.ts | adds thread-goal operation ledger test; straightforward and correct |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TUI as Codex TUI
    participant P as Runtime Rotation Proxy
    participant U as Upstream (OpenAI)
    participant F as threadGoalFallbacks (Map)

    TUI->>P: POST /thread/goal/set {threadId, goal}
    P->>U: POST /codex/thread/goal/set (managed auth)
    alt upstream 2xx
        U-->>P: 200 OK
        P-->>TUI: forward response
    else upstream 403
        U-->>P: 403 Forbidden
        P->>F: setThreadGoalFallback(sessionKey, goal)
        P-->>TUI: 200 {ok:true, goal}
    else upstream other 4xx
        U-->>P: 4xx
        P-->>TUI: forward error response
    end

    TUI->>P: POST /thread/goal/get {threadId}
    P->>U: POST /codex/thread/goal/get (managed auth)
    alt upstream 2xx
        U-->>P: 200 {goal}
        P-->>TUI: forward response
    else upstream 403
        U-->>P: 403 Forbidden
        P->>F: getThreadGoalFallback(sessionKey)
        F-->>P: goal (or null)
        P-->>TUI: 200 {goal}
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fgoals-tui-proxy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgoals-tui-proxy%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fapp-bind.test.ts%3A536-555%0A**restore%20path%20not%20tested%20for%20%60disable_response_storage%60**%0A%0Athe%20additions%20only%20assert%20the%20forward%20%28bind%29%20direction%20%E2%80%94%20%60bound%60%20containing%20%60disable_response_storage%20%3D%20false%60.%20there's%20no%20assertion%20that%20%60restoreConfigTomlFromRuntimeRotationProvider%60%20cleanly%20restores%20the%20original%20%60disable_response_storage%20%3D%20true%60%20line%20%28or%20omits%20it%20entirely%20when%20the%20original%20lacked%20the%20key%29.%20if%20%60restoreTopLevelResponseStorage%60%20regresses%2C%20shadow%20state%20leaks%20back%20into%20the%20real%20%60config.toml%60%20without%20a%20failing%20test.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcodex.js%3A1425-1438%0A**no%20retry%20on%20%60EBUSY%60%2F%60EPERM%60%20for%20SQLite%20hard-link%20creation**%0A%0A%60linkSync%60%20can%20throw%20%60EBUSY%60%20or%20%60EPERM%60%20transiently%20on%20Windows%20when%20the%20%60.sqlite%60%2C%20%60.sqlite-shm%60%2C%20or%20%60.sqlite-wal%60%20file%20is%20momentarily%20locked%20by%20another%20reader.%20the%20codebase%20convention%20%28%60lib%2FAGENTS.md%60%3A%20%22Settings%20writes%20use%20queued%20retry%20for%20%60EBUSY%60%2F%60EPERM%60%2F%60EAGAIN%60%22%29%20is%20to%20retry%20these%20errors%2C%20but%20%60materializeFileIntoShadowHome%60%20falls%20through%20to%20a%20single%20warning%20%2B%20silent%20skip%20with%20no%20retry.%20on%20a%20busy%20Windows%20TUI%20session%2C%20all%20three%20SQLite%20files%20could%20be%20skipped%2C%20leaving%20the%20shadow%20home%20without%20any%20state.%20consider%20wrapping%20%60linkSync%60%20in%20a%20brief%20retry%20loop%20%28e.g.%203%20attempts%20with%2010%20ms%20back-off%29%20consistent%20with%20the%20rest%20of%20the%20codebase%20before%20giving%20up.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/app-bind.test.ts:536-555
**restore path not tested for `disable_response_storage`**

the additions only assert the forward (bind) direction — `bound` containing `disable_response_storage = false`. there's no assertion that `restoreConfigTomlFromRuntimeRotationProvider` cleanly restores the original `disable_response_storage = true` line (or omits it entirely when the original lacked the key). if `restoreTopLevelResponseStorage` regresses, shadow state leaks back into the real `config.toml` without a failing test.

### Issue 2 of 2
scripts/codex.js:1425-1438
**no retry on `EBUSY`/`EPERM` for SQLite hard-link creation**

`linkSync` can throw `EBUSY` or `EPERM` transiently on Windows when the `.sqlite`, `.sqlite-shm`, or `.sqlite-wal` file is momentarily locked by another reader. the codebase convention (`lib/AGENTS.md`: "Settings writes use queued retry for `EBUSY`/`EPERM`/`EAGAIN`") is to retry these errors, but `materializeFileIntoShadowHome` falls through to a single warning + silent skip with no retry. on a busy Windows TUI session, all three SQLite files could be skipped, leaving the shadow home without any state. consider wrapping `linkSync` in a brief retry loop (e.g. 3 attempts with 10 ms back-off) consistent with the rest of the codebase before giving up.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Resolve PR body follow-up findings"](https://github.com/ndycode/codex-multi-auth/commit/e0bbc8585829827b5174f945f6ea30a58889c4b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30445403)</sub>

<!-- /greptile_comment -->