### PR TITLE
[codex] fix startup auto-update detachment

### DIFF
--- a/lib/auto-update-checker.ts
+++ b/lib/auto-update-checker.ts
@@ -29,6 +29,44 @@ const AUTO_UPDATE_TIMEOUT_MS = 2 * 60 * 1000;
 const AUTO_UPDATE_LOCK_STALE_MS = 10 * 60 * 1000;
 const TASKKILL_TIMEOUT_MS = 5_000;
 const AUTO_UPDATE_ENV_NAME = "CODEX_MULTI_AUTH_AUTO_UPDATE";
+const BACKGROUND_AUTO_UPDATE_PARENT_EXIT_TIMEOUT_MS = 12 * 60 * 60 * 1000;
+const BACKGROUND_AUTO_UPDATE_PARENT_POLL_MS = 250;
+const BACKGROUND_AUTO_UPDATE_HELPER_SCRIPT = `
+const { spawn } = require("node:child_process");
+const parentPid = Number.parseInt(process.env.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PARENT_PID || "0", 10);
+const timeoutMs = Number.parseInt(process.env.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PARENT_TIMEOUT_MS || "0", 10);
+const pollMs = Number.parseInt(process.env.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PARENT_POLL_MS || "250", 10);
+function isAlive(pid) {
+	if (!Number.isInteger(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return error && error.code === "EPERM";
+	}
+}
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+(async () => {
+	const startedAt = Date.now();
+	while (isAlive(parentPid) && (timeoutMs <= 0 || Date.now() - startedAt < timeoutMs)) {
+		await sleep(Math.max(25, pollMs));
+	}
+	const command = process.env.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_COMMAND;
+	const rawArgs = process.env.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_ARGS || "[]";
+	if (!command) return;
+	const args = JSON.parse(rawArgs);
+	if (!Array.isArray(args) || !args.every((arg) => typeof arg === "string")) return;
+	const child = spawn(command, args, {
+		detached: true,
+		env: { ...process.env, CODEX_MULTI_AUTH_AUTO_UPDATE: "0" },
+		stdio: "ignore",
+		windowsHide: process.env.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PLATFORM === "win32",
+	});
+	child.unref();
+})().catch(() => undefined);
+`;
 const TRUE_VALUES = new Set(["1", "true", "yes"]);
 const FALSE_VALUES = new Set(["0", "false", "no"]);
 const SAFE_SUBPROCESS_ENV_KEYS = new Set([
@@ -302,6 +340,7 @@ export interface AutoUpdateResult extends UpdateCheckResult {
 		| "not-updateable-install"
 		| "already-running"
 		| "current"
+		| "update-started"
 		| "updated"
 		| "update-failed";
 	exitCode: number | null;
@@ -317,6 +356,7 @@ export interface AutoUpdateOptions {
 	platform?: NodeJS.Platform;
 	fetchTimeoutMs?: number;
 	timeoutMs?: number;
+	background?: boolean;
 	onUpdateStart?: (result: UpdateCheckResult) => void;
 }
 
@@ -508,6 +548,45 @@ async function runUpdateCommand(options: {
 	});
 }
 
+function startUpdateCommandInBackground(options: {
+	command: string;
+	env: NodeJS.ProcessEnv;
+	platform: NodeJS.Platform;
+}): { ok: true; pid: number | null } | { ok: false; error: string } {
+	const updateSpawn = resolveUpdateSpawn({
+		command: options.command,
+		platform: options.platform,
+	});
+	const helperEnv = buildAutoUpdateSubprocessEnv(options.env);
+	helperEnv.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_ARGS = JSON.stringify(
+		updateSpawn.args,
+	);
+	helperEnv.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_COMMAND = updateSpawn.command;
+	helperEnv.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PARENT_PID = String(process.pid);
+	helperEnv.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PARENT_POLL_MS = String(
+		BACKGROUND_AUTO_UPDATE_PARENT_POLL_MS,
+	);
+	helperEnv.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PARENT_TIMEOUT_MS = String(
+		BACKGROUND_AUTO_UPDATE_PARENT_EXIT_TIMEOUT_MS,
+	);
+	helperEnv.CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PLATFORM = options.platform;
+	try {
+		const child = spawn(process.execPath, ["-e", BACKGROUND_AUTO_UPDATE_HELPER_SCRIPT], {
+			detached: true,
+			env: helperEnv,
+			stdio: "ignore",
+			windowsHide: options.platform === "win32",
+		});
+		child.unref();
+		return { ok: true, pid: child.pid ?? null };
+	} catch (error) {
+		return {
+			ok: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
 async function killUpdateProcessTree(
 	child: ReturnType<typeof spawn> | null,
 	platform: NodeJS.Platform,
@@ -630,11 +709,11 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
-function writeAutoUpdateLockOwner(): void {
+function writeAutoUpdateLockOwner(pid = process.pid): void {
 	writeFileSync(
 		AUTO_UPDATE_LOCK_OWNER_FILE,
 		`${JSON.stringify({
-			pid: process.pid,
+			pid,
 			startedAt: new Date().toISOString(),
 		})}\n`,
 		{ encoding: "utf8", mode: 0o600 },
@@ -801,6 +880,44 @@ export async function autoUpdateIfAvailable(
 
 	try {
 		notifyUpdateStart(options.onUpdateStart, result);
+		if (options.background) {
+			const updateResult = startUpdateCommandInBackground({
+				command: npmCommand,
+				env,
+				platform: options.platform ?? process.platform,
+			});
+			if (!updateResult.ok) {
+				log.warn("Auto-update failed", { error: updateResult.error });
+				return {
+					...result,
+					checked: true,
+					updated: false,
+					reason: "update-failed",
+					exitCode: null,
+					error: updateResult.error,
+				};
+			}
+			if (updateResult.pid !== null) {
+				try {
+					writeAutoUpdateLockOwner(updateResult.pid);
+				} catch (error) {
+					log.debug("Failed to update background auto-update lock owner", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			}
+			log.info(
+				`Started background auto-update for ${PACKAGE_NAME} to v${result.latestVersion}`,
+			);
+			return {
+				...result,
+				checked: true,
+				updated: false,
+				reason: "update-started",
+				exitCode: null,
+				error: null,
+			};
+		}
 		const updateResult = await runUpdateCommand({
 			command: npmCommand,
 			env,
@@ -829,7 +946,9 @@ export async function autoUpdateIfAvailable(
 			error: null,
 		};
 	} finally {
-		releaseLock();
+		if (!options.background) {
+			releaseLock();
+		}
 	}
 }
 

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -347,13 +347,14 @@ async function autoUpdatePackageIfEnabled(rawArgs, normalizedArgs) {
 			return;
 		}
 		const updatePromise = mod.autoUpdateIfAvailable({
+			background: true,
 			fetchTimeoutMs,
 			timeoutMs: updateTimeoutMs,
 			onUpdateStart: (update) => {
 				if (!update?.latestVersion) return;
 				if (!shouldLogStartupAutoUpdateProgress()) return;
 				console.error(
-					`codex-multi-auth: auto-update found ${update.latestVersion}; starting npm update -g codex-multi-auth. Startup will continue if it exceeds ${budgetMs}ms.`,
+					`codex-multi-auth: auto-update found ${update.latestVersion}; starting npm update -g codex-multi-auth in the background.`,
 				);
 			},
 		});

--- a/test/auto-update-checker.test.ts
+++ b/test/auto-update-checker.test.ts
@@ -783,6 +783,70 @@ describe("auto-update-checker", () => {
 			);
 		});
 
+		it("starts startup auto-updates in a detached background process", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue({
+				ok: true,
+				json: async () => ({ version: "5.0.0" }),
+			} as Response);
+			const child = new EventEmitter() as EventEmitter & {
+				kill: ReturnType<typeof vi.fn>;
+				unref: ReturnType<typeof vi.fn>;
+				pid: number;
+			};
+			child.kill = vi.fn();
+			child.unref = vi.fn();
+			child.pid = 5678;
+			vi.mocked(childProcess.spawn).mockReturnValue(child as never);
+
+			const result = await autoUpdateIfAvailable({
+				background: true,
+				env: { CODEX_MULTI_AUTH_AUTO_UPDATE: "1" },
+				forceCheck: true,
+				forceInstall: true,
+				npmCommand: "npm",
+				platform: "linux",
+			});
+
+			expect(result.reason).toBe("update-started");
+			expect(result.updated).toBe(false);
+			expect(childProcess.spawn).toHaveBeenCalledWith(
+				process.execPath,
+				[
+					"-e",
+					expect.stringContaining(
+						"CODEX_MULTI_AUTH_BACKGROUND_UPDATE_COMMAND",
+					),
+				],
+				expect.objectContaining({
+					detached: true,
+					env: expect.objectContaining({
+						CODEX_MULTI_AUTH_BACKGROUND_UPDATE_ARGS: JSON.stringify([
+							"update",
+							"-g",
+							"codex-multi-auth",
+						]),
+						CODEX_MULTI_AUTH_BACKGROUND_UPDATE_COMMAND: "npm",
+						CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PARENT_PID: String(
+							process.pid,
+						),
+						CODEX_MULTI_AUTH_BACKGROUND_UPDATE_PLATFORM: "linux",
+						CODEX_MULTI_AUTH_AUTO_UPDATE: "0",
+					}),
+					stdio: "ignore",
+				}),
+			);
+			expect(vi.mocked(childProcess.spawn).mock.calls[0]?.[1]?.[1]).toEqual(
+				expect.stringContaining("detached: true"),
+			);
+			expect(child.unref).toHaveBeenCalledTimes(1);
+			expect(fs.writeFileSync).toHaveBeenCalledWith(
+				expect.stringContaining("owner.json"),
+				expect.stringContaining('"pid":5678'),
+				expect.objectContaining({ encoding: "utf8", mode: 0o600 }),
+			);
+			expect(fs.rmdirSync).not.toHaveBeenCalled();
+		});
+
 		it("reports synchronous update spawn failures without throwing", async () => {
 			vi.mocked(globalThis.fetch).mockResolvedValue({
 				ok: true,

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -4023,7 +4023,7 @@ describe("codex bin wrapper", () => {
 			[
 				'import { writeFileSync } from "node:fs";',
 				"export async function autoUpdateIfAvailable(options) {",
-				"\twriteFileSync(process.env.CODEX_MULTI_AUTH_AUTO_UPDATE_OPTIONS, JSON.stringify({ fetchTimeoutMs: options.fetchTimeoutMs, timeoutMs: options.timeoutMs }), 'utf8');",
+				"\twriteFileSync(process.env.CODEX_MULTI_AUTH_AUTO_UPDATE_OPTIONS, JSON.stringify({ background: options.background, fetchTimeoutMs: options.fetchTimeoutMs, timeoutMs: options.timeoutMs }), 'utf8');",
 				"\toptions?.onUpdateStart?.({ latestVersion: '9.9.9' });",
 				"\treturn { updated: true, latestVersion: '9.9.9' };",
 				"}",
@@ -4040,11 +4040,12 @@ describe("codex bin wrapper", () => {
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("FORWARDED:exec status");
 		expect(JSON.parse(readFileSync(optionsPath, "utf8"))).toEqual({
+			background: true,
 			fetchTimeoutMs: 1200,
 			timeoutMs: 1800,
 		});
 		expect(result.stderr).toContain(
-			"codex-multi-auth: auto-update found 9.9.9; starting npm update -g codex-multi-auth. Startup will continue if it exceeds 3000ms.",
+			"codex-multi-auth: auto-update found 9.9.9; starting npm update -g codex-multi-auth in the background.",
 		);
 		expect(result.stderr).toContain(
 			"codex-multi-auth: auto-updated to 9.9.9. New sessions will use the latest package.",


### PR DESCRIPTION
﻿## What changed
- Startup auto-update now asks the updater to run in detached background mode.
- Background updates use a detached Node helper that waits for the wrapper process to exit before launching `npm update -g codex-multi-auth`.
- The helper also detaches the npm child process, which is required on Windows so npm survives after the helper exits.
- Background updates write the spawned helper PID into the auto-update lock, so concurrent launchers do not stampede while an update is already in progress.
- Wrapper startup progress copy now says the update is running in the background instead of promising a timeout fallback that the child process could still defeat.

## Root cause
The published 2.1.3 wrapper could detect 2.1.4 but then tried to update while Windows still had the package files open from the running wrapper/helper process. A first detach fixed startup continuation, but broad installed-shape testing showed the nested npm child also needed to be detached or it could disappear before doing the update.

## Validation
- npm test -- test/auto-update-checker.test.ts
- npm test -- test/codex-bin-wrapper.test.ts
- npm test -- test/auto-update-checker.test.ts test/codex-bin-wrapper.test.ts
- npm run typecheck
- npm run typecheck:scripts
- npm run build
- npm run lint
- npm pack --ignore-scripts from an isolated copy stamped as 2.1.3
- npm install -g <isolated 2.1.3 tarball> --prefix <temp prefix>
- launched temp-prefix wrapper with `CODEX_MULTI_AUTH_AUTO_UPDATE=1`, `CODEX_MULTI_AUTH_DEBUG=1`, and `npm_config_prefix=<temp prefix>`
- verified temp prefix changed from codex-multi-auth@2.1.3 to codex-multi-auth@2.1.4 on poll 0 after wrapper exit
