### PR TITLE
fix: return {goal:null} for all thread/goal/get upstream errors

### DIFF
--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1206,6 +1206,16 @@ export async function startRuntimeRotationProxy(
 						const goal =
 							typeof parsedGoalBody?.goal === "string" ? parsedGoalBody.goal : null;
 						if (!fallbackKey) {
+							if (context.upstreamPath.endsWith("/get")) {
+								writeJson(res, HTTP_STATUS.OK, { goal: null });
+								await usageRecorder.record({
+									outcome: "failure",
+									statusCode: upstream.status,
+									errorCode: "thread_goal_session_key_required",
+									account: refreshed.account,
+								});
+								return;
+							}
 							await usageRecorder.record({
 								outcome: "failure",
 								statusCode: HTTP_STATUS.BAD_REQUEST,
@@ -1238,6 +1248,16 @@ export async function startRuntimeRotationProxy(
 						return;
 					}
 
+					if (isThreadGoalRequest && context.upstreamPath.endsWith("/get")) {
+						writeJson(res, HTTP_STATUS.OK, { goal: null });
+						await usageRecorder.record({
+							outcome: "failure",
+							statusCode: upstream.status,
+							errorCode,
+							account: refreshed.account,
+						});
+						return;
+					}
 					res.writeHead(upstream.status, responseHeadersForClient(upstream.headers));
 					res.end(bodyText);
 					await usageRecorder.record({
@@ -1286,6 +1306,16 @@ export async function startRuntimeRotationProxy(
 				}
 
 				if (isThreadGoalRequest && upstream.status >= 400) {
+					if (context.upstreamPath.endsWith("/get")) {
+						writeJson(res, HTTP_STATUS.OK, { goal: null });
+						await usageRecorder.record({
+							outcome: "failure",
+							statusCode: upstream.status,
+							errorCode: "thread_goal_upstream_error",
+							account: refreshed.account,
+						});
+						return;
+					}
 					const forwarded = await forwardStreamingResponse(
 						upstream,
 						res,

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1405,15 +1405,19 @@ export async function startRuntimeRotationProxy(
 			await usageRecorder?.record({
 				outcome: "failure",
 				statusCode: normalizeExhaustionStatus(exhaustionReason),
-				errorCode: exhaustionReason,
+				errorCode: isThreadGoalRequest && context.upstreamPath.endsWith("/get") ? "thread_goal_pool_exhausted" : exhaustionReason,
 			});
-			writePoolExhausted({
-				res,
-				accountManager,
-				family: context.family,
-				model: context.model,
-				reason: exhaustionReason,
-			});
+			if (isThreadGoalRequest && context.upstreamPath.endsWith("/get")) {
+				writeJson(res, HTTP_STATUS.OK, { goal: null });
+			} else {
+				writePoolExhausted({
+					res,
+					accountManager,
+					family: context.family,
+					model: context.model,
+					reason: exhaustionReason,
+				});
+			}
 		} catch (error) {
 			status.lastError = error instanceof Error ? error.message : String(error);
 			if (!res.headersSent) {


### PR DESCRIPTION
## Summary

- **Bug:** Codex TUI shows red banner \"Failed to read thread goal: thread/goal/get failed in TUI\" on startup when accounts don't support the thread goal API
- Three code paths in `runtime-rotation-proxy.ts` were forwarding upstream errors (4xx) back to the TUI instead of returning a graceful empty response:
  1. **403 + no session key** → was returning `400 thread_goal_session_key_required`; now returns `{goal:null}` with 200
  2. **402 (payment required)** → was forwarding `402` to the TUI; now returns `{goal:null}` with 200
  3. **Other 4xx (e.g. 404)** → was forwarding the raw error; now returns `{goal:null}` with 200
- SET requests are intentionally unaffected — only GET is silenced since a missing thread goal is non-fatal

## Test plan

- [ ] Start Codex with accounts that return 403 on thread goal — no red banner appears
- [ ] Start Codex with accounts that return 402 on thread goal — no red banner appears
- [ ] Start Codex with accounts that return 404 on thread goal — no red banner appears
- [ ] Setting a thread goal still works (SET path unchanged)
- [ ] Existing fallback behaviour for 403 + valid session key still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

silences `thread/goal/get` upstream errors (403-no-key, 402, other 4xx, pool exhaustion) by returning `{goal:null}` with 200 instead of forwarding error codes to the tui. the set path is deliberately untouched, and the existing 403+valid-session-key fallback flow is preserved.

no test file changes were included; `test/runtime-rotation-proxy.test.ts` should cover the three new branches.

<h3>Confidence Score: 5/5</h3>

safe to merge — only GET thread goal errors are silenced, set path and all other proxy paths are unaffected

all four new branches are structurally correct: they check the right path suffix before suppressing, record the upstream status in the usage recorder, and return without consuming the response body redundantly. the only gap is vitest coverage (p2).

no files require special attention; test/runtime-rotation-proxy.test.ts should receive follow-up coverage

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime-rotation-proxy.ts | adds four graceful early-return blocks for thread/goal/get so upstream 4xx and pool exhaustion return {goal:null} instead of forwarding errors to the tui; set path is intentionally unchanged; logic is correct across all three stated code paths |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[thread/goal request] --> B{upstream status}
    B -->|429| C[rate-limit & rotate]
    B -->|402 or 403| D{workspace disabled?}
    D -->|yes| E[deactivate & rotate]
    D -->|no| F{isThreadGoalFallbackStatus 403 only}
    F -->|yes| G{has session key?}
    G -->|no + /get| H["NEW: return {goal:null} 200"]
    G -->|no + /set| I[return 400 error]
    G -->|yes + /set| J[set fallback & return OK]
    G -->|yes + /get| K[return fallback goal]
    F -->|no| L{"NEW: isThreadGoalRequest && /get?"}
    L -->|yes| M["return {goal:null} 200"]
    L -->|no| N[forward upstream status to client]
    B -->|401| O[auth-failure & rotate]
    B -->|5xx| P[server-error & rotate]
    B -->|other 4xx| Q{"NEW: isThreadGoalRequest && /get?"}
    Q -->|yes| R["return {goal:null} 200"]
    Q -->|no| S[forward streaming response]
    B -->|2xx/3xx| T[forward success response]
    C & E & O & P --> U[pool exhausted?]
    U -->|yes + isThreadGoalRequest + /get| V["NEW: return {goal:null} 200"]
    U -->|yes + other| W[writePoolExhausted]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fthread-goal-get-graceful-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fthread-goal-get-graceful-fallback%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fruntime-rotation-proxy.ts%3A1209-1218%0A**missing%20vitest%20coverage%20for%20all%20three%20new%20code%20paths**%0A%0Ano%20test%20file%20changes%20accompany%20this%20fix.%20the%20three%20new%20early-return%20branches%20%E2%80%94%20403%2Bno-session-key%20on%20%60%2Fget%60%2C%20non-403%204xx%20on%20%60%2Fget%60%20inside%20the%20402%2F403%20block%2C%20and%20other%204xx%20in%20the%20streaming-path%20block%20%E2%80%94%20are%20untested.%20%60test%2Fruntime-rotation-proxy.test.ts%60%20exists%3B%20adding%20cases%20for%20each%20upstream%20status%20%28403%20no-key%2C%20402%2C%20404%29%20hitting%20%60thread%2Fgoal%2Fget%60%20would%20lock%20in%20this%20behavior%20and%20catch%20regressions.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/runtime-rotation-proxy.ts:1209-1218
**missing vitest coverage for all three new code paths**

no test file changes accompany this fix. the three new early-return branches — 403+no-session-key on `/get`, non-403 4xx on `/get` inside the 402/403 block, and other 4xx in the streaming-path block — are untested. `test/runtime-rotation-proxy.test.ts` exists; adding cases for each upstream status (403 no-key, 402, 404) hitting `thread/goal/get` would lock in this behavior and catch regressions.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: return {goal:null} when all account..."](https://github.com/ndycode/codex-multi-auth/commit/59554117b21a4d85da9444112b28b472fcca3c87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30565061)</sub>

<!-- /greptile_comment -->