### PR TITLE
fix(runtime): surface skip reason in pinned 503 (#486)

### DIFF
--- a/docs/reference/error-contracts.md
+++ b/docs/reference/error-contracts.md
@@ -77,7 +77,7 @@ The default-on localhost Responses proxy returns JSON error payloads with a stab
 | `codex_pinned_account_unavailable` | `503` | A manual pin is set (via `codex-multi-auth switch`) but the pinned account is rate-limited, cooling down, disabled, or blocked by policy. Run `codex-multi-auth status` for details, or `codex-multi-auth unpin` to allow rotation |
 | `codex_runtime_rotation_proxy_error` | `500` | Proxy failed before forwarding the request |
 
-Pool exhaustion includes a `reason`, `retry_after_ms`, and a hint to run `codex-multi-auth rotation status`. Pinned-account-unavailable responses include a `pinnedAccountIndex` field identifying the pinned account.
+Pool exhaustion includes a `reason`, `retry_after_ms`, and a hint to run `codex-multi-auth rotation status`. Pinned-account-unavailable responses include a `pinnedAccountIndex` field identifying the pinned account, a structured `reason` field carrying the runtime skip reason (for example `rate-limited`, `cooling-down:auth-failure`, `circuit-open`, `disabled`, `workspace-disabled`, `policy-blocked`, `missing`, `already-attempted`) or `null` when no reason was recorded, and an `account_skip_reasons` map keyed by account index that mirrors the pool-exhausted response shape. The human-readable `message` appends the same reason in parentheses when present (see issue #486).
 
 ---
 

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1738,7 +1738,22 @@ export async function startRuntimeRotationProxy(
 			// When a manual pin is set and the pinned account is unavailable, do
 			// NOT silently fall through to rotation. Hard-fail with a 503 so the
 			// user is informed the pin cannot be honored. See issue #474.
+			//
+			// Surface the runtime skip reason in both the human-readable message
+			// and a structured `reason` field, mirroring `writePoolExhausted`. A
+			// null reason indicates a forecast/runtime state desync (the pinned
+			// account was selected but no skip reason was recorded) — see #486.
 			if (isPinned) {
+				const pinnedSkipReason =
+					typeof pinnedIndex === "number"
+						? accountSkipReasons.get(pinnedIndex) ?? null
+						: null;
+				if (pinnedSkipReason === null) {
+					status.lastError = `pinned-503 missing skip reason (pinnedIndex=${pinnedIndex})`;
+				}
+				const reasonSuffix = pinnedSkipReason
+					? ` (${pinnedSkipReason})`
+					: "";
 				await usageRecorder?.record({
 					outcome: "failure",
 					statusCode: HTTP_STATUS.SERVICE_UNAVAILABLE,
@@ -1746,9 +1761,16 @@ export async function startRuntimeRotationProxy(
 				});
 				writeJson(res, HTTP_STATUS.SERVICE_UNAVAILABLE, {
 					error: {
-						message: `Pinned account ${(pinnedIndex ?? 0) + 1} is currently unavailable; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
+						message: `Pinned account ${(pinnedIndex ?? 0) + 1} is currently unavailable${reasonSuffix}; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
 						code: "codex_pinned_account_unavailable",
 						pinnedAccountIndex: pinnedIndex,
+						reason: pinnedSkipReason,
+						account_skip_reasons: Object.fromEntries(
+							[...accountSkipReasons.entries()].map(([index, reason]) => [
+								String(index),
+								reason,
+							]),
+						),
 					},
 				});
 				return;

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1044,6 +1044,47 @@ function writePoolExhausted(params: {
 	});
 }
 
+/**
+ * Build the JSON `error` body for a pinned-account 503 response. Extracted so
+ * the null-reason desync path (`reason: null`, no parenthetical in `message`)
+ * can be unit-tested without standing up a full proxy. The shape mirrors
+ * `writePoolExhausted` so consumers can handle both 503 codes uniformly. See
+ * issue #486.
+ */
+export interface PinnedUnavailableErrorBody {
+	message: string;
+	code: "codex_pinned_account_unavailable";
+	pinnedAccountIndex: number | null;
+	reason: string | null;
+	account_skip_reasons: Record<string, string>;
+}
+
+export function buildPinnedUnavailableErrorBody(
+	pinnedIndex: number | null | undefined,
+	accountSkipReasons: ReadonlyMap<number, string>,
+): PinnedUnavailableErrorBody {
+	const normalizedPinnedIndex =
+		typeof pinnedIndex === "number" ? pinnedIndex : null;
+	const skipReason =
+		normalizedPinnedIndex !== null
+			? accountSkipReasons.get(normalizedPinnedIndex) ?? null
+			: null;
+	const reasonSuffix = skipReason ? ` (${skipReason})` : "";
+	const displayIndex = (normalizedPinnedIndex ?? 0) + 1;
+	return {
+		message: `Pinned account ${displayIndex} is currently unavailable${reasonSuffix}; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
+		code: "codex_pinned_account_unavailable",
+		pinnedAccountIndex: normalizedPinnedIndex,
+		reason: skipReason,
+		account_skip_reasons: Object.fromEntries(
+			[...accountSkipReasons.entries()].map(([index, reason]) => [
+				String(index),
+				reason,
+			]),
+		),
+	};
+}
+
 async function withTimeout<T>(
 	promise: Promise<T>,
 	timeoutMs: number,
@@ -1744,35 +1785,19 @@ export async function startRuntimeRotationProxy(
 			// null reason indicates a forecast/runtime state desync (the pinned
 			// account was selected but no skip reason was recorded) — see #486.
 			if (isPinned) {
-				const pinnedSkipReason =
-					typeof pinnedIndex === "number"
-						? accountSkipReasons.get(pinnedIndex) ?? null
-						: null;
-				if (pinnedSkipReason === null) {
+				const errorBody = buildPinnedUnavailableErrorBody(
+					pinnedIndex,
+					accountSkipReasons,
+				);
+				if (errorBody.reason === null) {
 					status.lastError = `pinned-503 missing skip reason (pinnedIndex=${pinnedIndex})`;
 				}
-				const reasonSuffix = pinnedSkipReason
-					? ` (${pinnedSkipReason})`
-					: "";
 				await usageRecorder?.record({
 					outcome: "failure",
 					statusCode: HTTP_STATUS.SERVICE_UNAVAILABLE,
 					errorCode: "codex_pinned_account_unavailable",
 				});
-				writeJson(res, HTTP_STATUS.SERVICE_UNAVAILABLE, {
-					error: {
-						message: `Pinned account ${(pinnedIndex ?? 0) + 1} is currently unavailable${reasonSuffix}; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
-						code: "codex_pinned_account_unavailable",
-						pinnedAccountIndex: pinnedIndex,
-						reason: pinnedSkipReason,
-						account_skip_reasons: Object.fromEntries(
-							[...accountSkipReasons.entries()].map(([index, reason]) => [
-								String(index),
-								reason,
-							]),
-						),
-					},
-				});
+				writeJson(res, HTTP_STATUS.SERVICE_UNAVAILABLE, { error: errorBody });
 				return;
 			}
 

--- a/test/issue-474-pin-end-to-end.test.ts
+++ b/test/issue-474-pin-end-to-end.test.ts
@@ -279,8 +279,163 @@ describe("issue #474 — end-to-end pin honored over real HTTP proxy", () => {
 			expect(thirdResult.bodyText).toContain(
 				"codex_pinned_account_unavailable",
 			);
+			// Issue #486: the 503 body must surface the runtime skip reason so
+			// users can diagnose why the pin cannot be honored without scraping
+			// `codex-multi-auth status` logs out-of-band.
+			const thirdBody = JSON.parse(thirdResult.bodyText) as {
+				error: {
+					code: string;
+					pinnedAccountIndex: number | null;
+					reason: string | null;
+					account_skip_reasons: Record<string, string>;
+					message: string;
+				};
+			};
+			expect(thirdBody.error.reason).toBe("disabled");
+			expect(thirdBody.error.message).toContain("(disabled)");
+			expect(thirdBody.error.pinnedAccountIndex).toBe(otherAccountIndex);
+			expect(
+				thirdBody.error.account_skip_reasons[String(otherAccountIndex)],
+			).toBe("disabled");
 			// No additional upstream call — the proxy refused before issuing one.
 			expect(upstreamCalls).toHaveLength(2);
+		},
+	);
+
+	it(
+		"surfaces 'rate-limited' skip reason in pinned 503 body (issue #486)",
+		async () => {
+			const storagePath = makeTmpStoragePath();
+			const now = Date.now();
+			const initialStorage = createStorage(now);
+			const pinnedIndex = 1;
+			writeStorageFile(storagePath, {
+				...initialStorage,
+				pinnedAccountIndex: pinnedIndex,
+				affinityGeneration: 1,
+			});
+			setStoragePathDirect(storagePath);
+
+			const accountManager = new AccountManager(undefined, initialStorage);
+			openManagers.push(accountManager);
+
+			const pinned = accountManager.getAccountByIndex(pinnedIndex);
+			expect(pinned).not.toBeNull();
+			if (!pinned) throw new Error("setup failed");
+			// Match the family the proxy will resolve from `model: "gpt-5-codex"`.
+			// `getModelFamily("gpt-5-codex")` returns "gpt-5-codex", not "codex",
+			// so the rate-limit must be keyed under that family for the runtime
+			// skip-reason check to detect it.
+			accountManager.markRateLimitedWithReason(
+				pinned,
+				60_000,
+				"gpt-5-codex",
+				"quota",
+			);
+
+			const upstreamCalls: number[] = [];
+			const fetchImpl: typeof fetch = async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				const auth = headers.get("authorization") ?? "";
+				const token = auth.replace(/^Bearer\s+/i, "");
+				const index = initialStorage.accounts.findIndex(
+					(a) => a.accessToken === token,
+				);
+				upstreamCalls.push(index);
+				return new Response(JSON.stringify({ ok: true, account: index }), {
+					status: HTTP_STATUS.OK,
+					headers: { "content-type": "application/json" },
+				});
+			};
+
+			const proxy = await startRuntimeRotationProxy({
+				accountManager,
+				fetchImpl,
+				upstreamBaseUrl: "https://example.test/backend-api",
+				clientApiKey: CLIENT_API_KEY,
+			});
+			openServers.push(proxy);
+
+			const result = await postViaHttp(
+				proxy,
+				{ model: "gpt-5-codex", stream: false },
+				"/v1/responses",
+			);
+			expect(result.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+			const body = JSON.parse(result.bodyText) as {
+				error: {
+					code: string;
+					reason: string | null;
+					account_skip_reasons: Record<string, string>;
+					message: string;
+				};
+			};
+			expect(body.error.code).toBe("codex_pinned_account_unavailable");
+			expect(body.error.reason).toBe("rate-limited");
+			expect(body.error.message).toContain("(rate-limited)");
+			expect(body.error.account_skip_reasons[String(pinnedIndex)]).toBe(
+				"rate-limited",
+			);
+			expect(upstreamCalls).toHaveLength(0);
+		},
+	);
+
+	it(
+		"surfaces a cooling-down skip reason in pinned 503 body (issue #486)",
+		async () => {
+			const storagePath = makeTmpStoragePath();
+			const now = Date.now();
+			const initialStorage = createStorage(now);
+			const pinnedIndex = 0;
+			writeStorageFile(storagePath, {
+				...initialStorage,
+				pinnedAccountIndex: pinnedIndex,
+				affinityGeneration: 1,
+			});
+			setStoragePathDirect(storagePath);
+
+			const accountManager = new AccountManager(undefined, initialStorage);
+			openManagers.push(accountManager);
+
+			const pinned = accountManager.getAccountByIndex(pinnedIndex);
+			if (!pinned) throw new Error("setup failed");
+			accountManager.markAccountCoolingDown(pinned, 60_000, "auth-failure");
+
+			const upstreamCalls: number[] = [];
+			const fetchImpl: typeof fetch = async () => {
+				upstreamCalls.push(-1);
+				return new Response("{}", { status: HTTP_STATUS.OK });
+			};
+
+			const proxy = await startRuntimeRotationProxy({
+				accountManager,
+				fetchImpl,
+				upstreamBaseUrl: "https://example.test/backend-api",
+				clientApiKey: CLIENT_API_KEY,
+			});
+			openServers.push(proxy);
+
+			const result = await postViaHttp(
+				proxy,
+				{ model: "gpt-5-codex", stream: false },
+				"/v1/responses",
+			);
+			expect(result.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+			const body = JSON.parse(result.bodyText) as {
+				error: {
+					code: string;
+					reason: string | null;
+					account_skip_reasons: Record<string, string>;
+					message: string;
+				};
+			};
+			expect(body.error.code).toBe("codex_pinned_account_unavailable");
+			expect(body.error.reason).toMatch(/^cooling-down/);
+			expect(body.error.message).toMatch(/\(cooling-down[^)]*\)/);
+			expect(body.error.account_skip_reasons[String(pinnedIndex)]).toMatch(
+				/^cooling-down/,
+			);
+			expect(upstreamCalls).toHaveLength(0);
 		},
 	);
 });

--- a/test/issue-474-pin-end-to-end.test.ts
+++ b/test/issue-474-pin-end-to-end.test.ts
@@ -430,10 +430,10 @@ describe("issue #474 — end-to-end pin honored over real HTTP proxy", () => {
 				};
 			};
 			expect(body.error.code).toBe("codex_pinned_account_unavailable");
-			expect(body.error.reason).toMatch(/^cooling-down/);
-			expect(body.error.message).toMatch(/\(cooling-down[^)]*\)/);
-			expect(body.error.account_skip_reasons[String(pinnedIndex)]).toMatch(
-				/^cooling-down/,
+			expect(body.error.reason).toBe("cooling-down:auth-failure");
+			expect(body.error.message).toContain("(cooling-down:auth-failure)");
+			expect(body.error.account_skip_reasons[String(pinnedIndex)]).toBe(
+				"cooling-down:auth-failure",
 			);
 			expect(upstreamCalls).toHaveLength(0);
 		},

--- a/test/issue-474-pin-honored.test.ts
+++ b/test/issue-474-pin-honored.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AccountManager } from "../lib/accounts.js";
 import { clearCircuitBreakers } from "../lib/circuit-breaker.js";
 import {
+	buildPinnedUnavailableErrorBody,
 	chooseAccount,
 	readPinnedAccountIndexFromDisk,
 	resetPinCacheForTesting,
@@ -622,6 +623,116 @@ describe("issue #474 — manual pin honored by runtime proxy", () => {
 
 			expect(result).toBeNull();
 			expect(skipReasons.get(0)).toBe("already-attempted");
+		});
+
+		it("records 'workspace-disabled' when every workspace on the pinned account is disabled", () => {
+			const now = Date.now();
+			const storage = createStorage(now, 3);
+			const accountManager = new AccountManager(undefined, storage);
+			const pinned = accountManager.getAccountByIndex(2);
+			if (!pinned) throw new Error("setup failed");
+			pinned.workspaces = [{ id: "ws-1", enabled: false }];
+			const skipReasons = new Map<number, string>();
+
+			const result = chooseAccount({
+				accountManager,
+				sessionAffinityStore: null,
+				sessionKey: null,
+				family: "codex",
+				model: null,
+				attemptedIndexes: new Set(),
+				now,
+				policy: null,
+				pinnedIndex: 2,
+				skipReasons,
+			});
+
+			expect(result).toBeNull();
+			expect(skipReasons.get(2)).toBe("workspace-disabled");
+		});
+
+		it("records 'circuit-open' when the pinned account's circuit breaker is open", () => {
+			const now = Date.now();
+			const storage = createStorage(now, 3);
+			const accountManager = new AccountManager(undefined, storage);
+			const pinned = accountManager.getAccountByIndex(1);
+			if (!pinned) throw new Error("setup failed");
+			// Default failure threshold is 3 — trip the breaker explicitly so
+			// `getAccountRuntimeSkipReason` resolves to "circuit-open".
+			accountManager.recordFailure(pinned, "codex");
+			accountManager.recordFailure(pinned, "codex");
+			accountManager.recordFailure(pinned, "codex");
+			const skipReasons = new Map<number, string>();
+
+			const result = chooseAccount({
+				accountManager,
+				sessionAffinityStore: null,
+				sessionKey: null,
+				family: "codex",
+				model: null,
+				attemptedIndexes: new Set(),
+				now,
+				policy: null,
+				pinnedIndex: 1,
+				skipReasons,
+			});
+
+			expect(result).toBeNull();
+			expect(skipReasons.get(1)).toBe("circuit-open");
+		});
+	});
+
+	// Issue #486: cover the null-reason desync branch directly. `chooseAccount`
+	// is supposed to record a skip reason for every pinned-unavailability path,
+	// but if internal state desyncs (e.g. forecast says "rotate" yet runtime
+	// state is missing a reason), the proxy still needs to produce a 503 body
+	// with an explicit `reason: null` instead of silently masking the gap.
+	describe("buildPinnedUnavailableErrorBody", () => {
+		it("returns reason: null and omits the parenthetical when no skip reason was recorded", () => {
+			const body = buildPinnedUnavailableErrorBody(
+				1,
+				new Map<number, string>(),
+			);
+			expect(body.code).toBe("codex_pinned_account_unavailable");
+			expect(body.reason).toBeNull();
+			expect(body.pinnedAccountIndex).toBe(1);
+			expect(body.account_skip_reasons).toEqual({});
+			expect(body.message).toBe(
+				"Pinned account 2 is currently unavailable; run `codex-multi-auth status` for details, or `codex-multi-auth unpin` to allow rotation.",
+			);
+			expect(body.message).not.toContain("(");
+		});
+
+		it("surfaces the skip reason and appends it to the message when present", () => {
+			const skipReasons = new Map<number, string>([[1, "rate-limited"]]);
+			const body = buildPinnedUnavailableErrorBody(1, skipReasons);
+			expect(body.reason).toBe("rate-limited");
+			expect(body.account_skip_reasons).toEqual({ "1": "rate-limited" });
+			expect(body.message).toContain("Pinned account 2");
+			expect(body.message).toContain("(rate-limited)");
+		});
+
+		it("handles a null pinnedIndex without throwing and emits reason: null", () => {
+			const body = buildPinnedUnavailableErrorBody(
+				null,
+				new Map<number, string>(),
+			);
+			expect(body.pinnedAccountIndex).toBeNull();
+			expect(body.reason).toBeNull();
+			expect(body.message).toContain("Pinned account 1");
+		});
+
+		it("mirrors the full accountSkipReasons map even when the pinned entry is unknown", () => {
+			const skipReasons = new Map<number, string>([
+				[0, "rate-limited"],
+				[2, "disabled"],
+			]);
+			const body = buildPinnedUnavailableErrorBody(1, skipReasons);
+			expect(body.reason).toBeNull();
+			expect(body.account_skip_reasons).toEqual({
+				"0": "rate-limited",
+				"2": "disabled",
+			});
 		});
 	});
 

--- a/test/issue-474-pin-honored.test.ts
+++ b/test/issue-474-pin-honored.test.ts
@@ -462,6 +462,169 @@ describe("issue #474 — manual pin honored by runtime proxy", () => {
 		});
 	});
 
+	// Issue #486: chooseAccount must record a skip reason for every pinned
+	// unavailability path so the runtime proxy can surface it in the 503 body.
+	describe("chooseAccount populates skipReasons for pinned unavailability", () => {
+		it("records 'rate-limited' when the pinned account is rate-limited", () => {
+			const now = Date.now();
+			const storage = createStorage(now, 3);
+			const accountManager = new AccountManager(undefined, storage);
+			const pinned = accountManager.getAccountByIndex(1);
+			if (!pinned) throw new Error("setup failed");
+			accountManager.markRateLimitedWithReason(
+				pinned,
+				60_000,
+				"codex",
+				"quota",
+			);
+			const skipReasons = new Map<number, string>();
+
+			const result = chooseAccount({
+				accountManager,
+				sessionAffinityStore: null,
+				sessionKey: null,
+				family: "codex",
+				model: null,
+				attemptedIndexes: new Set(),
+				now,
+				policy: null,
+				pinnedIndex: 1,
+				skipReasons,
+			});
+
+			expect(result).toBeNull();
+			expect(skipReasons.get(1)).toBe("rate-limited");
+		});
+
+		it("records 'cooling-down:auth-failure' when the pinned account is cooling down", () => {
+			const now = Date.now();
+			const storage = createStorage(now, 3);
+			const accountManager = new AccountManager(undefined, storage);
+			const pinned = accountManager.getAccountByIndex(0);
+			if (!pinned) throw new Error("setup failed");
+			accountManager.markAccountCoolingDown(pinned, 60_000, "auth-failure");
+			const skipReasons = new Map<number, string>();
+
+			const result = chooseAccount({
+				accountManager,
+				sessionAffinityStore: null,
+				sessionKey: null,
+				family: "codex",
+				model: null,
+				attemptedIndexes: new Set(),
+				now,
+				policy: null,
+				pinnedIndex: 0,
+				skipReasons,
+			});
+
+			expect(result).toBeNull();
+			expect(skipReasons.get(0)).toBe("cooling-down:auth-failure");
+		});
+
+		it("records 'disabled' when the pinned account is disabled", () => {
+			const now = Date.now();
+			const storage = createStorage(now, 3);
+			const accountManager = new AccountManager(undefined, storage);
+			accountManager.setAccountEnabled(2, false);
+			const skipReasons = new Map<number, string>();
+
+			const result = chooseAccount({
+				accountManager,
+				sessionAffinityStore: null,
+				sessionKey: null,
+				family: "codex",
+				model: null,
+				attemptedIndexes: new Set(),
+				now,
+				policy: null,
+				pinnedIndex: 2,
+				skipReasons,
+			});
+
+			expect(result).toBeNull();
+			expect(skipReasons.get(2)).toBe("disabled");
+		});
+
+		it("records 'policy-blocked' when the pinned account is policy-blocked", () => {
+			const now = Date.now();
+			const storage = createStorage(now, 3);
+			const accountManager = new AccountManager(undefined, storage);
+			const skipReasons = new Map<number, string>();
+
+			const result = chooseAccount({
+				accountManager,
+				sessionAffinityStore: null,
+				sessionKey: null,
+				family: "codex",
+				model: null,
+				attemptedIndexes: new Set(),
+				now,
+				policy: {
+					allowed: true,
+					statusCode: 200,
+					reasons: [],
+					errorCode: null,
+					projectKey: null,
+					blockedAccountIndexes: new Set([1]),
+					scoreBoostByAccount: {},
+					budgetEvaluations: [],
+				},
+				pinnedIndex: 1,
+				skipReasons,
+			});
+
+			expect(result).toBeNull();
+			expect(skipReasons.get(1)).toBe("policy-blocked");
+		});
+
+		it("records 'missing' when the pinned index is out of range", () => {
+			const now = Date.now();
+			const storage = createStorage(now, 2);
+			const accountManager = new AccountManager(undefined, storage);
+			const skipReasons = new Map<number, string>();
+
+			const result = chooseAccount({
+				accountManager,
+				sessionAffinityStore: null,
+				sessionKey: null,
+				family: "codex",
+				model: null,
+				attemptedIndexes: new Set(),
+				now,
+				policy: null,
+				pinnedIndex: 5,
+				skipReasons,
+			});
+
+			expect(result).toBeNull();
+			expect(skipReasons.get(5)).toBe("missing");
+		});
+
+		it("records 'already-attempted' when the pinned index was already tried", () => {
+			const now = Date.now();
+			const storage = createStorage(now, 3);
+			const accountManager = new AccountManager(undefined, storage);
+			const skipReasons = new Map<number, string>();
+
+			const result = chooseAccount({
+				accountManager,
+				sessionAffinityStore: null,
+				sessionKey: null,
+				family: "codex",
+				model: null,
+				attemptedIndexes: new Set([0]),
+				now,
+				policy: null,
+				pinnedIndex: 0,
+				skipReasons,
+			});
+
+			expect(result).toBeNull();
+			expect(skipReasons.get(0)).toBe("already-attempted");
+		});
+	});
+
 	describe("readPinnedAccountIndexFromDisk", () => {
 		it("returns the pinnedAccountIndex written to disk", () => {
 			const path = makeTmpStoragePath();


### PR DESCRIPTION
## Summary

- Pinned-account 503 response now includes the runtime skip reason (`reason` field) plus the full `account_skip_reasons` map, mirroring the existing `writePoolExhausted` shape.
- Human-readable `message` appends the reason in parentheses, for example `Pinned account 2 is currently unavailable (rate-limited); run ...`.
- A missing skip reason resolves to explicit `null` and is recorded in `status.lastError`, so a forecast-vs-runtime state desync is visible instead of silently masked.
- Updates `docs/reference/error-contracts.md` to reflect the new payload shape.

## Why

Issue #486 reports a 503 from `codex_pinned_account_unavailable` while `codex-multi-auth doctor` reports all green. The 503 body did not carry the runtime skip reason, so neither the user nor maintainers could tell whether the pin was rate-limited, cooling down, disabled, blocked by policy, or in some other unavailable state. The non-pinned `writePoolExhausted` path already surfaces this information; this change brings the pinned path to parity.

This PR lands the diagnostic surface so future occurrences self-describe. The underlying state-desync root cause (doctor green, runtime 503) still requires logs from the reporter to fully diagnose.

## Changes

- `lib/runtime-rotation-proxy.ts`: extend the pinned-503 response body with `reason` and `account_skip_reasons`; append reason to the message; record `status.lastError` when no skip reason was captured.
- `test/issue-474-pin-end-to-end.test.ts`: extend the existing disabled-account case to assert the new fields and add two new end-to-end cases for rate-limited and cooling-down pinned accounts.
- `test/issue-474-pin-honored.test.ts`: add a describe block that asserts `chooseAccount` populates `skipReasons` for every pinned unavailability path (rate-limited, cooling-down, disabled, policy-blocked, missing, already-attempted).
- `docs/reference/error-contracts.md`: document the new pinned-503 fields.

## Verification

- `npm run typecheck` clean
- `npm run lint:ts` clean
- `npm test` (vitest) 4014 passed, 268 files, 0 failures

## Risk Notes

- Response shape is additive. Existing consumers reading `error.code`, `error.message`, or `error.pinnedAccountIndex` are unaffected.
- A null `reason` is now explicit in the payload instead of absent. Any consumer that did `assert(body.error.reason === undefined)` would need updating; unlikely but worth calling out.
- `account_skip_reasons` mirrors the pool-exhausted shape, so consumers that already handle that payload do not need a new code path.

## Follow-ups

- The original report also mentions plugins being disabled and per-project history disappearing after an uninstall+reinstall cycle. These are separate code paths and should be tracked in their own issues once reproduced.
- The recurring 503 root cause (state desync between forecast and runtime) still needs logs from `ENABLE_PLUGIN_REQUEST_LOGGING=1` against this patch to identify.

Refs issue #486.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr brings the pinned-account 503 response to parity with `writePoolExhausted` by surfacing the runtime skip reason in both a structured `reason` field and the human-readable `message`, and explicitly records `null` when no skip reason was captured so a forecast/runtime state desync is visible instead of silently masked.

- `buildPinnedUnavailableErrorBody` is extracted as a pure, exported helper so the null-reason desync branch (`reason: null`, empty `account_skip_reasons`) can be unit-tested independently from the proxy; the interface mirrors `writePoolExhausted` for uniform consumer handling.
- `issue-474-pin-honored.test.ts` adds full coverage of every `chooseAccount` skip-reason path (rate-limited, cooling-down, disabled, workspace-disabled, policy-blocked, missing, already-attempted) plus four `buildPinnedUnavailableErrorBody` unit tests including the null/empty-map case.
- `issue-474-pin-end-to-end.test.ts` extends the existing disabled-account assertion and adds two new e2e scenarios (rate-limited, cooling-down) that exercise the full proxy path.

<h3>Confidence Score: 5/5</h3>

additive response shape change with no breaking modifications to existing fields; all new branches are covered by unit and e2e tests

the change is purely additive — existing consumers reading `error.code`, `error.message`, or `error.pinnedAccountIndex` are unaffected. `buildPinnedUnavailableErrorBody` is a pure function, easy to reason about, and fully exercised including the null/empty-map desync path. the production `if (isPinned)` guard ensures `pinnedIndex` is always a `number` when the new code runs, so the defensive `null` handling in the helper is a safe backstop rather than a live risk.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime-rotation-proxy.ts | extracts `buildPinnedUnavailableErrorBody` as an exported pure helper and wires it into the pinned-503 branch; adds `status.lastError` assignment for the null-reason desync path; response shape is additive and does not break existing consumers |
| test/issue-474-pin-honored.test.ts | adds `chooseAccount` skip-reason coverage for all six pinned-unavailability paths plus four `buildPinnedUnavailableErrorBody` unit tests including the null/empty-map (desync) branch |
| test/issue-474-pin-end-to-end.test.ts | extends existing disabled-account e2e assertion and adds rate-limited and cooling-down end-to-end scenarios through the full proxy; test setup correctly keys rate-limit under the model-family string returned by `getModelFamily` |
| docs/reference/error-contracts.md | documents the new `reason`, `account_skip_reasons`, and null-reason semantics for the pinned-account-unavailable 503 payload |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Proxy as runtime-rotation-proxy
    participant CA as chooseAccount
    participant AM as AccountManager

    Client->>Proxy: POST /v1/responses (model, pinnedIndex set)
    Proxy->>Proxy: "readStorageMetaFromDisk() → isPinned=true, pinnedIndex=N"
    Proxy->>CA: "chooseAccount({ pinnedIndex, skipReasons })"
    CA->>AM: getAccountByIndex(N)
    CA->>AM: getAccountRuntimeSkipReason(N, family, model)
    AM-->>CA: ""rate-limited" | "cooling-down:X" | "disabled" | ... | null"
    CA->>CA: skipReasons.set(N, reason)
    CA-->>Proxy: null (account unavailable)
    Proxy->>Proxy: buildPinnedUnavailableErrorBody(pinnedIndex, skipReasons)
    alt "reason !== null"
        Proxy->>Proxy: "errorBody.reason = "rate-limited" (or other)"
    else "reason === null (desync)"
        Proxy->>Proxy: "errorBody.reason = null"
        Proxy->>Proxy: "status.lastError = "pinned-503 missing skip reason""
    end
    Proxy->>Proxy: usageRecorder.record(failure, 503)
    Proxy-->>Client: "503 { error: { code, reason, message, account_skip_reasons } }"
```

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): address review feedback on..."](https://github.com/ndycode/codex-multi-auth/commit/0bf756b48266ba50973e672ebef4b18ef1cf978b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34177529)</sub>

<!-- /greptile_comment -->