### PR TITLE
fix: app-bind crash-recovery, transactions missing arg, quota save ordering

### DIFF
--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -1490,12 +1490,13 @@ export async function runFix(
 		});
 	}
 
+	if (!options.dryRun && workingQuotaCache && quotaCacheChanged) {
+		await saveQuotaCache(workingQuotaCache);
+	}
+
 	const changed = accountStorageChanged;
 
 	if (options.json) {
-		if (!options.dryRun && workingQuotaCache && quotaCacheChanged) {
-			await saveQuotaCache(workingQuotaCache);
-		}
 		console.log(
 			JSON.stringify(
 				{
@@ -1594,9 +1595,6 @@ export async function runFix(
 				`${deps.stylePromptText("Note:", "accent")} ${deps.stylePromptText(recommendation.reason, "muted")}`,
 			);
 		}
-	}
-	if (!options.dryRun && workingQuotaCache && quotaCacheChanged) {
-		await saveQuotaCache(workingQuotaCache);
 	}
 
 	if (accountStorageChanged && options.dryRun) {

--- a/lib/runtime/app-bind.ts
+++ b/lib/runtime/app-bind.ts
@@ -669,7 +669,6 @@ async function bindCodexAppRuntimeRotationLocked(
 	await mkdir(paths.bindDir, { recursive: true });
 	await mkdir(dirname(paths.configPath), { recursive: true });
 	await atomicWriteFile(paths.backupPath, `${JSON.stringify(backup, null, 2)}\n`);
-	await atomicWriteFile(paths.statePath, `${JSON.stringify(state, null, 2)}\n`);
 	const startedRouter = await maybeStartRouter(state, options);
 	const router = startedRouter
 		? await waitForRouterStatus(

--- a/lib/storage/transactions.ts
+++ b/lib/storage/transactions.ts
@@ -68,10 +68,12 @@ export async function withAccountAndFlaggedStorageTransaction<T>(
 			accountStorage: AccountStorageV3,
 			flaggedStorage: FlaggedAccountStorageV1,
 		) => Promise<void>,
+		currentFlagged: FlaggedAccountStorageV1,
 	) => Promise<T>,
 	deps: {
 		getStoragePath: () => string;
 		loadCurrent: () => Promise<AccountStorageV3 | null>;
+		loadCurrentFlagged: () => Promise<FlaggedAccountStorageV1>;
 		saveAccounts: (storage: AccountStorageV3) => Promise<void>;
 		saveFlaggedAccounts: (storage: FlaggedAccountStorageV1) => Promise<void>;
 		cloneAccountStorageForPersistence: (
@@ -87,6 +89,7 @@ export async function withAccountAndFlaggedStorageTransaction<T>(
 			active: true,
 		};
 		const current = state.snapshot;
+		const currentFlagged = await deps.loadCurrentFlagged();
 		const persist = async (
 			accountStorage: AccountStorageV3,
 			flaggedStorage: FlaggedAccountStorageV1,
@@ -115,7 +118,7 @@ export async function withAccountAndFlaggedStorageTransaction<T>(
 			}
 		};
 		return transactionSnapshotContext.run(state, () =>
-			handler(current, persist),
+			handler(current, persist, currentFlagged),
 		);
 	});
 }


### PR DESCRIPTION
## Summary

Three bugs found during codebase audit, all independent of each other.

### `lib/runtime/app-bind.ts` — premature state file write with stale hash

`bindCodexAppRuntimeRotationLocked` wrote `statePath` twice: once before the router started (with `port=0` and a `boundConfigHash` computed from the zero-port config), then again after with the real port. A crash between the two writes left the state file with a `boundConfigHash` that didn't match the actual `config.toml` on disk. On unbind, the hash comparison took the merge path (`restoreConfigTomlFromAppBind`) instead of the clean backup-restore path, leaving `config.toml` in a partially-merged state rather than cleanly restored.

**Fix:** Remove the first `atomicWriteFile(paths.statePath, ...)` before `maybeStartRouter`. State is now written only once, after the correct port is resolved. A crash before that write leaves a backup with no state — the unbind `backup.existed` branch already handles this case correctly.

### `lib/storage/transactions.ts` — `withAccountAndFlaggedStorageTransaction` missing third handler argument

The `transactions.ts` implementation had a 2-param handler `(current, persist)`, diverging from the `storage.ts` implementation which passes a third `currentFlagged: FlaggedAccountStorageV1` argument. Any caller importing from `transactions.ts` directly and expecting the third argument would receive `undefined` and silently operate on stale flagged-account state.

**Fix:** Add `loadCurrentFlagged` to the deps interface, load it inside the lock, and pass `currentFlagged` as the third argument to the handler — matching the `storage.ts` signature.

### `lib/codex-manager/repair-commands.ts` — quota cache saved after console output

In `runFix`, account storage was persisted first, then quota cache was saved only after all console output was printed. An interruption between the two saves left account storage reflecting freshly-refreshed tokens while quota cache remained stale, causing incorrect quota decisions on the next invocation.

**Fix:** Move `saveQuotaCache` immediately after `withAccountStorageTransaction` completes, before any output, so both writes complete together. Removed the two duplicate `saveQuotaCache` calls that were previously scattered across the JSON and non-JSON output paths.

## Test plan

- [ ] `codex-multi-auth rotation bind-app` followed by forced kill mid-bind restores `config.toml` cleanly from backup on next `rotation unbind-app`
- [ ] `codex-multi-auth fix` interrupted after account storage save does not leave quota cache stale
- [ ] `codex-multi-auth fix --json` and non-JSON paths both save quota cache exactly once
- [ ] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

three independent bug fixes: removes a premature state file write in `app-bind.ts` that left a stale `boundConfigHash` on crash, adds the missing `currentFlagged` third argument to the `transactions.ts` handler (matching the `storage.ts` contract), and consolidates duplicate `saveQuotaCache` calls into a single write before console output in `repair-commands.ts`.

- `test/transactions.test.ts` was not updated — the `deps` fixture is missing the now-required `loadCurrentFlagged` field, which will fail `tsc --noEmit` (the PR's own stated test criteria).

<h3>Confidence Score: 3/5</h3>

not safe to merge as-is — TypeScript compilation breaks due to a missing required dep in the test fixture

one P1 (missing `loadCurrentFlagged` in `test/transactions.test.ts` breaks `tsc --noEmit`) pulls the score below the P1 ceiling of 4; two independent P2s on the same file keep it at 3

`test/transactions.test.ts` — needs `loadCurrentFlagged` added to the `withAccountAndFlaggedStorageTransaction` deps fixture and a new test asserting `currentFlagged` is passed through to the handler

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/storage/transactions.ts | adds `loadCurrentFlagged` to deps and passes `currentFlagged` as third handler arg inside the lock — correct fix, but the companion test file was not updated and will fail tsc |
| lib/runtime/app-bind.ts | removes premature state file write before port resolution; crash-recovery path via backup.existed is correct and unchanged |
| lib/codex-manager/repair-commands.ts | consolidates duplicate `saveQuotaCache` calls into one before console output — correct ordering, but a non-atomic window between account storage and quota cache writes remains |
| test/transactions.test.ts | not in PR diff but affected: missing `loadCurrentFlagged` in `deps` fixture breaks TypeScript compilation and lacks a test for the third-arg pass-through |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant T as transactions.ts (withAccountAndFlaggedStorageTransaction)
    participant S as Storage (lock)
    participant FS as FlaggedStorage

    C->>T: call handler
    T->>S: acquire storageLock
    S->>S: loadCurrent()
    S->>FS: loadCurrentFlagged() ← new
    S->>C: handler(current, persist, currentFlagged) ← now 3 args
    C->>S: persist(accountStorage, flaggedStorage)
    S->>S: saveAccounts()
    alt saveFlaggedAccounts succeeds
        S->>FS: saveFlaggedAccounts()
        S->>S: state.snapshot = nextAccounts
    else saveFlaggedAccounts fails
        S->>S: rollback saveAccounts(previousAccounts)
        S-->>C: throw error
    end
    T->>S: release storageLock
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/transactions.test.ts`, line 57-78 ([link](https://github.com/ndycode/codex-multi-auth/blob/0ed58a023f4f2447ba6e3456ef34ca7552a22e66/test/transactions.test.ts#L57-L78)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`deps` missing required `loadCurrentFlagged` — breaks `tsc --noEmit`**

   `withAccountAndFlaggedStorageTransaction` now requires `loadCurrentFlagged` in the `deps` object (added in `transactions.ts`), but the test fixture at line 57 doesn't include it. TypeScript will reject this as a missing required property, failing the `tsc --noEmit` step in the test plan.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/transactions.test.ts
   Line: 57-78

   Comment:
   **`deps` missing required `loadCurrentFlagged` — breaks `tsc --noEmit`**

   `withAccountAndFlaggedStorageTransaction` now requires `loadCurrentFlagged` in the `deps` object (added in `transactions.ts`), but the test fixture at line 57 doesn't include it. TypeScript will reject this as a missing required property, failing the `tsc --noEmit` step in the test plan.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fapp-bind-dead-code-quota-ordering%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fapp-bind-dead-code-quota-ordering%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Ftransactions.test.ts%0ALine%3A%2057-78%0A%0AComment%3A%0A**%60deps%60%20missing%20required%20%60loadCurrentFlagged%60%20%E2%80%94%20breaks%20%60tsc%20--noEmit%60**%0A%0A%60withAccountAndFlaggedStorageTransaction%60%20now%20requires%20%60loadCurrentFlagged%60%20in%20the%20%60deps%60%20object%20%28added%20in%20%60transactions.ts%60%29%2C%20but%20the%20test%20fixture%20at%20line%2057%20doesn't%20include%20it.%20TypeScript%20will%20reject%20this%20as%20a%20missing%20required%20property%2C%20failing%20the%20%60tsc%20--noEmit%60%20step%20in%20the%20test%20plan.%0A%0A%60%60%60suggestion%0A%09%09%09%7B%0A%09%09%09%09getStoragePath%3A%20%28%29%20%3D%3E%20%22%2Ftmp%2Faccounts.json%22%2C%0A%09%09%09%09loadCurrent%3A%20async%20%28%29%20%3D%3E%20%28%7B%0A%09%09%09%09%09version%3A%203%2C%0A%09%09%09%09%09accounts%3A%20%5B%7B%20refreshToken%3A%20%22old%22%20%7D%5D%2C%0A%09%09%09%09%09activeIndex%3A%200%2C%0A%09%09%09%09%09activeIndexByFamily%3A%20%7B%7D%2C%0A%09%09%09%09%7D%29%2C%0A%09%09%09%09loadCurrentFlagged%3A%20async%20%28%29%20%3D%3E%20%28%7B%20version%3A%201%2C%20accounts%3A%20%5B%5D%20%7D%29%2C%0A%09%09%09%09saveAccounts%2C%0A%09%09%09%09saveFlaggedAccounts%3A%20async%20%28%29%20%3D%3E%20%7B%0A%09%09%09%09%09throw%20new%20Error%28%22flagged%20failed%22%29%3B%0A%09%09%09%09%7D%2C%0A%09%09%09%09cloneAccountStorageForPersistence%3A%20%28storage%29%20%3D%3E%0A%09%09%09%09%09storage%20%3F%3F%20%7B%0A%09%09%09%09%09%09version%3A%203%2C%0A%09%09%09%09%09%09accounts%3A%20%5B%5D%2C%0A%09%09%09%09%09%09activeIndex%3A%200%2C%0A%09%09%09%09%09%09activeIndexByFamily%3A%20%7B%7D%2C%0A%09%09%09%09%09%7D%2C%0A%09%09%09%09logRollbackError%3A%20vi.fn%28%29%2C%0A%09%09%09%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fapp-bind-dead-code-quota-ordering%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fapp-bind-dead-code-quota-ordering%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atest%2Ftransactions.test.ts%3A57-78%0A**%60deps%60%20missing%20required%20%60loadCurrentFlagged%60%20%E2%80%94%20breaks%20%60tsc%20--noEmit%60**%0A%0A%60withAccountAndFlaggedStorageTransaction%60%20now%20requires%20%60loadCurrentFlagged%60%20in%20the%20%60deps%60%20object%20%28added%20in%20%60transactions.ts%60%29%2C%20but%20the%20test%20fixture%20at%20line%2057%20doesn't%20include%20it.%20TypeScript%20will%20reject%20this%20as%20a%20missing%20required%20property%2C%20failing%20the%20%60tsc%20--noEmit%60%20step%20in%20the%20test%20plan.%0A%0A%60%60%60suggestion%0A%09%09%09%7B%0A%09%09%09%09getStoragePath%3A%20%28%29%20%3D%3E%20%22%2Ftmp%2Faccounts.json%22%2C%0A%09%09%09%09loadCurrent%3A%20async%20%28%29%20%3D%3E%20%28%7B%0A%09%09%09%09%09version%3A%203%2C%0A%09%09%09%09%09accounts%3A%20%5B%7B%20refreshToken%3A%20%22old%22%20%7D%5D%2C%0A%09%09%09%09%09activeIndex%3A%200%2C%0A%09%09%09%09%09activeIndexByFamily%3A%20%7B%7D%2C%0A%09%09%09%09%7D%29%2C%0A%09%09%09%09loadCurrentFlagged%3A%20async%20%28%29%20%3D%3E%20%28%7B%20version%3A%201%2C%20accounts%3A%20%5B%5D%20%7D%29%2C%0A%09%09%09%09saveAccounts%2C%0A%09%09%09%09saveFlaggedAccounts%3A%20async%20%28%29%20%3D%3E%20%7B%0A%09%09%09%09%09throw%20new%20Error%28%22flagged%20failed%22%29%3B%0A%09%09%09%09%7D%2C%0A%09%09%09%09cloneAccountStorageForPersistence%3A%20%28storage%29%20%3D%3E%0A%09%09%09%09%09storage%20%3F%3F%20%7B%0A%09%09%09%09%09%09version%3A%203%2C%0A%09%09%09%09%09%09accounts%3A%20%5B%5D%2C%0A%09%09%09%09%09%09activeIndex%3A%200%2C%0A%09%09%09%09%09%09activeIndexByFamily%3A%20%7B%7D%2C%0A%09%09%09%09%09%7D%2C%0A%09%09%09%09logRollbackError%3A%20vi.fn%28%29%2C%0A%09%09%09%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Ftransactions.test.ts%3A41-82%0A**missing%20vitest%20coverage%20for%20%60currentFlagged%60%20pass-through**%0A%0Athere's%20no%20test%20asserting%20that%20%60currentFlagged%60%20%28loaded%20via%20%60loadCurrentFlagged%60%29%20is%20actually%20passed%20as%20the%20third%20argument%20to%20the%20handler%20in%20%60transactions.ts%60.%20the%20existing%20rollback%20test%20ignores%20the%20third%20arg%20entirely%20%28%60_current%2C%20persist%60%29.%20a%20dedicated%20test%20%E2%80%94%20loading%20a%20non-empty%20flagged%20store%20and%20asserting%20the%20handler%20receives%20it%20%E2%80%94%20would%20catch%20a%20regression%20where%20the%20arg%20is%20dropped%20or%20loaded%20incorrectly.%20this%20is%20especially%20important%20given%20the%20prior%20bug%20%28missing%20arg%29%20that%20this%20PR%20fixes.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fcodex-manager%2Frepair-commands.ts%3A1493-1495%0A**%60saveQuotaCache%60%20and%20account%20storage%20are%20still%20non-atomic**%0A%0A%60withAccountStorageTransaction%60%20completes%20and%20releases%20the%20storage%20lock%20at%20line%201491%20before%20%60saveQuotaCache%60%20runs%20at%20line%201494.%20a%20concurrent%20invocation%20%28or%20SIGINT%20between%20the%20two%29%20can%20acquire%20the%20lock%2C%20read%20fresh%20account%20storage%20but%20stale%20quota%20cache%2C%20then%20save%20inconsistent%20state.%20on%20windows%2C%20abrupt%20process%20termination%20during%20%60saveQuotaCache%60%20has%20an%20elevated%20risk%20of%20leaving%20a%20partial%20file%20if%20the%20underlying%20atomic%20rename%20isn't%20truly%20atomic%20on%20the%20target%20volume.%20this%20is%20an%20improvement%20over%20before%2C%20but%20the%20concurrency%20window%20between%20the%20two%20writes%20is%20still%20open%20%E2%80%94%20worth%20a%20comment%20near%20the%20save%20site%20explaining%20the%20known%20limitation.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
test/transactions.test.ts:57-78
**`deps` missing required `loadCurrentFlagged` — breaks `tsc --noEmit`**

`withAccountAndFlaggedStorageTransaction` now requires `loadCurrentFlagged` in the `deps` object (added in `transactions.ts`), but the test fixture at line 57 doesn't include it. TypeScript will reject this as a missing required property, failing the `tsc --noEmit` step in the test plan.

```suggestion
			{
				getStoragePath: () => "/tmp/accounts.json",
				loadCurrent: async () => ({
					version: 3,
					accounts: [{ refreshToken: "old" }],
					activeIndex: 0,
					activeIndexByFamily: {},
				}),
				loadCurrentFlagged: async () => ({ version: 1, accounts: [] }),
				saveAccounts,
				saveFlaggedAccounts: async () => {
					throw new Error("flagged failed");
				},
				cloneAccountStorageForPersistence: (storage) =>
					storage ?? {
						version: 3,
						accounts: [],
						activeIndex: 0,
						activeIndexByFamily: {},
					},
				logRollbackError: vi.fn(),
			},
```

### Issue 2 of 3
test/transactions.test.ts:41-82
**missing vitest coverage for `currentFlagged` pass-through**

there's no test asserting that `currentFlagged` (loaded via `loadCurrentFlagged`) is actually passed as the third argument to the handler in `transactions.ts`. the existing rollback test ignores the third arg entirely (`_current, persist`). a dedicated test — loading a non-empty flagged store and asserting the handler receives it — would catch a regression where the arg is dropped or loaded incorrectly. this is especially important given the prior bug (missing arg) that this PR fixes.

### Issue 3 of 3
lib/codex-manager/repair-commands.ts:1493-1495
**`saveQuotaCache` and account storage are still non-atomic**

`withAccountStorageTransaction` completes and releases the storage lock at line 1491 before `saveQuotaCache` runs at line 1494. a concurrent invocation (or SIGINT between the two) can acquire the lock, read fresh account storage but stale quota cache, then save inconsistent state. on windows, abrupt process termination during `saveQuotaCache` has an elevated risk of leaving a partial file if the underlying atomic rename isn't truly atomic on the target volume. this is an improvement over before, but the concurrency window between the two writes is still open — worth a comment near the save site explaining the known limitation.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: app-bind double state write, transa..."](https://github.com/ndycode/codex-multi-auth/commit/0ed58a023f4f2447ba6e3456ef34ca7552a22e66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30696794)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->