### PR TITLE
fix(shadow-home): isolate runtime goal state

### DIFF
--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -41,6 +41,7 @@ const RUNTIME_ROTATION_SHADOW_HOME_OMIT_STATE_FILES = new Set([
 	"auth.json",
 	"accounts.json",
 ]);
+const RUNTIME_ROTATION_SHADOW_HOME_OMIT_ROOT_DIRS = new Set(["multi-auth"]);
 const SHADOW_HOME_STATE_FILE_SET = new Set(SHADOW_HOME_STATE_FILES);
 const SHADOW_HOME_CONFIG_FILE = "config.toml";
 const SHADOW_HOME_SYNC_LOCK_DIR = ".codex-multi-auth-shadow-sync.lock";
@@ -1899,12 +1900,31 @@ function isSqliteSidecarFile(name) {
 	return /\.sqlite-(?:shm|wal)$/i.test(name);
 }
 
+function normalizeRuntimeShadowHomeEntryName(name) {
+	return process.platform === "win32" || process.platform === "darwin"
+		? name.toLowerCase()
+		: name;
+}
+
 function isCodexRuntimeLocalSqliteFile(name) {
-	const normalizedName =
-		process.platform === "win32" || process.platform === "darwin"
-			? name.toLowerCase()
-			: name;
+	const normalizedName = normalizeRuntimeShadowHomeEntryName(name);
 	return /^(?:state|logs)_\d+\.sqlite(?:-(?:shm|wal))?$/.test(normalizedName);
+}
+
+function isCodexRuntimeTransientStateFile(name) {
+	const normalizedName = normalizeRuntimeShadowHomeEntryName(name);
+	return /^(?:auth|accounts)\.json\.\d+\.[a-z0-9]+\.tmp$/.test(
+		normalizedName,
+	);
+}
+
+function isRuntimeRotationShadowHomeOmittedEntry(name) {
+	const normalizedName = normalizeRuntimeShadowHomeEntryName(name);
+	return (
+		RUNTIME_ROTATION_SHADOW_HOME_OMIT_ROOT_DIRS.has(normalizedName) ||
+		isCodexRuntimeLocalSqliteFile(name) ||
+		isCodexRuntimeTransientStateFile(name)
+	);
 }
 
 function shouldMaterializeFileIntoShadowHome(name) {
@@ -2398,9 +2418,9 @@ function createRuntimeRotationProxyCodexHome(
 			shadowCodexHome,
 			tightenShadowHomePermissions,
 			{
-				skipMirrorPredicate: isCodexRuntimeLocalSqliteFile,
+				skipMirrorPredicate: isRuntimeRotationShadowHomeOmittedEntry,
 				skipSyncBackNames: RUNTIME_ROTATION_SHADOW_HOME_OMIT_STATE_FILES,
-				skipSyncBackPredicate: isCodexRuntimeLocalSqliteFile,
+				skipSyncBackPredicate: isRuntimeRotationShadowHomeOmittedEntry,
 			},
 		);
 		omitRuntimeRotationShadowHomeStateFiles(shadowCodexHome);

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1899,12 +1899,12 @@ function isSqliteSidecarFile(name) {
 	return /\.sqlite-(?:shm|wal)$/i.test(name);
 }
 
-function isCodexThreadStateFile(name) {
+function isCodexRuntimeLocalSqliteFile(name) {
 	const normalizedName =
 		process.platform === "win32" || process.platform === "darwin"
 			? name.toLowerCase()
 			: name;
-	return /^state_\d+\.sqlite(?:-(?:shm|wal))?$/.test(normalizedName);
+	return /^(?:state|logs)_\d+\.sqlite(?:-(?:shm|wal))?$/.test(normalizedName);
 }
 
 function shouldMaterializeFileIntoShadowHome(name) {
@@ -2398,9 +2398,9 @@ function createRuntimeRotationProxyCodexHome(
 			shadowCodexHome,
 			tightenShadowHomePermissions,
 			{
-				skipMirrorPredicate: isCodexThreadStateFile,
+				skipMirrorPredicate: isCodexRuntimeLocalSqliteFile,
 				skipSyncBackNames: RUNTIME_ROTATION_SHADOW_HOME_OMIT_STATE_FILES,
-				skipSyncBackPredicate: isCodexThreadStateFile,
+				skipSyncBackPredicate: isCodexRuntimeLocalSqliteFile,
 			},
 		);
 		omitRuntimeRotationShadowHomeStateFiles(shadowCodexHome);

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1906,24 +1906,28 @@ function shouldMaterializeFileIntoShadowHome(name) {
 	return isSqliteMainFile(name) || isSqliteSidecarFile(name);
 }
 
+function warnSkippedSqliteShadowHomeMaterialization() {
+	if (!warnedShadowHomeSqliteLinkFailure) {
+		warnedShadowHomeSqliteLinkFailure = true;
+		console.error(
+			"codex-multi-auth: skipped SQLite shadow-home materialization because linking failed; refusing to copy active SQLite state.",
+		);
+	}
+}
+
 function materializeFileIntoShadowHome(sourcePath, destinationPath) {
 	try {
 		if (linkFileIntoShadowHome(sourcePath, destinationPath)) {
 			return true;
 		}
 		if (existsSync(sourcePath)) {
-			linkSync(sourcePath, destinationPath);
-			return true;
+			warnSkippedSqliteShadowHomeMaterialization();
+			return false;
 		}
 		symlinkSync(sourcePath, destinationPath, "file");
 		return true;
 	} catch {
-		if (!warnedShadowHomeSqliteLinkFailure) {
-			warnedShadowHomeSqliteLinkFailure = true;
-			console.error(
-				"codex-multi-auth: skipped SQLite shadow-home materialization because linking failed; refusing to copy active SQLite state.",
-			);
-		}
+		warnSkippedSqliteShadowHomeMaterialization();
 	}
 	return false;
 }
@@ -1942,6 +1946,7 @@ function materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath) {
 		try {
 			symlinkSync(sourceSidecarPath, destinationSidecarPath, "file");
 		} catch {
+			warnSkippedSqliteShadowHomeMaterialization();
 		}
 	}
 }

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1890,23 +1890,60 @@ function mirrorFileIntoShadowHome(sourcePath, destinationPath, tightenFile) {
 	tightenFile(destinationPath);
 }
 
+function isSqliteMainFile(name) {
+	return /\.sqlite$/i.test(name);
+}
+
+function isSqliteSidecarFile(name) {
+	return /\.sqlite-(?:shm|wal)$/i.test(name);
+}
+
+function isCodexThreadStateFile(name) {
+	return /^state_\d+\.sqlite(?:-(?:shm|wal))?$/i.test(name);
+}
+
 function shouldMaterializeFileIntoShadowHome(name) {
-	return /\.sqlite(?:-(?:shm|wal))?$/i.test(name);
+	return isSqliteMainFile(name) || isSqliteSidecarFile(name);
 }
 
 function materializeFileIntoShadowHome(sourcePath, destinationPath) {
 	try {
-		linkSync(sourcePath, destinationPath);
+		if (linkFileIntoShadowHome(sourcePath, destinationPath)) {
+			return true;
+		}
+		if (existsSync(sourcePath)) {
+			linkSync(sourcePath, destinationPath);
+			return true;
+		}
+		symlinkSync(sourcePath, destinationPath, "file");
 		return true;
 	} catch {
 		if (!warnedShadowHomeSqliteLinkFailure) {
 			warnedShadowHomeSqliteLinkFailure = true;
 			console.error(
-				"codex-multi-auth: skipped SQLite shadow-home materialization because hard-linking failed; refusing to copy active SQLite state.",
+				"codex-multi-auth: skipped SQLite shadow-home materialization because linking failed; refusing to copy active SQLite state.",
 			);
 		}
 	}
 	return false;
+}
+
+function materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath) {
+	for (const suffix of ["-wal", "-shm"]) {
+		const sourceSidecarPath = `${sourcePath}${suffix}`;
+		const destinationSidecarPath = `${destinationPath}${suffix}`;
+		if (existsSync(destinationSidecarPath)) {
+			continue;
+		}
+		if (existsSync(sourceSidecarPath)) {
+			materializeFileIntoShadowHome(sourceSidecarPath, destinationSidecarPath);
+			continue;
+		}
+		try {
+			symlinkSync(sourceSidecarPath, destinationSidecarPath, "file");
+		} catch {
+		}
+	}
 }
 
 function collectShadowHomeSyncFileNames(shadowCodexHome, syncFileNames) {
@@ -2020,7 +2057,11 @@ function syncAdditionalShadowHomeFiles(
 	skipSyncBackNames = new Set(),
 ) {
 	for (const name of names) {
-		if (SHADOW_HOME_STATE_FILE_SET.has(name) || skipSyncBackNames.has(name)) {
+		if (
+			SHADOW_HOME_STATE_FILE_SET.has(name) ||
+			skipSyncBackNames.has(name) ||
+			isCodexThreadStateFile(name)
+		) {
 			continue;
 		}
 		const shadowPath = join(shadowCodexHome, name);
@@ -2056,6 +2097,7 @@ function createShadowHomeMirror(
 ) {
 	const syncFileNames = new Set(SHADOW_HOME_STATE_FILES);
 	const skipSyncBackNames = new Set(options.skipSyncBackNames ?? []);
+	const skipMirrorNames = new Set(options.skipMirrorNames ?? []);
 	const originalFileStates = new Map();
 	const copiedDirectoryNames = new Set();
 	const rememberSyncFile = (name) => {
@@ -2077,7 +2119,8 @@ function createShadowHomeMirror(
 			if (
 				name === SHADOW_HOME_CONFIG_FILE ||
 				name === SHADOW_HOME_SYNC_STATE_FILE ||
-				name === SHADOW_HOME_SYNC_LOCK_DIR
+				name === SHADOW_HOME_SYNC_LOCK_DIR ||
+				skipMirrorNames.has(name)
 			) {
 				continue;
 			}
@@ -2112,7 +2155,9 @@ function createShadowHomeMirror(
 						copyFileSync(sourcePath, destinationPath);
 						tightenFile(destinationPath);
 					} else if (shouldMaterializeFile) {
-						materializeFileIntoShadowHome(sourcePath, destinationPath);
+						if (materializeFileIntoShadowHome(sourcePath, destinationPath) && isSqliteMainFile(name)) {
+							materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath);
+						}
 					} else {
 						mirrorFileIntoShadowHome(sourcePath, destinationPath, tightenFile);
 					}
@@ -2316,6 +2361,11 @@ function createRuntimeRotationProxyCodexHome(
 			shadowCodexHome,
 			tightenShadowHomePermissions,
 			{
+				skipMirrorNames: new Set(
+					existsSync(originalCodexHome)
+						? readdirSync(originalCodexHome).filter(isCodexThreadStateFile)
+						: [],
+				),
 				skipSyncBackNames: RUNTIME_ROTATION_SHADOW_HOME_OMIT_STATE_FILES,
 			},
 		);

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -2021,15 +2021,26 @@ function materializeSqliteSidecarPlaceholder(sourceSidecarPath, destinationSidec
 			throw error;
 		}
 		symlinkSync(sourceSidecarPath, destinationSidecarPath, "file");
+		return true;
 	} catch (error) {
-		if (error?.code !== "EEXIST") {
-			warnSkippedSqliteShadowHomeSidecarPlaceholder(error, destinationSidecarPath);
+		if (error?.code === "EEXIST") {
+			return true;
 		}
+		warnSkippedSqliteShadowHomeSidecarPlaceholder(error, destinationSidecarPath);
+		return false;
 	}
 }
 
 function materializeFileIntoShadowHome(sourcePath, destinationPath) {
 	try {
+		if (
+			(process.env.CODEX_MULTI_AUTH_TEST_FORCE_SHADOW_SQLITE_SIDECAR_LINK_FAILURE ??
+				""
+			).trim() === "1" &&
+			isSqliteSidecarFile(basename(sourcePath))
+		) {
+			throw new Error("simulated SQLite sidecar link failure");
+		}
 		if (linkFileIntoShadowHome(sourcePath, destinationPath)) {
 			return true;
 		}
@@ -2049,14 +2060,28 @@ function materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath) {
 		}
 		if (existsSync(sourceSidecarPath)) {
 			if (!materializeFileIntoShadowHome(sourceSidecarPath, destinationSidecarPath)) {
-				materializeSqliteSidecarPlaceholder(
+				if (!materializeSqliteSidecarPlaceholder(
 					sourceSidecarPath,
 					destinationSidecarPath,
-				);
+				)) {
+					return false;
+				}
 			}
 			continue;
 		}
-		materializeSqliteSidecarPlaceholder(sourceSidecarPath, destinationSidecarPath);
+		if (!materializeSqliteSidecarPlaceholder(sourceSidecarPath, destinationSidecarPath)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function removeSqliteShadowHomeMaterialization(destinationPath) {
+	for (const path of [destinationPath, `${destinationPath}-wal`, `${destinationPath}-shm`]) {
+		try {
+			rmSync(path, { force: true });
+		} catch {
+		}
 	}
 }
 
@@ -2282,8 +2307,13 @@ function createShadowHomeMirror(
 						copyFileSync(sourcePath, destinationPath);
 						tightenFile(destinationPath);
 					} else if (shouldMaterializeFile) {
+						if (isSqliteSidecarFile(name)) {
+							continue;
+						}
 						if (materializeFileIntoShadowHome(sourcePath, destinationPath) && isSqliteMainFile(name)) {
-							materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath);
+							if (!materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath)) {
+								removeSqliteShadowHomeMaterialization(destinationPath);
+							}
 						}
 					} else {
 						mirrorFileIntoShadowHome(sourcePath, destinationPath, tightenFile);

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -2081,6 +2081,7 @@ function removeSqliteShadowHomeMaterialization(destinationPath) {
 		try {
 			rmSync(path, { force: true });
 		} catch {
+			// Best-effort cleanup; keep removing the remaining SQLite siblings.
 		}
 	}
 }

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -90,7 +90,7 @@ const shadowHomeCleanupRetryMarkerDir =
 let warnedInvalidRuntimeRotationProxyEnv = false;
 let warnedPendingAccountReadIdOverflow = false;
 let warnedShadowHomeSqliteLinkFailure = false;
-let warnedShadowHomeSqliteSidecarPlaceholderFailure = false;
+const warnedShadowHomeSqliteSidecarPlaceholderFailures = new Set();
 
 async function loadRuntimeConstants() {
 	const fallback = {
@@ -1916,12 +1916,31 @@ function warnSkippedSqliteShadowHomeMaterialization() {
 	}
 }
 
-function warnSkippedSqliteShadowHomeSidecarPlaceholder(error) {
-	if (!warnedShadowHomeSqliteSidecarPlaceholderFailure) {
-		warnedShadowHomeSqliteSidecarPlaceholderFailure = true;
+function warnSkippedSqliteShadowHomeSidecarPlaceholder(error, destinationPath) {
+	if (!warnedShadowHomeSqliteSidecarPlaceholderFailures.has(destinationPath)) {
+		warnedShadowHomeSqliteSidecarPlaceholderFailures.add(destinationPath);
 		console.error(
-			`codex-multi-auth: skipped SQLite shadow-home sidecar placeholder because linking failed: ${error instanceof Error ? error.message : String(error)}`,
+			`codex-multi-auth: skipped SQLite shadow-home sidecar placeholder for ${destinationPath} because linking failed: ${error instanceof Error ? error.message : String(error)}`,
 		);
+	}
+}
+
+function materializeSqliteSidecarPlaceholder(sourceSidecarPath, destinationSidecarPath) {
+	try {
+		if (
+			(process.env.CODEX_MULTI_AUTH_TEST_FORCE_SHADOW_SIDECAR_PLACEHOLDER_FAILURE ??
+				""
+			).trim() === "1"
+		) {
+			const error = new Error("simulated SQLite sidecar placeholder failure");
+			error.code = "EPERM";
+			throw error;
+		}
+		symlinkSync(sourceSidecarPath, destinationSidecarPath, "file");
+	} catch (error) {
+		if (error?.code !== "EEXIST") {
+			warnSkippedSqliteShadowHomeSidecarPlaceholder(error, destinationSidecarPath);
+		}
 	}
 }
 
@@ -1945,16 +1964,15 @@ function materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath) {
 			continue;
 		}
 		if (existsSync(sourceSidecarPath)) {
-			materializeFileIntoShadowHome(sourceSidecarPath, destinationSidecarPath);
+			if (!materializeFileIntoShadowHome(sourceSidecarPath, destinationSidecarPath)) {
+				materializeSqliteSidecarPlaceholder(
+					sourceSidecarPath,
+					destinationSidecarPath,
+				);
+			}
 			continue;
 		}
-		try {
-			symlinkSync(sourceSidecarPath, destinationSidecarPath, "file");
-		} catch (error) {
-			if (error?.code !== "EEXIST") {
-				warnSkippedSqliteShadowHomeSidecarPlaceholder(error);
-			}
-		}
+		materializeSqliteSidecarPlaceholder(sourceSidecarPath, destinationSidecarPath);
 	}
 }
 

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1941,7 +1941,6 @@ function materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath) {
 		try {
 			symlinkSync(sourceSidecarPath, destinationSidecarPath, "file");
 		} catch {
-			warnSkippedSqliteShadowHomeMaterialization();
 		}
 	}
 }

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1920,12 +1920,7 @@ function materializeFileIntoShadowHome(sourcePath, destinationPath) {
 		if (linkFileIntoShadowHome(sourcePath, destinationPath)) {
 			return true;
 		}
-		if (existsSync(sourcePath)) {
-			warnSkippedSqliteShadowHomeMaterialization();
-			return false;
-		}
-		symlinkSync(sourcePath, destinationPath, "file");
-		return true;
+		warnSkippedSqliteShadowHomeMaterialization();
 	} catch {
 		warnSkippedSqliteShadowHomeMaterialization();
 	}
@@ -2060,12 +2055,13 @@ function syncAdditionalShadowHomeFiles(
 	originalFileStates,
 	tightenFile,
 	skipSyncBackNames = new Set(),
+	skipSyncBackPredicate = () => false,
 ) {
 	for (const name of names) {
 		if (
 			SHADOW_HOME_STATE_FILE_SET.has(name) ||
 			skipSyncBackNames.has(name) ||
-			isCodexThreadStateFile(name)
+			skipSyncBackPredicate(name)
 		) {
 			continue;
 		}
@@ -2102,7 +2098,8 @@ function createShadowHomeMirror(
 ) {
 	const syncFileNames = new Set(SHADOW_HOME_STATE_FILES);
 	const skipSyncBackNames = new Set(options.skipSyncBackNames ?? []);
-	const skipMirrorNames = new Set(options.skipMirrorNames ?? []);
+	const skipMirrorPredicate = options.skipMirrorPredicate ?? (() => false);
+	const skipSyncBackPredicate = options.skipSyncBackPredicate ?? (() => false);
 	const originalFileStates = new Map();
 	const copiedDirectoryNames = new Set();
 	const rememberSyncFile = (name) => {
@@ -2125,7 +2122,7 @@ function createShadowHomeMirror(
 				name === SHADOW_HOME_CONFIG_FILE ||
 				name === SHADOW_HOME_SYNC_STATE_FILE ||
 				name === SHADOW_HOME_SYNC_LOCK_DIR ||
-				skipMirrorNames.has(name)
+				skipMirrorPredicate(name)
 			) {
 				continue;
 			}
@@ -2201,6 +2198,7 @@ function createShadowHomeMirror(
 				originalFileStates,
 				tightenFile,
 				skipSyncBackNames,
+				skipSyncBackPredicate,
 			);
 		} catch {
 			// Best-effort only; runtime auth refreshes should not fail cleanup.
@@ -2366,12 +2364,9 @@ function createRuntimeRotationProxyCodexHome(
 			shadowCodexHome,
 			tightenShadowHomePermissions,
 			{
-				skipMirrorNames: new Set(
-					existsSync(originalCodexHome)
-						? readdirSync(originalCodexHome).filter(isCodexThreadStateFile)
-						: [],
-				),
+				skipMirrorPredicate: isCodexThreadStateFile,
 				skipSyncBackNames: RUNTIME_ROTATION_SHADOW_HOME_OMIT_STATE_FILES,
+				skipSyncBackPredicate: isCodexThreadStateFile,
 			},
 		);
 		omitRuntimeRotationShadowHomeStateFiles(shadowCodexHome);

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -90,6 +90,7 @@ const shadowHomeCleanupRetryMarkerDir =
 let warnedInvalidRuntimeRotationProxyEnv = false;
 let warnedPendingAccountReadIdOverflow = false;
 let warnedShadowHomeSqliteLinkFailure = false;
+let warnedShadowHomeSqliteSidecarPlaceholderFailure = false;
 
 async function loadRuntimeConstants() {
 	const fallback = {
@@ -1899,7 +1900,7 @@ function isSqliteSidecarFile(name) {
 }
 
 function isCodexThreadStateFile(name) {
-	return /^state_\d+\.sqlite(?:-(?:shm|wal))?$/i.test(name);
+	return /^state_\d+\.sqlite(?:-(?:shm|wal))?$/.test(name);
 }
 
 function shouldMaterializeFileIntoShadowHome(name) {
@@ -1911,6 +1912,15 @@ function warnSkippedSqliteShadowHomeMaterialization() {
 		warnedShadowHomeSqliteLinkFailure = true;
 		console.error(
 			"codex-multi-auth: skipped SQLite shadow-home materialization because linking failed; refusing to copy active SQLite state.",
+		);
+	}
+}
+
+function warnSkippedSqliteShadowHomeSidecarPlaceholder(error) {
+	if (!warnedShadowHomeSqliteSidecarPlaceholderFailure) {
+		warnedShadowHomeSqliteSidecarPlaceholderFailure = true;
+		console.error(
+			`codex-multi-auth: skipped SQLite shadow-home sidecar placeholder because linking failed: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	}
 }
@@ -1940,7 +1950,10 @@ function materializeSqliteSidecarsIntoShadowHome(sourcePath, destinationPath) {
 		}
 		try {
 			symlinkSync(sourceSidecarPath, destinationSidecarPath, "file");
-		} catch {
+		} catch (error) {
+			if (error?.code !== "EEXIST") {
+				warnSkippedSqliteShadowHomeSidecarPlaceholder(error);
+			}
 		}
 	}
 }

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -42,6 +42,22 @@ const RUNTIME_ROTATION_SHADOW_HOME_OMIT_STATE_FILES = new Set([
 	"accounts.json",
 ]);
 const RUNTIME_ROTATION_SHADOW_HOME_OMIT_ROOT_DIRS = new Set(["multi-auth"]);
+const RUNTIME_ROTATION_SHADOW_HOME_LINK_ONLY_ROOT_DIRS = new Set([
+	".sandbox",
+	".sandbox-bin",
+	".sandbox-secrets",
+	".tmp",
+	"ambient-suggestions",
+	"archived_sessions",
+	"backups",
+	"cache",
+	"generated_images",
+	"log",
+	"sqlite",
+	"tmp",
+	"understand-anything",
+	"vendor_imports",
+]);
 const SHADOW_HOME_STATE_FILE_SET = new Set(SHADOW_HOME_STATE_FILES);
 const SHADOW_HOME_CONFIG_FILE = "config.toml";
 const SHADOW_HOME_SYNC_LOCK_DIR = ".codex-multi-auth-shadow-sync.lock";
@@ -91,6 +107,7 @@ const shadowHomeCleanupRetryMarkerDir =
 let warnedInvalidRuntimeRotationProxyEnv = false;
 let warnedPendingAccountReadIdOverflow = false;
 let warnedShadowHomeSqliteLinkFailure = false;
+const warnedShadowHomeLinkOnlyDirectoryFailures = new Set();
 const warnedShadowHomeSqliteSidecarPlaceholderFailures = new Set();
 
 async function loadRuntimeConstants() {
@@ -1868,6 +1885,41 @@ function mirrorDirectoryIntoShadowHome(sourcePath, destinationPath) {
 	return "copied";
 }
 
+function linkDirectoryIntoShadowHome(sourcePath, destinationPath) {
+	try {
+		if ((process.env.CODEX_MULTI_AUTH_TEST_FORCE_SHADOW_DIR_COPY ?? "").trim() === "1") {
+			throw new Error("simulated directory link failure");
+		}
+		symlinkSync(
+			sourcePath,
+			destinationPath,
+			process.platform === "win32" ? "junction" : "dir",
+		);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function warnSkippedLinkOnlyShadowHomeDirectory(name) {
+	if (warnedShadowHomeLinkOnlyDirectoryFailures.has(name)) {
+		return;
+	}
+	warnedShadowHomeLinkOnlyDirectoryFailures.add(name);
+	console.error(
+		`codex-multi-auth: skipped optional shadow-home directory ${name} because linking failed; refusing to copy generated runtime data.`,
+	);
+}
+
+function shouldCopyRuntimeGeneratedShadowHomeDirectoryFallback() {
+	const normalized = (
+		process.env.CODEX_MULTI_AUTH_RUNTIME_SHADOW_COPY_GENERATED_DIRS ?? ""
+	)
+		.trim()
+		.toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 function linkFileIntoShadowHome(sourcePath, destinationPath) {
 	try {
 		symlinkSync(sourcePath, destinationPath, "file");
@@ -1913,8 +1965,11 @@ function isCodexRuntimeLocalSqliteFile(name) {
 
 function isCodexRuntimeTransientStateFile(name) {
 	const normalizedName = normalizeRuntimeShadowHomeEntryName(name);
-	return /^(?:auth|accounts)\.json\.\d+\.[a-z0-9]+\.tmp$/.test(
-		normalizedName,
+	return (
+		/^(?:auth|accounts)\.json\.\d+\.[a-z0-9]+\.tmp$/.test(
+			normalizedName,
+		) ||
+		/^\.codex-global-state\.json\.tmp-[a-z0-9-]+$/.test(normalizedName)
 	);
 }
 
@@ -1925,6 +1980,11 @@ function isRuntimeRotationShadowHomeOmittedEntry(name) {
 		isCodexRuntimeLocalSqliteFile(name) ||
 		isCodexRuntimeTransientStateFile(name)
 	);
+}
+
+function isRuntimeRotationShadowHomeLinkOnlyDirectory(name) {
+	const normalizedName = normalizeRuntimeShadowHomeEntryName(name);
+	return RUNTIME_ROTATION_SHADOW_HOME_LINK_ONLY_ROOT_DIRS.has(normalizedName);
 }
 
 function shouldMaterializeFileIntoShadowHome(name) {
@@ -2154,6 +2214,8 @@ function createShadowHomeMirror(
 	const skipSyncBackNames = new Set(options.skipSyncBackNames ?? []);
 	const skipMirrorPredicate = options.skipMirrorPredicate ?? (() => false);
 	const skipSyncBackPredicate = options.skipSyncBackPredicate ?? (() => false);
+	const linkOnlyDirectoryPredicate =
+		options.linkOnlyDirectoryPredicate ?? (() => false);
 	const originalFileStates = new Map();
 	const copiedDirectoryNames = new Set();
 	const rememberSyncFile = (name) => {
@@ -2200,6 +2262,15 @@ function createShadowHomeMirror(
 					throw new Error(`Expected ${name} to be a file`);
 				}
 				if (directoryLike) {
+					if (
+						linkOnlyDirectoryPredicate(name) &&
+						!shouldCopyRuntimeGeneratedShadowHomeDirectoryFallback()
+					) {
+						if (!linkDirectoryIntoShadowHome(sourcePath, destinationPath)) {
+							warnSkippedLinkOnlyShadowHomeDirectory(name);
+						}
+						continue;
+					}
 					if (mirrorDirectoryIntoShadowHome(sourcePath, destinationPath) === "copied") {
 						copiedDirectoryNames.add(name);
 					}
@@ -2307,6 +2378,10 @@ function resolveOriginalMultiAuthDir(env) {
 		return explicit;
 	}
 	return undefined;
+}
+
+function resolveRuntimeRotationOriginalMultiAuthDir(originalCodexHome, env) {
+	return resolveOriginalMultiAuthDir(env) ?? join(originalCodexHome, "multi-auth");
 }
 
 function parseRuntimeRotationProxyEnv(value) {
@@ -2421,6 +2496,7 @@ function createRuntimeRotationProxyCodexHome(
 				skipMirrorPredicate: isRuntimeRotationShadowHomeOmittedEntry,
 				skipSyncBackNames: RUNTIME_ROTATION_SHADOW_HOME_OMIT_STATE_FILES,
 				skipSyncBackPredicate: isRuntimeRotationShadowHomeOmittedEntry,
+				linkOnlyDirectoryPredicate: isRuntimeRotationShadowHomeLinkOnlyDirectory,
 			},
 		);
 		omitRuntimeRotationShadowHomeStateFiles(shadowCodexHome);
@@ -2445,11 +2521,11 @@ function createRuntimeRotationProxyCodexHome(
 		...baseEnv,
 		CODEX_HOME: shadowCodexHome,
 		OPENAI_API_KEY: clientApiKey,
+		CODEX_MULTI_AUTH_DIR: resolveRuntimeRotationOriginalMultiAuthDir(
+			originalCodexHome,
+			baseEnv,
+		),
 	};
-	const originalMultiAuthDir = resolveOriginalMultiAuthDir(baseEnv);
-	if (originalMultiAuthDir) {
-		forwardedEnv.CODEX_MULTI_AUTH_DIR = originalMultiAuthDir;
-	}
 
 	return {
 		env: forwardedEnv,
@@ -2904,6 +2980,10 @@ function startRuntimeRotationAppHelper(baseContext) {
 			{
 				env: {
 					...baseContext.env,
+					CODEX_MULTI_AUTH_DIR: resolveRuntimeRotationOriginalMultiAuthDir(
+						realCodexHome,
+						baseContext.env,
+					),
 					[APP_RUNTIME_HELPER_OWNER_PID_ENV]: String(process.pid),
 					[APP_RUNTIME_HELPER_REAL_CODEX_HOME_ENV]: realCodexHome,
 				},
@@ -3632,6 +3712,8 @@ function repairCodexSessionIndex(codexHome) {
 
 		const additions = [];
 		for (const rolloutPath of collectRolloutFiles(sessionsDir)) {
+			const idFromName = extractRolloutIdFromFilename(basename(rolloutPath));
+			if (idFromName && seen.has(idFromName)) continue;
 			const entry = parseRolloutIndexEntry(rolloutPath);
 			if (!entry || seen.has(entry.id)) continue;
 			seen.add(entry.id);

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -1900,7 +1900,11 @@ function isSqliteSidecarFile(name) {
 }
 
 function isCodexThreadStateFile(name) {
-	return /^state_\d+\.sqlite(?:-(?:shm|wal))?$/.test(name);
+	const normalizedName =
+		process.platform === "win32" || process.platform === "darwin"
+			? name.toLowerCase()
+			: name;
+	return /^state_\d+\.sqlite(?:-(?:shm|wal))?$/.test(normalizedName);
 }
 
 function shouldMaterializeFileIntoShadowHome(name) {

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1068,9 +1068,7 @@ describe("codex bin wrapper", () => {
 			'const cacheShmPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-shm");',
 			'console.log(`CACHE_SQLITE_MIRRORED:${fs.existsSync(cachePath)}`);',
 			'console.log(`CACHE_WAL_MIRRORED:${fs.existsSync(cacheWalPath)}`);',
-			'let cacheShmPlaceholder = "false";',
-			'try { cacheShmPlaceholder = String(fs.lstatSync(cacheShmPath).isSymbolicLink()); } catch { cacheShmPlaceholder = process.platform === "win32" ? "skipped" : "false"; }',
-			'console.log(`CACHE_SHM_PLACEHOLDER:${cacheShmPlaceholder}`);',
+			'console.log(`CACHE_SHM_MIRRORED:${fs.existsSync(cacheShmPath)}`);',
 			'const logPath = path.join(process.env.CODEX_HOME ?? "", "logs_2.sqlite");',
 			'const logWalPath = path.join(process.env.CODEX_HOME ?? "", "logs_2.sqlite-wal");',
 			'const logShmPath = path.join(process.env.CODEX_HOME ?? "", "logs_2.sqlite-shm");',
@@ -1176,6 +1174,7 @@ describe("codex bin wrapper", () => {
 		writeFileSync(join(originalHome, "LOGS_3.sqlite"), "upper log\n", "utf8");
 		writeFileSync(join(originalHome, "plugin_cache.sqlite"), "cache\n", "utf8");
 		writeFileSync(join(originalHome, "plugin_cache.sqlite-wal"), "cache wal\n", "utf8");
+		writeFileSync(join(originalHome, "plugin_cache.sqlite-shm"), "cache shm\n", "utf8");
 		writeFileSync(
 			join(originalHome, "config.toml"),
 			[
@@ -1228,7 +1227,7 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("GLOBAL_STATE_TMP_ISOLATED:true");
 		expect(output).toContain("CACHE_SQLITE_MIRRORED:true");
 		expect(output).toContain("CACHE_WAL_MIRRORED:true");
-		expect(output).toMatch(/^CACHE_SHM_PLACEHOLDER:(?:true|skipped)$/m);
+		expect(output).toContain("CACHE_SHM_MIRRORED:true");
 		expect(output).toContain("LOG_SQLITE_MIRRORED:false");
 		expect(output).toContain("LOG_WAL_MIRRORED:false");
 		expect(output).toContain("LOG_SHM_MIRRORED:false");
@@ -1368,10 +1367,57 @@ describe("codex bin wrapper", () => {
 			"#!/usr/bin/env node",
 			'const fs = require("node:fs");',
 			'const path = require("node:path");',
+			'const cachePath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite");',
+			'const cacheWalPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-wal");',
 			'const cacheShmPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-shm");',
-			'let cacheShmPlaceholder = "false";',
-			'try { cacheShmPlaceholder = String(fs.lstatSync(cacheShmPath).isSymbolicLink()); } catch { cacheShmPlaceholder = "false"; }',
-			'console.log(`CACHE_SHM_PLACEHOLDER:${cacheShmPlaceholder}`);',
+			'console.log(`CACHE_SQLITE_MIRRORED:${fs.existsSync(cachePath)}`);',
+			'console.log(`CACHE_WAL_MIRRORED:${fs.existsSync(cacheWalPath)}`);',
+			'console.log(`CACHE_SHM_MIRRORED:${fs.existsSync(cacheShmPath)}`);',
+			"process.exit(0);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const markerPath = join(fixtureRoot, "proxy-marker.txt");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "plugin_cache.sqlite"), "cache\n", "utf8");
+		writeFileSync(join(originalHome, "plugin_cache.sqlite-wal"), "cache wal\n", "utf8");
+		writeFileSync(join(originalHome, "plugin_cache.sqlite-shm"), "cache shm\n", "utf8");
+
+		const result = runWrapper(fixtureRoot, ["exec", "status"], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_HOME: originalHome,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+			CODEX_MULTI_AUTH_TEST_PROXY_BASE_URL: "http://127.0.0.1:4567",
+			CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+			CODEX_MULTI_AUTH_TEST_FORCE_SHADOW_SQLITE_SIDECAR_LINK_FAILURE: "1",
+			CODEX_MULTI_AUTH_TEST_FORCE_SHADOW_SIDECAR_PLACEHOLDER_FAILURE: "1",
+			OPENAI_API_KEY: undefined,
+		});
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(0);
+		expect(output).toContain("CACHE_SQLITE_MIRRORED:false");
+		expect(output).toContain("CACHE_WAL_MIRRORED:false");
+		expect(output).toContain("CACHE_SHM_MIRRORED:false");
+		expect(output).toContain(
+			"codex-multi-auth: skipped SQLite shadow-home sidecar placeholder for",
+		);
+		expect(output).toContain("plugin_cache.sqlite-wal");
+		expect(output).toContain("simulated SQLite sidecar placeholder failure");
+	});
+
+	it("removes sqlite materialization when a missing sidecar placeholder fails", () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
+			'const cachePath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite");',
+			'const cacheWalPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-wal");',
+			'const cacheShmPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-shm");',
+			'console.log(`CACHE_SQLITE_MIRRORED:${fs.existsSync(cachePath)}`);',
+			'console.log(`CACHE_WAL_MIRRORED:${fs.existsSync(cacheWalPath)}`);',
+			'console.log(`CACHE_SHM_MIRRORED:${fs.existsSync(cacheShmPath)}`);',
 			"process.exit(0);",
 		]);
 		const originalHome = join(fixtureRoot, "codex-home");
@@ -1392,7 +1438,9 @@ describe("codex bin wrapper", () => {
 
 		const output = combinedOutput(result);
 		expect(result.status).toBe(0);
-		expect(output).toContain("CACHE_SHM_PLACEHOLDER:false");
+		expect(output).toContain("CACHE_SQLITE_MIRRORED:false");
+		expect(output).toContain("CACHE_WAL_MIRRORED:false");
+		expect(output).toContain("CACHE_SHM_MIRRORED:false");
 		expect(output).toContain(
 			"codex-multi-auth: skipped SQLite shadow-home sidecar placeholder for",
 		);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1127,6 +1127,45 @@ describe("codex bin wrapper", () => {
 		).toBe('{"last":"runtime"}');
 	});
 
+	it("warns when sqlite sidecar placeholder materialization fails", () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
+			'const cacheShmPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-shm");',
+			'let cacheShmPlaceholder = "false";',
+			'try { cacheShmPlaceholder = String(fs.lstatSync(cacheShmPath).isSymbolicLink()); } catch { cacheShmPlaceholder = "false"; }',
+			'console.log(`CACHE_SHM_PLACEHOLDER:${cacheShmPlaceholder}`);',
+			"process.exit(0);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const markerPath = join(fixtureRoot, "proxy-marker.txt");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "plugin_cache.sqlite"), "cache\n", "utf8");
+		writeFileSync(join(originalHome, "plugin_cache.sqlite-wal"), "cache wal\n", "utf8");
+
+		const result = runWrapper(fixtureRoot, ["exec", "status"], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_HOME: originalHome,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+			CODEX_MULTI_AUTH_TEST_PROXY_BASE_URL: "http://127.0.0.1:4567",
+			CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+			CODEX_MULTI_AUTH_TEST_FORCE_SHADOW_SIDECAR_PLACEHOLDER_FAILURE: "1",
+			OPENAI_API_KEY: undefined,
+		});
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(0);
+		expect(output).toContain("CACHE_SHM_PLACEHOLDER:false");
+		expect(output).toContain(
+			"codex-multi-auth: skipped SQLite shadow-home sidecar placeholder for",
+		);
+		expect(output).toContain("plugin_cache.sqlite-shm");
+		expect(output).toContain("simulated SQLite sidecar placeholder failure");
+	});
+
 	it("inserts the runtime model provider before TOML array tables", () => {
 		const fixtureRoot = createWrapperFixture();
 		createRuntimeRotationProxyFixtureModule(fixtureRoot);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -952,6 +952,17 @@ describe("codex bin wrapper", () => {
 			'let cacheShmPlaceholder = "false";',
 			'try { cacheShmPlaceholder = String(fs.lstatSync(cacheShmPath).isSymbolicLink()); } catch { cacheShmPlaceholder = process.platform === "win32" ? "skipped" : "false"; }',
 			'console.log(`CACHE_SHM_PLACEHOLDER:${cacheShmPlaceholder}`);',
+			'const logPath = path.join(process.env.CODEX_HOME ?? "", "logs_2.sqlite");',
+			'const logWalPath = path.join(process.env.CODEX_HOME ?? "", "logs_2.sqlite-wal");',
+			'const logShmPath = path.join(process.env.CODEX_HOME ?? "", "logs_2.sqlite-shm");',
+			'const originalLogPath = path.join(process.env.ORIGINAL_CODEX_HOME ?? "", "logs_2.sqlite");',
+			'console.log(`LOG_SQLITE_MIRRORED:${fs.existsSync(logPath)}`);',
+			'console.log(`LOG_WAL_MIRRORED:${fs.existsSync(logWalPath)}`);',
+			'console.log(`LOG_SHM_MIRRORED:${fs.existsSync(logShmPath)}`);',
+			'fs.writeFileSync(logPath, "shadow-log\\n", "utf8");',
+			'fs.writeFileSync(logWalPath, "shadow-log-wal\\n", "utf8");',
+			'fs.writeFileSync(logShmPath, "shadow-log-shm\\n", "utf8");',
+			'console.log(`LOG_SQLITE_ISOLATED:${!fs.readFileSync(originalLogPath, "utf8").includes("shadow-log")}`);',
 			'fs.appendFileSync(cachePath, "shadow-cache\\n", "utf8");',
 			'fs.appendFileSync(cacheWalPath, "shadow-wal\\n", "utf8");',
 			'const upperStatePath = path.join(process.env.CODEX_HOME ?? "", "STATE_6.sqlite");',
@@ -1009,6 +1020,9 @@ describe("codex bin wrapper", () => {
 		writeFileSync(join(originalHome, "state_5.sqlite-wal"), "original wal\n", "utf8");
 		writeFileSync(join(originalHome, "state_5.sqlite-shm"), "original shm\n", "utf8");
 		writeFileSync(join(originalHome, "STATE_6.sqlite"), "upper state\n", "utf8");
+		writeFileSync(join(originalHome, "logs_2.sqlite"), "original log\n", "utf8");
+		writeFileSync(join(originalHome, "logs_2.sqlite-wal"), "original log wal\n", "utf8");
+		writeFileSync(join(originalHome, "logs_2.sqlite-shm"), "original log shm\n", "utf8");
 		writeFileSync(join(originalHome, "plugin_cache.sqlite"), "cache\n", "utf8");
 		writeFileSync(join(originalHome, "plugin_cache.sqlite-wal"), "cache wal\n", "utf8");
 		writeFileSync(
@@ -1052,6 +1066,10 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("CACHE_SQLITE_MIRRORED:true");
 		expect(output).toContain("CACHE_WAL_MIRRORED:true");
 		expect(output).toMatch(/^CACHE_SHM_PLACEHOLDER:(?:true|skipped)$/m);
+		expect(output).toContain("LOG_SQLITE_MIRRORED:false");
+		expect(output).toContain("LOG_WAL_MIRRORED:false");
+		expect(output).toContain("LOG_SHM_MIRRORED:false");
+		expect(output).toContain("LOG_SQLITE_ISOLATED:true");
 		expect(output).toContain(
 			`UPPER_STATE_MIRRORED:${process.platform === "win32" || process.platform === "darwin" ? "false" : "true"}`,
 		);
@@ -1105,6 +1123,15 @@ describe("codex bin wrapper", () => {
 		);
 		expect(readFileSync(join(originalHome, "state_5.sqlite-shm"), "utf8")).toBe(
 			"original shm\n",
+		);
+		expect(readFileSync(join(originalHome, "logs_2.sqlite"), "utf8")).toBe(
+			"original log\n",
+		);
+		expect(readFileSync(join(originalHome, "logs_2.sqlite-wal"), "utf8")).toBe(
+			"original log wal\n",
+		);
+		expect(readFileSync(join(originalHome, "logs_2.sqlite-shm"), "utf8")).toBe(
+			"original log shm\n",
 		);
 		if (process.platform === "win32" || process.platform === "darwin") {
 			expect(readFileSync(join(originalHome, "STATE_6.sqlite"), "utf8")).toBe(

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -945,9 +945,10 @@ describe("codex bin wrapper", () => {
 			'console.log(`MEMORY_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "memories", "user.md"))}`);',
 			'console.log(`INSTRUCTION_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "instructions", "profile.md"))}`);',
 			'const statePath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite");',
-			'console.log(`ROOT_STATE_SYMLINK:${fs.lstatSync(statePath).isSymbolicLink()}`);',
-			'fs.appendFileSync(statePath, "shadow\\n", "utf8");',
-			'console.log(`ROOT_STATE_REALTIME:${fs.readFileSync(path.join(process.env.ORIGINAL_CODEX_HOME ?? "", "state_5.sqlite"), "utf8").includes("shadow")}`);',
+			'const originalStatePath = path.join(process.env.ORIGINAL_CODEX_HOME ?? "", "state_5.sqlite");',
+			'console.log(`ROOT_STATE_MIRRORED:${fs.existsSync(statePath)}`);',
+			'fs.writeFileSync(statePath, "shadow-only\\n", "utf8");',
+			'console.log(`ROOT_STATE_ISOLATED:${!fs.readFileSync(originalStatePath, "utf8").includes("shadow-only")}`);',
 			'fs.writeFileSync(path.join(process.env.CODEX_HOME ?? "", "new-root-state.json"), "new\\n", "utf8");',
 			'fs.writeFileSync(path.join(process.env.CODEX_HOME ?? "", "sessions", "runtime-session.jsonl"), "runtime\\n", "utf8");',
 			'fs.writeFileSync(path.join(process.env.CODEX_HOME ?? "", "auth.json"), \'{"token":"proxy-scoped"}\\n\', "utf8");',
@@ -1026,8 +1027,8 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("SKILL_EXISTS:true");
 		expect(output).toContain("MEMORY_EXISTS:true");
 		expect(output).toContain("INSTRUCTION_EXISTS:true");
-		expect(output).toContain("ROOT_STATE_SYMLINK:false");
-		expect(output).toContain("ROOT_STATE_REALTIME:true");
+		expect(output).toContain("ROOT_STATE_MIRRORED:false");
+		expect(output).toContain("ROOT_STATE_ISOLATED:true");
 		const apiKeyMatch = output.match(/^OPENAI_API_KEY:([0-9a-f]{64})$/m);
 		expect(apiKeyMatch?.[1]).toBeTruthy();
 		expect(output).toContain(
@@ -1066,9 +1067,7 @@ describe("codex bin wrapper", () => {
 		expect(
 			readFileSync(join(originalHome, "sessions", "runtime-session.jsonl"), "utf8"),
 		).toBe("runtime\n");
-		expect(readFileSync(join(originalHome, "state_5.sqlite"), "utf8")).toContain(
-			"shadow",
-		);
+		expect(readFileSync(join(originalHome, "state_5.sqlite"), "utf8")).toBe("state\n");
 		expect(readFileSync(join(originalHome, "new-root-state.json"), "utf8")).toBe(
 			"new\n",
 		);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -944,6 +944,12 @@ describe("codex bin wrapper", () => {
 			'console.log(`SKILL_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "skills", "skill.txt"))}`);',
 			'console.log(`MEMORY_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "memories", "user.md"))}`);',
 			'console.log(`INSTRUCTION_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "instructions", "profile.md"))}`);',
+			'console.log(`MULTI_AUTH_MIRRORED:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "multi-auth"))}`);',
+			'const authTmpPath = path.join(process.env.CODEX_HOME ?? "", "auth.json.1772056142508.3nwgwa.tmp");',
+			'const originalAuthTmpPath = path.join(process.env.ORIGINAL_CODEX_HOME ?? "", "auth.json.1772056142508.3nwgwa.tmp");',
+			'console.log(`AUTH_TMP_MIRRORED:${fs.existsSync(authTmpPath)}`);',
+			'fs.writeFileSync(authTmpPath, "shadow-auth-tmp\\n", "utf8");',
+			'console.log(`AUTH_TMP_ISOLATED:${!fs.readFileSync(originalAuthTmpPath, "utf8").includes("shadow-auth-tmp")}`);',
 			'const cachePath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite");',
 			'const cacheWalPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-wal");',
 			'const cacheShmPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-shm");',
@@ -996,11 +1002,24 @@ describe("codex bin wrapper", () => {
 		mkdirSync(join(originalHome, "skills"), { recursive: true });
 		mkdirSync(join(originalHome, "memories"), { recursive: true });
 		mkdirSync(join(originalHome, "instructions"), { recursive: true });
+		mkdirSync(join(originalHome, "multi-auth", "runtime-shadow-homes", "stale"), {
+			recursive: true,
+		});
 		writeFileSync(join(originalHome, "sessions", "resume.jsonl"), "resume\n", "utf8");
 		writeFileSync(join(originalHome, "plugins", "plugin.txt"), "plugin\n", "utf8");
 		writeFileSync(join(originalHome, "skills", "skill.txt"), "skill\n", "utf8");
 		writeFileSync(join(originalHome, "memories", "user.md"), "memory\n", "utf8");
+		writeFileSync(
+			join(originalHome, "multi-auth", "runtime-shadow-homes", "stale", "payload.txt"),
+			"stale shadow\n",
+			"utf8",
+		);
 		writeFileSync(join(originalHome, "auth.json"), '{"token":"original"}\n', "utf8");
+		writeFileSync(
+			join(originalHome, "auth.json.1772056142508.3nwgwa.tmp"),
+			"original auth tmp\n",
+			"utf8",
+		);
 		writeFileSync(
 			join(originalHome, "accounts.json"),
 			'{"accounts":["original"]}\n',
@@ -1063,6 +1082,9 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("SKILL_EXISTS:true");
 		expect(output).toContain("MEMORY_EXISTS:true");
 		expect(output).toContain("INSTRUCTION_EXISTS:true");
+		expect(output).toContain("MULTI_AUTH_MIRRORED:false");
+		expect(output).toContain("AUTH_TMP_MIRRORED:false");
+		expect(output).toContain("AUTH_TMP_ISOLATED:true");
 		expect(output).toContain("CACHE_SQLITE_MIRRORED:true");
 		expect(output).toContain("CACHE_WAL_MIRRORED:true");
 		expect(output).toMatch(/^CACHE_SHM_PLACEHOLDER:(?:true|skipped)$/m);
@@ -1124,6 +1146,12 @@ describe("codex bin wrapper", () => {
 		expect(readFileSync(join(originalHome, "state_5.sqlite-shm"), "utf8")).toBe(
 			"original shm\n",
 		);
+		expect(
+			readFileSync(
+				join(originalHome, "auth.json.1772056142508.3nwgwa.tmp"),
+				"utf8",
+			),
+		).toBe("original auth tmp\n");
 		expect(readFileSync(join(originalHome, "logs_2.sqlite"), "utf8")).toBe(
 			"original log\n",
 		);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -945,8 +945,12 @@ describe("codex bin wrapper", () => {
 			'console.log(`MEMORY_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "memories", "user.md"))}`);',
 			'console.log(`INSTRUCTION_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "instructions", "profile.md"))}`);',
 			'const statePath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite");',
+			'const stateWalPath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite-wal");',
+			'const stateShmPath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite-shm");',
 			'const originalStatePath = path.join(process.env.ORIGINAL_CODEX_HOME ?? "", "state_5.sqlite");',
 			'console.log(`ROOT_STATE_MIRRORED:${fs.existsSync(statePath)}`);',
+			'console.log(`ROOT_STATE_WAL_MIRRORED:${fs.existsSync(stateWalPath)}`);',
+			'console.log(`ROOT_STATE_SHM_MIRRORED:${fs.existsSync(stateShmPath)}`);',
 			'fs.writeFileSync(statePath, "shadow-only\\n", "utf8");',
 			'console.log(`ROOT_STATE_ISOLATED:${!fs.readFileSync(originalStatePath, "utf8").includes("shadow-only")}`);',
 			'fs.writeFileSync(path.join(process.env.CODEX_HOME ?? "", "new-root-state.json"), "new\\n", "utf8");',
@@ -988,7 +992,9 @@ describe("codex bin wrapper", () => {
 			"instruction\n",
 			"utf8",
 		);
-		writeFileSync(join(originalHome, "state_5.sqlite"), "state\n", "utf8");
+		writeFileSync(join(originalHome, "state_5.sqlite"), "not a sqlite database\n", "utf8");
+		writeFileSync(join(originalHome, "state_5.sqlite-wal"), "original wal\n", "utf8");
+		writeFileSync(join(originalHome, "state_5.sqlite-shm"), "original shm\n", "utf8");
 		writeFileSync(
 			join(originalHome, "config.toml"),
 			[
@@ -1028,6 +1034,8 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("MEMORY_EXISTS:true");
 		expect(output).toContain("INSTRUCTION_EXISTS:true");
 		expect(output).toContain("ROOT_STATE_MIRRORED:false");
+		expect(output).toContain("ROOT_STATE_WAL_MIRRORED:false");
+		expect(output).toContain("ROOT_STATE_SHM_MIRRORED:false");
 		expect(output).toContain("ROOT_STATE_ISOLATED:true");
 		const apiKeyMatch = output.match(/^OPENAI_API_KEY:([0-9a-f]{64})$/m);
 		expect(apiKeyMatch?.[1]).toBeTruthy();
@@ -1067,7 +1075,15 @@ describe("codex bin wrapper", () => {
 		expect(
 			readFileSync(join(originalHome, "sessions", "runtime-session.jsonl"), "utf8"),
 		).toBe("runtime\n");
-		expect(readFileSync(join(originalHome, "state_5.sqlite"), "utf8")).toBe("state\n");
+		expect(readFileSync(join(originalHome, "state_5.sqlite"), "utf8")).toBe(
+			"not a sqlite database\n",
+		);
+		expect(readFileSync(join(originalHome, "state_5.sqlite-wal"), "utf8")).toBe(
+			"original wal\n",
+		);
+		expect(readFileSync(join(originalHome, "state_5.sqlite-shm"), "utf8")).toBe(
+			"original shm\n",
+		);
 		expect(readFileSync(join(originalHome, "new-root-state.json"), "utf8")).toBe(
 			"new\n",
 		);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -954,6 +954,9 @@ describe("codex bin wrapper", () => {
 			'console.log(`CACHE_SHM_PLACEHOLDER:${cacheShmPlaceholder}`);',
 			'fs.appendFileSync(cachePath, "shadow-cache\\n", "utf8");',
 			'fs.appendFileSync(cacheWalPath, "shadow-wal\\n", "utf8");',
+			'const upperStatePath = path.join(process.env.CODEX_HOME ?? "", "STATE_6.sqlite");',
+			'console.log(`UPPER_STATE_MIRRORED:${fs.existsSync(upperStatePath)}`);',
+			'fs.appendFileSync(upperStatePath, "shadow-upper\\n", "utf8");',
 			'const statePath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite");',
 			'const stateWalPath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite-wal");',
 			'const stateShmPath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite-shm");',
@@ -1005,6 +1008,7 @@ describe("codex bin wrapper", () => {
 		writeFileSync(join(originalHome, "state_5.sqlite"), "not a sqlite database\n", "utf8");
 		writeFileSync(join(originalHome, "state_5.sqlite-wal"), "original wal\n", "utf8");
 		writeFileSync(join(originalHome, "state_5.sqlite-shm"), "original shm\n", "utf8");
+		writeFileSync(join(originalHome, "STATE_6.sqlite"), "upper state\n", "utf8");
 		writeFileSync(join(originalHome, "plugin_cache.sqlite"), "cache\n", "utf8");
 		writeFileSync(join(originalHome, "plugin_cache.sqlite-wal"), "cache wal\n", "utf8");
 		writeFileSync(
@@ -1048,6 +1052,7 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("CACHE_SQLITE_MIRRORED:true");
 		expect(output).toContain("CACHE_WAL_MIRRORED:true");
 		expect(output).toMatch(/^CACHE_SHM_PLACEHOLDER:(?:true|skipped)$/m);
+		expect(output).toContain("UPPER_STATE_MIRRORED:true");
 		expect(output).toContain("ROOT_STATE_MIRRORED:false");
 		expect(output).toContain("ROOT_STATE_WAL_MIRRORED:false");
 		expect(output).toContain("ROOT_STATE_SHM_MIRRORED:false");
@@ -1098,6 +1103,9 @@ describe("codex bin wrapper", () => {
 		);
 		expect(readFileSync(join(originalHome, "state_5.sqlite-shm"), "utf8")).toBe(
 			"original shm\n",
+		);
+		expect(readFileSync(join(originalHome, "STATE_6.sqlite"), "utf8")).toContain(
+			"shadow-upper",
 		);
 		expect(readFileSync(join(originalHome, "plugin_cache.sqlite"), "utf8")).toContain(
 			"shadow-cache",

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1052,7 +1052,9 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("CACHE_SQLITE_MIRRORED:true");
 		expect(output).toContain("CACHE_WAL_MIRRORED:true");
 		expect(output).toMatch(/^CACHE_SHM_PLACEHOLDER:(?:true|skipped)$/m);
-		expect(output).toContain("UPPER_STATE_MIRRORED:true");
+		expect(output).toContain(
+			`UPPER_STATE_MIRRORED:${process.platform === "win32" || process.platform === "darwin" ? "false" : "true"}`,
+		);
 		expect(output).toContain("ROOT_STATE_MIRRORED:false");
 		expect(output).toContain("ROOT_STATE_WAL_MIRRORED:false");
 		expect(output).toContain("ROOT_STATE_SHM_MIRRORED:false");
@@ -1104,9 +1106,15 @@ describe("codex bin wrapper", () => {
 		expect(readFileSync(join(originalHome, "state_5.sqlite-shm"), "utf8")).toBe(
 			"original shm\n",
 		);
-		expect(readFileSync(join(originalHome, "STATE_6.sqlite"), "utf8")).toContain(
-			"shadow-upper",
-		);
+		if (process.platform === "win32" || process.platform === "darwin") {
+			expect(readFileSync(join(originalHome, "STATE_6.sqlite"), "utf8")).toBe(
+				"upper state\n",
+			);
+		} else {
+			expect(readFileSync(join(originalHome, "STATE_6.sqlite"), "utf8")).toContain(
+				"shadow-upper",
+			);
+		}
 		expect(readFileSync(join(originalHome, "plugin_cache.sqlite"), "utf8")).toContain(
 			"shadow-cache",
 		);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -712,6 +712,45 @@ describe("codex bin wrapper", () => {
 		expect(output).not.toContain("Cannot find module");
 	});
 
+	it("copies generated runtime directories only when explicitly requested", () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
+			'console.log(`CODEX_MULTI_AUTH_DIR:${process.env.CODEX_MULTI_AUTH_DIR ?? ""}`);',
+			'console.log(`CODEX_CLI_PATH:${process.env.CODEX_CLI_PATH ?? ""}`);',
+			'console.log(`SHADOW_MULTI_AUTH_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "multi-auth"))}`);',
+			'console.log(`SANDBOX_BIN_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", ".sandbox-bin", "codex.exe"))}`);',
+			"process.exit(0);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const markerPath = join(fixtureRoot, "proxy-marker.txt");
+		mkdirSync(join(originalHome, ".sandbox-bin"), { recursive: true });
+		writeFileSync(join(originalHome, ".sandbox-bin", "codex.exe"), "sandbox\n", "utf8");
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			'model_provider = "openai"\n',
+			"utf8",
+		);
+
+		const result = runWrapper(fixtureRoot, ["exec", "status"], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_HOME: originalHome,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+			CODEX_MULTI_AUTH_RUNTIME_SHADOW_COPY_GENERATED_DIRS: "1",
+			CODEX_MULTI_AUTH_TEST_FORCE_SHADOW_DIR_COPY: "1",
+			CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+			OPENAI_API_KEY: undefined,
+		});
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(0);
+		expect(output).toContain("SANDBOX_BIN_EXISTS:true");
+		expect(output).not.toContain("skipped optional shadow-home directory .sandbox-bin");
+	});
+
 	it("forwards non-auth commands when dist output is missing", () => {
 		const fixtureRoot = createWrapperFixture();
 		const fakeBin = createFakeCodexBin(fixtureRoot);
@@ -813,6 +852,68 @@ describe("codex bin wrapper", () => {
 		expect(result.status).toBe(1);
 		expect(result.stderr).toContain("FAILED_FORWARD");
 		expect(existsSync(join(codexHome, "session_index.jsonl"))).toBe(false);
+	});
+
+	it("skips already indexed rollout files during local session index repair", () => {
+		const fixtureRoot = createWrapperFixture();
+		const codexHome = join(fixtureRoot, "codex-home");
+		const indexedSessionId = "019ddf58-f831-7e12-bf4a-fae1ed000011";
+		const mismatchedPayloadId = "019ddf58-f831-7e12-bf4a-fae1ed000012";
+		const missingSessionId = "019ddf58-f831-7e12-bf4a-fae1ed000013";
+		mkdirSync(codexHome, { recursive: true });
+		writeFileSync(
+			join(codexHome, "session_index.jsonl"),
+			`${JSON.stringify({
+				id: indexedSessionId,
+				thread_name: "Already indexed",
+				updated_at: "2026-04-30T17:10:00.000Z",
+			})}\n`,
+			"utf8",
+		);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"const { mkdirSync, writeFileSync } = require('node:fs');",
+			"const { join } = require('node:path');",
+			`const indexedSessionId = ${JSON.stringify(indexedSessionId)};`,
+			`const mismatchedPayloadId = ${JSON.stringify(mismatchedPayloadId)};`,
+			`const missingSessionId = ${JSON.stringify(missingSessionId)};`,
+			"const codexHome = process.env.CODEX_HOME;",
+			"const sessionDir = join(codexHome, 'sessions', '2026', '05', '01');",
+			"mkdirSync(sessionDir, { recursive: true });",
+			"writeFileSync(",
+			"  join(sessionDir, `rollout-2026-05-01T01-10-00-${indexedSessionId}.jsonl`),",
+			"  [",
+			"    JSON.stringify({ timestamp: '2026-04-30T17:10:00.000Z', type: 'session_meta', payload: { id: mismatchedPayloadId } }),",
+			"    JSON.stringify({ timestamp: '2026-04-30T17:10:01.000Z', type: 'event_msg', payload: { type: 'user_message', message: 'SHOULD_NOT_BE_REPAIRED' } }),",
+			"    '',",
+			"  ].join('\\n'),",
+			"  'utf8',",
+			");",
+			"writeFileSync(",
+			"  join(sessionDir, `rollout-2026-05-01T01-11-00-${missingSessionId}.jsonl`),",
+			"  [",
+			"    JSON.stringify({ timestamp: '2026-04-30T17:11:00.000Z', type: 'session_meta', payload: { id: missingSessionId } }),",
+			"    JSON.stringify({ timestamp: '2026-04-30T17:11:01.000Z', type: 'event_msg', payload: { type: 'user_message', message: 'MISSING_SESSION' } }),",
+			"    '',",
+			"  ].join('\\n'),",
+			"  'utf8',",
+			");",
+			"console.log('FORWARDED_INDEX_FAST_PATH');",
+			"process.exit(0);",
+		]);
+		const result = runWrapper(fixtureRoot, ["exec", "status"], {
+			CODEX_HOME: codexHome,
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "0",
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("FORWARDED_INDEX_FAST_PATH");
+		const index = readFileSync(join(codexHome, "session_index.jsonl"), "utf8");
+		expect(index).toContain(indexedSessionId);
+		expect(index).toContain(missingSessionId);
+		expect(index).toContain("MISSING_SESSION");
+		expect(index).not.toContain(mismatchedPayloadId);
+		expect(index).not.toContain("SHOULD_NOT_BE_REPAIRED");
 	});
 
 	it("serializes concurrent local session index repairs", async () => {
@@ -938,18 +1039,30 @@ describe("codex bin wrapper", () => {
 			'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
 			'console.log(`CODEX_HOME:${process.env.CODEX_HOME ?? ""}`);',
 			'console.log(`CODEX_HOME_IS_ORIGINAL:${process.env.CODEX_HOME === process.env.ORIGINAL_CODEX_HOME}`);',
+			'console.log(`CODEX_MULTI_AUTH_DIR:${process.env.CODEX_MULTI_AUTH_DIR ?? ""}`);',
 			'console.log(`OPENAI_API_KEY:${process.env.OPENAI_API_KEY ?? ""}`);',
 			'console.log(`SESSION_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "sessions", "resume.jsonl"))}`);',
 			'console.log(`PLUGIN_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "plugins", "plugin.txt"))}`);',
 			'console.log(`SKILL_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "skills", "skill.txt"))}`);',
 			'console.log(`MEMORY_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "memories", "user.md"))}`);',
 			'console.log(`INSTRUCTION_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "instructions", "profile.md"))}`);',
+			'console.log(`SANDBOX_BIN_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", ".sandbox-bin", "codex.exe"))}`);',
 			'console.log(`MULTI_AUTH_MIRRORED:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "multi-auth"))}`);',
 			'const authTmpPath = path.join(process.env.CODEX_HOME ?? "", "auth.json.1772056142508.3nwgwa.tmp");',
+			'const accountsTmpPath = path.join(process.env.CODEX_HOME ?? "", "accounts.json.1772056142508.3nwgwa.tmp");',
+			'const globalStateTmpPath = path.join(process.env.CODEX_HOME ?? "", ".codex-global-state.json.tmp-1777087904981-b612ed77-42c6-452a-a3ee-181a3806b475");',
 			'const originalAuthTmpPath = path.join(process.env.ORIGINAL_CODEX_HOME ?? "", "auth.json.1772056142508.3nwgwa.tmp");',
+			'const originalAccountsTmpPath = path.join(process.env.ORIGINAL_CODEX_HOME ?? "", "accounts.json.1772056142508.3nwgwa.tmp");',
+			'const originalGlobalStateTmpPath = path.join(process.env.ORIGINAL_CODEX_HOME ?? "", ".codex-global-state.json.tmp-1777087904981-b612ed77-42c6-452a-a3ee-181a3806b475");',
 			'console.log(`AUTH_TMP_MIRRORED:${fs.existsSync(authTmpPath)}`);',
+			'console.log(`ACCOUNTS_TMP_MIRRORED:${fs.existsSync(accountsTmpPath)}`);',
+			'console.log(`GLOBAL_STATE_TMP_MIRRORED:${fs.existsSync(globalStateTmpPath)}`);',
 			'fs.writeFileSync(authTmpPath, "shadow-auth-tmp\\n", "utf8");',
+			'fs.writeFileSync(accountsTmpPath, "shadow-accounts-tmp\\n", "utf8");',
+			'fs.writeFileSync(globalStateTmpPath, "shadow-global-state-tmp\\n", "utf8");',
 			'console.log(`AUTH_TMP_ISOLATED:${!fs.readFileSync(originalAuthTmpPath, "utf8").includes("shadow-auth-tmp")}`);',
+			'console.log(`ACCOUNTS_TMP_ISOLATED:${!fs.readFileSync(originalAccountsTmpPath, "utf8").includes("shadow-accounts-tmp")}`);',
+			'console.log(`GLOBAL_STATE_TMP_ISOLATED:${!fs.readFileSync(originalGlobalStateTmpPath, "utf8").includes("shadow-global-state-tmp")}`);',
 			'const cachePath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite");',
 			'const cacheWalPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-wal");',
 			'const cacheShmPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-shm");',
@@ -969,6 +1082,9 @@ describe("codex bin wrapper", () => {
 			'fs.writeFileSync(logWalPath, "shadow-log-wal\\n", "utf8");',
 			'fs.writeFileSync(logShmPath, "shadow-log-shm\\n", "utf8");',
 			'console.log(`LOG_SQLITE_ISOLATED:${!fs.readFileSync(originalLogPath, "utf8").includes("shadow-log")}`);',
+			'const upperLogPath = path.join(process.env.CODEX_HOME ?? "", "LOGS_3.sqlite");',
+			'console.log(`UPPER_LOG_MIRRORED:${fs.existsSync(upperLogPath)}`);',
+			'fs.appendFileSync(upperLogPath, "shadow-upper-log\\n", "utf8");',
 			'fs.appendFileSync(cachePath, "shadow-cache\\n", "utf8");',
 			'fs.appendFileSync(cacheWalPath, "shadow-wal\\n", "utf8");',
 			'const upperStatePath = path.join(process.env.CODEX_HOME ?? "", "STATE_6.sqlite");',
@@ -1002,6 +1118,7 @@ describe("codex bin wrapper", () => {
 		mkdirSync(join(originalHome, "skills"), { recursive: true });
 		mkdirSync(join(originalHome, "memories"), { recursive: true });
 		mkdirSync(join(originalHome, "instructions"), { recursive: true });
+		mkdirSync(join(originalHome, ".sandbox-bin"), { recursive: true });
 		mkdirSync(join(originalHome, "multi-auth", "runtime-shadow-homes", "stale"), {
 			recursive: true,
 		});
@@ -1009,6 +1126,7 @@ describe("codex bin wrapper", () => {
 		writeFileSync(join(originalHome, "plugins", "plugin.txt"), "plugin\n", "utf8");
 		writeFileSync(join(originalHome, "skills", "skill.txt"), "skill\n", "utf8");
 		writeFileSync(join(originalHome, "memories", "user.md"), "memory\n", "utf8");
+		writeFileSync(join(originalHome, ".sandbox-bin", "codex.exe"), "sandbox\n", "utf8");
 		writeFileSync(
 			join(originalHome, "multi-auth", "runtime-shadow-homes", "stale", "payload.txt"),
 			"stale shadow\n",
@@ -1018,6 +1136,19 @@ describe("codex bin wrapper", () => {
 		writeFileSync(
 			join(originalHome, "auth.json.1772056142508.3nwgwa.tmp"),
 			"original auth tmp\n",
+			"utf8",
+		);
+		writeFileSync(
+			join(originalHome, "accounts.json.1772056142508.3nwgwa.tmp"),
+			"original accounts tmp\n",
+			"utf8",
+		);
+		writeFileSync(
+			join(
+				originalHome,
+				".codex-global-state.json.tmp-1777087904981-b612ed77-42c6-452a-a3ee-181a3806b475",
+			),
+			"original global state tmp\n",
 			"utf8",
 		);
 		writeFileSync(
@@ -1042,6 +1173,7 @@ describe("codex bin wrapper", () => {
 		writeFileSync(join(originalHome, "logs_2.sqlite"), "original log\n", "utf8");
 		writeFileSync(join(originalHome, "logs_2.sqlite-wal"), "original log wal\n", "utf8");
 		writeFileSync(join(originalHome, "logs_2.sqlite-shm"), "original log shm\n", "utf8");
+		writeFileSync(join(originalHome, "LOGS_3.sqlite"), "upper log\n", "utf8");
 		writeFileSync(join(originalHome, "plugin_cache.sqlite"), "cache\n", "utf8");
 		writeFileSync(join(originalHome, "plugin_cache.sqlite-wal"), "cache wal\n", "utf8");
 		writeFileSync(
@@ -1068,6 +1200,7 @@ describe("codex bin wrapper", () => {
 			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
 			CODEX_MULTI_AUTH_TEST_PROXY_BASE_URL: "http://127.0.0.1:4567",
 			CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+			CODEX_MULTI_AUTH_TEST_FORCE_SHADOW_DIR_COPY: "1",
 			OPENAI_API_KEY: undefined,
 		});
 
@@ -1077,14 +1210,22 @@ describe("codex bin wrapper", () => {
 			`FORWARDED:exec status -c cli_auth_credentials_store="file" -c model_provider="${RUNTIME_ROTATION_PROXY_PROVIDER_ID}"`,
 		);
 		expect(output).toContain("CODEX_HOME_IS_ORIGINAL:false");
+		expect(output).toContain(
+			`CODEX_MULTI_AUTH_DIR:${join(originalHome, "multi-auth")}`,
+		);
 		expect(output).toContain("SESSION_EXISTS:true");
 		expect(output).toContain("PLUGIN_EXISTS:true");
 		expect(output).toContain("SKILL_EXISTS:true");
 		expect(output).toContain("MEMORY_EXISTS:true");
 		expect(output).toContain("INSTRUCTION_EXISTS:true");
+		expect(output).toContain("SANDBOX_BIN_EXISTS:false");
 		expect(output).toContain("MULTI_AUTH_MIRRORED:false");
 		expect(output).toContain("AUTH_TMP_MIRRORED:false");
+		expect(output).toContain("ACCOUNTS_TMP_MIRRORED:false");
+		expect(output).toContain("GLOBAL_STATE_TMP_MIRRORED:false");
 		expect(output).toContain("AUTH_TMP_ISOLATED:true");
+		expect(output).toContain("ACCOUNTS_TMP_ISOLATED:true");
+		expect(output).toContain("GLOBAL_STATE_TMP_ISOLATED:true");
 		expect(output).toContain("CACHE_SQLITE_MIRRORED:true");
 		expect(output).toContain("CACHE_WAL_MIRRORED:true");
 		expect(output).toMatch(/^CACHE_SHM_PLACEHOLDER:(?:true|skipped)$/m);
@@ -1092,6 +1233,9 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("LOG_WAL_MIRRORED:false");
 		expect(output).toContain("LOG_SHM_MIRRORED:false");
 		expect(output).toContain("LOG_SQLITE_ISOLATED:true");
+		expect(output).toContain(
+			`UPPER_LOG_MIRRORED:${process.platform === "win32" || process.platform === "darwin" ? "false" : "true"}`,
+		);
 		expect(output).toContain(
 			`UPPER_STATE_MIRRORED:${process.platform === "win32" || process.platform === "darwin" ? "false" : "true"}`,
 		);
@@ -1152,6 +1296,21 @@ describe("codex bin wrapper", () => {
 				"utf8",
 			),
 		).toBe("original auth tmp\n");
+		expect(
+			readFileSync(
+				join(originalHome, "accounts.json.1772056142508.3nwgwa.tmp"),
+				"utf8",
+			),
+		).toBe("original accounts tmp\n");
+		expect(
+			readFileSync(
+				join(
+					originalHome,
+					".codex-global-state.json.tmp-1777087904981-b612ed77-42c6-452a-a3ee-181a3806b475",
+				),
+				"utf8",
+			),
+		).toBe("original global state tmp\n");
 		expect(readFileSync(join(originalHome, "logs_2.sqlite"), "utf8")).toBe(
 			"original log\n",
 		);
@@ -1161,6 +1320,15 @@ describe("codex bin wrapper", () => {
 		expect(readFileSync(join(originalHome, "logs_2.sqlite-shm"), "utf8")).toBe(
 			"original log shm\n",
 		);
+		if (process.platform === "win32" || process.platform === "darwin") {
+			expect(readFileSync(join(originalHome, "LOGS_3.sqlite"), "utf8")).toBe(
+				"upper log\n",
+			);
+		} else {
+			expect(readFileSync(join(originalHome, "LOGS_3.sqlite"), "utf8")).toContain(
+				"shadow-upper-log",
+			);
+		}
 		if (process.platform === "win32" || process.platform === "darwin") {
 			expect(readFileSync(join(originalHome, "STATE_6.sqlite"), "utf8")).toBe(
 				"upper state\n",
@@ -1188,6 +1356,9 @@ describe("codex bin wrapper", () => {
 		expect(
 			readFileSync(join(originalHome, ".codex-global-state.json"), "utf8").trim(),
 		).toBe('{"last":"runtime"}');
+		expect(output).toContain(
+			"codex-multi-auth: skipped optional shadow-home directory .sandbox-bin because linking failed",
+		);
 	});
 
 	it("warns when sqlite sidecar placeholder materialization fails", () => {
@@ -1921,8 +2092,13 @@ describe("codex bin wrapper", () => {
 		createRuntimeRotationProxyFixtureModule(fixtureRoot);
 		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
 			"#!/usr/bin/env node",
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
 			'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
 			'console.log(`CODEX_HOME:${process.env.CODEX_HOME ?? ""}`);',
+			'console.log(`CODEX_MULTI_AUTH_DIR:${process.env.CODEX_MULTI_AUTH_DIR ?? ""}`);',
+			'console.log(`CODEX_CLI_PATH:${process.env.CODEX_CLI_PATH ?? ""}`);',
+			'console.log(`SHADOW_MULTI_AUTH_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "multi-auth"))}`);',
 			"process.exit(0);",
 		]);
 		const originalHome = join(fixtureRoot, "codex-home");
@@ -1949,11 +2125,28 @@ describe("codex bin wrapper", () => {
 			throw new Error(output);
 		}
 		expect(output).toContain("FORWARDED:app . --model gpt-5.1");
+		expect(output).toContain(
+			`CODEX_MULTI_AUTH_DIR:${join(originalHome, "multi-auth")}`,
+		);
+		expect(output).toContain("SHADOW_MULTI_AUTH_EXISTS:false");
+		const cliPathMatch = output.match(/^CODEX_CLI_PATH:(.+)$/m);
+		expect(cliPathMatch?.[1]).toBeTruthy();
+		if (cliPathMatch?.[1]) {
+			const shimRelativePath = relative(
+				join(originalHome, "multi-auth", "app-server-shims"),
+				resolve(cliPathMatch[1]),
+			);
+			expect(shimRelativePath).not.toMatch(/^\.\.(?:[\\/]|$)/);
+			expect(isAbsolute(shimRelativePath)).toBe(false);
+		}
 
 		await sleep(2200);
 
 		const marker = readFileSync(markerPath, "utf8");
 		expect(marker).toContain(`real-home-env:${originalHome}\n`);
+		expect(
+			existsSync(join(originalHome, "multi-auth", "runtime-rotation-app-helper.json")),
+		).toBe(true);
 		const compatibilityHomeMatch = marker.match(/^codex-home-env:(.+)$/m);
 		expect(compatibilityHomeMatch?.[1]).toBeTruthy();
 		expect(compatibilityHomeMatch?.[1]).not.toBe(originalHome);

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -880,6 +880,15 @@ describe("codex bin wrapper", () => {
 			"const sessionDir = join(codexHome, 'sessions', '2026', '05', '01');",
 			"mkdirSync(sessionDir, { recursive: true });",
 			"writeFileSync(",
+			"  join(sessionDir, `rollout-2026-05-01T01-09-00-${indexedSessionId}.jsonl`),",
+			"  [",
+			"    JSON.stringify({ timestamp: '2026-04-30T17:09:00.000Z', type: 'session_meta', payload: { id: indexedSessionId } }),",
+			"    JSON.stringify({ timestamp: '2026-04-30T17:09:01.000Z', type: 'event_msg', payload: { type: 'user_message', message: 'ALREADY_INDEXED_SHOULD_SKIP' } }),",
+			"    '',",
+			"  ].join('\\n'),",
+			"  'utf8',",
+			");",
+			"writeFileSync(",
 			"  join(sessionDir, `rollout-2026-05-01T01-10-00-${indexedSessionId}.jsonl`),",
 			"  [",
 			"    JSON.stringify({ timestamp: '2026-04-30T17:10:00.000Z', type: 'session_meta', payload: { id: mismatchedPayloadId } }),",
@@ -913,6 +922,7 @@ describe("codex bin wrapper", () => {
 		expect(index).toContain(missingSessionId);
 		expect(index).toContain("MISSING_SESSION");
 		expect(index).not.toContain(mismatchedPayloadId);
+		expect(index).not.toContain("ALREADY_INDEXED_SHOULD_SKIP");
 		expect(index).not.toContain("SHOULD_NOT_BE_REPAIRED");
 	});
 

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -944,6 +944,16 @@ describe("codex bin wrapper", () => {
 			'console.log(`SKILL_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "skills", "skill.txt"))}`);',
 			'console.log(`MEMORY_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "memories", "user.md"))}`);',
 			'console.log(`INSTRUCTION_EXISTS:${fs.existsSync(path.join(process.env.CODEX_HOME ?? "", "instructions", "profile.md"))}`);',
+			'const cachePath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite");',
+			'const cacheWalPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-wal");',
+			'const cacheShmPath = path.join(process.env.CODEX_HOME ?? "", "plugin_cache.sqlite-shm");',
+			'console.log(`CACHE_SQLITE_MIRRORED:${fs.existsSync(cachePath)}`);',
+			'console.log(`CACHE_WAL_MIRRORED:${fs.existsSync(cacheWalPath)}`);',
+			'let cacheShmPlaceholder = "false";',
+			'try { cacheShmPlaceholder = String(fs.lstatSync(cacheShmPath).isSymbolicLink()); } catch { cacheShmPlaceholder = process.platform === "win32" ? "skipped" : "false"; }',
+			'console.log(`CACHE_SHM_PLACEHOLDER:${cacheShmPlaceholder}`);',
+			'fs.appendFileSync(cachePath, "shadow-cache\\n", "utf8");',
+			'fs.appendFileSync(cacheWalPath, "shadow-wal\\n", "utf8");',
 			'const statePath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite");',
 			'const stateWalPath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite-wal");',
 			'const stateShmPath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite-shm");',
@@ -995,6 +1005,8 @@ describe("codex bin wrapper", () => {
 		writeFileSync(join(originalHome, "state_5.sqlite"), "not a sqlite database\n", "utf8");
 		writeFileSync(join(originalHome, "state_5.sqlite-wal"), "original wal\n", "utf8");
 		writeFileSync(join(originalHome, "state_5.sqlite-shm"), "original shm\n", "utf8");
+		writeFileSync(join(originalHome, "plugin_cache.sqlite"), "cache\n", "utf8");
+		writeFileSync(join(originalHome, "plugin_cache.sqlite-wal"), "cache wal\n", "utf8");
 		writeFileSync(
 			join(originalHome, "config.toml"),
 			[
@@ -1033,6 +1045,9 @@ describe("codex bin wrapper", () => {
 		expect(output).toContain("SKILL_EXISTS:true");
 		expect(output).toContain("MEMORY_EXISTS:true");
 		expect(output).toContain("INSTRUCTION_EXISTS:true");
+		expect(output).toContain("CACHE_SQLITE_MIRRORED:true");
+		expect(output).toContain("CACHE_WAL_MIRRORED:true");
+		expect(output).toMatch(/^CACHE_SHM_PLACEHOLDER:(?:true|skipped)$/m);
 		expect(output).toContain("ROOT_STATE_MIRRORED:false");
 		expect(output).toContain("ROOT_STATE_WAL_MIRRORED:false");
 		expect(output).toContain("ROOT_STATE_SHM_MIRRORED:false");
@@ -1083,6 +1098,12 @@ describe("codex bin wrapper", () => {
 		);
 		expect(readFileSync(join(originalHome, "state_5.sqlite-shm"), "utf8")).toBe(
 			"original shm\n",
+		);
+		expect(readFileSync(join(originalHome, "plugin_cache.sqlite"), "utf8")).toContain(
+			"shadow-cache",
+		);
+		expect(readFileSync(join(originalHome, "plugin_cache.sqlite-wal"), "utf8")).toContain(
+			"shadow-wal",
 		);
 		expect(readFileSync(join(originalHome, "new-root-state.json"), "utf8")).toBe(
 			"new\n",


### PR DESCRIPTION
## Summary
- Prevent runtime rotation shadow homes from mirroring Codex thread state SQLite files.
- Keep per-shadow-home goal state isolated so malformed or locked real state DBs cannot break /goal.
- Add regression coverage for malformed state DB isolation, state_*.sqlite wal/shm exclusion, non-thread SQLite sidecar mirroring, platform-specific uppercase state-like SQLite names, and sidecar placeholder warning failures.
- Address review findings for redundant link attempts, Windows sidecar placeholder diagnostics, runtime-only sync-back scoping, platform-aware thread-state filename matching, per-destination sidecar placeholder diagnostics, and explicit sidecar failure fallback handling.

## Risk
- Low to medium. The change only affects Codex thread-state SQLite handling in runtime shadow homes and SQLite root-file materialization in shadow homes.
- Existing shared sessions, config, plugin, skill, memory, and non-thread SQLite mirroring remain intact.
- Compatibility shadow-home sync-back keeps its existing behavior; runtime rotation alone isolates Codex thread state.

## Verification
- npm test -- test/codex-bin-wrapper.test.ts -t "starts the opt-in runtime rotation proxy"
- npm test -- test/codex-bin-wrapper.test.ts -t "sqlite sidecar placeholder|starts the opt-in runtime rotation proxy"
- npm test -- test/codex-bin-wrapper.test.ts
- npm run typecheck:scripts
- npm run build
- npm run lint:scripts
- npm run lint:ts -- --quiet test/codex-bin-wrapper.test.ts
- Manual TUI smoke: /goal with gpt-5.5 low, fast off, and malformed original state_5.sqlite

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

isolates codex thread-state sqlite files (`state_*.sqlite`, `logs_*.sqlite`, and their wal/shm sidecars) from runtime rotation shadow homes so a malformed or locked real state db cannot break `/goal`. non-thread sqlite files (e.g., `plugin_cache.sqlite`) continue to be materialized into the shadow home via hard-link with symlink-based sidecar placeholders, and a new `CODEX_MULTI_AUTH_DIR` fallback ensures multi-auth directory is always forwarded to the subprocess. all findings are P2.

<h3>Confidence Score: 5/5</h3>

safe to merge; no P0/P1 issues found — all findings are diagnostic or platform-edge-case P2s

no correctness bugs introduced; the isolation logic is well-tested; only concerns are warning dedup granularity (name vs path) and a windows-specific path where a missing sidecar causes full sqlite materialization rollback, both P2

scripts/codex.js lines 58-66 (warnedShadowHomeLinkOnlyDirectoryFailures dedup) and 2072-2074 (windows missing-sidecar rollback path)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/codex.js | adds codex thread-state sqlite isolation for runtime rotation shadow homes: new predicate functions, link-only directory materialization, and sidecar placeholder logic; warning dedup keyed by name (not path) may suppress per-rotation diagnostics, and the windows missing-sidecar path collapses sqlite materialization |
| test/codex-bin-wrapper.test.ts | solid integration test expansion covering malformed state db isolation, wal/shm exclusion, transient-file omission, platform-specific uppercase state matching, sidecar placeholder failure, and rollout index filename fast-skip; all assertions are tight and behaviorally meaningful |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[readdirSync originalCodexHome] --> B{skipMirrorPredicate?}
    B -- yes: state_N.sqlite / logs_N.sqlite / transient tmp / multi-auth dir --> SKIP[skip entry]
    B -- no --> C{entry type}
    C -- directory --> D{linkOnlyDirectoryPredicate?}
    D -- yes: .sandbox-bin etc --> E[linkDirectoryIntoShadowHome symlink/junction]
    E -- fail --> WARN1[warnSkippedLinkOnlyShadowHomeDirectory]
    D -- no --> F[mirrorDirectoryIntoShadowHome]
    C -- sqlite sidecar file --> SKIP2[continue — handled by main sqlite step]
    C -- sqlite main file --> G[materializeFileIntoShadowHome hard-link]
    G -- success --> H[materializeSqliteSidecarsIntoShadowHome]
    H -- sidecar exists in src --> I[hard-link sidecar]
    I -- fail --> J[symlinkSync sidecar placeholder]
    H -- sidecar missing in src --> J
    J -- fail EPERM --> WARN2[warn + return false]
    WARN2 --> ROLLBACK[removeSqliteShadowHomeMaterialization]
    H -- all ok --> OK[shadow sqlite ready]
    C -- other file --> COPY[copyFileSync / mirrorFileIntoShadowHome]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fruntime-shadow-goal-state-isolation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fruntime-shadow-goal-state-isolation%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fcodex.js%3A58-66%0A**Warning%20dedup%20keyed%20by%20name%2C%20not%20by%20destination%20path**%0A%0A%60warnedShadowHomeLinkOnlyDirectoryFailures%60%20deduplicates%20by%20bare%20directory%20name%20%28e.g.%2C%20%60.sandbox-bin%60%29%20across%20all%20rotations%20in%20the%20same%20process.%20once%20the%20warning%20fires%20for%20%60.sandbox-bin%60%20in%20rotation%201%2C%20rotation%202's%20identical%20link%20failure%20is%20silently%20swallowed%20%E2%80%94%20no%20second%20diagnostic%2C%20even%20though%20a%20fresh%20shadow%20home%20is%20involved.%20contrast%20with%20%60warnedShadowHomeSqliteSidecarPlaceholderFailures%60%20which%20correctly%20keys%20by%20full%20destination%20path%20%28unique%20per%20rotation%29.%0A%0Aswitching%20the%20set%20key%20to%20%60destinationPath%60%20%28passed%20down%20from%20the%20call%20site%29%20would%20give%20per-rotation%20diagnostics%20consistent%20with%20the%20sidecar%20warning%20behavior.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fcodex.js%3A2072-2074%0A**Windows%3A%20dangling%20symlink%20for%20missing%20sidecar%20collapses%20the%20entire%20SQLite%20materialization**%0A%0Awhen%20%60sourceSidecarPath%60%20doesn't%20exist%2C%20%60materializeSqliteSidecarPlaceholder%60%20creates%20a%20dangling%20symlink%20%28%60symlinkSync%28nonExistentSource%2C%20dest%2C%20%22file%22%29%60%29.%20on%20windows%20without%20developer%20mode%20or%20%60SeCreateSymbolicLinkPrivilege%60%2C%20%60symlinkSync%60%20throws%20%60EPERM%60%2C%20the%20placeholder%20returns%20%60false%60%2C%20%60materializeSqliteSidecarsIntoShadowHome%60%20returns%20%60false%60%2C%20and%20the%20caller%20rolls%20back%20the%20successfully%20hard-linked%20main%20%60.sqlite%60%20via%20%60removeSqliteShadowHomeMaterialization%60.%0A%0Aresult%3A%20on%20windows%20without%20symlink%20privilege%2C%20any%20%60.sqlite%60%20file%20whose%20%60-wal%60%20or%20%60-shm%60%20counterpart%20is%20absent%20%28common%20for%20an%20idle%20database%29%20is%20silently%20dropped%20from%20the%20shadow%20home%20entirely%20%E2%80%94%20including%20%60plugin_cache.sqlite%60.%20the%20hard-link%20fallback%20inside%20%60linkFileIntoShadowHome%60%20doesn't%20help%20here%20because%20you%20can't%20hard-link%20a%20non-existent%20file.%0A%0Aworth%20a%20comment%20or%20a%20fallback%20that%20skips%20the%20placeholder%20on%20windows%20rather%20than%20rolling%20back%20the%20main%20file.%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fcodex.js%3A1947-1988%0A**Missing%20vitest%20unit%20coverage%20for%20new%20pure%20predicate%20functions**%0A%0A%60isSqliteMainFile%60%2C%20%60isSqliteSidecarFile%60%2C%20%60isCodexRuntimeLocalSqliteFile%60%2C%20%60isCodexRuntimeTransientStateFile%60%2C%20and%20%60normalizeRuntimeShadowHomeEntryName%60%20are%20only%20exercised%20through%20integration%20tests.%20regex%20edge%20cases%20%28e.g.%2C%20%60.SQLITE%60%20extension%20on%20linux%2C%20filenames%20like%20%60state_.sqlite%60%2C%20%60logs_abc.sqlite%60%2C%20or%20a%20sidecar%20with%20no%20corresponding%20main%20file%20in%20a%20fresh%20home%29%20can%20only%20be%20caught%20by%20reading%20the%20diff%20carefully%20rather%20than%20by%20a%20fast%20failing%20unit%20test.%20vitest%20unit%20tests%20for%20these%20five%20functions%20would%20pay%20off%20quickly%20given%20how%20central%20they%20are%20to%20the%20isolation%20logic.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
scripts/codex.js:58-66
**Warning dedup keyed by name, not by destination path**

`warnedShadowHomeLinkOnlyDirectoryFailures` deduplicates by bare directory name (e.g., `.sandbox-bin`) across all rotations in the same process. once the warning fires for `.sandbox-bin` in rotation 1, rotation 2's identical link failure is silently swallowed — no second diagnostic, even though a fresh shadow home is involved. contrast with `warnedShadowHomeSqliteSidecarPlaceholderFailures` which correctly keys by full destination path (unique per rotation).

switching the set key to `destinationPath` (passed down from the call site) would give per-rotation diagnostics consistent with the sidecar warning behavior.

### Issue 2 of 3
scripts/codex.js:2072-2074
**Windows: dangling symlink for missing sidecar collapses the entire SQLite materialization**

when `sourceSidecarPath` doesn't exist, `materializeSqliteSidecarPlaceholder` creates a dangling symlink (`symlinkSync(nonExistentSource, dest, "file")`). on windows without developer mode or `SeCreateSymbolicLinkPrivilege`, `symlinkSync` throws `EPERM`, the placeholder returns `false`, `materializeSqliteSidecarsIntoShadowHome` returns `false`, and the caller rolls back the successfully hard-linked main `.sqlite` via `removeSqliteShadowHomeMaterialization`.

result: on windows without symlink privilege, any `.sqlite` file whose `-wal` or `-shm` counterpart is absent (common for an idle database) is silently dropped from the shadow home entirely — including `plugin_cache.sqlite`. the hard-link fallback inside `linkFileIntoShadowHome` doesn't help here because you can't hard-link a non-existent file.

worth a comment or a fallback that skips the placeholder on windows rather than rolling back the main file.

### Issue 3 of 3
scripts/codex.js:1947-1988
**Missing vitest unit coverage for new pure predicate functions**

`isSqliteMainFile`, `isSqliteSidecarFile`, `isCodexRuntimeLocalSqliteFile`, `isCodexRuntimeTransientStateFile`, and `normalizeRuntimeShadowHomeEntryName` are only exercised through integration tests. regex edge cases (e.g., `.SQLITE` extension on linux, filenames like `state_.sqlite`, `logs_abc.sqlite`, or a sidecar with no corresponding main file in a fresh home) can only be caught by reading the diff carefully rather than by a fast failing unit test. vitest unit tests for these five functions would pay off quickly given how central they are to the isolation logic.

`````

</details>

<sub>Reviews (12): Last reviewed commit: ["chore: clarify sqlite cleanup fallback"](https://github.com/ndycode/codex-multi-auth/commit/9a81f73823ee2f88922c052cb84f1765f227ff80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30568711)</sub>

<!-- /greptile_comment -->