### PR TITLE
Fix runtime rotation pool diagnostics

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -17,6 +17,7 @@ import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
 import {
 	getHealthTracker,
 	getTokenTracker,
+	resetTrackers,
 	selectHybridAccount,
 	type AccountWithMetrics,
 	type HybridSelectionOptions,
@@ -39,7 +40,7 @@ import {
 	getAccountIdentityKey,
 	getRuntimeAccountIdentityKey,
 } from "./storage/identity.js";
-import { getCircuitBreaker } from "./circuit-breaker.js";
+import { getCircuitBreaker, resetAllCircuitBreakers } from "./circuit-breaker.js";
 import {
 	getStoragePathState,
 	runWithStoragePathState,
@@ -642,6 +643,31 @@ export class AccountManager {
 			!this.isAccountCoolingDown(account) &&
 			this.isCircuitAvailable(account)
 		);
+	}
+
+	getAccountRuntimeSkipReason(
+		index: number,
+		family: ModelFamily,
+		model?: string | null,
+	): string | null {
+		const account = this.getAccountByIndex(index);
+		if (!account) return "missing";
+		if (account.enabled === false) return "disabled";
+		if (!this.hasEnabledWorkspaces(account)) return "workspace-disabled";
+		clearExpiredRateLimits(account);
+		if (isRateLimitedForFamily(account, family, model)) return "rate-limited";
+		if (this.isAccountCoolingDown(account)) {
+			return account.cooldownReason
+				? `cooling-down:${account.cooldownReason}`
+				: "cooling-down";
+		}
+		if (!this.isCircuitAvailable(account)) return "circuit-open";
+		return null;
+	}
+
+	static resetVolatileRuntimeState(): void {
+		resetTrackers();
+		resetAllCircuitBreakers();
 	}
 
 	setActiveIndex(index: number): ManagedAccount | null {

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -2542,6 +2542,7 @@ async function runForecast(args: string[]): Promise<number> {
 		formatWaitTime,
 		defaultDisplay: DEFAULT_DASHBOARD_DISPLAY_SETTINGS,
 		formatQuotaSnapshotLine,
+		loadRuntimeObservabilitySnapshot: loadPersistedRuntimeObservabilitySnapshot,
 	});
 }
 

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -3,6 +3,7 @@ import { extractAccountEmail, sanitizeEmail } from "../../accounts.js";
 import {
 	buildForecastExplanation,
 	type ForecastAccountResult,
+	type RuntimeForecastOverlay,
 } from "../../forecast.js";
 import {
 	applyRefreshedAccountPatch,
@@ -22,6 +23,7 @@ interface ForecastCliOptions {
 	json: boolean;
 	explain: boolean;
 	model: string;
+	runtimeOverlay: boolean;
 }
 
 type ParsedArgsResult<T> =
@@ -80,6 +82,9 @@ export interface ForecastCommandDeps {
 			now: number;
 			refreshFailure?: TokenFailure;
 			liveQuota?: CodexQuotaSnapshot;
+			quotaCache?: QuotaCacheData | null;
+			allAccounts?: readonly AccountMetadataV3[];
+			runtimeOverlay?: RuntimeForecastOverlay | null;
 		}>,
 	) => ForecastAccountResult[];
 	summarizeForecast: (results: ForecastAccountResult[]) => {
@@ -107,6 +112,7 @@ export interface ForecastCommandDeps {
 	) => "success" | "warning" | "danger";
 	formatWaitTime: (ms: number) => string;
 	defaultDisplay: DashboardDisplaySettings;
+	loadRuntimeObservabilitySnapshot?: () => Promise<RuntimeForecastOverlay | null>;
 	logInfo?: (message: string) => void;
 	logError?: (message: string) => void;
 	getNow?: () => number;
@@ -131,6 +137,7 @@ function printForecastUsage(logInfo: (message: string) => void): void {
 			"  --json, -j         Print machine-readable JSON output",
 			"  --explain          Include structured recommendation reasoning",
 			"  --model, -m        Probe model for live mode (default: gpt-5.3-codex)",
+			"  --no-runtime-overlay  Ignore persisted runtime skip diagnostics",
 		].join("\n"),
 	);
 }
@@ -143,6 +150,7 @@ function parseForecastArgs(
 		json: false,
 		explain: false,
 		model: "gpt-5.3-codex",
+		runtimeOverlay: true,
 	};
 
 	for (let i = 0; i < args.length; i += 1) {
@@ -158,6 +166,10 @@ function parseForecastArgs(
 		}
 		if (arg === "--explain") {
 			options.explain = true;
+			continue;
+		}
+		if (arg === "--no-runtime-overlay") {
+			options.runtimeOverlay = false;
 			continue;
 		}
 		if (arg === "--model" || arg === "-m") {
@@ -205,7 +217,11 @@ export async function runForecastCommand(
 		? (await deps.loadDashboardDisplaySettings().catch(() => null)) ??
 			deps.defaultDisplay
 		: deps.defaultDisplay;
-	const quotaCache = options.live ? await deps.loadQuotaCache() : null;
+	const quotaCache = await deps.loadQuotaCache();
+	const runtimeOverlay =
+		options.runtimeOverlay && deps.loadRuntimeObservabilitySnapshot
+			? await deps.loadRuntimeObservabilitySnapshot().catch(() => null)
+			: null;
 	const workingQuotaCache = quotaCache
 		? deps.cloneQuotaCacheData(quotaCache)
 		: null;
@@ -346,6 +362,9 @@ export async function runForecastCommand(
 		now,
 		refreshFailure: refreshFailures.get(index),
 		liveQuota: liveQuotaByIndex.get(index),
+		quotaCache,
+		allAccounts: storage.accounts,
+		runtimeOverlay,
 	}));
 	const forecastResults = deps.evaluateForecastAccounts(forecastInputs);
 	const summary = deps.summarizeForecast(forecastResults);
@@ -373,6 +392,7 @@ export async function runForecastCommand(
 					command: "forecast",
 					model: requestedModel,
 					liveProbe: options.live,
+					runtimeOverlay: options.runtimeOverlay,
 					summary,
 					recommendation,
 					explanation: options.explain ? explanation : undefined,

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -315,6 +315,7 @@ export async function runReportCommand(
 	const refreshFailures = new Map<number, TokenFailure>();
 	const liveQuotaByIndex = new Map<number, CodexQuotaSnapshot>();
 	const probeErrors: string[] = [];
+	const runtimeSnapshot = await deps.loadRuntimeObservabilitySnapshot?.();
 	let consideredLiveAccounts = 0;
 	let executedLiveProbes = 0;
 
@@ -453,6 +454,7 @@ export async function runReportCommand(
 					now,
 					refreshFailure: refreshFailures.get(index),
 					liveQuota: liveQuotaByIndex.get(index),
+					runtimeOverlay: runtimeSnapshot,
 				})),
 			)
 		: [];
@@ -521,7 +523,7 @@ export async function runReportCommand(
 				formatQuotaSnapshotLine,
 			),
 		},
-		runtime: await deps.loadRuntimeObservabilitySnapshot?.(),
+		runtime: runtimeSnapshot,
 	};
 	if (report.forecast.recommendation.recommendedIndex !== null) {
 		const selectedIndex = report.forecast.recommendation.recommendedIndex;

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -315,7 +315,15 @@ export async function runReportCommand(
 	const refreshFailures = new Map<number, TokenFailure>();
 	const liveQuotaByIndex = new Map<number, CodexQuotaSnapshot>();
 	const probeErrors: string[] = [];
-	const runtimeSnapshot = await deps.loadRuntimeObservabilitySnapshot?.();
+	let runtimeSnapshot: RuntimeObservabilitySnapshot | null | undefined;
+	let runtimeSnapshotLoadError: string | null = null;
+	try {
+		runtimeSnapshot = await deps.loadRuntimeObservabilitySnapshot?.();
+	} catch (error) {
+		runtimeSnapshot = null;
+		runtimeSnapshotLoadError = error instanceof Error ? error.message : String(error);
+		deps.logError?.(`Runtime observability snapshot unavailable: ${runtimeSnapshotLoadError}`);
+	}
 	let consideredLiveAccounts = 0;
 	let executedLiveProbes = 0;
 
@@ -523,7 +531,9 @@ export async function runReportCommand(
 				formatQuotaSnapshotLine,
 			),
 		},
+		runtimeOverlay: runtimeSnapshot !== null && runtimeSnapshot !== undefined,
 		runtime: runtimeSnapshot,
+		runtimeSnapshotLoadError,
 	};
 	if (report.forecast.recommendation.recommendedIndex !== null) {
 		const selectedIndex = report.forecast.recommendation.recommendedIndex;

--- a/lib/codex-manager/commands/rotation.ts
+++ b/lib/codex-manager/commands/rotation.ts
@@ -1,6 +1,11 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { formatAccountLabel, formatCooldown, formatWaitTime } from "../../accounts.js";
+import {
+	AccountManager,
+	formatAccountLabel,
+	formatCooldown,
+	formatWaitTime,
+} from "../../accounts.js";
 import { parseBooleanEnv } from "../../env-parsing.js";
 import { getCodexMultiAuthDir } from "../../runtime-paths.js";
 import { saveAccountsWithRetry } from "../forecast-report-shared.js";
@@ -32,7 +37,10 @@ import {
 	isQuotaCacheEntryExhausted,
 } from "../../quota-readiness.js";
 import type { QuotaCacheData } from "../../quota-cache.js";
-import type { RuntimeObservabilitySnapshot } from "../../runtime/runtime-observability.js";
+import {
+	recordRuntimeReset,
+	type RuntimeObservabilitySnapshot,
+} from "../../runtime/runtime-observability.js";
 import {
 	appRuntimeHelperStatusToSignal as appRuntimeHelperStatusToRuntimeSignal,
 	resolveAccountCurrentMarkers,
@@ -88,14 +96,82 @@ function printRotationUsage(logInfo: (message: string) => void): void {
 			"  codex-multi-auth rotation bind-app",
 			"  codex-multi-auth rotation unbind-app",
 			"  codex-multi-auth rotation reset-rate-limits [--all | --account <idx>] [--dry-run] [--json]",
+			"  codex-multi-auth rotation reset-runtime [--json]",
 			"",
 			"Behavior:",
 			"  - Runtime rotation is enabled by default for request-bearing Codex sessions",
 			"  - Binds the packaged Codex desktop app to the same localhost router when enabled or repaired",
 			"  - Use CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0 to disable the proxy for the current process without changing persistent settings",
 			"  - reset-rate-limits clears stored rateLimitResetTimes and active coolingDownUntil entries; use when `fix --live` confirms quota is available but the proxy still returns 503 pool-exhausted",
+			"  - reset-runtime clears process-local runtime trackers and re-applies the Codex app bind when available",
 		].join("\n"),
 	);
+}
+
+async function runResetRuntime(
+	args: string[],
+	deps: RotationCommandDeps,
+): Promise<number> {
+	const logInfo = deps.logInfo ?? console.log;
+	const logError = deps.logError ?? console.error;
+	let json = false;
+	for (const arg of args) {
+		if (arg === "--json" || arg === "-j") {
+			json = true;
+			continue;
+		}
+		if (arg === "--help" || arg === "-h" || arg === "help") {
+			logInfo("Usage: codex-multi-auth rotation reset-runtime [--json]");
+			return 0;
+		}
+		logError(`Unknown reset-runtime option: ${arg}`);
+		return 1;
+	}
+
+	AccountManager.resetVolatileRuntimeState();
+	recordRuntimeReset("rotation-reset-runtime");
+	let unbind: AppBindResult | null = null;
+	let bind: AppBindResult | null = null;
+	let appBindRestarted = false;
+	if (deps.unbindCodexApp && deps.bindCodexApp) {
+		try {
+			unbind = await deps.unbindCodexApp();
+			bind = await deps.bindCodexApp();
+			appBindRestarted = true;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (json) {
+				logInfo(
+					JSON.stringify({
+						ok: false,
+						command: "rotation reset-runtime",
+						resetVolatileRuntimeState: true,
+						appBindRestarted,
+						error: message,
+					}),
+				);
+			} else {
+				logError(`Runtime reset completed, but app bind restart failed: ${message}`);
+			}
+			return 1;
+		}
+	}
+	const payload = {
+		ok: true,
+		command: "rotation reset-runtime",
+		resetVolatileRuntimeState: true,
+		appBindRestarted,
+		unbindStatus: unbind?.status.state ?? null,
+		bindStatus: bind?.status.state ?? null,
+	};
+	if (json) {
+		logInfo(JSON.stringify(payload));
+	} else {
+		logInfo("Runtime rotation volatile state reset.");
+		if (appBindRestarted) logInfo("Codex app bind restarted.");
+		else logInfo("Codex app bind helpers unavailable; new wrapper sessions will use the reset state.");
+	}
+	return 0;
 }
 
 interface ResetRateLimitsOptions {
@@ -659,6 +735,9 @@ export async function runRotationCommand(
 	}
 	if (subcommand === "reset-rate-limits") {
 		return runResetRateLimits(rest, deps);
+	}
+	if (subcommand === "reset-runtime") {
+		return runResetRuntime(rest, deps);
 	}
 	if (rest.length > 0) {
 		logError(`Unknown rotation option: ${rest[0]}`);

--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -37,6 +37,7 @@ import {
 import { setCodexCliActiveSelection } from "../codex-cli/writer.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import { resolveNormalizedModel } from "../request/helpers/model-map.js";
+import { loadPersistedRuntimeObservabilitySnapshot } from "../runtime/runtime-observability.js";
 import type { AccountIdSource, TokenFailure, TokenResult } from "../types.js";
 
 type TokenSuccess = Extract<TokenResult, { type: "success" }>;
@@ -1922,12 +1923,24 @@ export async function runDoctor(
 		});
 
 		const now = Date.now();
+		const runtimeSnapshot =
+			(await loadPersistedRuntimeObservabilitySnapshot().catch(() => null)) ??
+			null;
 		const forecastResults = evaluateForecastAccounts(
 			storageForChecks.accounts.map((account, index) => ({
 				index,
 				account,
 				isCurrent: index === activeIndex,
 				now,
+			})),
+		);
+		const runtimeForecastResults = evaluateForecastAccounts(
+			storageForChecks.accounts.map((account, index) => ({
+				index,
+				account,
+				isCurrent: index === activeIndex,
+				now,
+				runtimeOverlay: runtimeSnapshot,
 			})),
 		);
 		const recommendation = recommendForecastAccount(forecastResults);
@@ -1948,6 +1961,31 @@ export async function runDoctor(
 				message: "Current account aligns with forecast recommendation",
 			});
 		}
+
+		const divergent = forecastResults.filter((result) => {
+			const runtimeResult = runtimeForecastResults[result.index];
+			return (
+				result.availability === "ready" &&
+				runtimeResult?.availability === "unavailable"
+			);
+		});
+		addCheck({
+			key: "forecast-runtime-alignment",
+			severity: divergent.length > 0 ? "warn" : "ok",
+			message:
+				divergent.length > 0
+					? `${divergent.length} account(s) look ready on disk but unavailable in runtime state`
+					: "Forecast and runtime availability are aligned",
+			details:
+				divergent.length > 0
+					? divergent
+							.map((result) => {
+								const runtimeResult = runtimeForecastResults[result.index];
+								return `account ${result.index + 1}: ${runtimeResult?.reasons.join("; ") || "runtime unavailable"}`;
+							})
+							.join(" | ")
+					: undefined,
+		});
 
 		if (activeExists) {
 			const activeAccount = storageForChecks.accounts[activeIndex];

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -1,5 +1,10 @@
 import { formatAccountLabel, formatWaitTime } from "./accounts.js";
 import type { CodexQuotaSnapshot } from "./quota-probe.js";
+import type { QuotaCacheData } from "./quota-cache.js";
+import {
+	findQuotaCacheEntryForAccount,
+	isQuotaCacheEntryExhausted,
+} from "./quota-readiness.js";
 import { getRateLimitResetTimeForFamily } from "./runtime/account-status.js";
 import type { AccountMetadataV3 } from "./storage.js";
 import type { TokenFailure } from "./types.js";
@@ -14,6 +19,15 @@ export interface ForecastAccountInput {
 	now: number;
 	refreshFailure?: TokenFailure;
 	liveQuota?: CodexQuotaSnapshot;
+	quotaCache?: QuotaCacheData | null;
+	allAccounts?: readonly AccountMetadataV3[];
+	runtimeOverlay?: RuntimeForecastOverlay | null;
+}
+
+export interface RuntimeForecastOverlay {
+	accountSkipReasons?: Record<string, string>;
+	lastPoolExhaustionSkipReasons?: Record<string, string>;
+	policyBlockedIndexes?: number[];
 }
 
 export interface ForecastAccountResult {
@@ -206,6 +220,40 @@ export function evaluateForecastAccount(
 		if (availability === "ready") availability = "delayed";
 		riskScore += 35;
 		appendWaitReason(reasons, "rate limit resets in", remaining);
+	}
+
+	const quotaEntry = findQuotaCacheEntryForAccount(
+		input.quotaCache,
+		account,
+		input.allAccounts ?? [account],
+	);
+	if (isQuotaCacheEntryExhausted(quotaEntry, now)) {
+		const resetAts = [quotaEntry?.primary.resetAtMs, quotaEntry?.secondary.resetAtMs]
+			.filter((value): value is number => typeof value === "number")
+			.filter((value) => Number.isFinite(value) && value > now);
+		const quotaWait = resetAts.length > 0 ? Math.min(...resetAts) - now : waitMs;
+		waitMs = Math.max(waitMs, quotaWait);
+		if (availability === "ready") availability = "delayed";
+		riskScore += 60;
+		reasons.push("quota cache exhausted");
+		appendWaitReason(reasons, "quota resets in", quotaWait);
+	}
+
+	const overlay = input.runtimeOverlay;
+	const overlayReason =
+		overlay?.accountSkipReasons?.[String(index)] ??
+		overlay?.lastPoolExhaustionSkipReasons?.[String(index)] ??
+		null;
+	if (overlay?.policyBlockedIndexes?.includes(index)) {
+		availability = "unavailable";
+		riskScore += 95;
+		reasons.push("runtime policy blocked account");
+	} else if (overlayReason && overlayReason !== "already-attempted") {
+		if (overlayReason === "circuit-open" || overlayReason === "token-exhausted") {
+			availability = "unavailable";
+			riskScore += overlayReason === "circuit-open" ? 90 : 70;
+		}
+		reasons.push(`runtime skip: ${overlayReason}`);
 	}
 
 	const quota = input.liveQuota;

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -4,6 +4,7 @@ import type { QuotaCacheData } from "./quota-cache.js";
 import {
 	findQuotaCacheEntryForAccount,
 	isQuotaCacheEntryExhausted,
+	quotaLeftPercentFromUsed,
 } from "./quota-readiness.js";
 import { getRateLimitResetTimeForFamily } from "./runtime/account-status.js";
 import type { AccountMetadataV3 } from "./storage.js";
@@ -228,10 +229,16 @@ export function evaluateForecastAccount(
 		input.allAccounts ?? [account],
 	);
 	if (isQuotaCacheEntryExhausted(quotaEntry, now)) {
-		const resetAts = [quotaEntry?.primary.resetAtMs, quotaEntry?.secondary.resetAtMs]
-			.filter((value): value is number => typeof value === "number")
-			.filter((value) => Number.isFinite(value) && value > now);
-		const quotaWait = resetAts.length > 0 ? Math.min(...resetAts) - now : waitMs;
+		const resetAts = [quotaEntry?.primary, quotaEntry?.secondary]
+			.filter(
+				(window) =>
+					quotaLeftPercentFromUsed(window?.usedPercent) === 0 &&
+					typeof window?.resetAtMs === "number" &&
+					Number.isFinite(window.resetAtMs) &&
+					window.resetAtMs > now,
+			)
+			.map((window) => window?.resetAtMs ?? 0);
+		const quotaWait = resetAts.length > 0 ? Math.max(...resetAts) - now : waitMs;
 		waitMs = Math.max(waitMs, quotaWait);
 		if (availability === "ready") availability = "delayed";
 		riskScore += 60;
@@ -249,10 +256,13 @@ export function evaluateForecastAccount(
 		riskScore += 95;
 		reasons.push("runtime policy blocked account");
 	} else if (overlayReason && overlayReason !== "already-attempted") {
-		if (overlayReason === "circuit-open" || overlayReason === "token-exhausted") {
-			availability = "unavailable";
-			riskScore += overlayReason === "circuit-open" ? 90 : 70;
-		}
+		availability = "unavailable";
+		riskScore +=
+			overlayReason === "circuit-open"
+				? 90
+				: overlayReason === "token-exhausted"
+					? 70
+					: 50;
 		reasons.push(`runtime skip: ${overlayReason}`);
 	}
 

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1174,6 +1174,35 @@ export async function startRuntimeRotationProxy(
 		lastAccountUpdatedAt: null,
 	};
 	const threadGoalFallbacks = new Map<string, string | null>();
+	let staleRuntimeReloadPromise: Promise<boolean> | null = null;
+	let lastStaleRuntimeReloadAt = 0;
+	const staleRuntimeReloadDedupeMs = 1_000;
+
+	const recoverStaleRuntimeState = async (): Promise<boolean> => {
+		if (Date.now() - lastStaleRuntimeReloadAt <= staleRuntimeReloadDedupeMs) {
+			return true;
+		}
+		if (staleRuntimeReloadPromise) {
+			return staleRuntimeReloadPromise;
+		}
+		staleRuntimeReloadPromise = (async () => {
+			AccountManager.resetVolatileRuntimeState();
+			recordRuntimeReset("pool-exhausted-no-account");
+			const reloaded = await AccountManager.loadFromDisk();
+			accountManager = reloaded;
+			lastStaleRuntimeReloadAt = Date.now();
+			recordRuntimeReload("pool-exhausted-no-account");
+			return true;
+		})()
+			.catch((error) => {
+				status.lastError = error instanceof Error ? error.message : String(error);
+				return false;
+			})
+			.finally(() => {
+				staleRuntimeReloadPromise = null;
+			});
+		return staleRuntimeReloadPromise;
+	};
 
 	const handleRequest = async (
 		req: IncomingMessage,
@@ -1343,13 +1372,11 @@ export async function startRuntimeRotationProxy(
 						accountManager.getMinWaitTimeForFamily(context.family, context.model) === 0
 					) {
 						reloadedAfterNoAccount = true;
-						AccountManager.resetVolatileRuntimeState();
-						recordRuntimeReset("pool-exhausted-no-account");
-						accountManager = await AccountManager.loadFromDisk();
-						recordRuntimeReload("pool-exhausted-no-account");
-						accountSkipReasons.clear();
-						attemptedIndexes.clear();
-						continue;
+						if (await recoverStaleRuntimeState()) {
+							accountSkipReasons.clear();
+							attemptedIndexes.clear();
+							continue;
+						}
 					}
 					break;
 				}

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1120,7 +1120,8 @@ export async function startRuntimeRotationProxy(
 	options: RuntimeRotationProxyOptions,
 ): Promise<RuntimeRotationProxyServer> {
 	const pluginConfig = loadPluginConfig();
-	let accountManager = options.accountManager ?? (await AccountManager.loadFromDisk());
+	let activeAccountManager = options.accountManager ?? (await AccountManager.loadFromDisk());
+	const knownAccountManagers = new Set<AccountManager>([activeAccountManager]);
 	const fetchImpl = options.fetchImpl ?? fetch;
 	const host = options.host ?? DEFAULT_HOST;
 	const port = options.port ?? 0;
@@ -1174,13 +1175,13 @@ export async function startRuntimeRotationProxy(
 		lastAccountUpdatedAt: null,
 	};
 	const threadGoalFallbacks = new Map<string, string | null>();
-	let staleRuntimeReloadPromise: Promise<boolean> | null = null;
+	let staleRuntimeReloadPromise: Promise<AccountManager | null> | null = null;
 	let lastStaleRuntimeReloadAt = 0;
 	const staleRuntimeReloadDedupeMs = 1_000;
 
-	const recoverStaleRuntimeState = async (): Promise<boolean> => {
+	const recoverStaleRuntimeState = async (): Promise<AccountManager | null> => {
 		if (Date.now() - lastStaleRuntimeReloadAt <= staleRuntimeReloadDedupeMs) {
-			return true;
+			return activeAccountManager;
 		}
 		if (staleRuntimeReloadPromise) {
 			return staleRuntimeReloadPromise;
@@ -1189,14 +1190,15 @@ export async function startRuntimeRotationProxy(
 			AccountManager.resetVolatileRuntimeState();
 			recordRuntimeReset("pool-exhausted-no-account");
 			const reloaded = await AccountManager.loadFromDisk();
-			accountManager = reloaded;
+			activeAccountManager = reloaded;
+			knownAccountManagers.add(reloaded);
 			lastStaleRuntimeReloadAt = Date.now();
 			recordRuntimeReload("pool-exhausted-no-account");
-			return true;
+			return reloaded;
 		})()
 			.catch((error) => {
 				status.lastError = error instanceof Error ? error.message : String(error);
-				return false;
+				return null;
 			})
 			.finally(() => {
 				staleRuntimeReloadPromise = null;
@@ -1209,6 +1211,7 @@ export async function startRuntimeRotationProxy(
 		res: ServerResponse,
 	): Promise<void> => {
 		let usageRecorder: ReturnType<typeof createRuntimeUsageRecorder> | null = null;
+		let accountManager = activeAccountManager;
 		try {
 			const incomingUrl = new URL(req.url ?? "/", "http://127.0.0.1");
 			const isResponsesRequest =
@@ -1314,8 +1317,8 @@ export async function startRuntimeRotationProxy(
 			);
 			const attemptedIndexes = new Set<number>();
 			let exhaustionReason: ExhaustionReason = "no-account";
-			const accountCount = accountManager.getAccountCount();
-			const transientAttemptLimit = Math.max(
+			let accountCount = accountManager.getAccountCount();
+			let transientAttemptLimit = Math.max(
 				1,
 				Math.min(accountCount, maxRuntimeAccountAttempts),
 			);
@@ -1372,7 +1375,14 @@ export async function startRuntimeRotationProxy(
 						accountManager.getMinWaitTimeForFamily(context.family, context.model) === 0
 					) {
 						reloadedAfterNoAccount = true;
-						if (await recoverStaleRuntimeState()) {
+						const reloadedManager = await recoverStaleRuntimeState();
+						if (reloadedManager) {
+							accountManager = reloadedManager;
+							accountCount = accountManager.getAccountCount();
+							transientAttemptLimit = Math.max(
+								1,
+								Math.min(accountCount, maxRuntimeAccountAttempts),
+							);
 							accountSkipReasons.clear();
 							attemptedIndexes.clear();
 							continue;
@@ -1840,7 +1850,9 @@ export async function startRuntimeRotationProxy(
 		baseUrl: `http://${host}:${resolvedPort}`,
 		close: async () => {
 			await closeServer(server, sockets);
-			await accountManager.flushPendingSave();
+			await Promise.all(
+				[...knownAccountManagers].map((manager) => manager.flushPendingSave()),
+			);
 		},
 		getStatus: () => ({ ...status }),
 	};

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -29,7 +29,12 @@ import {
 } from "./constants.js";
 import { getModelFamily, type ModelFamily } from "./prompts/codex.js";
 import { queuedRefresh } from "./refresh-queue.js";
-import { mutateRuntimeObservabilitySnapshot } from "./runtime/runtime-observability.js";
+import {
+	mutateRuntimeObservabilitySnapshot,
+	recordRuntimePoolExhaustion,
+	recordRuntimeReload,
+	recordRuntimeReset,
+} from "./runtime/runtime-observability.js";
 import {
 	createRuntimeUsageRecorder,
 	evaluateRuntimePolicy,
@@ -863,6 +868,7 @@ export function chooseAccount(params: {
 	now: number;
 	policy: RuntimePolicyDecision | null;
 	pinnedIndex: number | null;
+	skipReasons?: Map<number, string>;
 }): ManagedAccount | null {
 	const {
 		accountManager,
@@ -874,22 +880,37 @@ export function chooseAccount(params: {
 		now,
 		policy,
 		pinnedIndex,
+		skipReasons,
 	} = params;
 
 	// Manual pin (from `codex-multi-auth switch <n>`) overrides every other
 	// selection signal. We do NOT call markSwitched here — the proxy must not
 	// clobber the pin set by the CLI. See issue #474.
 	if (typeof pinnedIndex === "number") {
-		if (attemptedIndexes.has(pinnedIndex)) return null;
-		if (pinnedIndex < 0 || pinnedIndex >= accountManager.getAccountCount()) {
+		if (attemptedIndexes.has(pinnedIndex)) {
+			skipReasons?.set(pinnedIndex, "already-attempted");
 			return null;
 		}
-		if (policy?.blockedAccountIndexes.has(pinnedIndex)) return null;
+		if (pinnedIndex < 0 || pinnedIndex >= accountManager.getAccountCount()) {
+			skipReasons?.set(pinnedIndex, "missing");
+			return null;
+		}
+		if (policy?.blockedAccountIndexes.has(pinnedIndex)) {
+			skipReasons?.set(pinnedIndex, "policy-blocked");
+			return null;
+		}
 		const pinned = accountManager.getAccountByIndex(pinnedIndex);
-		if (!pinned || pinned.enabled === false) return null;
-		if (
-			!accountManager.isAccountAvailableForFamily(pinnedIndex, family, model)
-		) {
+		if (!pinned || pinned.enabled === false) {
+			skipReasons?.set(pinnedIndex, "disabled");
+			return null;
+		}
+		const reason = accountManager.getAccountRuntimeSkipReason(
+			pinnedIndex,
+			family,
+			model,
+		);
+		if (reason) {
+			skipReasons?.set(pinnedIndex, reason);
 			return null;
 		}
 		return pinned;
@@ -903,11 +924,18 @@ export function chooseAccount(params: {
 	) {
 		const preferred = accountManager.getAccountByIndex(preferredIndex);
 		if (
-			preferred &&
-			accountManager.isAccountAvailableForFamily(preferred.index, family, model)
-		) {
+			preferred) {
+			const reason = accountManager.getAccountRuntimeSkipReason(
+				preferred.index,
+				family,
+				model,
+			);
+			if (reason) {
+				skipReasons?.set(preferred.index, reason);
+			} else {
 			accountManager.markSwitched(preferred, "rotation", family);
 			return preferred;
+			}
 		}
 	}
 
@@ -919,18 +947,36 @@ export function chooseAccount(params: {
 		!attemptedIndexes.has(selected.index) &&
 		!policy?.blockedAccountIndexes.has(selected.index)
 	) {
-		return selected;
+		const reason = accountManager.getAccountRuntimeSkipReason(
+			selected.index,
+			family,
+			model,
+		);
+		if (!reason) return selected;
+		skipReasons?.set(selected.index, reason);
 	}
 
 	for (const account of accountManager.getAccountsSnapshot()) {
-		if (attemptedIndexes.has(account.index)) continue;
-		if (policy?.blockedAccountIndexes.has(account.index)) continue;
-		if (accountManager.isAccountAvailableForFamily(account.index, family, model)) {
+		if (attemptedIndexes.has(account.index)) {
+			skipReasons?.set(account.index, "already-attempted");
+			continue;
+		}
+		if (policy?.blockedAccountIndexes.has(account.index)) {
+			skipReasons?.set(account.index, "policy-blocked");
+			continue;
+		}
+		const reason = accountManager.getAccountRuntimeSkipReason(
+			account.index,
+			family,
+			model,
+		);
+		if (!reason) {
 			const live = accountManager.getAccountByIndex(account.index);
 			if (!live) continue;
 			accountManager.markSwitched(live, "rotation", family);
 			return live;
 		}
+		skipReasons?.set(account.index, reason);
 	}
 
 	return null;
@@ -970,9 +1016,21 @@ function writePoolExhausted(params: {
 	family: ModelFamily;
 	model: string | null;
 	reason: ExhaustionReason;
+	accountSkipReasons?: Record<string, string>;
 }): void {
 	const { res, accountManager, family, model, reason } = params;
 	const waitMs = accountManager.getMinWaitTimeForFamily(family, model);
+	const accountCount = accountManager.getAccountCount();
+	const accountSkipReasons = params.accountSkipReasons ?? {};
+	recordRuntimePoolExhaustion({
+		reason,
+		retryAfterMs: waitMs,
+		accountSkipReasons,
+	});
+	const hint =
+		reason === "no-account" && accountCount > 0
+			? "Accounts exist but all failed runtime availability checks. Run `codex-multi-auth report --json` to inspect runtime skip reasons, or `codex-multi-auth rotation reset-runtime` to reload the runtime proxy."
+			: "Run `codex-multi-auth rotation status` to inspect account state.";
 	writeJson(res, normalizeExhaustionStatus(reason), {
 		error: {
 			message:
@@ -980,7 +1038,8 @@ function writePoolExhausted(params: {
 			code: "codex_runtime_rotation_pool_exhausted",
 			reason,
 			retry_after_ms: waitMs,
-			hint: "Run `codex-multi-auth rotation status` to inspect account state.",
+			account_skip_reasons: accountSkipReasons,
+			hint,
 		},
 	});
 }
@@ -1061,7 +1120,7 @@ export async function startRuntimeRotationProxy(
 	options: RuntimeRotationProxyOptions,
 ): Promise<RuntimeRotationProxyServer> {
 	const pluginConfig = loadPluginConfig();
-	const accountManager = options.accountManager ?? (await AccountManager.loadFromDisk());
+	let accountManager = options.accountManager ?? (await AccountManager.loadFromDisk());
 	const fetchImpl = options.fetchImpl ?? fetch;
 	const host = options.host ?? DEFAULT_HOST;
 	const port = options.port ?? 0;
@@ -1164,6 +1223,16 @@ export async function startRuntimeRotationProxy(
 					model: context.model,
 					now: requestStartedAt,
 				});
+				mutateRuntimeObservabilitySnapshot((snapshot) => {
+					snapshot.policyBlockedIndexes = [
+						...(policyDecision?.blockedAccountIndexes ?? new Set<number>()),
+					];
+					snapshot.policyBlockedReasons = Object.fromEntries(
+						[...(policyDecision?.blockedAccountIndexes ?? new Set<number>())].map(
+							(index) => [String(index), "policy-blocked"],
+						),
+					);
+				});
 			} catch (error) {
 				policyError = error instanceof Error ? error.message : String(error);
 				status.lastError = policyError;
@@ -1223,6 +1292,8 @@ export async function startRuntimeRotationProxy(
 			);
 			let transientAttempts = 0;
 			let transientExhaustionReason: ExhaustionReason | null = null;
+			const accountSkipReasons = new Map<number, string>();
+			let reloadedAfterNoAccount = false;
 
 			// Read the manual pin and affinity generation from disk (mtime-cached)
 			// on each request so a `codex-multi-auth switch|unpin|best` invocation
@@ -1254,11 +1325,38 @@ export async function startRuntimeRotationProxy(
 					now: now(),
 					policy: policyDecision,
 					pinnedIndex,
+					skipReasons: accountSkipReasons,
 				});
-				if (!selected) break;
+				if (!selected) {
+					if (
+						!reloadedAfterNoAccount &&
+						!isPinned &&
+						accountCount > 0 &&
+						exhaustionReason === "no-account" &&
+						(policyDecision?.blockedAccountIndexes.size ?? 0) === 0 &&
+						![...accountSkipReasons.values()].some(
+							(reason) =>
+								reason === "rate-limited" ||
+								reason.startsWith("cooling-down") ||
+								reason === "policy-blocked",
+						) &&
+						accountManager.getMinWaitTimeForFamily(context.family, context.model) === 0
+					) {
+						reloadedAfterNoAccount = true;
+						AccountManager.resetVolatileRuntimeState();
+						recordRuntimeReset("pool-exhausted-no-account");
+						accountManager = await AccountManager.loadFromDisk();
+						recordRuntimeReload("pool-exhausted-no-account");
+						accountSkipReasons.clear();
+						attemptedIndexes.clear();
+						continue;
+					}
+					break;
+				}
 				attemptedIndexes.add(selected.index);
 
 				if (!accountManager.consumeToken(selected, context.family, context.model)) {
+					accountSkipReasons.set(selected.index, "token-exhausted");
 					exhaustionReason = "rate-limit";
 					continue;
 				}
@@ -1634,6 +1732,12 @@ export async function startRuntimeRotationProxy(
 					family: context.family,
 					model: context.model,
 					reason: exhaustionReason,
+					accountSkipReasons: Object.fromEntries(
+						[...accountSkipReasons.entries()].map(([index, reason]) => [
+							String(index),
+							reason,
+						]),
+					),
 				});
 			}
 		} catch (error) {

--- a/lib/runtime/runtime-observability.ts
+++ b/lib/runtime/runtime-observability.ts
@@ -47,6 +47,16 @@ export interface RuntimeObservabilitySnapshot {
 	lastAccountEmail?: string | null;
 	lastAccountId?: string | null;
 	lastAccountUpdatedAt?: number | null;
+	lastPoolExhaustionReason?: string | null;
+	lastPoolExhaustionRetryAfterMs?: number | null;
+	lastPoolExhaustionSkipReasons?: Record<string, string>;
+	lastRuntimeResetAt?: number | null;
+	lastRuntimeResetReason?: string | null;
+	lastRuntimeReloadAt?: number | null;
+	lastRuntimeReloadReason?: string | null;
+	accountSkipReasons?: Record<string, string>;
+	policyBlockedIndexes?: number[];
+	policyBlockedReasons?: Record<string, string>;
 	runtimeMetrics: RuntimeMetricsSnapshot;
 }
 
@@ -77,6 +87,16 @@ function createDefaultSnapshot(): RuntimeObservabilitySnapshot {
 		lastAccountEmail: null,
 		lastAccountId: null,
 		lastAccountUpdatedAt: null,
+		lastPoolExhaustionReason: null,
+		lastPoolExhaustionRetryAfterMs: null,
+		lastPoolExhaustionSkipReasons: {},
+		lastRuntimeResetAt: null,
+		lastRuntimeResetReason: null,
+		lastRuntimeReloadAt: null,
+		lastRuntimeReloadReason: null,
+		accountSkipReasons: {},
+		policyBlockedIndexes: [],
+		policyBlockedReasons: {},
 		runtimeMetrics: {
 			startedAt: 0,
 			totalRequests: 0,
@@ -130,6 +150,20 @@ function normalizePersistedSnapshot(
 		runtimeMetrics: {
 			...base.runtimeMetrics,
 			...(parsed.runtimeMetrics ?? {}),
+		},
+		lastPoolExhaustionSkipReasons: {
+			...(parsed.lastPoolExhaustionSkipReasons ?? {}),
+		},
+		accountSkipReasons: {
+			...(parsed.accountSkipReasons ?? {}),
+		},
+		policyBlockedIndexes: Array.isArray(parsed.policyBlockedIndexes)
+			? parsed.policyBlockedIndexes.filter((value): value is number =>
+					Number.isInteger(value),
+				)
+			: [],
+		policyBlockedReasons: {
+			...(parsed.policyBlockedReasons ?? {}),
 		},
 	};
 }
@@ -210,6 +244,39 @@ export function mutateRuntimeObservabilitySnapshot(
 		.catch(() => undefined)
 		.then(() => writeSnapshot(nextSnapshot))
 		.catch(() => undefined);
+}
+
+export function recordRuntimePoolExhaustion(params: {
+	reason: string;
+	retryAfterMs: number;
+	accountSkipReasons: Record<string, string>;
+}): void {
+	mutateRuntimeObservabilitySnapshot((snapshot) => {
+		snapshot.lastPoolExhaustionReason = params.reason;
+		snapshot.lastPoolExhaustionRetryAfterMs = params.retryAfterMs;
+		snapshot.lastPoolExhaustionSkipReasons = { ...params.accountSkipReasons };
+		snapshot.accountSkipReasons = { ...params.accountSkipReasons };
+	});
+}
+
+export function recordRuntimeReload(reason: string): void {
+	mutateRuntimeObservabilitySnapshot((snapshot) => {
+		snapshot.lastRuntimeReloadAt = Date.now();
+		snapshot.lastRuntimeReloadReason = reason;
+	});
+}
+
+export function recordRuntimeReset(reason: string): void {
+	mutateRuntimeObservabilitySnapshot((snapshot) => {
+		snapshot.lastRuntimeResetAt = Date.now();
+		snapshot.lastRuntimeResetReason = reason;
+		snapshot.lastPoolExhaustionReason = null;
+		snapshot.lastPoolExhaustionRetryAfterMs = null;
+		snapshot.lastPoolExhaustionSkipReasons = {};
+		snapshot.accountSkipReasons = {};
+		snapshot.policyBlockedIndexes = [];
+		snapshot.policyBlockedReasons = {};
+	});
 }
 
 export async function loadPersistedRuntimeObservabilitySnapshot(): Promise<RuntimeObservabilitySnapshot | null> {

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -141,6 +141,71 @@ describe("runForecastCommand", () => {
 		);
 	});
 
+	it("honors --no-runtime-overlay in json forecast output", async () => {
+		const evaluateForecastAccounts = vi.fn((inputs) => {
+			const overlay = inputs[0]?.runtimeOverlay as
+				| { lastPoolExhaustionSkipReasons?: Record<string, string> }
+				| null
+				| undefined;
+			const reason = overlay?.lastPoolExhaustionSkipReasons?.["0"];
+			return [
+				{
+					index: 0,
+					label: "1. forecast@example.com",
+					isCurrent: true,
+					availability: reason ? "unavailable" : "ready",
+					riskScore: reason ? 90 : 0,
+					riskLevel: reason ? "high" : "low",
+					waitMs: 0,
+					reasons: reason ? [`runtime skip: ${reason}`] : [],
+					hardFailure: false,
+					disabled: false,
+				},
+			] as const;
+		});
+		const deps = createDeps({
+			evaluateForecastAccounts,
+			summarizeForecast: vi.fn((results) => ({
+				total: 1,
+				ready: results.filter((result) => result.availability === "ready").length,
+				delayed: 0,
+				unavailable: results.filter(
+					(result) => result.availability === "unavailable",
+				).length,
+				highRisk: results.filter((result) => result.riskLevel === "high").length,
+			})),
+			loadRuntimeObservabilitySnapshot: vi.fn(async () => ({
+				lastPoolExhaustionSkipReasons: { "0": "circuit-open" },
+			})),
+		});
+
+		await expect(runForecastCommand(["--json"], deps)).resolves.toBe(0);
+		await expect(
+			runForecastCommand(["--json", "--no-runtime-overlay"], deps),
+		).resolves.toBe(0);
+
+		const withOverlay = JSON.parse(
+			(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-2)?.[0] ?? "{}",
+		) as {
+			runtimeOverlay: boolean;
+			accounts: Array<{ availability: string; reasons: string[] }>;
+		};
+		const withoutOverlay = JSON.parse(
+			(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? "{}",
+		) as {
+			runtimeOverlay: boolean;
+			accounts: Array<{ availability: string; reasons: string[] }>;
+		};
+		expect(withOverlay.runtimeOverlay).toBe(true);
+		expect(withOverlay.accounts[0]?.availability).toBe("unavailable");
+		expect(withOverlay.accounts[0]?.reasons).toContain(
+			"runtime skip: circuit-open",
+		);
+		expect(withoutOverlay.runtimeOverlay).toBe(false);
+		expect(withoutOverlay.accounts[0]?.availability).toBe("ready");
+		expect(withoutOverlay.accounts[0]?.reasons).toEqual([]);
+	});
+
 	it("persists refreshed probe tokens before forecasting live quota", async () => {
 		const storage = createStorage();
 		const concurrentStorage = createStorage();

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -202,6 +202,98 @@ describe("runReportCommand", () => {
 		expect(jsonOutput.runtime.runtimeMetrics).toBeDefined();
 	});
 
+	it("applies runtime overlay to report forecast output", async () => {
+		const deps = createDeps({
+			loadRuntimeObservabilitySnapshot: vi.fn(async () => ({
+				version: 1,
+				updatedAt: 2000,
+				responsesRequests: 0,
+				authRefreshRequests: 0,
+				diagnosticProbeRequests: 0,
+				currentRequestId: null,
+				poolExhaustionCooldownUntil: null,
+				serverBurstCooldownUntil: null,
+				lastPoolExhaustionSkipReasons: { "0": "circuit-open" },
+				runtimeMetrics: {
+					startedAt: 1000,
+					totalRequests: 0,
+					successfulRequests: 0,
+					failedRequests: 0,
+					responsesRequests: 0,
+					authRefreshRequests: 0,
+					diagnosticProbeRequests: 0,
+					outboundRequestAttemptBudget: null,
+					outboundRequestAttemptsConsumed: 0,
+					requestAttemptBudgetExhaustions: 0,
+					poolExhaustionFastFails: 0,
+					serverBurstFastFails: 0,
+					rateLimitedResponses: 0,
+					serverErrors: 0,
+					networkErrors: 0,
+					userAborts: 0,
+					authRefreshFailures: 0,
+					emptyResponseRetries: 0,
+					accountRotations: 0,
+					sameAccountRetries: 0,
+					streamFailoverAttempts: 0,
+					streamFailoverCandidatesConsidered: 0,
+					lastStreamFailoverCandidateCount: 0,
+					streamFailoverRecoveries: 0,
+					streamFailoverCrossAccountRecoveries: 0,
+					cumulativeLatencyMs: 0,
+					lastRequestAt: null,
+					lastError: null,
+				},
+			})),
+		});
+
+		await expect(runReportCommand(["--json"], deps)).resolves.toBe(0);
+
+		const jsonOutput = JSON.parse(
+			(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? "{}",
+		) as {
+			runtimeOverlay: boolean;
+			runtimeSnapshotLoadError: string | null;
+			forecast: { accounts: Array<{ availability: string; reasons: string[] }> };
+			runtime: { lastPoolExhaustionSkipReasons: Record<string, string> };
+		};
+		expect(jsonOutput.runtimeOverlay).toBe(true);
+		expect(jsonOutput.runtimeSnapshotLoadError).toBeNull();
+		expect(jsonOutput.runtime.lastPoolExhaustionSkipReasons).toEqual({
+			"0": "circuit-open",
+		});
+		expect(jsonOutput.forecast.accounts[0]?.availability).toBe("unavailable");
+		expect(jsonOutput.forecast.accounts[0]?.reasons).toContain(
+			"runtime skip: circuit-open",
+		);
+	});
+
+	it("continues report generation when runtime snapshot loading fails", async () => {
+		const deps = createDeps({
+			loadRuntimeObservabilitySnapshot: vi.fn(async () => {
+				throw new Error("snapshot busy");
+			}),
+		});
+
+		await expect(runReportCommand(["--json"], deps)).resolves.toBe(0);
+
+		const jsonOutput = JSON.parse(
+			(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? "{}",
+		) as {
+			runtimeOverlay: boolean;
+			runtime: null;
+			runtimeSnapshotLoadError: string;
+			forecast: { accounts: Array<{ availability: string }> };
+		};
+		expect(deps.logError).toHaveBeenCalledWith(
+			"Runtime observability snapshot unavailable: snapshot busy",
+		);
+		expect(jsonOutput.runtimeOverlay).toBe(false);
+		expect(jsonOutput.runtime).toBeNull();
+		expect(jsonOutput.runtimeSnapshotLoadError).toBe("snapshot busy");
+		expect(jsonOutput.forecast.accounts[0]?.availability).toBe("ready");
+	});
+
 	it("respects live probe account and probe budgets", async () => {
 		const deps = createDeps({
 			loadAccounts: vi.fn(async () =>

--- a/test/codex-manager-rotation-command.test.ts
+++ b/test/codex-manager-rotation-command.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { AccountManager } from "../lib/accounts.js";
 import { runRotationCommand } from "../lib/codex-manager/commands/rotation.js";
 import type { RotationCommandDeps } from "../lib/codex-manager/commands/rotation.js";
 import type { AppBindResult, AppBindStatus } from "../lib/runtime/app-bind.js";
@@ -214,18 +215,70 @@ beforeEach(() => {
 describe("rotation reset-runtime", () => {
 	it("returns deterministic json and restarts app bind when helpers exist", async () => {
 		const { deps, infos, bindCodexAppMock, unbindCodexAppMock } = createDeps();
+		const resetSpy = vi.spyOn(AccountManager, "resetVolatileRuntimeState");
 
-		const exitCode = await runRotationCommand(["reset-runtime", "--json"], deps);
+		try {
+			const exitCode = await runRotationCommand(["reset-runtime", "--json"], deps);
 
-		expect(exitCode).toBe(0);
-		expect(unbindCodexAppMock).toHaveBeenCalledTimes(1);
-		expect(bindCodexAppMock).toHaveBeenCalledTimes(1);
-		expect(JSON.parse(infos.at(-1) ?? "{}")).toMatchObject({
-			ok: true,
-			command: "rotation reset-runtime",
-			resetVolatileRuntimeState: true,
-			appBindRestarted: true,
-		});
+			expect(exitCode).toBe(0);
+			expect(resetSpy).toHaveBeenCalledTimes(1);
+			expect(unbindCodexAppMock).toHaveBeenCalledTimes(1);
+			expect(bindCodexAppMock).toHaveBeenCalledTimes(1);
+			expect(JSON.parse(infos.at(-1) ?? "{}")).toMatchObject({
+				ok: true,
+				command: "rotation reset-runtime",
+				resetVolatileRuntimeState: true,
+				appBindRestarted: true,
+			});
+		} finally {
+			resetSpy.mockRestore();
+		}
+	});
+
+	it("returns failure json when app bind restart throws after runtime reset", async () => {
+		const { deps, infos, errors, bindCodexAppMock, unbindCodexAppMock } =
+			createDeps();
+		const resetSpy = vi.spyOn(AccountManager, "resetVolatileRuntimeState");
+		unbindCodexAppMock.mockRejectedValueOnce(new Error("unbind busy"));
+
+		try {
+			const exitCode = await runRotationCommand(["reset-runtime", "--json"], deps);
+
+			expect(exitCode).toBe(1);
+			expect(resetSpy).toHaveBeenCalledTimes(1);
+			expect(unbindCodexAppMock).toHaveBeenCalledTimes(1);
+			expect(bindCodexAppMock).not.toHaveBeenCalled();
+			expect(errors).toEqual([]);
+			expect(JSON.parse(infos.at(-1) ?? "{}")).toMatchObject({
+				ok: false,
+				command: "rotation reset-runtime",
+				resetVolatileRuntimeState: true,
+				appBindRestarted: false,
+				error: "unbind busy",
+			});
+		} finally {
+			resetSpy.mockRestore();
+		}
+	});
+
+	it("succeeds without app bind helpers and reports wrapper-session fallback", async () => {
+		const { deps, infos } = createDeps();
+		const resetSpy = vi.spyOn(AccountManager, "resetVolatileRuntimeState");
+		delete deps.bindCodexApp;
+		delete deps.unbindCodexApp;
+
+		try {
+			const exitCode = await runRotationCommand(["reset-runtime"], deps);
+
+			expect(exitCode).toBe(0);
+			expect(resetSpy).toHaveBeenCalledTimes(1);
+			expect(infos).toEqual([
+				"Runtime rotation volatile state reset.",
+				"Codex app bind helpers unavailable; new wrapper sessions will use the reset state.",
+			]);
+		} finally {
+			resetSpy.mockRestore();
+		}
 	});
 });
 

--- a/test/codex-manager-rotation-command.test.ts
+++ b/test/codex-manager-rotation-command.test.ts
@@ -211,6 +211,24 @@ beforeEach(() => {
 	delete process.env.CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY;
 });
 
+describe("rotation reset-runtime", () => {
+	it("returns deterministic json and restarts app bind when helpers exist", async () => {
+		const { deps, infos, bindCodexAppMock, unbindCodexAppMock } = createDeps();
+
+		const exitCode = await runRotationCommand(["reset-runtime", "--json"], deps);
+
+		expect(exitCode).toBe(0);
+		expect(unbindCodexAppMock).toHaveBeenCalledTimes(1);
+		expect(bindCodexAppMock).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(infos.at(-1) ?? "{}")).toMatchObject({
+			ok: true,
+			command: "rotation reset-runtime",
+			resetVolatileRuntimeState: true,
+			appBindRestarted: true,
+		});
+	});
+});
+
 afterEach(() => {
 	if (originalRuntimeRotationProxyEnv === undefined) {
 		delete process.env.CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY;

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -115,6 +115,45 @@ describe("forecast helpers", () => {
 		expect(result.reasons).toContain("quota cache exhausted");
 	});
 
+	it("waits for the later quota reset when both cached windows are exhausted", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			email: "quota@example.com",
+			accountId: "acc_quota",
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+		};
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			allAccounts: [account],
+			quotaCache: {
+				version: 1,
+				updatedAt: now,
+				byAccountId: {
+					acc_quota: {
+						accountId: "acc_quota",
+						status: 200,
+						model: "gpt-5.3-codex",
+						updatedAt: now,
+						primary: { usedPercent: 100, resetAtMs: now + 60_000 },
+						secondary: { usedPercent: 100, resetAtMs: now + 300_000 },
+					},
+				},
+				byEmail: {},
+			},
+		});
+
+		expect(result.availability).toBe("delayed");
+		expect(result.waitMs).toBe(300_000);
+		expect(result.reasons).toEqual(
+			expect.arrayContaining(["quota cache exhausted", "quota resets in 5m 0s"]),
+		);
+	});
+
 	it("applies runtime overlay skip reasons to forecast availability", () => {
 		const now = 1_700_000_000_000;
 		const account = {
@@ -142,6 +181,29 @@ describe("forecast helpers", () => {
 		expect(overlaid.availability).toBe("unavailable");
 		expect(overlaid.reasons).toContain("runtime skip: circuit-open");
 	});
+
+	it.each(["rate-limited", "cooling-down:server-error", "workspace-disabled"])(
+		"marks runtime skip reason %s as unavailable",
+		(reason) => {
+			const now = 1_700_000_000_000;
+			const result = evaluateForecastAccount({
+				index: 0,
+				now,
+				isCurrent: false,
+				account: {
+					refreshToken: "refresh-1",
+					addedAt: now - 10_000,
+					lastUsed: now - 10_000,
+				},
+				runtimeOverlay: {
+					lastPoolExhaustionSkipReasons: { "0": reason },
+				},
+			});
+
+			expect(result.availability).toBe("unavailable");
+			expect(result.reasons).toContain(`runtime skip: ${reason}`);
+		},
+	);
 
 	it("recommends the best ready account", () => {
 		const now = 1_700_000_000_000;

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -78,6 +78,71 @@ describe("forecast helpers", () => {
 		).toBe(true);
 	});
 
+	it("marks quota-cache exhausted accounts as delayed instead of ready", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			email: "quota@example.com",
+			accountId: "acc_quota",
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+		};
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			allAccounts: [account],
+			quotaCache: {
+				version: 1,
+				updatedAt: now,
+				byAccountId: {
+					acc_quota: {
+						accountId: "acc_quota",
+						status: 200,
+						model: "gpt-5.3-codex",
+						updatedAt: now,
+						primary: { usedPercent: 100, resetAtMs: now + 60_000 },
+						secondary: { usedPercent: 25, resetAtMs: now + 300_000 },
+					},
+				},
+				byEmail: {},
+			},
+		});
+
+		expect(result.availability).toBe("delayed");
+		expect(result.waitMs).toBe(60_000);
+		expect(result.reasons).toContain("quota cache exhausted");
+	});
+
+	it("applies runtime overlay skip reasons to forecast availability", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+		};
+		const raw = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+		});
+		const overlaid = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "circuit-open" },
+			},
+		});
+
+		expect(raw.availability).toBe("ready");
+		expect(overlaid.availability).toBe("unavailable");
+		expect(overlaid.reasons).toContain("runtime skip: circuit-open");
+	});
+
 	it("recommends the best ready account", () => {
 		const now = 1_700_000_000_000;
 		const results = evaluateForecastAccounts([

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -39,6 +39,7 @@ const getCodexCliAuthPathMock = vi.fn(() => "/mock/auth.json");
 const getCodexCliConfigPathMock = vi.fn(() => "/mock/config.toml");
 const loadCodexCliStateMock = vi.fn();
 const setCodexCliActiveSelectionMock = vi.fn();
+const loadPersistedRuntimeObservabilitySnapshotMock = vi.fn();
 
 vi.mock("node:fs", () => ({
 	existsSync: existsSyncMock,
@@ -99,6 +100,11 @@ vi.mock("../lib/codex-cli/writer.js", () => ({
 	setCodexCliActiveSelection: setCodexCliActiveSelectionMock,
 }));
 
+vi.mock("../lib/runtime/runtime-observability.js", () => ({
+	loadPersistedRuntimeObservabilitySnapshot:
+		loadPersistedRuntimeObservabilitySnapshotMock,
+}));
+
 const {
 	runDoctor,
 	runFix,
@@ -138,6 +144,12 @@ describe("repair-commands direct deps coverage", () => {
 		loadCodexCliStateMock.mockResolvedValue(null);
 		extractAccountEmailMock.mockReturnValue(undefined);
 		extractAccountIdMock.mockReturnValue(undefined);
+		loadPersistedRuntimeObservabilitySnapshotMock.mockResolvedValue(null);
+		evaluateForecastAccountsMock.mockImplementation(() => []);
+		recommendForecastAccountMock.mockReturnValue({
+			recommendedIndex: null,
+			reason: "stay",
+		});
 	});
 
 	afterEach(() => {
@@ -711,6 +723,113 @@ describe("repair-commands direct deps coverage", () => {
 			expect.objectContaining({
 				key: "refresh-token-shape",
 				severity: "warn",
+			}),
+		);
+	});
+
+	it("runDoctor warns when disk forecast and runtime overlay diverge", async () => {
+		loadAccountsMock.mockResolvedValue({
+			version: 3,
+			accounts: [
+				{
+					email: "doctor@example.com",
+					refreshToken: "refresh-token",
+					accessToken: "access",
+					expiresAt: 100,
+					accountId: "doctor-account",
+					enabled: true,
+				},
+			],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		});
+		loadPersistedRuntimeObservabilitySnapshotMock.mockResolvedValue({
+			lastPoolExhaustionSkipReasons: { "0": "circuit-open" },
+		});
+		evaluateForecastAccountsMock.mockImplementation((inputs) =>
+			inputs.map((input: { index: number; runtimeOverlay?: unknown }) => ({
+				index: input.index,
+				label: `account ${input.index + 1}`,
+				isCurrent: true,
+				availability: input.runtimeOverlay ? "unavailable" : "ready",
+				riskScore: input.runtimeOverlay ? 90 : 0,
+				riskLevel: input.runtimeOverlay ? "high" : "low",
+				waitMs: 0,
+				reasons: input.runtimeOverlay
+					? ["runtime skip: circuit-open"]
+					: [],
+				hardFailure: false,
+				disabled: false,
+			})),
+		);
+		recommendForecastAccountMock.mockReturnValue({
+			recommendedIndex: 0,
+			reason: "stay",
+		});
+		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const exitCode = await runDoctor(["--json"], createDeps());
+
+		expect(exitCode).toBe(0);
+		const payload = JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")) as {
+			checks: Array<{ key: string; severity: string; message: string; details?: string }>;
+		};
+		expect(payload.checks).toContainEqual(
+			expect.objectContaining({
+				key: "forecast-runtime-alignment",
+				severity: "warn",
+				message: "1 account(s) look ready on disk but unavailable in runtime state",
+				details: expect.stringContaining("runtime skip: circuit-open"),
+			}),
+		);
+	});
+
+	it("runDoctor treats failed runtime snapshot loads as aligned diagnostics", async () => {
+		loadAccountsMock.mockResolvedValue({
+			version: 3,
+			accounts: [
+				{
+					email: "doctor@example.com",
+					refreshToken: "refresh-token",
+					accessToken: "access",
+					expiresAt: 100,
+					accountId: "doctor-account",
+					enabled: true,
+				},
+			],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		});
+		loadPersistedRuntimeObservabilitySnapshotMock.mockRejectedValue(
+			new Error("snapshot busy"),
+		);
+		evaluateForecastAccountsMock.mockImplementation((inputs) =>
+			inputs.map((input: { index: number }) => ({
+				index: input.index,
+				label: `account ${input.index + 1}`,
+				isCurrent: true,
+				availability: "ready",
+				riskScore: 0,
+				riskLevel: "low",
+				waitMs: 0,
+				reasons: [],
+				hardFailure: false,
+				disabled: false,
+			})),
+		);
+		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const exitCode = await runDoctor(["--json"], createDeps());
+
+		expect(exitCode).toBe(0);
+		const payload = JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")) as {
+			checks: Array<{ key: string; severity: string; message: string }>;
+		};
+		expect(payload.checks).toContainEqual(
+			expect.objectContaining({
+				key: "forecast-runtime-alignment",
+				severity: "ok",
+				message: "Forecast and runtime availability are aligned",
 			}),
 		);
 	});

--- a/test/runtime-observability.test.ts
+++ b/test/runtime-observability.test.ts
@@ -146,4 +146,39 @@ describe("runtime observability snapshot versioning", () => {
 		expect(snapshot.poolExhaustionCooldownUntil).toBe(12345);
 		expect(snapshot.runtimeMetrics.failedRequests).toBe(4);
 	});
+
+	it("normalizes and persists runtime pool exhaustion diagnostics", async () => {
+		process.env.VITEST = "";
+		readFileSyncMock.mockReturnValue(
+			JSON.stringify({
+				version: 1,
+				lastPoolExhaustionReason: "no-account",
+				lastPoolExhaustionRetryAfterMs: 0,
+				lastPoolExhaustionSkipReasons: { "0": "circuit-open" },
+				accountSkipReasons: { "0": "circuit-open" },
+				policyBlockedIndexes: [1],
+				policyBlockedReasons: { "1": "policy-blocked" },
+			}),
+		);
+
+		const mod = await import("../lib/runtime/runtime-observability.js");
+		const snapshot = mod.getRuntimeObservabilitySnapshot();
+		expect(snapshot.lastPoolExhaustionReason).toBe("no-account");
+		expect(snapshot.lastPoolExhaustionSkipReasons).toEqual({
+			"0": "circuit-open",
+		});
+		expect(snapshot.policyBlockedIndexes).toEqual([1]);
+
+		mod.recordRuntimePoolExhaustion({
+			reason: "rate-limit",
+			retryAfterMs: 5000,
+			accountSkipReasons: { "2": "token-exhausted" },
+		});
+		await vi.waitFor(() => {
+			expect(renameMock).toHaveBeenCalled();
+		});
+		expect(mod.getRuntimeObservabilitySnapshot().accountSkipReasons).toEqual({
+			"2": "token-exhausted",
+		});
+	});
 });

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1589,6 +1589,62 @@ describe("runtime rotation proxy", () => {
 		expect(payload.error.retry_after_ms).toBeGreaterThan(0);
 	});
 
+	it("includes per-account skip reasons in final pool exhaustion responses", async () => {
+		const now = Date.now();
+		const storage = createStorage(now, 2);
+		const first = storage.accounts[0];
+		if (first) {
+			first.rateLimitResetTimes = { codex: now + 60_000 };
+		}
+		const second = storage.accounts[1];
+		if (second) {
+			second.enabled = true;
+			second.coolingDownUntil = now + 60_000;
+			second.cooldownReason = "server-error";
+		}
+		const accountManager = new AccountManager(undefined, storage);
+		const managedFirst = accountManager.getAccountByIndex(0);
+		const managedSecond = accountManager.getAccountByIndex(1);
+		if (managedFirst) {
+			accountManager.markAccountCoolingDown(
+				managedFirst,
+				60_000,
+				"network-error",
+			);
+		}
+		if (managedSecond) {
+			accountManager.markAccountCoolingDown(
+				managedSecond,
+				60_000,
+				"server-error",
+			);
+		}
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			new Response("should not be called", { status: HTTP_STATUS.OK }),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, { model: "gpt-5-codex" });
+		const payload = (await response.json()) as {
+			error: {
+				code: string;
+				reason: string;
+				account_skip_reasons: Record<string, string>;
+				hint: string;
+			};
+		};
+
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		expect(payload.error.code).toBe("codex_runtime_rotation_pool_exhausted");
+		expect(payload.error.reason).toBe("no-account");
+		expect(payload.error.account_skip_reasons).toMatchObject({
+			"0": "cooling-down:network-error",
+			"1": "cooling-down:server-error",
+		});
+		expect(payload.error.hint).toContain("rotation reset-runtime");
+		expect(calls).toHaveLength(0);
+	});
+
 	it("caps per-request upstream attempts instead of walking a large pool", async () => {
 		const now = Date.now();
 		const accountManager = new AccountManager(undefined, createStorage(now, 6));

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1696,6 +1696,47 @@ describe("runtime rotation proxy", () => {
 		}
 	});
 
+	it("refreshes request pool limits when stale-runtime reload increases account count", async () => {
+		const now = Date.now();
+		const staleManager = new AccountManager(undefined, createStorage(now, 1));
+		const freshManager = new AccountManager(undefined, createStorage(now, 2));
+		const originalSkipReason = staleManager.getAccountRuntimeSkipReason;
+		const skipReasonSpy = vi
+			.spyOn(AccountManager.prototype, "getAccountRuntimeSkipReason")
+			.mockImplementation(function mockedSkipReason(index, family, model) {
+				if (this === staleManager) return "circuit-open";
+				return originalSkipReason.call(this, index, family, model);
+			});
+		const loadSpy = vi
+			.spyOn(AccountManager, "loadFromDisk")
+			.mockResolvedValueOnce(freshManager);
+		const { calls, fetchImpl } = createRecordingFetch((_call, attempt) =>
+			attempt === 1
+				? new Response("first account failed", { status: HTTP_STATUS.SERVICE_UNAVAILABLE })
+				: textEventStream(),
+		);
+		try {
+			const proxy = await startProxy({
+				accountManager: staleManager,
+				fetchImpl,
+			});
+
+			const response = await postResponses(proxy, { model: "gpt-5-codex" });
+			await response.text();
+
+			expect(response.status).toBe(HTTP_STATUS.OK);
+			expect(loadSpy).toHaveBeenCalledTimes(1);
+			expect(calls).toHaveLength(2);
+			expect(calls.map((call) => call.headers.get(OPENAI_HEADERS.ACCOUNT_ID))).toEqual([
+				"acc_1",
+				"acc_2",
+			]);
+		} finally {
+			skipReasonSpy.mockRestore();
+			loadSpy.mockRestore();
+		}
+	});
+
 	it("caps per-request upstream attempts instead of walking a large pool", async () => {
 		const now = Date.now();
 		const accountManager = new AccountManager(undefined, createStorage(now, 6));

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1645,6 +1645,57 @@ describe("runtime rotation proxy", () => {
 		expect(calls).toHaveLength(0);
 	});
 
+	it("deduplicates concurrent stale-runtime reload recovery", async () => {
+		const now = Date.now();
+		const staleManager = new AccountManager(undefined, createStorage(now, 2));
+		const freshManager = new AccountManager(undefined, createStorage(now, 2));
+		let releaseReload: (() => void) | null = null;
+		const originalSkipReason = staleManager.getAccountRuntimeSkipReason;
+		const skipReasonSpy = vi
+			.spyOn(AccountManager.prototype, "getAccountRuntimeSkipReason")
+			.mockImplementation(function mockedSkipReason(index, family, model) {
+				if (this === staleManager) return "circuit-open";
+				return originalSkipReason.call(this, index, family, model);
+			});
+		const loadSpy = vi
+			.spyOn(AccountManager, "loadFromDisk")
+			.mockImplementationOnce(
+				async () =>
+					new Promise<AccountManager>((resolveReload) => {
+						releaseReload = () => resolveReload(freshManager);
+					}),
+			);
+		const resetSpy = vi.spyOn(AccountManager, "resetVolatileRuntimeState");
+		const { calls, fetchImpl } = createRecordingFetch(() => textEventStream());
+		try {
+			const proxy = await startProxy({
+				accountManager: staleManager,
+				fetchImpl,
+			});
+			const responses = [
+				postResponses(proxy, { model: "gpt-5-codex" }),
+				postResponses(proxy, { model: "gpt-5-codex" }),
+			];
+			await vi.waitFor(() => {
+				expect(loadSpy).toHaveBeenCalledTimes(1);
+			});
+			releaseReload?.();
+			const settled = await Promise.all(responses);
+			expect(settled.map((response) => response.status)).toEqual([
+				HTTP_STATUS.OK,
+				HTTP_STATUS.OK,
+			]);
+			await Promise.all(settled.map((response) => response.text()));
+			expect(loadSpy).toHaveBeenCalledTimes(1);
+			expect(resetSpy).toHaveBeenCalledTimes(1);
+			expect(calls).toHaveLength(2);
+		} finally {
+			skipReasonSpy.mockRestore();
+			loadSpy.mockRestore();
+			resetSpy.mockRestore();
+		}
+	});
+
 	it("caps per-request upstream attempts instead of walking a large pool", async () => {
 		const now = Date.now();
 		const accountManager = new AccountManager(undefined, createStorage(now, 6));


### PR DESCRIPTION
## Summary
- add runtime pool exhaustion diagnostics with per-account skip reasons, persisted reset/reload metadata, and clearer 503 hints
- recover stale no-account runtime divergence by resetting volatile runtime state, serializing disk reload recovery, pinning each request to a consistent AccountManager, and retrying selection while preserving pinned-account hard-fail behavior
- align forecast/report/doctor with runtime skip diagnostics and quota-exhausted cache state; add rotation reset-runtime --json recovery command
- address PR review follow-ups for runtime reload concurrency, pool-size recompute after reload, forecast/report/doctor regressions, and reset-runtime error/no-helper coverage

Fixes #479

## Validation
- npm run typecheck
- npm run lint
- npx vitest run test/codex-manager-rotation-command.test.ts test/runtime-rotation-proxy.test.ts test/forecast.test.ts test/codex-manager-report-command.test.ts test/codex-manager-forecast-command.test.ts test/repair-commands.test.ts (150 tests passed)
- npm test (267 files, 4000 tests passed)
- npm run build
- npm run pack:check (Pack budget ok: 970854 bytes across 1088 files)

## Risk notes
- Runtime recovery is limited to one unpinned no-account retry when there is no explicit policy block, cooldown, or rate-limit wait.
- Pinned unavailable accounts still return codex_pinned_account_unavailable.
- New 503/report fields are additive JSON diagnostics.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds runtime rotation pool exhaustion diagnostics with per-account skip reasons, stale-runtime recovery via a promise-deduplicated `recoverStaleRuntimeState` closure, and persisted reset/reload metadata. `forecast`, `report`, and `doctor` are extended to consume the new runtime overlay, and a `rotation reset-runtime` subcommand is added for manual recovery.

- **`recoverStaleRuntimeState`** (runtime-rotation-proxy.ts): uses a module-scoped promise (`staleRuntimeReloadPromise`) to deduplicate concurrent reload attempts and a 1 s dedup window after success; `reloadedAfterNoAccount` per-request guard caps recovery to one retry per request. the previous concurrent-reload race is addressed.
- **`knownAccountManagers` flush-on-close**: correctly flushes all AccountManager instances (original + any reloaded) on proxy close.
- **forecast overlay**: quota-cache exhausted and runtime skip-reason signals now fold into `evaluateForecastAccount` availability, guarded by `appendWaitReason`'s `<= 0` guard so zero-wait entries don't emit spurious wait strings.

<h3>Confidence Score: 5/5</h3>

safe to merge; all changed paths are additive diagnostics or bounded recovery logic with per-request guards preventing infinite loops

the concurrent reload race that existed before this PR is resolved by promise deduplication; the per-request reloadedAfterNoAccount flag prevents retry loops; knownAccountManagers flush-on-close prevents data loss on proxy shutdown after a reload; new snapshot fields are additive and backward-compatible; the two remaining nits do not affect correctness

lib/runtime-rotation-proxy.ts — the chooseAccount preferred-account else-block indentation and the missing lastStaleRuntimeReloadAt update on loadFromDisk failure are worth a quick look before merge

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime-rotation-proxy.ts | adds per-account skip-reason collection, stale-runtime recovery via recoverStaleRuntimeState (promise-deduplicated, 1 s cooldown), policyBlockedIndexes snapshot on every request, and knownAccountManagers flush-on-close; indentation bug in preferred-account else branch and missing failure cooldown in recoverStaleRuntimeState |
| lib/forecast.ts | adds quota-cache exhausted downgrade (ready→delayed) and runtime overlay skip-reason/policy-block check; appendWaitReason correctly guards against 0 ms, logic is sound |
| lib/accounts.ts | adds getAccountRuntimeSkipReason (diagnostic) and static resetVolatileRuntimeState; straightforward delegation to existing tracker/circuit-breaker reset APIs |
| lib/runtime/runtime-observability.ts | extends snapshot schema with pool-exhaustion, reset, and reload metadata; adds recordRuntimePoolExhaustion/Reset/Reload helpers; normalization handles missing fields correctly |
| lib/codex-manager/commands/rotation.ts | adds reset-runtime subcommand; AccountManager.resetVolatileRuntimeState() is a no-op in the CLI process but recordRuntimeReset correctly persists the recovery signal cross-process; app unbind/bind path is the real in-process reset mechanism |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fissue-479-runtime-pool-diagnostics%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fissue-479-runtime-pool-diagnostics%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fruntime-rotation-proxy.ts%3A935-938%0A**Misindented%20%60else%60%20block%20body%20in%20preferred-account%20path**%0A%0A%60accountManager.markSwitched%60%20and%20%60return%20preferred%60%20sit%20at%20the%20same%20tab%20depth%20as%20%60%7D%20else%20%7B%60%20instead%20of%20being%20indented%20inside%20it.%20The%20code%20is%20syntactically%20valid%2C%20but%20any%20maintainer%20scanning%20this%20block%20will%20misread%20the%20control%20flow%20%E2%80%94%20the%20two%20statements%20look%20like%20they%20are%20unconditional%20siblings%20of%20the%20inner%20%60if%2Felse%60%20rather%20than%20the%20%60else%60%20body.%20This%20is%20the%20only%20place%20in%20%60chooseAccount%60%20where%20the%20skip-reason%20branch%20got%20this%20indentation%20treatment%3B%20all%20other%20new%20branches%20are%20correctly%20indented.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fruntime-rotation-proxy.ts%3A1195-1205%0A**%60lastStaleRuntimeReloadAt%60%20not%20set%20on%20%60loadFromDisk%60%20failure**%0A%0A%60lastStaleRuntimeReloadAt%60%20is%20only%20assigned%20when%20%60loadFromDisk%60%20succeeds%3B%20the%20%60.catch%60%20branch%20returns%20%60null%60%20without%20touching%20it.%20This%20means%20successive%20requests%20that%20all%20hit%20the%20recovery%20path%20%28each%20with%20%60reloadedAfterNoAccount%20%3D%20false%60%29%20can%20each%20trigger%20a%20separate%20%60loadFromDisk%60%20call%20immediately%20after%20a%20failed%20one%20with%20no%20inter-request%20cooldown.%20On%20windows%20the%20rapid%20burst%20of%20file%20reads%20can%20produce%20%60EBUSY%60%2F%60EPERM%60%20errors%20that%20compound%20the%20original%20failure.%20setting%20%60lastStaleRuntimeReloadAt%20%3D%20Date.now%28%29%60%20inside%20the%20%60.catch%60%20block%2C%20before%20returning%20null%2C%20would%20apply%20the%201%20s%20dedup%20window%20on%20failure%20as%20well.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/runtime-rotation-proxy.ts:935-938
**Misindented `else` block body in preferred-account path**

`accountManager.markSwitched` and `return preferred` sit at the same tab depth as `} else {` instead of being indented inside it. The code is syntactically valid, but any maintainer scanning this block will misread the control flow — the two statements look like they are unconditional siblings of the inner `if/else` rather than the `else` body. This is the only place in `chooseAccount` where the skip-reason branch got this indentation treatment; all other new branches are correctly indented.

### Issue 2 of 2
lib/runtime-rotation-proxy.ts:1195-1205
**`lastStaleRuntimeReloadAt` not set on `loadFromDisk` failure**

`lastStaleRuntimeReloadAt` is only assigned when `loadFromDisk` succeeds; the `.catch` branch returns `null` without touching it. This means successive requests that all hit the recovery path (each with `reloadedAfterNoAccount = false`) can each trigger a separate `loadFromDisk` call immediately after a failed one with no inter-request cooldown. On windows the rapid burst of file reads can produce `EBUSY`/`EPERM` errors that compound the original failure. setting `lastStaleRuntimeReloadAt = Date.now()` inside the `.catch` block, before returning null, would apply the 1 s dedup window on failure as well.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test: cover reset runtime review paths"](https://github.com/ndycode/codex-multi-auth/commit/dc52333b412f8edc796a8e21e4f3bf8e114aa232) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31542826)</sub>

<!-- /greptile_comment -->