### PR TITLE
fix: update hono security floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.7",
+	"version": "2.1.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
@@ -15,7 +15,7 @@
 			"dependencies": {
 				"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 				"@openauthjs/openauth": "^0.4.3",
-				"hono": "4.12.14",
+				"hono": "4.12.18",
 				"undici": "^6.24.1",
 				"zod": "^4.3.6"
 			},
@@ -2378,9 +2378,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.14",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-			"integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+			"version": "4.12.18",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+			"integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -164,12 +164,12 @@
 	"dependencies": {
 		"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 		"@openauthjs/openauth": "^0.4.3",
-		"hono": "4.12.14",
+		"hono": "4.12.18",
 		"undici": "^6.24.1",
 		"zod": "^4.3.6"
 	},
 	"overrides": {
-		"hono": "4.12.14",
+		"hono": "4.12.18",
 		"flatted": "3.4.2",
 		"minimatch": "10.2.4",
 		"picomatch": "4.0.4",


### PR DESCRIPTION
## Summary
- raise the direct and override Hono floor to 4.12.18
- refresh package-lock so Dependabot's five open package-lock alerts resolve after merge

## Verification
- npm install
- npm audit --audit-level=high
- npm run audit:ci
- npm run typecheck
- npm run lint
- npm run build
- npm test
- npm run clean:repo:check

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

bumps hono from 4.12.14 to 4.12.18 (direct dep + override) and refreshes `package-lock.json` to close dependabot alerts. snyk confirms 4.12.18 is the current latest non-vulnerable version with no known cves.

- `package.json`: hono pinned to `4.12.18` in both `dependencies` and `overrides`; `overrides` entry keeps indirect consumers on the same floor, which is correct.
- `package-lock.json`: resolved url and sha512 integrity hash updated; package version bumped `2.1.7 → 2.1.8`; no unexpected transitive dependency changes in the diff.

<h3>Confidence Score: 5/5</h3>

safe to merge — isolated dep bump touching only hono, no logic changes, no token or filesystem paths affected

the change is a single-package version pin from 4.12.14 to 4.12.18 in both the direct dependency and the override; the lockfile integrity hash matches the published npm artifact, snyk shows no known vulnerabilities in 4.12.18, and the override pattern correctly floors all transitive consumers to the same version

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | bumps hono direct dependency and override from 4.12.14 to 4.12.18; no other dep changes, override remains consistent |
| package-lock.json | lockfile refreshed: hono resolved to 4.12.18 with updated integrity hash; package version bumped 2.1.7→2.1.8; no unexpected transitive dep changes visible in diff |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[dependabot alerts\nhono < 4.12.18] --> B[bump package.json\ndependencies: hono 4.12.18\noverrides: hono 4.12.18]
    B --> C[npm install\nrefreshes package-lock.json\nintegrity hash updated]
    C --> D{npm audit\n--audit-level=high}
    D -- clean --> E[alerts resolved\nsafe to merge]
    D -- findings --> F[investigate & fix]
```

<sub>Reviews (1): Last reviewed commit: ["fix: update hono security floor"](https://github.com/ndycode/codex-multi-auth/commit/fd188882c19a95e00c69dc68eac7e75791910af8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31486109)</sub>

<!-- /greptile_comment -->