### PR TITLE
docs: document withAppBindLock invariants (BUG-2 audit followup)

### DIFF
--- a/lib/runtime/app-bind.ts
+++ b/lib/runtime/app-bind.ts
@@ -104,6 +104,13 @@ export interface AppBindOptions {
 	log?: (message: string) => void;
 }
 
+// Per-key mutex. `tail` resolves only after `current` resolves, so each
+// caller waits for the previous holder to call releaseCurrent(). The map
+// check and optional delete run synchronously after releaseCurrent() with no
+// await between them — JS's single-threaded event loop guarantees no other
+// caller can modify the map entry in that window. If a later caller has
+// already replaced the entry, the identity check is false and the chain is
+// preserved.
 async function withAppBindLock<T>(
 	key: string,
 	operation: () => Promise<T>,


### PR DESCRIPTION
## Summary

`withAppBindLock` uses a subtle promise-chaining pattern that a code reviewer flagged as a potential race condition between `releaseCurrent()` and the `appBindLocks.get(key) === tail` map check.

The concern: in a multi-threaded model, another caller could modify the map between those two lines. In practice this cannot happen — JavaScript's single-threaded event loop guarantees that no other code can run between `releaseCurrent()` and the map check since there is no `await` between them. The pattern is correct.

This PR adds a comment explaining the invariant so the reasoning is clear to future readers and the pattern is not incorrectly "fixed" in a way that would break the lock chain.

## Why no code change

The lock implementation is correct as written. The comment is the entire change. BUG-2 from the audit was a false positive caused by applying a multi-threaded mental model to single-threaded JS.

## Test plan

- [ ] `tsc --noEmit` passes (no logic change, just a comment)
- [ ] Comment accurately describes the invariant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds a documentation comment above `withAppBindLock` in `lib/runtime/app-bind.ts` explaining why the `releaseCurrent()` → map-identity-check sequence is safe under js's single-threaded event loop. the comment is accurate: `tail` adopts `current`'s resolved state, the map check has no `await` before it, and the identity guard (`appBindLocks.get(key) === tail`) correctly preserves the chain when a later caller has already replaced the map entry. no logic is changed.

<h3>Confidence Score: 4/5</h3>

safe to merge — docs-only change with an accurate comment; no logic altered

only finding is a pre-existing P2: no vitest coverage for `withAppBindLock`'s queue-chaining and map-cleanup logic. the comment itself is correct and the underlying implementation is sound.

no files require special attention beyond the noted test gap

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime/app-bind.ts | docs-only change: adds a 7-line comment explaining the per-key mutex chain invariant above `withAppBindLock`; comment is accurate and no logic is altered |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CallerA
    participant CallerB
    participant LockMap as appBindLocks (Map)
    participant Current as current (Promise)
    participant Tail as tail (Promise)

    CallerA->>LockMap: get(key) → undefined → previous = resolved
    CallerA->>Current: new Promise(resolve → releaseCurrent)
    CallerA->>Tail: previous.then(() => current)
    CallerA->>LockMap: set(key, tail)
    CallerA->>CallerA: await previous (already resolved)
    CallerA->>CallerA: run operation()

    CallerB->>LockMap: get(key) → tail (CallerA's tail)
    CallerB->>Current: new Promise(resolve → releaseCurrent_B)
    CallerB->>Tail: tailA.then(() => currentB)
    CallerB->>LockMap: set(key, tailB) — replaces tailA
    CallerB->>CallerB: await tailA (blocks until CallerA releases)

    CallerA->>Current: releaseCurrent() — resolves currentA
    Note over CallerA: synchronously: get(key) === tailA? NO (tailB replaced it) → map entry preserved
    Current->>Tail: currentA resolves → tailA resolves (microtask)
    CallerB->>CallerB: await tailA unblocked → run operation()
    CallerB->>Current: releaseCurrent_B() — resolves currentB
    Note over CallerB: synchronously: get(key) === tailB? YES → delete(key)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fapp-bind-lock-comment%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fapp-bind-lock-comment%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fruntime%2Fapp-bind.ts%3A107-113%0A**Missing%20vitest%20coverage%20for%20%60withAppBindLock%60**%0A%0A%60withAppBindLock%60%20is%20a%20non-trivial%20concurrency%20primitive%20%E2%80%94%20the%20queue-chaining%20logic%20%28%60tail%20%3D%20previous.then%28%28%29%20%3D%3E%20current%29%60%2C%20identity%20check%20on%20map%20delete%29%20is%20exactly%20the%20kind%20of%20subtle%20code%20that%20should%20have%20unit%20tests%20alongside%20the%20new%20doc%20comment.%20%60test%2Fapp-bind.test.ts%60%20exists%20but%20contains%20zero%20coverage%20of%20the%20lock%20itself.%20a%20vitest%20that%20exercises%20at%20least%3A%20%281%29%20two%20concurrent%20callers%20serialised%2C%20%282%29%20the%20map%20entry%20deleted%20after%20the%20last%20caller%2C%20and%20%283%29%20the%20map%20entry%20preserved%20when%20a%20second%20caller%20enqueues%20before%20the%20first%20finishes%2C%20would%20lock%20in%20the%20invariant%20the%20comment%20describes.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/runtime/app-bind.ts:107-113
**Missing vitest coverage for `withAppBindLock`**

`withAppBindLock` is a non-trivial concurrency primitive — the queue-chaining logic (`tail = previous.then(() => current)`, identity check on map delete) is exactly the kind of subtle code that should have unit tests alongside the new doc comment. `test/app-bind.test.ts` exists but contains zero coverage of the lock itself. a vitest that exercises at least: (1) two concurrent callers serialised, (2) the map entry deleted after the last caller, and (3) the map entry preserved when a second caller enqueues before the first finishes, would lock in the invariant the comment describes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document withAppBindLock invariant..."](https://github.com/ndycode/codex-multi-auth/commit/92792df682b6855c93bca692197db70104fbd272) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30698121)</sub>

<!-- /greptile_comment -->