### PR TITLE
Fix runtime skip for deactivated accounts

### DIFF
--- a/lib/auto-update-checker.ts
+++ b/lib/auto-update-checker.ts
@@ -542,7 +542,7 @@ function taskkillProcessTree(pid: number): Promise<boolean> {
 					"/d",
 					"/s",
 					"/c",
-					`taskkill /PID ${pid} /T /F >NUL 2>NUL`,
+					`taskkill /PID ${pid} /T /F`,
 				],
 				{
 					stdio: "ignore",

--- a/lib/auto-update-checker.ts
+++ b/lib/auto-update-checker.ts
@@ -537,8 +537,13 @@ function taskkillProcessTree(pid: number): Promise<boolean> {
 		timeout.unref?.();
 		try {
 			const killer = spawn(
-				"taskkill",
-				["/PID", String(pid), "/T", "/F"],
+				"cmd.exe",
+				[
+					"/d",
+					"/s",
+					"/c",
+					`taskkill /PID ${pid} /T /F >NUL 2>NUL`,
+				],
 				{
 					stdio: "ignore",
 					windowsHide: true,

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -337,7 +337,6 @@ export function isWorkspaceDisabledError(
 
         if (status === 402) {
                 return (
-                        normalizedCode === "deactivated_workspace" ||
                         normalizedTokens.includes("deactivated_workspace") ||
                         /\bdeactivated_workspace\b/i.test(bodyText)
                 );

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -329,13 +329,12 @@ export function isWorkspaceDisabledError(
         bodyText: string,
 ): boolean {
         const normalizedCode = typeof code === "string" ? code.trim().toLowerCase() : "";
-        const haystack = `${normalizedCode} ${bodyText}`.toLowerCase();
-        const normalizedTokens = normalizedCode
-                .split(/[^a-z0-9_]+/i)
-                .map((token) => token.trim())
-                .filter((token) => token.length > 0);
 
         if (status === 402) {
+                const normalizedTokens = normalizedCode
+                        .split(/[^a-z0-9_]+/i)
+                        .map((token) => token.trim())
+                        .filter((token) => token.length > 0);
                 return (
                         normalizedTokens.includes("deactivated_workspace") ||
                         /\bdeactivated_workspace\b/i.test(bodyText)
@@ -345,6 +344,12 @@ export function isWorkspaceDisabledError(
         if (status !== 403) {
                 return false;
         }
+
+        const haystack = `${normalizedCode} ${bodyText}`.toLowerCase();
+        const normalizedTokens = normalizedCode
+                .split(/[^a-z0-9_]+/i)
+                .map((token) => token.trim())
+                .filter((token) => token.length > 0);
 
 		const disabledPatterns = [
 				/workspace.*(?:disabled|expired|deactivated|terminated)/i,

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -328,12 +328,24 @@ export function isWorkspaceDisabledError(
         code: unknown,
         bodyText: string,
 ): boolean {
+        const normalizedCode = typeof code === "string" ? code.trim().toLowerCase() : "";
+        const haystack = `${normalizedCode} ${bodyText}`.toLowerCase();
+        const normalizedTokens = normalizedCode
+                .split(/[^a-z0-9_]+/i)
+                .map((token) => token.trim())
+                .filter((token) => token.length > 0);
+
+        if (status === 402) {
+                return (
+                        normalizedCode === "deactivated_workspace" ||
+                        normalizedTokens.includes("deactivated_workspace") ||
+                        /\bdeactivated_workspace\b/i.test(bodyText)
+                );
+        }
+
         if (status !== 403) {
                 return false;
         }
-
-        const normalizedCode = typeof code === "string" ? code.trim().toLowerCase() : "";
-        const haystack = `${normalizedCode} ${bodyText}`.toLowerCase();
 
 		const disabledPatterns = [
 				/workspace.*(?:disabled|expired|deactivated|terminated)/i,
@@ -361,11 +373,6 @@ export function isWorkspaceDisabledError(
         if (workspaceErrorCodes.has(normalizedCode)) {
                 return true;
         }
-
-        const normalizedTokens = normalizedCode
-                .split(/[^a-z0-9_]+/i)
-                .map((token) => token.trim())
-                .filter((token) => token.length > 0);
 
         return normalizedTokens.some((token) => workspaceErrorCodes.has(token));
 }

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1086,19 +1086,24 @@ export async function startRuntimeRotationProxy(
 					const bodyText = await readErrorBody(upstream);
 					const errorCode = extractErrorCodeFromBody(bodyText);
 					if (isWorkspaceDisabledError(upstream.status, errorCode, bodyText)) {
+						const accountWasEnabled =
+							accountManager.getAccountByIndex(refreshed.account.index)?.enabled !==
+							false;
 						accountManager.refundToken(
 							refreshed.account,
 							context.family,
 							context.model,
 						);
-						accountManager.recordFailure(
-							refreshed.account,
-							context.family,
-							context.model,
-						);
-						accountManager.setAccountEnabled(refreshed.account.index, false);
+						if (accountWasEnabled) {
+							accountManager.recordFailure(
+								refreshed.account,
+								context.family,
+								context.model,
+							);
+							accountManager.setAccountEnabled(refreshed.account.index, false);
+							accountManager.saveToDiskDebounced();
+						}
 						sessionAffinityStore?.forgetSession(context.sessionKey);
-						accountManager.saveToDiskDebounced();
 						exhaustionReason = "deactivated";
 						status.retries += 1;
 						status.rotations += 1;

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -951,6 +951,7 @@ export async function startRuntimeRotationProxy(
 				Math.min(accountCount, maxRuntimeAccountAttempts),
 			);
 			let transientAttempts = 0;
+			let transientExhaustionReason: ExhaustionReason | null = null;
 
 			while (
 				attemptedIndexes.size < accountCount &&
@@ -987,6 +988,7 @@ export async function startRuntimeRotationProxy(
 					exhaustionReason = "auth-failure";
 					if (!refreshed.retryable) continue;
 					transientAttempts += 1;
+					transientExhaustionReason = "auth-failure";
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1003,6 +1005,7 @@ export async function startRuntimeRotationProxy(
 					);
 					exhaustionReason = "auth-failure";
 					transientAttempts += 1;
+					transientExhaustionReason = "auth-failure";
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1048,6 +1051,7 @@ export async function startRuntimeRotationProxy(
 					accountManager.saveToDiskDebounced();
 					exhaustionReason = "network-error";
 					transientAttempts += 1;
+					transientExhaustionReason = "network-error";
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1072,6 +1076,7 @@ export async function startRuntimeRotationProxy(
 					accountManager.saveToDiskDebounced();
 					exhaustionReason = "rate-limit";
 					transientAttempts += 1;
+					transientExhaustionReason = "rate-limit";
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1123,6 +1128,7 @@ export async function startRuntimeRotationProxy(
 					accountManager.saveToDiskDebounced();
 					exhaustionReason = "auth-failure";
 					transientAttempts += 1;
+					transientExhaustionReason = "auth-failure";
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1140,6 +1146,7 @@ export async function startRuntimeRotationProxy(
 					accountManager.saveToDiskDebounced();
 					exhaustionReason = "server-error";
 					transientAttempts += 1;
+					transientExhaustionReason = "server-error";
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1209,6 +1216,11 @@ export async function startRuntimeRotationProxy(
 				exhaustionReason !== "deactivated"
 			) {
 				exhaustionReason = "budget";
+			} else if (
+				exhaustionReason === "deactivated" &&
+				transientExhaustionReason
+			) {
+				exhaustionReason = transientExhaustionReason;
 			}
 
 			await usageRecorder?.record({

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1212,8 +1212,7 @@ export async function startRuntimeRotationProxy(
 
 			if (
 				transientAttempts >= transientAttemptLimit &&
-				attemptedIndexes.size < accountCount &&
-				exhaustionReason !== "deactivated"
+				attemptedIndexes.size < accountCount
 			) {
 				exhaustionReason = "budget";
 			} else if (

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -34,6 +34,7 @@ import {
 	loadRuntimePolicyState,
 	type RuntimePolicyDecision,
 } from "./policy/runtime-policy.js";
+import { isWorkspaceDisabledError } from "./request/fetch-helpers.js";
 import { SessionAffinityStore } from "./session-affinity.js";
 import type { OAuthAuthDetails, RequestBody, TokenResult } from "./types.js";
 import { isRecord } from "./utils.js";
@@ -91,6 +92,7 @@ type ExhaustionReason =
 	| "network-error"
 	| "auth-failure"
 	| "budget"
+	| "deactivated"
 	| "no-account";
 type RuntimeProxyHttpError = Error & {
 	statusCode: number;
@@ -558,6 +560,26 @@ async function readErrorBody(response: Response): Promise<string> {
 	}
 }
 
+function extractErrorCodeFromBody(bodyText: string): string | null {
+	if (!bodyText.trim()) return null;
+	try {
+		const parsed = JSON.parse(bodyText) as unknown;
+		if (!isRecord(parsed)) return null;
+		const directCode = parsed.code;
+		if (typeof directCode === "string" && directCode.trim()) {
+			return directCode.trim();
+		}
+		const maybeError = parsed.error;
+		if (!isRecord(maybeError)) return null;
+		const nestedCode = maybeError.code;
+		return typeof nestedCode === "string" && nestedCode.trim()
+			? nestedCode.trim()
+			: null;
+	} catch {
+		return null;
+	}
+}
+
 function getQuotaWindowWaitMs(headers: Headers, prefix: string, now: number): number {
 	const resetAfterSeconds = Number.parseInt(
 		headers.get(`${prefix}-reset-after-seconds`) ?? "",
@@ -923,12 +945,17 @@ export async function startRuntimeRotationProxy(
 			);
 			const attemptedIndexes = new Set<number>();
 			let exhaustionReason: ExhaustionReason = "no-account";
-			const accountAttemptLimit = Math.max(
+			const accountCount = accountManager.getAccountCount();
+			const transientAttemptLimit = Math.max(
 				1,
-				Math.min(accountManager.getAccountCount(), maxRuntimeAccountAttempts),
+				Math.min(accountCount, maxRuntimeAccountAttempts),
 			);
+			let transientAttempts = 0;
 
-			while (attemptedIndexes.size < accountAttemptLimit) {
+			while (
+				attemptedIndexes.size < accountCount &&
+				transientAttempts < transientAttemptLimit
+			) {
 				const selected = chooseAccount({
 					accountManager,
 					sessionAffinityStore,
@@ -959,6 +986,7 @@ export async function startRuntimeRotationProxy(
 					accountManager.refundToken(selected, context.family, context.model);
 					exhaustionReason = "auth-failure";
 					if (!refreshed.retryable) continue;
+					transientAttempts += 1;
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -974,6 +1002,7 @@ export async function startRuntimeRotationProxy(
 						"auth-failure",
 					);
 					exhaustionReason = "auth-failure";
+					transientAttempts += 1;
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1018,6 +1047,7 @@ export async function startRuntimeRotationProxy(
 					);
 					accountManager.saveToDiskDebounced();
 					exhaustionReason = "network-error";
+					transientAttempts += 1;
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1041,9 +1071,44 @@ export async function startRuntimeRotationProxy(
 					);
 					accountManager.saveToDiskDebounced();
 					exhaustionReason = "rate-limit";
+					transientAttempts += 1;
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
+				}
+
+				if (upstream.status === 402 || upstream.status === HTTP_STATUS.FORBIDDEN) {
+					const bodyText = await readErrorBody(upstream);
+					const errorCode = extractErrorCodeFromBody(bodyText);
+					if (isWorkspaceDisabledError(upstream.status, errorCode, bodyText)) {
+						accountManager.refundToken(
+							refreshed.account,
+							context.family,
+							context.model,
+						);
+						accountManager.recordFailure(
+							refreshed.account,
+							context.family,
+							context.model,
+						);
+						accountManager.setAccountEnabled(refreshed.account.index, false);
+						sessionAffinityStore?.forgetSession(context.sessionKey);
+						accountManager.saveToDiskDebounced();
+						exhaustionReason = "deactivated";
+						status.retries += 1;
+						status.rotations += 1;
+						continue;
+					}
+
+					res.writeHead(upstream.status, responseHeadersForClient(upstream.headers));
+					res.end(bodyText);
+					await usageRecorder.record({
+						outcome: "failure",
+						statusCode: upstream.status,
+						errorCode,
+						account: refreshed.account,
+					});
+					return;
 				}
 
 				if (upstream.status === HTTP_STATUS.UNAUTHORIZED) {
@@ -1057,6 +1122,7 @@ export async function startRuntimeRotationProxy(
 					);
 					accountManager.saveToDiskDebounced();
 					exhaustionReason = "auth-failure";
+					transientAttempts += 1;
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1073,6 +1139,7 @@ export async function startRuntimeRotationProxy(
 					);
 					accountManager.saveToDiskDebounced();
 					exhaustionReason = "server-error";
+					transientAttempts += 1;
 					status.retries += 1;
 					status.rotations += 1;
 					continue;
@@ -1137,8 +1204,9 @@ export async function startRuntimeRotationProxy(
 			}
 
 			if (
-				attemptedIndexes.size >= accountAttemptLimit &&
-				accountAttemptLimit < accountManager.getAccountCount()
+				transientAttempts >= transientAttemptLimit &&
+				attemptedIndexes.size < accountCount &&
+				exhaustionReason !== "deactivated"
 			) {
 				exhaustionReason = "budget";
 			}

--- a/scripts/codex-multi-auth.js
+++ b/scripts/codex-multi-auth.js
@@ -21,6 +21,10 @@ function resolveCliVersion() {
 	return "";
 }
 
+/**
+ * @param {string[]} args
+ * @returns {string[]}
+ */
 function normalizeStandaloneArgs(args) {
 	if (args[0] === "auth") return args;
 	const firstArg = args[0] ?? "";

--- a/scripts/codex-routing.js
+++ b/scripts/codex-routing.js
@@ -26,6 +26,10 @@ const AUTH_SUBCOMMANDS = new Set([
 	"debug",
 ]);
 
+/**
+ * @param {string[]} args
+ * @returns {string[]}
+ */
 export function normalizeAuthAlias(args) {
 	if (args.length >= 2 && args[0] === "multi" && args[1] === "auth") {
 		return ["auth", ...args.slice(2)];
@@ -36,6 +40,10 @@ export function normalizeAuthAlias(args) {
 	return args;
 }
 
+/**
+ * @param {string[]} args
+ * @returns {boolean}
+ */
 export function shouldHandleMultiAuthAuth(args) {
 	if (args[0] !== "auth") return false;
 	if (args.length === 1) return true;

--- a/scripts/test-model-matrix.js
+++ b/scripts/test-model-matrix.js
@@ -153,7 +153,7 @@ function runQuietWindowsTaskkill(pid) {
 		"/d",
 		"/s",
 		"/c",
-		`taskkill /F /T /PID ${pid} >NUL 2>NUL`,
+		`taskkill /F /T /PID ${pid}`,
 	]);
 }
 

--- a/scripts/test-model-matrix.js
+++ b/scripts/test-model-matrix.js
@@ -148,6 +148,15 @@ function runQuiet(command, commandArgs) {
 	}
 }
 
+function runQuietWindowsTaskkill(pid) {
+	runQuiet("cmd.exe", [
+		"/d",
+		"/s",
+		"/c",
+		`taskkill /F /T /PID ${pid} >NUL 2>NUL`,
+	]);
+}
+
 export function registerSpawnedCodex(pid) {
 	if (!Number.isInteger(pid) || pid <= 0) return;
 	spawnedCodexPids.add(pid);
@@ -228,7 +237,7 @@ function stopCodexServersInternal() {
 	spawnedCodexPids.clear();
 	for (const pid of tracked) {
 		if (process.platform === "win32") {
-			runQuiet("taskkill", ["/F", "/T", "/PID", String(pid)]);
+			runQuietWindowsTaskkill(pid);
 			continue;
 		}
 		runQuiet("kill", ["-9", String(pid)]);

--- a/test/auto-update-checker.test.ts
+++ b/test/auto-update-checker.test.ts
@@ -894,7 +894,7 @@ describe("auto-update-checker", () => {
 					"/d",
 					"/s",
 					"/c",
-					"taskkill /PID 1234 /T /F >NUL 2>NUL",
+					"taskkill /PID 1234 /T /F",
 				],
 				expect.objectContaining({ stdio: "ignore", windowsHide: true }),
 			);

--- a/test/auto-update-checker.test.ts
+++ b/test/auto-update-checker.test.ts
@@ -889,8 +889,13 @@ describe("auto-update-checker", () => {
 			await flushUpdateStartup();
 			await vi.advanceTimersByTimeAsync(25);
 			expect(childProcess.spawn).toHaveBeenLastCalledWith(
-				"taskkill",
-				["/PID", "1234", "/T", "/F"],
+				"cmd.exe",
+				[
+					"/d",
+					"/s",
+					"/c",
+					"taskkill /PID 1234 /T /F >NUL 2>NUL",
+				],
 				expect.objectContaining({ stdio: "ignore", windowsHide: true }),
 			);
 			killer.emit("exit", 0, null);

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -688,12 +688,21 @@ describe('isWorkspaceDisabledError', () => {
 		expect(isWorkspaceDisabledError(403, 'error.usage_not_included', '')).toBe(false);
 	});
 
-	it('returns false for non-403 status even with disabled message', () => {
+	it('returns true for 402 deactivated_workspace signals', () => {
+		expect(isWorkspaceDisabledError(402, 'deactivated_workspace', '')).toBe(true);
+		expect(isWorkspaceDisabledError(402, 'error.deactivated_workspace', '')).toBe(true);
+		expect(
+			isWorkspaceDisabledError(402, '', '{"error":{"code":"deactivated_workspace"}}'),
+		).toBe(true);
+	});
+
+	it('returns false for statuses without supported disabled signals', () => {
 		expect(isWorkspaceDisabledError(400, '', 'Your workspace has been disabled')).toBe(false);
 		expect(isWorkspaceDisabledError(401, '', 'Your workspace has been disabled')).toBe(false);
 		expect(isWorkspaceDisabledError(500, '', 'Your workspace has been disabled')).toBe(false);
 		expect(isWorkspaceDisabledError(400, 'workspace_disabled', '')).toBe(false);
 		expect(isWorkspaceDisabledError(402, 'payment_required', '')).toBe(false);
+		expect(isWorkspaceDisabledError(402, '', 'Your workspace has been disabled')).toBe(false);
 	});
 
 	it('returns false for 403 with unrelated messages', () => {

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -694,7 +694,6 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 	});
 
 	it("keeps the total request cap when empty-response retries and server-error rotation combine", async () => {
-		vi.useFakeTimers();
 		const logger = await import("../lib/logger.js");
 		const logWarnSpy = vi.spyOn(logger, "logWarn").mockImplementation(() => {});
 
@@ -752,11 +751,7 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 		});
 
 		const sdk = (await plugin.auth.loader(getAuth, { options: {}, models: {} })) as any;
-		const fetchPromise = sdk.fetch("https://example.com", {});
-
-		await vi.advanceTimersByTimeAsync(1500);
-
-		const response = await fetchPromise;
+		const response = await sdk.fetch("https://example.com", {});
 		const payload = await response.json();
 
 		expect(fetchMock).toHaveBeenCalledTimes(6);

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -862,6 +862,60 @@ describe("runtime rotation proxy", () => {
 		});
 	});
 
+	it("records a concurrent deactivation failure once for the account", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 1));
+		const recordFailureSpy = vi.spyOn(accountManager, "recordFailure");
+		let disabledCalls = 0;
+		let releaseDisabledCalls: (() => void) | null = null;
+		const allDisabledCallsArrived = new Promise<void>((resolve) => {
+			releaseDisabledCalls = resolve;
+		});
+		const { calls, fetchImpl } = createRecordingFetch(async (call) => {
+			if (call.headers.get(OPENAI_HEADERS.ACCOUNT_ID) === "acc_1") {
+				disabledCalls += 1;
+				if (disabledCalls === 2) releaseDisabledCalls?.();
+				await allDisabledCallsArrived;
+				return new Response(
+					JSON.stringify({ error: { code: "deactivated_workspace" } }),
+					{
+						status: 402,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+			return textEventStream("data: recovered\n\n");
+		});
+		const proxy = await startProxy({ accountManager, fetchImpl });
+		const body = {
+			model: "gpt-5-codex",
+			stream: true,
+			metadata: { session_id: "thread-concurrent-deactivated" },
+		};
+
+		const responses = await Promise.all([postResponses(proxy, body), postResponses(proxy, body)]);
+		const payloads = (await Promise.all(responses.map((response) => response.json()))) as Array<{
+			error: { reason: string };
+		}>;
+
+		expect(responses.map((response) => response.status)).toEqual([
+			HTTP_STATUS.SERVICE_UNAVAILABLE,
+			HTTP_STATUS.SERVICE_UNAVAILABLE,
+		]);
+		expect(payloads.map((payload) => payload.error.reason)).toEqual([
+			"deactivated",
+			"deactivated",
+		]);
+		expect(calls.map((call) => call.headers.get(OPENAI_HEADERS.ACCOUNT_ID))).toEqual([
+			"acc_1",
+			"acc_1",
+		]);
+		expect(
+			recordFailureSpy.mock.calls.filter(([account]) => account.index === 0),
+		).toHaveLength(1);
+		expect(accountManager.getAccountByIndex(0)?.enabled).toBe(false);
+	});
+
 	it("returns pool exhaustion after all accounts are deactivated", async () => {
 		const now = Date.now();
 		const accountManager = new AccountManager(undefined, createStorage(now, 6));

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -940,6 +940,27 @@ describe("runtime rotation proxy", () => {
 		expect(accountManager.getAccountByIndex(1)?.enabled).toBe(true);
 	});
 
+	it("forwards unrelated 403 errors without disabling the account", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			new Response(JSON.stringify({ error: { code: "permission_denied" } }), {
+				status: HTTP_STATUS.FORBIDDEN,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, { model: "gpt-5-codex" });
+		const payload = (await response.json()) as { error: { code: string } };
+
+		expect(response.status).toBe(HTTP_STATUS.FORBIDDEN);
+		expect(payload.error.code).toBe("permission_denied");
+		expect(calls).toHaveLength(1);
+		expect(accountManager.getAccountByIndex(0)?.enabled).toBe(true);
+		expect(accountManager.getAccountByIndex(1)?.enabled).toBe(true);
+	});
+
 	it("persists cooldowns so a restarted proxy avoids limited accounts", async () => {
 		const now = Date.now();
 		const persisted: AccountStorageV3[] = [];

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -828,6 +828,40 @@ describe("runtime rotation proxy", () => {
 		).toEqual(["acc_2"]);
 	});
 
+	it("disables a 403 workspace-disabled account and retries another account", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const { calls, fetchImpl } = createRecordingFetch((_call, attempt) => {
+			if (attempt === 1) {
+				return new Response(
+					JSON.stringify({ error: { code: "workspace_disabled" } }),
+					{
+						status: HTTP_STATUS.FORBIDDEN,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+			return textEventStream("data: recovered\n\n");
+		});
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, { model: "gpt-5-codex" });
+
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		expect(await response.text()).toBe("data: recovered\n\n");
+		expect(calls.map((call) => call.headers.get(OPENAI_HEADERS.ACCOUNT_ID))).toEqual([
+			"acc_1",
+			"acc_2",
+		]);
+		expect(accountManager.getAccountByIndex(0)?.enabled).toBe(false);
+		expect(accountManager.getAccountByIndex(1)?.enabled).toBe(true);
+		expect(proxy.getStatus()).toMatchObject({
+			retries: 1,
+			rotations: 1,
+			lastAccountIndex: 1,
+		});
+	});
+
 	it("returns pool exhaustion after all accounts are deactivated", async () => {
 		const now = Date.now();
 		const accountManager = new AccountManager(undefined, createStorage(now, 6));
@@ -851,6 +885,38 @@ describe("runtime rotation proxy", () => {
 		expect(accountManager.getAccountsSnapshot().every((account) => account.enabled === false)).toBe(
 			true,
 		);
+	});
+
+	it("reports a transient exhaustion reason when deactivated skips also occurred", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 3));
+		const { calls, fetchImpl } = createRecordingFetch((_call, attempt) => {
+			if (attempt === 2) {
+				return new Response("upstream failed", { status: 503 });
+			}
+			return new Response(
+				JSON.stringify({ error: { code: "deactivated_workspace" } }),
+				{
+					status: 402,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		});
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, { model: "gpt-5-codex" });
+		const payload = (await response.json()) as { error: { reason: string } };
+
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		expect(payload.error.reason).toBe("server-error");
+		expect(calls.map((call) => call.headers.get(OPENAI_HEADERS.ACCOUNT_ID))).toEqual([
+			"acc_1",
+			"acc_2",
+			"acc_3",
+		]);
+		expect(accountManager.getAccountByIndex(0)?.enabled).toBe(false);
+		expect(accountManager.getAccountByIndex(1)?.cooldownReason).toBe("server-error");
+		expect(accountManager.getAccountByIndex(2)?.enabled).toBe(false);
 	});
 
 	it("forwards unrelated 402 errors without disabling the account", async () => {

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1046,6 +1046,7 @@ describe("runtime rotation proxy", () => {
 			};
 		});
 		const accountManager = new AccountManager(undefined, storage);
+		vi.spyOn(accountManager, "saveToDiskDebounced").mockImplementation(() => undefined);
 		const { calls, fetchImpl } = createRecordingFetch((_call, attempt) =>
 			textEventStream(`data: refreshed-${attempt}\n\n`),
 		);
@@ -1100,6 +1101,7 @@ describe("runtime rotation proxy", () => {
 				expires: now + 7_200_000,
 			});
 		const accountManager = new AccountManager(undefined, storage);
+		vi.spyOn(accountManager, "saveToDiskDebounced").mockImplementation(() => undefined);
 		const originalCommit = accountManager.commitRefreshedAuth.bind(accountManager);
 		let releaseCommit: (() => void) | undefined;
 		const commitBlocked = new Promise<void>((resolve) => {

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -761,6 +761,119 @@ describe("runtime rotation proxy", () => {
 		expect(proxy.getStatus().retries).toBe(1);
 	});
 
+	it("disables a deactivated workspace account and rebinds session affinity", async () => {
+		const now = Date.now();
+		const persisted: AccountStorageV3[] = [];
+		withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+			handler(null, async (storage: AccountStorageV3) => {
+				persisted.push(structuredClone(storage));
+			}),
+		);
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const { calls, fetchImpl } = createRecordingFetch((_call, attempt) => {
+			if (attempt === 1) {
+				return new Response(
+					JSON.stringify({ error: { code: "deactivated_workspace" } }),
+					{
+						status: 402,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+			return textEventStream("data: recovered\n\n");
+		});
+		const proxy = await startProxy({ accountManager, fetchImpl });
+		const body = {
+			model: "gpt-5-codex",
+			stream: true,
+			metadata: { session_id: "thread-deactivated" },
+		};
+
+		const first = await postResponses(proxy, body);
+		expect(first.status).toBe(HTTP_STATUS.OK);
+		expect(await first.text()).toBe("data: recovered\n\n");
+		const second = await postResponses(proxy, body);
+		expect(second.status).toBe(HTTP_STATUS.OK);
+		await second.text();
+		await accountManager.flushPendingSave();
+
+		expect(calls.map((call) => call.headers.get(OPENAI_HEADERS.ACCOUNT_ID))).toEqual([
+			"acc_1",
+			"acc_2",
+			"acc_2",
+		]);
+		expect(accountManager.getAccountByIndex(0)?.enabled).toBe(false);
+		expect(accountManager.getAccountByIndex(1)?.enabled).toBe(true);
+		expect(proxy.getStatus()).toMatchObject({
+			retries: 1,
+			rotations: 1,
+			lastAccountIndex: 1,
+		});
+		expect(persisted.at(-1)?.accounts[0]?.enabled).toBe(false);
+
+		const reloadedStorage = persisted.at(-1);
+		expect(reloadedStorage).toBeDefined();
+		if (!reloadedStorage) throw new Error("expected persisted storage");
+		const reloadedManager = new AccountManager(undefined, reloadedStorage);
+		const reloadedFetch = createRecordingFetch(() => textEventStream("data: restart\n\n"));
+		const reloadedProxy = await startProxy({
+			accountManager: reloadedManager,
+			fetchImpl: reloadedFetch.fetchImpl,
+		});
+
+		await (await postResponses(reloadedProxy, { model: "gpt-5-codex" })).text();
+
+		expect(
+			reloadedFetch.calls.map((call) => call.headers.get(OPENAI_HEADERS.ACCOUNT_ID)),
+		).toEqual(["acc_2"]);
+	});
+
+	it("returns pool exhaustion after all accounts are deactivated", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 6));
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			new Response(JSON.stringify({ error: { code: "deactivated_workspace" } }), {
+				status: 402,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, { model: "gpt-5-codex" });
+		const payload = (await response.json()) as { error: { code: string; reason: string } };
+
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		expect(payload.error).toMatchObject({
+			code: "codex_runtime_rotation_pool_exhausted",
+			reason: "deactivated",
+		});
+		expect(calls).toHaveLength(6);
+		expect(accountManager.getAccountsSnapshot().every((account) => account.enabled === false)).toBe(
+			true,
+		);
+	});
+
+	it("forwards unrelated 402 errors without disabling the account", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			new Response(JSON.stringify({ error: { code: "payment_required" } }), {
+				status: 402,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, { model: "gpt-5-codex" });
+		const payload = (await response.json()) as { error: { code: string } };
+
+		expect(response.status).toBe(402);
+		expect(payload.error.code).toBe("payment_required");
+		expect(calls).toHaveLength(1);
+		expect(accountManager.getAccountByIndex(0)?.enabled).toBe(true);
+		expect(accountManager.getAccountByIndex(1)?.enabled).toBe(true);
+	});
+
 	it("persists cooldowns so a restarted proxy avoids limited accounts", async () => {
 		const now = Date.now();
 		const persisted: AccountStorageV3[] = [];

--- a/test/test-model-matrix-script.test.ts
+++ b/test/test-model-matrix-script.test.ts
@@ -246,14 +246,14 @@ describe("test-model-matrix script helpers", () => {
 			expect(spawnSync).toHaveBeenCalledTimes(2);
 			expect(spawnSync).toHaveBeenNthCalledWith(
 				1,
-				"taskkill",
-				["/F", "/T", "/PID", "1001"],
+				"cmd.exe",
+				["/d", "/s", "/c", "taskkill /F /T /PID 1001 >NUL 2>NUL"],
 				expect.objectContaining({ windowsHide: true, stdio: "ignore" }),
 			);
 			expect(spawnSync).toHaveBeenNthCalledWith(
 				2,
-				"taskkill",
-				["/F", "/T", "/PID", "2002"],
+				"cmd.exe",
+				["/d", "/s", "/c", "taskkill /F /T /PID 2002 >NUL 2>NUL"],
 				expect.objectContaining({ windowsHide: true, stdio: "ignore" }),
 			);
 		} finally {

--- a/test/test-model-matrix-script.test.ts
+++ b/test/test-model-matrix-script.test.ts
@@ -247,13 +247,13 @@ describe("test-model-matrix script helpers", () => {
 			expect(spawnSync).toHaveBeenNthCalledWith(
 				1,
 				"cmd.exe",
-				["/d", "/s", "/c", "taskkill /F /T /PID 1001 >NUL 2>NUL"],
+				["/d", "/s", "/c", "taskkill /F /T /PID 1001"],
 				expect.objectContaining({ windowsHide: true, stdio: "ignore" }),
 			);
 			expect(spawnSync).toHaveBeenNthCalledWith(
 				2,
 				"cmd.exe",
-				["/d", "/s", "/c", "taskkill /F /T /PID 2002 >NUL 2>NUL"],
+				["/d", "/s", "/c", "taskkill /F /T /PID 2002"],
 				expect.objectContaining({ windowsHide: true, stdio: "ignore" }),
 			);
 		} finally {


### PR DESCRIPTION
Summary:
- Treat upstream `402` `deactivated_workspace` as a disabled workspace signal while preserving existing `403` workspace-disabled handling.
- Disable deactivated runtime pool entries with `enabled=false`, clear session affinity for the request, persist the pool, and retry on another account.
- Keep normal transient retry budgets capped while allowing terminal deactivated skips to walk the full account count.
- Silence Windows `taskkill` cleanup output in TUI-facing flows without exposing process output.
- Harden concurrent deactivation handling so one account deactivation does not double-record account failure.
- Stabilize the index retry stress test by removing unnecessary fake-timer scheduling from a path whose retry sleeps are already mocked.

What changed:
- Runtime proxy now detects `402 deactivated_workspace` before generic error forwarding and retries the request on another enabled account.
- Deactivated accounts are persisted through existing `enabled=false` storage and skipped after reload.
- Session affinity is cleared when the pinned account is disabled so later requests can bind to a live account.
- Pool exhaustion now returns structured `codex_runtime_rotation_pool_exhausted` JSON with `reason: "deactivated"` when all usable accounts are deactivated.
- Unrelated `402` and `403` responses still pass through unchanged.
- Windows process cleanup uses `cmd.exe /d /s /c taskkill ...` with ignored stdio to avoid noisy `SUCCESS: The process with PID ... has been terminated.` output.
- Script JSDoc annotations keep `typecheck:scripts` green.

Verification:
- `npm.cmd test -- test/runtime-rotation-proxy.test.ts test/fetch-helpers.test.ts test/auto-update-checker.test.ts test/test-model-matrix-script.test.ts`
- `npm.cmd test -- test/codex-routing.test.ts test/package-bin.test.ts`
- `npm.cmd test -- test/index-retry.test.ts`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run typecheck:scripts`
- `npm.cmd run build`
- `npm.cmd test`
- `npm.cmd run pack:check`

Stress notes:
- Runtime/helper stress loop previously passed 20/20 after stabilizing the refresh persistence test.
- Full `npm.cmd test` passed with 257 files and 3872 tests.
- The previous concurrent `npm.cmd test` + `npm.cmd run pack:check` timeout was fixed in `test/index-retry.test.ts`; the concurrent stress condition now passes.

Risk:
- Medium. The runtime retry path affects live Responses traffic, session affinity, and account persistence. Coverage now includes 402 failover, 403 workspace-disabled failover, unrelated 402/403 passthrough, all-deactivated exhaustion, mixed transient/deactivated exhaustion, persistence after reload, and concurrent deactivation failure de-duplication.

Rollback:
- Revert the PR commits on `fix/runtime-skip-deactivated-accounts`.
- Re-enable any accounts intentionally disabled during manual testing with the existing account enable flow if needed.

Docs:
- No user-facing command or storage schema change. Existing status output already shows disabled accounts.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds 402 `deactivated_workspace` failover to the runtime rotation proxy: deactivated accounts are disabled, session affinity is cleared, and the proxy retries on the remaining pool, with pool exhaustion emitting a structured `codex_runtime_rotation_pool_exhausted` response. the transient-vs-deactivated attempt tracking and the post-loop exhaustion reason promotion are well-designed and the concurrent deactivation guard (`accountWasEnabled`) correctly prevents double-recording.

<h3>Confidence Score: 5/5</h3>

safe to merge — all new paths are guarded, tested, and have no P0/P1 issues

no P0 or P1 issues found; concurrency guard, exhaustion reason promotion, and transient-vs-deactivated budget split are all correct; coverage now includes 402 failover, 403 failover, concurrent deactivation, mixed exhaustion, persistence, and passthrough — only minor P2 style observations remain

lib/runtime-rotation-proxy.ts and lib/request/fetch-helpers.ts are the highest-impact files but reviewed clean

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime-rotation-proxy.ts | core change: 402/403 workspace-disabled detection, deactivated-account skip path, `transientAttempts` budget split, and post-loop exhaustion reason promotion — logic is sound and well-guarded against concurrent deactivation |
| lib/request/fetch-helpers.ts | extends `isWorkspaceDisabledError` to handle 402 status with `deactivated_workspace` token or body-text regex; 403 handling is preserved unchanged |
| test/runtime-rotation-proxy.test.ts | adds 8 new proxy-level tests covering 402 failover, 403 workspace-disabled failover, concurrent deactivation de-duplication, all-deactivated exhaustion, mixed transient+deactivated exhaustion, unrelated 402/403 passthrough, and persistence after reload |
| test/fetch-helpers.test.ts | adds unit tests for the new 402 `deactivated_workspace` path and verifies the false-positive guard for `payment_required` and plain body text |
| lib/auto-update-checker.ts | wraps `taskkill` in `cmd.exe /d /s /c` to silence the SUCCESS stdout noise on windows; no logic change |
| scripts/test-model-matrix.js | extracts `runQuietWindowsTaskkill` using the same `cmd.exe /d /s /c` pattern; consistent with the auto-update-checker change |
| test/index-retry.test.ts | removes `vi.useFakeTimers()` from a test that doesn't need fake timer control, eliminating the source of flakiness under concurrent load |
| scripts/codex-multi-auth.js | adds jsdoc annotation to `normalizeStandaloneArgs` to keep `typecheck:scripts` green; no logic change |
| scripts/codex-routing.js | adds jsdoc annotations to `normalizeAuthAlias` and `shouldHandleMultiAuthAuth`; no logic change |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming request] --> B{chooseAccount}
    B -- no account --> Z[break: pool exhausted]
    B -- account selected --> C[consumeToken]
    C --> D[ensureFreshAccessToken]
    D -- not ok retryable --> E[transientAttempts++
exhaustionReason=auth-failure]
    D -- not ok non-retryable --> E2[exhaustionReason=auth-failure
continue]
    D -- ok --> F[fetch upstream]
    F -- network error --> G[transientAttempts++
exhaustionReason=network-error
continue]
    F -- rate-limit 429 --> H[transientAttempts++
exhaustionReason=rate-limit
continue]
    F -- 402 or 403 --> I{isWorkspaceDisabledError?}
    I -- yes --> J[refundToken
recordFailure if accountWasEnabled
setAccountEnabled false
forgetSession
exhaustionReason=deactivated
continue]
    I -- no --> K[forward bodyText to client
record usage
return]
    F -- 401 --> L[transientAttempts++
exhaustionReason=auth-failure
continue]
    F -- 5xx --> M[transientAttempts++
exhaustionReason=server-error
continue]
    F -- 200 OK --> N[stream forward to client
return]
    E --> LOOP{while:
attemptedIndexes lt accountCount
AND transientAttempts lt transientAttemptLimit}
    J --> LOOP
    G --> LOOP
    H --> LOOP
    L --> LOOP
    M --> LOOP
    E2 --> LOOP
    LOOP -- continue --> B
    LOOP -- exit --> P{post-loop reason}
    P -- transientAttempts gte limit AND size lt count --> Q[exhaustionReason=budget]
    P -- exhaustionReason==deactivated AND transientReason set --> R[exhaustionReason=transientExhaustionReason]
    P --> S[writePoolExhausted]
    Z --> S
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fruntime-skip-deactivated-accounts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fruntime-skip-deactivated-accounts%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Frequest%2Ffetch-helpers.ts%3A338-341%0A**402%20body-text%20fallback%20matches%20%60deactivated_workspace%60%20in%20any%20field**%0A%0Athe%20bodyText%20regex%20%60%2F%5Cbdeactivated_workspace%5Cb%2Fi%60%20fires%20on%20any%20occurrence%20of%20that%20string%20in%20the%20raw%20body%20%E2%80%94%20including%20inside%20an%20%60error.message%60%20like%20%60%22contact%20support%3A%20deactivated_workspace%22%60.%20%60extractErrorCodeFromBody%60%20already%20handles%20structured%20JSON%20and%20returns%20the%20code%2C%20so%20the%20regex%20is%20only%20a%20fallback%20for%20unstructured%20responses.%20in%20practice%20the%20risk%20is%20low%2C%20but%20worth%20noting%20that%20a%20%60%7B%22error%22%3A%20%7B%22message%22%3A%20%22deactivated_workspace%20info%22%7D%7D%60%20body%20with%20no%20%60code%60%20field%20would%20still%20trigger%20account%20disable%20on%20402.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fruntime-rotation-proxy.ts%3A1113-1121%0A**non-workspace%20402%2F403%20forwarding%20skips%20%60Content-Length%60%20recalculation**%0A%0A%60bodyText%60%20is%20forwarded%20with%20the%20original%20upstream%20headers%20%28including%20any%20%60content-length%60%20set%20by%20the%20upstream%29.%20since%20%60readErrorBody%60%20decodes%20via%20%60.text%28%29%60%2C%20a%20body%20with%20a%20%60content-encoding%60%20or%20multi-byte%20encoding%20could%20produce%20a%20string%20whose%20%60Buffer.byteLength%60%20differs%20from%20the%20original%20header%20value%2C%20sending%20a%20mismatched%20%60Content-Length%60%20to%20the%20client.%20in%20practice%20402%2F403%20error%20bodies%20are%20always%20UTF-8%20JSON%20so%20this%20is%20unlikely%2C%20but%20if%20upstream%20ever%20gzip-encodes%20an%20error%20response%20the%20forwarded%20bytes%20will%20mismatch.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/request/fetch-helpers.ts:338-341
**402 body-text fallback matches `deactivated_workspace` in any field**

the bodyText regex `/\bdeactivated_workspace\b/i` fires on any occurrence of that string in the raw body — including inside an `error.message` like `"contact support: deactivated_workspace"`. `extractErrorCodeFromBody` already handles structured JSON and returns the code, so the regex is only a fallback for unstructured responses. in practice the risk is low, but worth noting that a `{"error": {"message": "deactivated_workspace info"}}` body with no `code` field would still trigger account disable on 402.

### Issue 2 of 2
lib/runtime-rotation-proxy.ts:1113-1121
**non-workspace 402/403 forwarding skips `Content-Length` recalculation**

`bodyText` is forwarded with the original upstream headers (including any `content-length` set by the upstream). since `readErrorBody` decodes via `.text()`, a body with a `content-encoding` or multi-byte encoding could produce a string whose `Buffer.byteLength` differs from the original header value, sending a mismatched `Content-Length` to the client. in practice 402/403 error bodies are always UTF-8 JSON so this is unlikely, but if upstream ever gzip-encodes an error response the forwarded bytes will mismatch.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["stabilize index retry stress test"](https://github.com/ndycode/codex-multi-auth/commit/6a1496291dfd82ba8945427e5724335368464d5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30446212)</sub>

<!-- /greptile_comment -->