### PR TITLE
Add Codex marketplace plugin icon

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "codex-multi-auth",
-  "version": "1.2.2",
+  "version": "2.1.10",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
+  "interface": {
+    "composerIcon": "./assets/codex-multi-auth-icon.svg"
+  },
   "skills": "./skills/"
 }

--- a/assets/codex-multi-auth-icon.svg
+++ b/assets/codex-multi-auth-icon.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="bg" x1="72" y1="44" x2="440" y2="468" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="1" stop-color="#020617"/>
+    </linearGradient>
+    <linearGradient id="card" x1="138" y1="152" x2="366" y2="352" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#cbd5e1"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="164" y1="184" x2="344" y2="332" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#22c55e"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="16" flood-color="#000000" flood-opacity="0.34"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)"/>
+  <circle cx="256" cy="256" r="176" fill="none" stroke="#1e293b" stroke-width="24"/>
+  <path d="M376 138a176 176 0 0 1 54 116" fill="none" stroke="#38bdf8" stroke-linecap="round" stroke-width="24"/>
+  <path d="M136 374a176 176 0 0 1-54-116" fill="none" stroke="#22c55e" stroke-linecap="round" stroke-width="24"/>
+  <path d="M424 232l20 33 19-34" fill="none" stroke="#38bdf8" stroke-linecap="round" stroke-linejoin="round" stroke-width="18"/>
+  <path d="M88 280l-20-33-19 34" fill="none" stroke="#22c55e" stroke-linecap="round" stroke-linejoin="round" stroke-width="18"/>
+  <g filter="url(#shadow)">
+    <rect x="142" y="158" width="228" height="170" rx="34" fill="#334155" opacity="0.9"/>
+    <rect x="124" y="184" width="228" height="170" rx="34" fill="#475569"/>
+    <rect x="104" y="210" width="228" height="170" rx="34" fill="url(#card)"/>
+  </g>
+  <circle cx="172" cy="278" r="36" fill="url(#accent)"/>
+  <path d="M130 342c12-31 35-47 70-47s58 16 70 47" fill="none" stroke="#0f172a" stroke-linecap="round" stroke-width="22"/>
+  <rect x="210" y="254" width="82" height="18" rx="9" fill="#0f172a" opacity="0.9"/>
+  <rect x="210" y="290" width="58" height="18" rx="9" fill="#0f172a" opacity="0.56"/>
+  <g transform="translate(302 318)">
+    <rect x="0" y="0" width="104" height="74" rx="20" fill="#020617" stroke="#38bdf8" stroke-width="10"/>
+    <path d="M28 26l16 12-16 12" fill="none" stroke="#e2e8f0" stroke-linecap="round" stroke-linejoin="round" stroke-width="10"/>
+    <path d="M56 52h26" fill="none" stroke="#22c55e" stroke-linecap="round" stroke-width="10"/>
+  </g>
+</svg>

--- a/test/plugin-manifest.test.ts
+++ b/test/plugin-manifest.test.ts
@@ -17,6 +17,9 @@ const pluginManifestPath = path.join(".codex-plugin", "plugin.json");
 
 const readJson = <T>(filePath: string): T => JSON.parse(readFileSync(filePath, "utf8")) as T;
 
+const resolveRepoRootRelativePath = (relativePath: string): string =>
+	path.resolve(relativePath.replace(/^\.\//, ""));
+
 describe("Codex plugin manifest", () => {
 	it("declares an existing marketplace composer icon and matches the package version", () => {
 		const manifest = readJson<PluginManifest>(pluginManifestPath);
@@ -27,7 +30,12 @@ describe("Codex plugin manifest", () => {
 
 		const iconPath = manifest.interface?.composerIcon;
 		expect(iconPath).toBeDefined();
-		expect(iconPath?.startsWith("./")).toBe(true);
-		expect(existsSync(path.join(path.dirname(pluginManifestPath), "..", iconPath ?? ""))).toBe(true);
+		expect(existsSync(resolveRepoRootRelativePath(iconPath ?? ""))).toBe(true);
+	});
+
+	it("normalizes dot-slash icon paths before resolving them from the repository root", () => {
+		expect(resolveRepoRootRelativePath("./assets/codex-multi-auth-icon.svg")).toBe(
+			path.resolve("assets", "codex-multi-auth-icon.svg"),
+		);
 	});
 });

--- a/test/plugin-manifest.test.ts
+++ b/test/plugin-manifest.test.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type PluginManifest = {
+	version?: string;
+	interface?: {
+		composerIcon?: string;
+	};
+};
+
+type PackageManifest = {
+	version?: string;
+};
+
+const pluginManifestPath = path.join(".codex-plugin", "plugin.json");
+
+const readJson = <T>(filePath: string): T => JSON.parse(readFileSync(filePath, "utf8")) as T;
+
+describe("Codex plugin manifest", () => {
+	it("declares an existing marketplace composer icon and matches the package version", () => {
+		const manifest = readJson<PluginManifest>(pluginManifestPath);
+		const pkg = readJson<PackageManifest>("package.json");
+
+		expect(manifest.interface?.composerIcon).toBe("./assets/codex-multi-auth-icon.svg");
+		expect(manifest.version).toBe(pkg.version);
+
+		const iconPath = manifest.interface?.composerIcon;
+		expect(iconPath).toBeDefined();
+		expect(iconPath?.startsWith("./")).toBe(true);
+		expect(existsSync(path.join(path.dirname(pluginManifestPath), "..", iconPath ?? ""))).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #481

Summary:
- Added a self-contained SVG marketplace icon at assets/codex-multi-auth-icon.svg.
- Wired .codex-plugin/plugin.json interface.composerIcon to the new asset.
- Updated the plugin manifest version to match package.json and added a manifest integrity test.

Risk:
- Low. This changes only the plugin manifest, a static SVG asset, and a focused manifest test.

Validation:
- PASS npm test -- test/plugin-manifest.test.ts
- PASS npm test -- test/package-bin.test.ts test/device-auth.test.ts test/runtime-rotation-proxy.test.ts
- PASS npm test (268 files, 4003 tests)
- PASS npm run test:coverage (268 files, 4003 tests; all files 89.02 statements / 80.18 branches / 93.71 functions / 90.53 lines)
- PASS npm run typecheck
- PASS npm run typecheck:scripts
- PASS npm run lint
- PASS npm run build
- PASS npm run clean:repo:check
- PASS npm run pack:check
- PASS npm run audit:ci
- PASS npm run vendor:verify
- PASS Codex plugin scanner equivalent: uvx --from codex-plugin-scanner python -m codex_plugin_scanner.cli scan . --min-score 70 (Final Score 78/100, policy_pass true, verify_pass true)
- PASS npm pack --dry-run --json --ignore-scripts includes assets/codex-multi-auth-icon.svg
- PASS .codex-plugin/plugin.json points to an existing repo-root relative SVG asset path and matches package.json version

Notes:
- The issue explicitly asks for composerIcon: ./assets/your-icon.svg under repo assets; the local plugin scanner resolves plugin_dir from the repo root and passes with this path.
- npm packaging includes the icon asset via the existing assets/ files entry. The plugin manifest and skills are not currently part of the npm tarball; this PR does not change package publishing scope because marketplace scanning is repo/plugin-dir based.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds a marketplace composer icon for the codex plugin: a new static SVG at `assets/codex-multi-auth-icon.svg`, wired via `interface.composerIcon` in `.codex-plugin/plugin.json`, with the manifest version synced to `package.json`. a new vitest suite validates both the icon path and version parity.

- `plugin.json` version bumped from 1.2.2 → 2.1.10 to match `package.json`; `interface.composerIcon` set to `./assets/codex-multi-auth-icon.svg`.
- `assets/codex-multi-auth-icon.svg` is a self-contained 39-line SVG with no scripts, no external resource references, and unique gradient/filter IDs.
- `test/plugin-manifest.test.ts` covers icon file existence (resolved from repo root via `path.resolve`) and version parity; `resolveRepoRootRelativePath` strips the `./` prefix before resolving from CWD.

<h3>Confidence Score: 5/5</h3>

safe to merge — only a static SVG asset, a manifest field addition, and a focused integrity test are touched; no runtime logic or token handling is changed.

the change is confined to a new static SVG, a two-field manifest update, and a new test that validates both the icon's presence on disk and version parity with package.json. no auth, storage, rotation, or proxy code is modified. the SVG contains no scripts or external references. the test uses standard vitest patterns consistent with the rest of the suite.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .codex-plugin/plugin.json | version bumped from 1.2.2 to 2.1.10 to match package.json, and interface.composerIcon wired to the new SVG asset |
| assets/codex-multi-auth-icon.svg | new self-contained 39-line SVG icon; no scripts, no external resource refs, no conflicting gradient IDs — clean static asset |
| test/plugin-manifest.test.ts | new vitest suite validating composerIcon path existence and version parity with package.json; resolveRepoRootRelativePath helper correctly strips ./ prefix before path.resolve from CWD |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".codex-plugin/plugin.json"] -->|"interface.composerIcon: ./assets/codex-multi-auth-icon.svg"| B["assets/codex-multi-auth-icon.svg"]
    A -->|"version: 2.1.10"| C["package.json version: 2.1.10"]
    D["test/plugin-manifest.test.ts"] -->|"readJson"| A
    D -->|"readJson"| C
    D -->|"resolveRepoRootRelativePath strips ./ then path.resolve from CWD"| B
    D -->|"existsSync"| B
```

<sub>Reviews (2): Last reviewed commit: ["test: harden plugin icon manifest path c..."](https://github.com/ndycode/codex-multi-auth/commit/180cf8164e751520200e6e3a8ad0c09213c73342) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33143372)</sub>

<!-- /greptile_comment -->