### PR TITLE
Prepare v2.1.11 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/README.md
+++ b/README.md
@@ -383,8 +383,9 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current stable: [docs/releases/v2.1.10.md](docs/releases/v2.1.10.md)
-- Previous stable: [docs/releases/v2.1.9.md](docs/releases/v2.1.9.md)
+- Current stable: [docs/releases/v2.1.11.md](docs/releases/v2.1.11.md)
+- Previous stable: [docs/releases/v2.1.10.md](docs/releases/v2.1.10.md)
+- Earlier stable: [docs/releases/v2.1.9.md](docs/releases/v2.1.9.md)
 - Earlier stable: [docs/releases/v2.1.8.md](docs/releases/v2.1.8.md)
 - Earlier stable: [docs/releases/v2.1.7.md](docs/releases/v2.1.7.md)
 - Earlier stable: [docs/releases/v2.1.6.md](docs/releases/v2.1.6.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,9 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.1.10.md](releases/v2.1.10.md) | Current stable release notes |
-| [releases/v2.1.9.md](releases/v2.1.9.md) | Prior stable release notes |
+| [releases/v2.1.11.md](releases/v2.1.11.md) | Current stable release notes |
+| [releases/v2.1.10.md](releases/v2.1.10.md) | Prior stable release notes |
+| [releases/v2.1.9.md](releases/v2.1.9.md) | Earlier stable release notes |
 | [releases/v2.1.8.md](releases/v2.1.8.md) | Earlier stable release notes |
 | [releases/v2.1.7.md](releases/v2.1.7.md) | Earlier stable release notes |
 | [releases/v2.1.6.md](releases/v2.1.6.md) | Earlier stable release notes |

--- a/docs/releases/v2.1.11.md
+++ b/docs/releases/v2.1.11.md
@@ -1,0 +1,18 @@
+# v2.1.11
+
+Patch release for the Codex marketplace icon update. The package now ships a self-contained SVG composer icon, the plugin manifest advertises it for marketplace display, and a manifest integrity test keeps the plugin metadata aligned with the package release version.
+
+## Marketplace
+
+### Improvements
+
+- Added `assets/codex-multi-auth-icon.svg`, a small vector icon designed for Codex marketplace and composer surfaces.
+- Added `interface.composerIcon` to `.codex-plugin/plugin.json` so marketplace scanners and curated plugin lists can display the icon.
+- Kept the icon path repository-root relative, matching the Codex plugin scanner and the curated marketplace ingestion path.
+
+## Release Hygiene
+
+### Improvements
+
+- Added a focused plugin manifest integrity test that validates JSON parsing, package-version parity, and icon path resolution.
+- Bumped package and plugin manifest versions to `2.1.11` for the icon release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.10",
+	"version": "2.1.11",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.1.10",
+			"version": "2.1.11",
 			"bundleDependencies": [
 				"@codex-ai/plugin"
 			],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.10",
+	"version": "2.1.11",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
Summary:
- Bump package, lockfile, and Codex plugin manifest from 2.1.10 to 2.1.11.
- Add v2.1.11 release notes for the marketplace icon release.
- Promote v2.1.11 in README and docs release indexes.

Release basis:
- Includes the merged marketplace icon fix from PR #483.
- npm latest checked before bump: codex-multi-auth@2.1.10.

Validation:
- PASS npm test -- test/plugin-manifest.test.ts test/documentation.test.ts test/package-bin.test.ts
- PASS npm test (268 files, 4004 tests)
- PASS npm run typecheck
- PASS npm run lint
- PASS npm run build
- PASS npm run clean:repo:check
- PASS npm run pack:check
- PASS npm run audit:ci
- PASS npm run vendor:verify
- PASS git diff --check

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

mechanical v2.1.11 release prep: bumps `package.json`, `package-lock.json`, and `.codex-plugin/plugin.json` from 2.1.10 to 2.1.11, adds release notes, and advances the stable pointer in both readme indexes. all version fields are consistent and the `assets/` directory remains in the `files` array so the icon ships in the npm tarball.

- version is now consistent across `package.json`, `package-lock.json`, and `.codex-plugin/plugin.json`; `assets/codex-multi-auth-icon.svg` exists on disk and is covered by the manifest integrity test added in pr #483.
- `docs/releases/v2.1.11.md` accurately describes the marketplace icon and plugin-manifest integrity test work; no content issues.

<h3>Confidence Score: 5/5</h3>

straightforward version bump with no logic changes; all version fields are consistent and the icon asset is already on disk and test-covered.

every changed file is either a version string update or a documentation addition. the icon asset exists, the assets/ directory is in the npm files array, .codex-plugin/ is intentionally excluded from the tarball so the marketplace scanner reads it from the github tree, and the manifest integrity test already validates version parity and icon path resolution. no runtime code, auth flow, or token-handling paths are touched.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version bumped from 2.1.10 to 2.1.11; no other changes; assets/ already in files array so icon ships in npm tarball |
| package-lock.json | lockfile version fields updated to match package.json 2.1.11; no dependency changes |
| .codex-plugin/plugin.json | version bumped to 2.1.11, consistent with package.json; composerIcon path is correct and file exists at assets/codex-multi-auth-icon.svg |
| docs/releases/v2.1.11.md | new release notes file; accurately describes the marketplace icon and manifest integrity test changes from PR #483 |
| README.md | release index updated correctly; v2.1.9 label correctly relabeled from Previous stable to Earlier stable |
| docs/README.md | docs release table updated with v2.1.11 as current stable; consistent with README.md changes |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Repo
    participant NPM as npm Registry
    participant MKT as Codex Marketplace Scanner

    Dev->>GH: "merge PR #484 (v2.1.11 bump)"
    GH-->>MKT: scanner reads .codex-plugin/plugin.json v2.1.11
    MKT-->>MKT: resolves ./assets/codex-multi-auth-icon.svg from repo root
    Dev->>NPM: npm publish
    NPM-->>NPM: tarball includes assets/ icon + dist/ + scripts/
    NPM-->>NPM: .codex-plugin/ NOT in files array (marketplace uses GH path)
```

<sub>Reviews (1): Last reviewed commit: ["chore: prepare v2.1.11 release"](https://github.com/ndycode/codex-multi-auth/commit/a7a524ee177ef973474ad33441b77aa808b8a4d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33150156)</sub>

<!-- /greptile_comment -->