### PR TITLE
fix: preserve hook trust in runtime shadows

### DIFF
--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -2518,6 +2518,7 @@ function isTomlTableLine(line) {
 	);
 }
 
+// Keep these TOML block scan helpers aligned with test/codex-bin-wrapper.test.ts.
 function createTomlBlockScanState() {
 	return {
 		arrayDepth: 0,
@@ -2561,8 +2562,9 @@ function updateTomlBlockScanState(line, state) {
 			continue;
 		}
 		if (line[index] === "'") {
-			index = line.indexOf("'", index + 1);
-			if (index < 0) return;
+			const closeIndex = line.indexOf("'", index + 1);
+			if (closeIndex < 0) return;
+			index = closeIndex;
 			continue;
 		}
 		if (line[index] === "[") {

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -2495,21 +2495,82 @@ function createRuntimeRotationShadowHome(originalCodexHome) {
 }
 
 function parseHookStateTableKey(line) {
-	const match =
+	const basicStringMatch =
 		/^\s*\[\s*hooks\.state\.("(?:[^"\\]|\\.)*")\s*\]\s*$/.exec(line);
-	if (!match) {
-		return null;
+	if (basicStringMatch) {
+		try {
+			const parsed = JSON.parse(basicStringMatch[1]);
+			return typeof parsed === "string" ? parsed : null;
+		} catch {
+			return null;
+		}
 	}
-	try {
-		const parsed = JSON.parse(match[1]);
-		return typeof parsed === "string" ? parsed : null;
-	} catch {
-		return null;
-	}
+
+	const literalStringMatch = /^\s*\[\s*hooks\.state\.'([^']*)'\s*\]\s*$/.exec(
+		line,
+	);
+	return literalStringMatch ? literalStringMatch[1] : null;
 }
 
 function isTomlTableLine(line) {
-	return /^\s*\[/.test(line);
+	return /^\s*\[\[?\s*(?:"(?:[^"\\]|\\.)*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.|\s*\]\]?\s*(?:#.*)?$)/.test(
+		line,
+	);
+}
+
+function createTomlBlockScanState() {
+	return {
+		arrayDepth: 0,
+		multilineStringDelimiter: null,
+	};
+}
+
+function isTopLevelTomlBlockScanState(state) {
+	return state.arrayDepth === 0 && state.multilineStringDelimiter === null;
+}
+
+function updateTomlBlockScanState(line, state) {
+	for (let index = 0; index < line.length; index += 1) {
+		if (state.multilineStringDelimiter) {
+			const closeIndex = line.indexOf(state.multilineStringDelimiter, index);
+			if (closeIndex < 0) {
+				return;
+			}
+			index = closeIndex + state.multilineStringDelimiter.length - 1;
+			state.multilineStringDelimiter = null;
+			continue;
+		}
+
+		if (line[index] === "#") {
+			return;
+		}
+		if (line.startsWith('"""', index) || line.startsWith("'''", index)) {
+			state.multilineStringDelimiter = line.slice(index, index + 3);
+			index += 2;
+			continue;
+		}
+		if (line[index] === '"') {
+			index += 1;
+			for (; index < line.length; index += 1) {
+				if (line[index] === "\\") {
+					index += 1;
+				} else if (line[index] === '"') {
+					break;
+				}
+			}
+			continue;
+		}
+		if (line[index] === "'") {
+			index = line.indexOf("'", index + 1);
+			if (index < 0) return;
+			continue;
+		}
+		if (line[index] === "[") {
+			state.arrayDepth += 1;
+		} else if (line[index] === "]" && state.arrayDepth > 0) {
+			state.arrayDepth -= 1;
+		}
+	}
 }
 
 function mirrorRuntimeShadowHookTrustState(
@@ -2547,12 +2608,17 @@ function mirrorRuntimeShadowHookTrustState(
 
 		const blockLines = [];
 		let nextIndex = index + 1;
-		for (
-			;
-			nextIndex < lines.length && !isTomlTableLine(lines[nextIndex]);
-			nextIndex += 1
-		) {
-			blockLines.push(lines[nextIndex]);
+		const blockState = createTomlBlockScanState();
+		for (; nextIndex < lines.length; nextIndex += 1) {
+			const nextLine = lines[nextIndex];
+			if (
+				isTopLevelTomlBlockScanState(blockState) &&
+				isTomlTableLine(nextLine)
+			) {
+				break;
+			}
+			blockLines.push(nextLine);
+			updateTomlBlockScanState(nextLine, blockState);
 		}
 		output.push(...blockLines);
 		index = nextIndex - 1;

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -2494,6 +2494,82 @@ function createRuntimeRotationShadowHome(originalCodexHome) {
 	return mkdtempSync(join(shadowRoot, "codex-multi-auth-runtime-home-"));
 }
 
+function parseHookStateTableKey(line) {
+	const match =
+		/^\s*\[\s*hooks\.state\.("(?:[^"\\]|\\.)*")\s*\]\s*$/.exec(line);
+	if (!match) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(match[1]);
+		return typeof parsed === "string" ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+function isTomlTableLine(line) {
+	return /^\s*\[/.test(line);
+}
+
+function mirrorRuntimeShadowHookTrustState(
+	rawConfig,
+	originalCodexHome,
+	shadowCodexHome,
+	tomlStringLiteral,
+) {
+	const sourceHooksPath = join(originalCodexHome, "hooks.json");
+	const shadowHooksPath = join(shadowCodexHome, "hooks.json");
+	if (sourceHooksPath === shadowHooksPath) {
+		return rawConfig;
+	}
+
+	const lineEnding = rawConfig.includes("\r\n") ? "\r\n" : "\n";
+	const lines = rawConfig.length > 0 ? rawConfig.split(/\r?\n/) : [];
+	const sourcePrefix = `${sourceHooksPath}:`;
+	const existingHookStateKeys = new Set();
+	for (const line of lines) {
+		const key = parseHookStateTableKey(line);
+		if (key) {
+			existingHookStateKeys.add(key);
+		}
+	}
+
+	const output = [];
+	let changed = false;
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index];
+		const key = parseHookStateTableKey(line);
+		output.push(line);
+		if (!key || !key.startsWith(sourcePrefix)) {
+			continue;
+		}
+
+		const blockLines = [];
+		let nextIndex = index + 1;
+		for (
+			;
+			nextIndex < lines.length && !isTomlTableLine(lines[nextIndex]);
+			nextIndex += 1
+		) {
+			blockLines.push(lines[nextIndex]);
+		}
+		output.push(...blockLines);
+		index = nextIndex - 1;
+		const shadowKey = `${shadowHooksPath}:${key.slice(sourcePrefix.length)}`;
+		if (existingHookStateKeys.has(shadowKey)) {
+			continue;
+		}
+		output.push("");
+		output.push(`[hooks.state.${tomlStringLiteral(shadowKey)}]`);
+		output.push(...blockLines);
+		existingHookStateKeys.add(shadowKey);
+		changed = true;
+	}
+
+	return changed ? output.join(lineEnding) : rawConfig;
+}
+
 function createRuntimeRotationProxyCodexHome(
 	baseEnv,
 	proxyBaseUrl,
@@ -2535,10 +2611,15 @@ function createRuntimeRotationProxyCodexHome(
 		const rawConfig = existsSync(originalConfigPath)
 			? readFileSync(originalConfigPath, "utf8")
 			: "";
-		const runtimeConfig = configTomlModule.rewriteConfigTomlForRuntimeRotationProvider(
-			rawConfig,
-			proxyBaseUrl,
-			clientApiKey,
+		const runtimeConfig = mirrorRuntimeShadowHookTrustState(
+			configTomlModule.rewriteConfigTomlForRuntimeRotationProvider(
+				rawConfig,
+				proxyBaseUrl,
+				clientApiKey,
+			),
+			originalCodexHome,
+			shadowCodexHome,
+			configTomlModule.tomlStringLiteral,
 		);
 		const runtimeConfigPath = join(shadowCodexHome, "config.toml");
 		writeFileSync(runtimeConfigPath, runtimeConfig, "utf8");

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -34,6 +34,7 @@ const testFileDir = dirname(fileURLToPath(import.meta.url));
 const repoRootDir = join(testFileDir, "..");
 const EXIT_SUCCESS_LINE = "exit 0";
 const SHADOW_HOME_ORPHAN_LOCK_TEST_AGE_MS = 2_200;
+const HOOKS_JSON_TEXT = '{"hooks":{}}\n';
 
 function isRetriableFsError(error: unknown): boolean {
 	if (!error || typeof error !== "object" || !("code" in error)) {
@@ -689,6 +690,122 @@ function combinedOutput(
 	result: SpawnSyncReturns<string> | WrapperAsyncResult,
 ): string {
 	return `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+}
+
+function hookStateHeader(key: string): string {
+	return `[hooks.state.${JSON.stringify(key)}]`;
+}
+
+function literalHookStateHeader(key: string): string {
+	return `[hooks.state.'${key}']`;
+}
+
+function extractLineValue(output: string, prefix: string): string {
+	const line = output.split(/\r?\n/).find((entry) => entry.startsWith(prefix));
+	expect(line).toBeTruthy();
+	return line?.slice(prefix.length) ?? "";
+}
+
+function isTomlHeaderLine(line: string): boolean {
+	return /^\s*\[\[?\s*(?:"(?:[^"\\]|\\.)*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.|\s*\]\]?\s*(?:#.*)?$)/.test(
+		line,
+	);
+}
+
+type TomlBlockScanState = {
+	arrayDepth: number;
+	multilineStringDelimiter: string | null;
+};
+
+function createTomlBlockScanState(): TomlBlockScanState {
+	return {
+		arrayDepth: 0,
+		multilineStringDelimiter: null,
+	};
+}
+
+function isTopLevelTomlBlockScanState(state: TomlBlockScanState): boolean {
+	return state.arrayDepth === 0 && state.multilineStringDelimiter === null;
+}
+
+function updateTomlBlockScanState(
+	line: string,
+	state: TomlBlockScanState,
+): void {
+	for (let index = 0; index < line.length; index += 1) {
+		if (state.multilineStringDelimiter) {
+			const closeIndex = line.indexOf(state.multilineStringDelimiter, index);
+			if (closeIndex < 0) return;
+			index = closeIndex + state.multilineStringDelimiter.length - 1;
+			state.multilineStringDelimiter = null;
+			continue;
+		}
+
+		if (line[index] === "#") return;
+		if (line.startsWith('"""', index) || line.startsWith("'''", index)) {
+			state.multilineStringDelimiter = line.slice(index, index + 3);
+			index += 2;
+			continue;
+		}
+		if (line[index] === '"') {
+			index += 1;
+			for (; index < line.length; index += 1) {
+				if (line[index] === "\\") {
+					index += 1;
+				} else if (line[index] === '"') {
+					break;
+				}
+			}
+			continue;
+		}
+		if (line[index] === "'") {
+			const closeIndex = line.indexOf("'", index + 1);
+			if (closeIndex < 0) return;
+			index = closeIndex;
+			continue;
+		}
+		if (line[index] === "[") {
+			state.arrayDepth += 1;
+		} else if (line[index] === "]" && state.arrayDepth > 0) {
+			state.arrayDepth -= 1;
+		}
+	}
+}
+
+function extractTomlTableBody(output: string, header: string): string {
+	const lines = output.split(/\r?\n/);
+	const start = lines.indexOf(header);
+	expect(start).toBeGreaterThanOrEqual(0);
+	const body: string[] = [];
+	const blockState = createTomlBlockScanState();
+	for (let index = start + 1; index < lines.length; index += 1) {
+		if (
+			isTopLevelTomlBlockScanState(blockState) &&
+			isTomlHeaderLine(lines[index])
+		) {
+			break;
+		}
+		body.push(lines[index]);
+		updateTomlBlockScanState(lines[index], blockState);
+	}
+	while (body.length > 0 && body[body.length - 1] === "") {
+		body.pop();
+	}
+	return body.join("\n");
+}
+
+function expectMirroredHookStateBlock(
+	output: string,
+	sourceHeader: string,
+	shadowHeader: string,
+	expectedBodyLines: string[],
+): void {
+	const sourceBody = extractTomlTableBody(output, sourceHeader);
+	const shadowBody = extractTomlTableBody(output, shadowHeader);
+	expect(shadowBody).toBe(sourceBody);
+	for (const line of expectedBodyLines) {
+		expect(shadowBody).toContain(line);
+	}
 }
 
 afterEach(async () => {
@@ -1499,25 +1616,69 @@ describe("codex bin wrapper", () => {
 			"#!/usr/bin/env node",
 			'const fs = require("node:fs");',
 			'const path = require("node:path");',
+			'const config = fs.readFileSync(path.join(process.env.CODEX_HOME, "config.toml"), "utf8");',
+			'const hooks = fs.readFileSync(path.join(process.env.CODEX_HOME, "hooks.json"), "utf8");',
 			'console.log(`SHADOW_HOME:${process.env.CODEX_HOME ?? ""}`);',
-			'console.log(fs.readFileSync(path.join(process.env.CODEX_HOME, "config.toml"), "utf8"));',
+			'console.log(`HOOKS_JSON:${JSON.stringify(hooks)}`);',
+			'console.log(`CONFIG_HAS_CRLF:${config.includes("\\r\\n")}`);',
+			'console.log(config);',
 		]);
-		const originalHome = join(fixtureRoot, "codex-home");
+		const originalHome = join(
+			fixtureRoot,
+			`codex-home-${"x".repeat(64)}`,
+			`nested-${"y".repeat(64)}`,
+			process.platform === "win32" ? "windows-path" : "C:\\Users\\rob\\.codex",
+		);
+		const alternateHome = join(fixtureRoot, "other-codex-home");
+		const sourceHooksPath = join(originalHome, "hooks.json");
+		const alternateHooksPath = join(alternateHome, "hooks.json");
+		const sessionStartKey = `${sourceHooksPath}:session_start:0:0`;
+		const stopKey = `${sourceHooksPath}:stop:0:0`;
+		const userPromptSubmitKey = `${sourceHooksPath}:user_prompt_submit:0:0`;
+		const preCompactKey = `${sourceHooksPath}:pre_compact:0:0`;
+		const longPathKey = `${sourceHooksPath}:${"long-event-".repeat(24)}:0:0`;
+		const alternateKey = `${alternateHooksPath}:alternate_event:0:0`;
 		mkdirSync(originalHome, { recursive: true });
-		writeFileSync(join(originalHome, "hooks.json"), '{"hooks":{}}\n', "utf8");
+		mkdirSync(alternateHome, { recursive: true });
+		expect(longPathKey.length).toBeGreaterThan(256);
+		writeFileSync(sourceHooksPath, HOOKS_JSON_TEXT, "utf8");
+		writeFileSync(alternateHooksPath, '{"alternate":true}\n', "utf8");
 		writeFileSync(
 			join(originalHome, "config.toml"),
 			[
 				'model_provider = "openai"',
 				"",
-				`[hooks.state.${JSON.stringify(`${join(originalHome, "hooks.json")}:session_start:0:0`)}]`,
+				hookStateHeader(sessionStartKey),
 				"enabled = true",
 				'trusted_hash = "sha256:session-start"',
 				"",
-				`[hooks.state.${JSON.stringify(`${join(originalHome, "hooks.json")}:stop:0:0`)}]`,
+				hookStateHeader(stopKey),
 				"enabled = true",
 				'trusted_hash = "sha256:stop"',
-			].join("\n"),
+				"",
+				literalHookStateHeader(userPromptSubmitKey),
+				"enabled = true",
+				"",
+				hookStateHeader(preCompactKey),
+				"enabled = true",
+				'trusted_hash = "sha256:pre-compact"',
+				'approval_reason = "reviewed manually"',
+				'review_notes = """',
+				"[not-a-table]",
+				'"""',
+				"review_batches = [",
+				'  ["alpha"],',
+				'  ["omega"]',
+				"]",
+				"",
+				hookStateHeader(longPathKey),
+				"enabled = true",
+				'trusted_hash = "sha256:long-path"',
+				"",
+				hookStateHeader(alternateKey),
+				"enabled = true",
+				'trusted_hash = "sha256:alternate"',
+			].join("\r\n"),
 			"utf8",
 		);
 
@@ -1530,33 +1691,132 @@ describe("codex bin wrapper", () => {
 
 		const output = combinedOutput(result);
 		expect(result.status).toBe(0);
-		const shadowHome = output.match(/^SHADOW_HOME:(.+)$/m)?.[1];
-		expect(shadowHome).toBeTruthy();
-		if (!shadowHome) return;
-		const sourceSessionHeader =
-			`[hooks.state.${JSON.stringify(`${join(originalHome, "hooks.json")}:session_start:0:0`)}]`;
-		const shadowSessionHeader =
-			`[hooks.state.${JSON.stringify(`${join(shadowHome, "hooks.json")}:session_start:0:0`)}]`;
-		expect(output).toContain(sourceSessionHeader);
-		expect(output).toContain(shadowSessionHeader);
-		expect(output).toContain(
-			`[hooks.state.${JSON.stringify(`${join(shadowHome, "hooks.json")}:stop:0:0`)}]`,
+		expect(JSON.parse(extractLineValue(output, "HOOKS_JSON:"))).toBe(
+			HOOKS_JSON_TEXT,
 		);
-		const sourceSessionIndex = output.indexOf(sourceSessionHeader);
-		const sourceSessionEnabledIndex = output.indexOf(
-			"enabled = true",
-			sourceSessionIndex,
+		expect(extractLineValue(output, "CONFIG_HAS_CRLF:")).toBe("true");
+
+		const shadowHome = extractLineValue(output, "SHADOW_HOME:");
+		const shadowHooksPath = join(shadowHome, "hooks.json");
+		expectMirroredHookStateBlock(
+			output,
+			hookStateHeader(sessionStartKey),
+			hookStateHeader(`${shadowHooksPath}:session_start:0:0`),
+			["enabled = true", 'trusted_hash = "sha256:session-start"'],
 		);
-		const shadowSessionIndex = output.indexOf(shadowSessionHeader);
-		const shadowSessionEnabledIndex = output.indexOf(
-			"enabled = true",
-			shadowSessionIndex,
+		expectMirroredHookStateBlock(
+			output,
+			hookStateHeader(stopKey),
+			hookStateHeader(`${shadowHooksPath}:stop:0:0`),
+			["enabled = true", 'trusted_hash = "sha256:stop"'],
 		);
-		expect(sourceSessionIndex).toBeLessThan(sourceSessionEnabledIndex);
-		expect(sourceSessionEnabledIndex).toBeLessThan(shadowSessionIndex);
-		expect(shadowSessionIndex).toBeLessThan(shadowSessionEnabledIndex);
-		expect(output).toContain('trusted_hash = "sha256:session-start"');
-		expect(output).toContain('trusted_hash = "sha256:stop"');
+		expectMirroredHookStateBlock(
+			output,
+			literalHookStateHeader(userPromptSubmitKey),
+			hookStateHeader(`${shadowHooksPath}:user_prompt_submit:0:0`),
+			["enabled = true"],
+		);
+		expectMirroredHookStateBlock(
+			output,
+			hookStateHeader(preCompactKey),
+			hookStateHeader(`${shadowHooksPath}:pre_compact:0:0`),
+			[
+				"enabled = true",
+				'trusted_hash = "sha256:pre-compact"',
+				'approval_reason = "reviewed manually"',
+				'review_notes = """',
+				"[not-a-table]",
+				'"""',
+				"review_batches = [",
+				'  ["alpha"],',
+				'  ["omega"]',
+				"]",
+			],
+		);
+		expectMirroredHookStateBlock(
+			output,
+			hookStateHeader(longPathKey),
+			hookStateHeader(`${shadowHooksPath}:${"long-event-".repeat(24)}:0:0`),
+			["enabled = true", 'trusted_hash = "sha256:long-path"'],
+		);
+		expect(output).toContain(hookStateHeader(alternateKey));
+		expect(output).not.toContain(
+			hookStateHeader(`${shadowHooksPath}:alternate_event:0:0`),
+		);
+	});
+
+	it("mirrors trusted hook state consistently for concurrent shadow launches", async () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const readyDir = join(fixtureRoot, "ready");
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
+			'const readyDir = process.env.CODEX_MULTI_AUTH_TEST_READY_DIR;',
+			'const marker = process.env.CODEX_MULTI_AUTH_TEST_MARKER;',
+			'fs.mkdirSync(readyDir, { recursive: true });',
+			'fs.writeFileSync(path.join(readyDir, `${marker}.ready`), "1", "utf8");',
+			"const deadline = Date.now() + 3000;",
+			"while (Date.now() < deadline && fs.readdirSync(readyDir).filter((entry) => entry.endsWith('.ready')).length < 3) {",
+			"  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);",
+			"}",
+			'console.log(`SHADOW_HOME:${process.env.CODEX_HOME ?? ""}`);',
+			'console.log(fs.readFileSync(path.join(process.env.CODEX_HOME, "config.toml"), "utf8"));',
+			"process.exit(0);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const sourceHooksPath = join(originalHome, "hooks.json");
+		const sessionStartKey = `${sourceHooksPath}:session_start:0:0`;
+		const stopKey = `${sourceHooksPath}:stop:0:0`;
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(sourceHooksPath, HOOKS_JSON_TEXT, "utf8");
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			[
+				'model_provider = "openai"',
+				"",
+				hookStateHeader(sessionStartKey),
+				"enabled = true",
+				'trusted_hash = "sha256:session-start"',
+				"",
+				hookStateHeader(stopKey),
+				"enabled = true",
+				'trusted_hash = "sha256:stop"',
+			].join("\n"),
+			"utf8",
+		);
+
+		const launches = ["first", "second", "third"].map((marker) =>
+			runWrapperAsync(fixtureRoot, ["exec", "status"], {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				CODEX_MULTI_AUTH_TEST_READY_DIR: readyDir,
+				CODEX_MULTI_AUTH_TEST_MARKER: marker,
+				OPENAI_API_KEY: undefined,
+			}),
+		);
+		const results = await Promise.all(launches);
+
+		for (const result of results) {
+			const output = combinedOutput(result);
+			expect(result.status).toBe(0);
+			const shadowHome = extractLineValue(output, "SHADOW_HOME:");
+			const shadowHooksPath = join(shadowHome, "hooks.json");
+			expectMirroredHookStateBlock(
+				output,
+				hookStateHeader(sessionStartKey),
+				hookStateHeader(`${shadowHooksPath}:session_start:0:0`),
+				["enabled = true", 'trusted_hash = "sha256:session-start"'],
+			);
+			expectMirroredHookStateBlock(
+				output,
+				hookStateHeader(stopKey),
+				hookStateHeader(`${shadowHooksPath}:stop:0:0`),
+				["enabled = true", 'trusted_hash = "sha256:stop"'],
+			);
+		}
 	});
 
 	it("starts the opt-in runtime rotation proxy for app-server without capturing protocol stdio", () => {

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -717,6 +717,7 @@ type TomlBlockScanState = {
 	multilineStringDelimiter: string | null;
 };
 
+// Keep these TOML block scan helpers aligned with scripts/codex.js.
 function createTomlBlockScanState(): TomlBlockScanState {
 	return {
 		arrayDepth: 0,
@@ -796,11 +797,12 @@ function extractTomlTableBody(output: string, header: string): string {
 
 function expectMirroredHookStateBlock(
 	output: string,
+	sourceText: string,
 	sourceHeader: string,
 	shadowHeader: string,
 	expectedBodyLines: string[],
 ): void {
-	const sourceBody = extractTomlTableBody(output, sourceHeader);
+	const sourceBody = extractTomlTableBody(sourceText, sourceHeader);
 	const shadowBody = extractTomlTableBody(output, shadowHeader);
 	expect(shadowBody).toBe(sourceBody);
 	for (const line of expectedBodyLines) {
@@ -1623,12 +1625,7 @@ describe("codex bin wrapper", () => {
 			'console.log(`CONFIG_HAS_CRLF:${config.includes("\\r\\n")}`);',
 			'console.log(config);',
 		]);
-		const originalHome = join(
-			fixtureRoot,
-			`codex-home-${"x".repeat(64)}`,
-			`nested-${"y".repeat(64)}`,
-			process.platform === "win32" ? "windows-path" : "C:\\Users\\rob\\.codex",
-		);
+		const originalHome = join(fixtureRoot, "codex-home");
 		const alternateHome = join(fixtureRoot, "other-codex-home");
 		const sourceHooksPath = join(originalHome, "hooks.json");
 		const alternateHooksPath = join(alternateHome, "hooks.json");
@@ -1643,44 +1640,41 @@ describe("codex bin wrapper", () => {
 		expect(longPathKey.length).toBeGreaterThan(256);
 		writeFileSync(sourceHooksPath, HOOKS_JSON_TEXT, "utf8");
 		writeFileSync(alternateHooksPath, '{"alternate":true}\n', "utf8");
-		writeFileSync(
-			join(originalHome, "config.toml"),
-			[
-				'model_provider = "openai"',
-				"",
-				hookStateHeader(sessionStartKey),
-				"enabled = true",
-				'trusted_hash = "sha256:session-start"',
-				"",
-				hookStateHeader(stopKey),
-				"enabled = true",
-				'trusted_hash = "sha256:stop"',
-				"",
-				literalHookStateHeader(userPromptSubmitKey),
-				"enabled = true",
-				"",
-				hookStateHeader(preCompactKey),
-				"enabled = true",
-				'trusted_hash = "sha256:pre-compact"',
-				'approval_reason = "reviewed manually"',
-				'review_notes = """',
-				"[not-a-table]",
-				'"""',
-				"review_batches = [",
-				'  ["alpha"],',
-				'  ["omega"]',
-				"]",
-				"",
-				hookStateHeader(longPathKey),
-				"enabled = true",
-				'trusted_hash = "sha256:long-path"',
-				"",
-				hookStateHeader(alternateKey),
-				"enabled = true",
-				'trusted_hash = "sha256:alternate"',
-			].join("\r\n"),
-			"utf8",
-		);
+		const originalConfig = [
+			'model_provider = "openai"',
+			"",
+			hookStateHeader(sessionStartKey),
+			"enabled = true",
+			'trusted_hash = "sha256:session-start"',
+			"",
+			hookStateHeader(stopKey),
+			"enabled = true",
+			'trusted_hash = "sha256:stop"',
+			"",
+			literalHookStateHeader(userPromptSubmitKey),
+			"enabled = true",
+			"",
+			hookStateHeader(preCompactKey),
+			"enabled = true",
+			'trusted_hash = "sha256:pre-compact"',
+			'approval_reason = "reviewed manually"',
+			'review_notes = """',
+			"[not-a-table]",
+			'"""',
+			"review_batches = [",
+			'  ["alpha"],',
+			'  ["omega"]',
+			"]",
+			"",
+			hookStateHeader(longPathKey),
+			"enabled = true",
+			'trusted_hash = "sha256:long-path"',
+			"",
+			hookStateHeader(alternateKey),
+			"enabled = true",
+			'trusted_hash = "sha256:alternate"',
+		].join("\r\n");
+		writeFileSync(join(originalHome, "config.toml"), originalConfig, "utf8");
 
 		const result = runWrapper(fixtureRoot, ["exec", "status"], {
 			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
@@ -1700,24 +1694,25 @@ describe("codex bin wrapper", () => {
 		const shadowHooksPath = join(shadowHome, "hooks.json");
 		expectMirroredHookStateBlock(
 			output,
+			originalConfig,
 			hookStateHeader(sessionStartKey),
 			hookStateHeader(`${shadowHooksPath}:session_start:0:0`),
 			["enabled = true", 'trusted_hash = "sha256:session-start"'],
 		);
 		expectMirroredHookStateBlock(
 			output,
+			originalConfig,
 			hookStateHeader(stopKey),
 			hookStateHeader(`${shadowHooksPath}:stop:0:0`),
 			["enabled = true", 'trusted_hash = "sha256:stop"'],
 		);
-		expectMirroredHookStateBlock(
+		expect(extractTomlTableBody(
 			output,
-			literalHookStateHeader(userPromptSubmitKey),
 			hookStateHeader(`${shadowHooksPath}:user_prompt_submit:0:0`),
-			["enabled = true"],
-		);
+		)).toBe("enabled = true");
 		expectMirroredHookStateBlock(
 			output,
+			originalConfig,
 			hookStateHeader(preCompactKey),
 			hookStateHeader(`${shadowHooksPath}:pre_compact:0:0`),
 			[
@@ -1735,6 +1730,7 @@ describe("codex bin wrapper", () => {
 		);
 		expectMirroredHookStateBlock(
 			output,
+			originalConfig,
 			hookStateHeader(longPathKey),
 			hookStateHeader(`${shadowHooksPath}:${"long-event-".repeat(24)}:0:0`),
 			["enabled = true", 'trusted_hash = "sha256:long-path"'],
@@ -1771,21 +1767,18 @@ describe("codex bin wrapper", () => {
 		const stopKey = `${sourceHooksPath}:stop:0:0`;
 		mkdirSync(originalHome, { recursive: true });
 		writeFileSync(sourceHooksPath, HOOKS_JSON_TEXT, "utf8");
-		writeFileSync(
-			join(originalHome, "config.toml"),
-			[
-				'model_provider = "openai"',
-				"",
-				hookStateHeader(sessionStartKey),
-				"enabled = true",
-				'trusted_hash = "sha256:session-start"',
-				"",
-				hookStateHeader(stopKey),
-				"enabled = true",
-				'trusted_hash = "sha256:stop"',
-			].join("\n"),
-			"utf8",
-		);
+		const originalConfig = [
+			'model_provider = "openai"',
+			"",
+			hookStateHeader(sessionStartKey),
+			"enabled = true",
+			'trusted_hash = "sha256:session-start"',
+			"",
+			hookStateHeader(stopKey),
+			"enabled = true",
+			'trusted_hash = "sha256:stop"',
+		].join("\n");
+		writeFileSync(join(originalHome, "config.toml"), originalConfig, "utf8");
 
 		const launches = ["first", "second", "third"].map((marker) =>
 			runWrapperAsync(fixtureRoot, ["exec", "status"], {
@@ -1806,12 +1799,14 @@ describe("codex bin wrapper", () => {
 			const shadowHooksPath = join(shadowHome, "hooks.json");
 			expectMirroredHookStateBlock(
 				output,
+				originalConfig,
 				hookStateHeader(sessionStartKey),
 				hookStateHeader(`${shadowHooksPath}:session_start:0:0`),
 				["enabled = true", 'trusted_hash = "sha256:session-start"'],
 			);
 			expectMirroredHookStateBlock(
 				output,
+				originalConfig,
 				hookStateHeader(stopKey),
 				hookStateHeader(`${shadowHooksPath}:stop:0:0`),
 				["enabled = true", 'trusted_hash = "sha256:stop"'],

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -1492,6 +1492,73 @@ describe("codex bin wrapper", () => {
 		);
 	});
 
+	it("mirrors trusted user hook state into the runtime shadow config", () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
+			'console.log(`SHADOW_HOME:${process.env.CODEX_HOME ?? ""}`);',
+			'console.log(fs.readFileSync(path.join(process.env.CODEX_HOME, "config.toml"), "utf8"));',
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(join(originalHome, "hooks.json"), '{"hooks":{}}\n', "utf8");
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			[
+				'model_provider = "openai"',
+				"",
+				`[hooks.state.${JSON.stringify(`${join(originalHome, "hooks.json")}:session_start:0:0`)}]`,
+				"enabled = true",
+				'trusted_hash = "sha256:session-start"',
+				"",
+				`[hooks.state.${JSON.stringify(`${join(originalHome, "hooks.json")}:stop:0:0`)}]`,
+				"enabled = true",
+				'trusted_hash = "sha256:stop"',
+			].join("\n"),
+			"utf8",
+		);
+
+		const result = runWrapper(fixtureRoot, ["exec", "status"], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_HOME: originalHome,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+			OPENAI_API_KEY: undefined,
+		});
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(0);
+		const shadowHome = output.match(/^SHADOW_HOME:(.+)$/m)?.[1];
+		expect(shadowHome).toBeTruthy();
+		if (!shadowHome) return;
+		const sourceSessionHeader =
+			`[hooks.state.${JSON.stringify(`${join(originalHome, "hooks.json")}:session_start:0:0`)}]`;
+		const shadowSessionHeader =
+			`[hooks.state.${JSON.stringify(`${join(shadowHome, "hooks.json")}:session_start:0:0`)}]`;
+		expect(output).toContain(sourceSessionHeader);
+		expect(output).toContain(shadowSessionHeader);
+		expect(output).toContain(
+			`[hooks.state.${JSON.stringify(`${join(shadowHome, "hooks.json")}:stop:0:0`)}]`,
+		);
+		const sourceSessionIndex = output.indexOf(sourceSessionHeader);
+		const sourceSessionEnabledIndex = output.indexOf(
+			"enabled = true",
+			sourceSessionIndex,
+		);
+		const shadowSessionIndex = output.indexOf(shadowSessionHeader);
+		const shadowSessionEnabledIndex = output.indexOf(
+			"enabled = true",
+			shadowSessionIndex,
+		);
+		expect(sourceSessionIndex).toBeLessThan(sourceSessionEnabledIndex);
+		expect(sourceSessionEnabledIndex).toBeLessThan(shadowSessionIndex);
+		expect(shadowSessionIndex).toBeLessThan(shadowSessionEnabledIndex);
+		expect(output).toContain('trusted_hash = "sha256:session-start"');
+		expect(output).toContain('trusted_hash = "sha256:stop"');
+	});
+
 	it("starts the opt-in runtime rotation proxy for app-server without capturing protocol stdio", () => {
 		const fixtureRoot = createWrapperFixture();
 		createRuntimeRotationProxyFixtureModule(fixtureRoot);


### PR DESCRIPTION
## Summary
- Mirror trusted `[hooks.state]` entries from the real Codex home to the runtime shadow home hook path.
- Preserve the original trusted hook entries while adding shadow-path equivalents, avoiding repeated hook approval prompts when using `codex-multi-auth-codex`.
- Keep runtime shadow state isolated from official Codex auth/account files.

## Why
`codex-multi-auth-codex` creates a temporary `CODEX_HOME` for runtime rotation. Codex keys hook trust by the absolute `hooks.json` path, so the shadow home used a different trust key and prompted for hook approval on every launch even when the user's real `~/.codex/config.toml` already trusted those hooks.

## Tests
- `git diff --check origin/main...HEAD`
- `npx vitest run test/codex-bin-wrapper.test.ts -t "mirrors trusted user hook state"`
- Previously run on this branch before commit: `npm run typecheck`, `npm run lint`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr fixes hook approval prompts firing on every `codex-multi-auth-codex` launch by mirroring `[hooks.state.*]` entries from the real codex home into the runtime shadow config, rewriting their keys to use the shadow `hooks.json` path.

- adds `mirrorRuntimeShadowHookTrustState` with a careful line-by-line toml scanner (`updateTomlBlockScanState`) that correctly handles multiline strings, inline arrays, and both basic and literal-string table keys, avoiding premature block termination.
- integrates the mirror step between `rewriteConfigTomlForRuntimeRotationProvider` and the final `writeFileSync` in `createRuntimeRotationProxyCodexHome`, with deduplication to guard against re-running on an already-patched config.
- adds two integration tests: a single-process test covering crlf preservation, literal-string keys, multiline string values, inline arrays, long keys, and passthrough of non-matching entries; and a concurrent three-process test confirming each shadow home gets its own correctly mirrored config.

<h3>Confidence Score: 5/5</h3>

change is safe to merge; each shadow home is an isolated temp dir so concurrent launches can't step on each other, and the mirroring logic is read-only on the original config

the toml block scanner correctly handles multiline strings and inline arrays before checking for table boundaries, the dedup guard prevents double-injection, and both the functional and concurrency tests exercise the core paths. no production code path was found that could silently drop trust entries or corrupt the shadow config.

the duplicated toml helper functions shared between scripts/codex.js and test/codex-bin-wrapper.test.ts are the most likely source of future confusion if either copy drifts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/codex.js | adds `mirrorRuntimeShadowHookTrustState` and related TOML helpers; logic handles basic strings, literal strings, multiline strings, and inline arrays correctly, but the helpers are duplicated verbatim into the test file with only a comment asking devs to keep them in sync |
| test/codex-bin-wrapper.test.ts | adds single-process and concurrent launch tests for hook state mirroring; covers CRLF preservation, literal-string source keys, multiline string blocks, inline arrays, long keys, and passthrough of non-source-prefix entries; deduplication guard path (existingHookStateKeys.has) has no dedicated test |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createRuntimeRotationProxyCodexHome] --> B[createRuntimeRotationShadowHome\nmkdtempSync → unique temp dir]
    A --> C[readFileSync originalCodexHome/config.toml]
    C --> D[rewriteConfigTomlForRuntimeRotationProvider\nswap provider / API key]
    D --> E[mirrorRuntimeShadowHookTrustState\nrawConfig, originalHome, shadowHome, tomlStringLiteral]
    E --> F{sourceHooksPath === shadowHooksPath?}
    F -- yes --> G[return rawConfig unchanged]
    F -- no --> H[pre-scan: collect all existingHookStateKeys]
    H --> I[main loop over lines]
    I --> J{parseHookStateTableKey\nbasic or literal string?}
    J -- no match --> K[pass line through]
    J -- match --> L{key.startsWith sourcePrefix?}
    L -- no --> K
    L -- yes --> M[collect blockLines until next top-level table header\nupdateTomlBlockScanState tracks multiline strings + array depth]
    M --> N{existingHookStateKeys.has shadowKey?}
    N -- yes --> O[skip, already mirrored]
    N -- no --> P[emit separator + shadow header + copy blockLines]
    P --> Q[writeFileSync shadowCodexHome/config.toml]
    K --> I
    O --> I
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/codex-bin-wrapper.test.ts`, line 1496-1565 ([link](https://github.com/ndycode/codex-multi-auth/blob/2b9e72afba67381fce7e29859fd37397a474cb4d/test/codex-bin-wrapper.test.ts#L1496-L1565)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **missing vitest coverage for key edge cases**

   the happy path is well covered, but a few branches have no test: deduplication guard (`existingHookStateKeys.has(shadowKey)` path), entries not matching the source prefix (passthrough correctness), and CRLF line endings (detection code exists but is untested).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/codex-bin-wrapper.test.ts
   Line: 1496-1565

   Comment:
   **missing vitest coverage for key edge cases**

   the happy path is well covered, but a few branches have no test: deduplication guard (`existingHookStateKeys.has(shadowKey)` path), entries not matching the source prefix (passthrough correctness), and CRLF line endings (detection code exists but is untested).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/codex.js:2521-2575
**duplicated TOML helpers — drift risk between production and test**

`createTomlBlockScanState`, `isTopLevelTomlBlockScanState`, and `updateTomlBlockScanState` are copied verbatim into `test/codex-bin-wrapper.test.ts`, with only a comment asking devs to keep them aligned. if the production copy is ever tightened (e.g., to handle `''''` four-quote edge cases or dotted quoted keys) without updating the test copy, `extractTomlTableBody` will use different boundary logic than `mirrorRuntimeShadowHookTrustState`. the test could then pass while silently failing to mirror a block that the production scanner truncates, or vice versa. consider extracting these helpers into a shared util module imported by both, which would make misalignment a compile-time error.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address hook trust review comments"](https://github.com/ndycode/codex-multi-auth/commit/aabbed6e2185670b0fa988a72383373fb82cb257) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33755031)</sub>

<!-- /greptile_comment -->