### PR TITLE
fix: storage lock uninitialized variable and false CI detection for ignore-scripts

### DIFF
--- a/lib/storage/transactions.ts
+++ b/lib/storage/transactions.ts
@@ -26,7 +26,7 @@ export function runInTransactionSnapshotContext<T>(
 
 export function withStorageLock<T>(fn: () => Promise<T>): Promise<T> {
 	const previousMutex = storageMutex;
-	let releaseLock: () => void;
+	let releaseLock: () => void = () => undefined;
 	storageMutex = new Promise<void>((resolve) => {
 		releaseLock = resolve;
 	});

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -59,7 +59,6 @@ function isEnabledEnvFlag(env, key) {
  * @param {NodeJS.ProcessEnv} [env]
  */
 export function isCiEnvironment(env = process.env) {
-	if (readOptionalBoolean(env.npm_config_ignore_scripts) === true) return true;
 	return CI_ENV_KEYS.some((key) => isEnabledEnvFlag(env, key));
 }
 


### PR DESCRIPTION
## Summary

Two independent pre-existing bugs found during codebase audit.

- **`lib/storage/transactions.ts`** — `releaseLock` declared without an initializer (`let releaseLock: () => void`). TypeScript strict mode flags this as a definite-assignment violation. If the variable is ever read before the Promise constructor executor assigns it (possible if the executor ever becomes async, or the pattern is copied elsewhere), the call `releaseLock()` in `.finally()` would throw `TypeError`, permanently deadlocking the storage mutex for all subsequent operations. Fixed by initializing with a no-op `= () => undefined`.

- **`scripts/postinstall.js`** — `isCiEnvironment()` treated `npm_config_ignore_scripts=true` as a CI signal. This is semantically wrong: the flag is a user preference to skip lifecycle scripts, not a CI indicator. In the `postinstall`/`preuninstall` context the check is unreachable anyway (npm won't run the script if `ignore-scripts=true`). In the CLI context (`codex-multi-auth uninstall`, `runPreuninstallCleanup`), it caused the entire cleanup to be silently skipped for any developer machine with `ignore-scripts=true` in their `.npmrc` — a common security hardening setting — leaving app-bind and launcher artifacts behind on uninstall. Fixed by removing the check entirely.

## Test plan

- [ ] `isCiEnvironment()` returns `false` in a shell where `npm_config_ignore_scripts=true` but no standard CI env vars are set
- [ ] `codex-multi-auth uninstall` runs cleanup on machines with `ignore-scripts=true` in `.npmrc`
- [ ] Storage lock does not deadlock under concurrent access (existing behavior preserved)
- [ ] TypeScript compiles cleanly with `--strict` (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr fixes two pre-existing bugs: a TS strict-mode definite-assignment violation in `withStorageLock` (no runtime impact today, but a correct defensive init) and a semantically wrong CI signal in `isCiEnvironment` that caused `codex-multi-auth uninstall` to silently skip cleanup for any dev with `ignore-scripts=true` in their `.npmrc`.

- the test at `test/install-codex-auth.test.ts:445` and the `shouldAutoBindCodexAppOnInstall` case at line 468 both assert the old (now-removed) behavior and will fail on `npm test` — these must be updated before merging.

<h3>Confidence Score: 3/5</h3>

not safe to merge as-is — two existing vitest assertions directly test the removed behavior and will fail on CI

one P1 finding: the PR removes a behavior that is still asserted by live vitest tests (`npm_config_ignore_scripts` CI check), guaranteeing a broken test run. the logic fixes themselves are correct, but the missing test updates make the CI gate fail, pulling the score below the P1 ceiling of 4.

test/install-codex-auth.test.ts — stale assertions at lines 445 and 468-476 must be updated

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/storage/transactions.ts | initializes `releaseLock` to a no-op to satisfy TS strict definite-assignment; runtime behavior is unchanged since the Promise executor runs synchronously, but the defensive init is correct and guards against future async drift. no concurrent-access vitest coverage exists. |
| scripts/postinstall.js | removes `npm_config_ignore_scripts` from CI detection — semantically correct fix. however, the corresponding test in `install-codex-auth.test.ts` still asserts the old (removed) behavior and will fail. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["withStorageLock(fn)"] --> B["save previousMutex"]
    B --> C["releaseLock = () => undefined (no-op init — NEW)"]
    C --> D["storageMutex = new Promise(resolve => releaseLock = resolve)"]
    D --> E["previousMutex.then(fn)"]
    E --> F{".finally()"}
    F --> G["releaseLock() — always valid now"]
    G --> H["next queued caller unblocked"]

    subgraph isCiEnvironment ["isCiEnvironment() — AFTER FIX"]
        I["check CI_ENV_KEYS only"]
        J["npm_config_ignore_scripts removed (NEW)"]
    end

    K["codex-multi-auth uninstall with ignore-scripts=true in .npmrc"] --> L["isCiEnvironment() → false (correct)"]
    L --> M["runPreuninstallCleanup executes"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/install-codex-auth.test.ts`, line 442-476 ([link](https://github.com/ndycode/codex-multi-auth/blob/087383813cf8ddf06b1afb9af8807f21d6b3672f/test/install-codex-auth.test.ts#L442-L476)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **stale test assertions will fail after this PR**

   line 445 asserts `isCiEnvironment({ npm_config_ignore_scripts: "true" })` returns `true`, but the PR removes that branch — this assertion will now fail. additionally, the `shouldAutoBindCodexAppOnInstall` case at line 468 passes `npm_config_ignore_scripts: "true"` plus `CODEX_MULTI_AUTH_APP_BIND_INSTALL: "1"` and expects `false`. after the fix, `isCiEnvironment` returns `false`, so execution reaches `installOverride = readOptionalBoolean("1")` → `true` and the function returns `true`, flipping the assertion. both assertions need to be updated to match the new intended semantics.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/install-codex-auth.test.ts
   Line: 442-476

   Comment:
   **stale test assertions will fail after this PR**

   line 445 asserts `isCiEnvironment({ npm_config_ignore_scripts: "true" })` returns `true`, but the PR removes that branch — this assertion will now fail. additionally, the `shouldAutoBindCodexAppOnInstall` case at line 468 passes `npm_config_ignore_scripts: "true"` plus `CODEX_MULTI_AUTH_APP_BIND_INSTALL: "1"` and expects `false`. after the fix, `isCiEnvironment` returns `false`, so execution reaches `installOverride = readOptionalBoolean("1")` → `true` and the function returns `true`, flipping the assertion. both assertions need to be updated to match the new intended semantics.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fstorage-lock-and-ci-detection%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstorage-lock-and-ci-detection%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Finstall-codex-auth.test.ts%0ALine%3A%20442-476%0A%0AComment%3A%0A**stale%20test%20assertions%20will%20fail%20after%20this%20PR**%0A%0Aline%20445%20asserts%20%60isCiEnvironment%28%7B%20npm_config_ignore_scripts%3A%20%22true%22%20%7D%29%60%20returns%20%60true%60%2C%20but%20the%20PR%20removes%20that%20branch%20%E2%80%94%20this%20assertion%20will%20now%20fail.%20additionally%2C%20the%20%60shouldAutoBindCodexAppOnInstall%60%20case%20at%20line%20468%20passes%20%60npm_config_ignore_scripts%3A%20%22true%22%60%20plus%20%60CODEX_MULTI_AUTH_APP_BIND_INSTALL%3A%20%221%22%60%20and%20expects%20%60false%60.%20after%20the%20fix%2C%20%60isCiEnvironment%60%20returns%20%60false%60%2C%20so%20execution%20reaches%20%60installOverride%20%3D%20readOptionalBoolean%28%221%22%29%60%20%E2%86%92%20%60true%60%20and%20the%20function%20returns%20%60true%60%2C%20flipping%20the%20assertion.%20both%20assertions%20need%20to%20be%20updated%20to%20match%20the%20new%20intended%20semantics.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fstorage-lock-and-ci-detection%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstorage-lock-and-ci-detection%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atest%2Finstall-codex-auth.test.ts%3A442-476%0A**stale%20test%20assertions%20will%20fail%20after%20this%20PR**%0A%0Aline%20445%20asserts%20%60isCiEnvironment%28%7B%20npm_config_ignore_scripts%3A%20%22true%22%20%7D%29%60%20returns%20%60true%60%2C%20but%20the%20PR%20removes%20that%20branch%20%E2%80%94%20this%20assertion%20will%20now%20fail.%20additionally%2C%20the%20%60shouldAutoBindCodexAppOnInstall%60%20case%20at%20line%20468%20passes%20%60npm_config_ignore_scripts%3A%20%22true%22%60%20plus%20%60CODEX_MULTI_AUTH_APP_BIND_INSTALL%3A%20%221%22%60%20and%20expects%20%60false%60.%20after%20the%20fix%2C%20%60isCiEnvironment%60%20returns%20%60false%60%2C%20so%20execution%20reaches%20%60installOverride%20%3D%20readOptionalBoolean%28%221%22%29%60%20%E2%86%92%20%60true%60%20and%20the%20function%20returns%20%60true%60%2C%20flipping%20the%20assertion.%20both%20assertions%20need%20to%20be%20updated%20to%20match%20the%20new%20intended%20semantics.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fpostinstall.js%3A61-63%0A**missing%20vitest%20coverage%20for%20the%20removed%20branch**%0A%0Athe%20test%20plan%20mentions%20a%20manual%20shell%20check%20for%20%60isCiEnvironment%28%29%60%20returning%20%60false%60%20when%20%60npm_config_ignore_scripts%3Dtrue%60%2C%20but%20no%20vitest%20case%20is%20added%20that%20asserts%20this%20directly.%20the%20test%20at%20%60test%2Finstall-codex-auth.test.ts%3A445%60%20tested%20the%20old%20%28now-removed%29%20behavior%20%E2%80%94%20it%20should%20be%20replaced%20with%20an%20explicit%20assertion%20confirming%20the%20new%20semantics%3A%20%60expect%28isCiEnvironment%28%7B%20npm_config_ignore_scripts%3A%20%22true%22%20%7D%29%29.toBe%28false%29%60.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fstorage%2Ftransactions.ts%3A27-34%0A**no%20vitest%20coverage%20for%20concurrent%20lock%20ordering**%0A%0A%60withStorageLock%60%20is%20a%20critical%20concurrency%20primitive%20%E2%80%94%20storage%20deadlock%20would%20affect%20all%20subsequent%20writes%20on%20windows%20and%20unix%20alike.%20%60test%2Ftransactions.test.ts%60%20has%20no%20assertions%20exercising%20concurrent%20callers%20%28e.g.%2C%20two%20overlapping%20%60withStorageLock%60%20calls%20verifying%20serial%20ordering%29.%20given%20the%20codebase's%20existing%20chaos%2Ffault-injection%20test%20infra%2C%20a%20concurrent-access%20test%20would%20catch%20any%20regression%20in%20this%20pattern.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
test/install-codex-auth.test.ts:442-476
**stale test assertions will fail after this PR**

line 445 asserts `isCiEnvironment({ npm_config_ignore_scripts: "true" })` returns `true`, but the PR removes that branch — this assertion will now fail. additionally, the `shouldAutoBindCodexAppOnInstall` case at line 468 passes `npm_config_ignore_scripts: "true"` plus `CODEX_MULTI_AUTH_APP_BIND_INSTALL: "1"` and expects `false`. after the fix, `isCiEnvironment` returns `false`, so execution reaches `installOverride = readOptionalBoolean("1")` → `true` and the function returns `true`, flipping the assertion. both assertions need to be updated to match the new intended semantics.

### Issue 2 of 3
scripts/postinstall.js:61-63
**missing vitest coverage for the removed branch**

the test plan mentions a manual shell check for `isCiEnvironment()` returning `false` when `npm_config_ignore_scripts=true`, but no vitest case is added that asserts this directly. the test at `test/install-codex-auth.test.ts:445` tested the old (now-removed) behavior — it should be replaced with an explicit assertion confirming the new semantics: `expect(isCiEnvironment({ npm_config_ignore_scripts: "true" })).toBe(false)`.

### Issue 3 of 3
lib/storage/transactions.ts:27-34
**no vitest coverage for concurrent lock ordering**

`withStorageLock` is a critical concurrency primitive — storage deadlock would affect all subsequent writes on windows and unix alike. `test/transactions.test.ts` has no assertions exercising concurrent callers (e.g., two overlapping `withStorageLock` calls verifying serial ordering). given the codebase's existing chaos/fault-injection test infra, a concurrent-access test would catch any regression in this pattern.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: initialize releaseLock and remove f..."](https://github.com/ndycode/codex-multi-auth/commit/087383813cf8ddf06b1afb9af8807f21d6b3672f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30695967)</sub>

<!-- /greptile_comment -->