### PR TITLE
chore: release v2.1.13-beta.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.1.12",
+  "version": "2.1.13-beta.0",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
+- Current prerelease: [docs/releases/v2.1.13-beta.0.md](docs/releases/v2.1.13-beta.0.md) — install via `npm i -g codex-multi-auth@beta`
 - Current stable: [docs/releases/v2.1.12.md](docs/releases/v2.1.12.md)
 - Previous stable: [docs/releases/v2.1.11.md](docs/releases/v2.1.11.md)
 - Earlier stable: [docs/releases/v2.1.10.md](docs/releases/v2.1.10.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
+| [releases/v2.1.13-beta.0.md](releases/v2.1.13-beta.0.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
 | [releases/v2.1.12.md](releases/v2.1.12.md) | Current stable release notes |
 | [releases/v2.1.11.md](releases/v2.1.11.md) | Prior stable release notes |
 | [releases/v2.1.10.md](releases/v2.1.10.md) | Earlier stable release notes |

--- a/docs/releases/v2.1.13-beta.0.md
+++ b/docs/releases/v2.1.13-beta.0.md
@@ -1,0 +1,42 @@
+# v2.1.13-beta.0
+
+Beta prerelease that adds a diagnostic surface to the runtime rotation proxy's pinned-account 503 path. Issued so users who hit the recurring 503 reported in issue #486 can install the patched build, reproduce, and return the new structured `reason` field for root-cause analysis.
+
+This is a **prerelease**. Stable `v2.1.13` will land once the underlying forecast-vs-runtime state desync is identified and patched.
+
+## Install
+
+```bash
+npm i -g codex-multi-auth@beta
+```
+
+## Runtime Rotation
+
+### Fixes
+
+- Pinned-account 503 (`codex_pinned_account_unavailable`) now carries a structured `reason` field and a full `account_skip_reasons` map keyed by account index, mirroring the existing `writePoolExhausted` shape. Consumers can branch on the same payload across both 503 codes.
+- Human-readable `message` appends the skip reason in parentheses when present, for example `Pinned account 2 is currently unavailable (rate-limited); run ...`.
+- A missing skip reason resolves to explicit `null` in the response body and is recorded in `status.lastError` so a forecast-vs-runtime state desync becomes detectable instead of silently masked as `unknown`.
+- Extracted `buildPinnedUnavailableErrorBody` helper so the 503 payload shape is unit-testable in isolation; exported alongside a typed `PinnedUnavailableErrorBody` interface for stable external consumption.
+
+## Release Hygiene
+
+### Tests
+
+- Added end-to-end regression coverage for the pinned-503 rate-limited and cooling-down paths; existing disabled-account case extended to assert the new structured fields.
+- Extended `chooseAccount` unit suite to cover every pinned skip reason returned by `AccountManager.getAccountRuntimeSkipReason`: `rate-limited`, `cooling-down:auth-failure`, `disabled`, `workspace-disabled`, `circuit-open`, `policy-blocked`, `missing`, `already-attempted`.
+- Added direct unit coverage for `buildPinnedUnavailableErrorBody` across the empty-map (`reason: null`), populated-map, null-`pinnedIndex`, and mismatched-pinned-entry shapes.
+
+## Documentation
+
+- `docs/reference/error-contracts.md` documents the new `reason` and `account_skip_reasons` fields on the pinned-503 payload.
+
+## Known Gaps
+
+- The 503 root cause from issue #486 (doctor reports all green, runtime still returns 503) is **not** fixed by this prerelease. Users who reproduce on this build should set `ENABLE_PLUGIN_REQUEST_LOGGING=1`, repro, and attach the new 503 body plus logs from `~/.codex/multi-auth/logs/codex-plugin/` to issue #486.
+- Plugins-disabled and per-project history-loss symptoms reported alongside #486 are tracked separately in #488 and #489.
+
+## Refs
+
+- Issue #486 — `[bug] 503 Service Unavailable`
+- PR #487 — `fix(runtime): surface skip reason in pinned 503 (#486)`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.12",
+	"version": "2.1.13-beta.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.1.12",
+			"version": "2.1.13-beta.0",
 			"bundleDependencies": [
 				"@codex-ai/plugin"
 			],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.12",
+	"version": "2.1.13-beta.0",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Prerelease to npm `beta` dist-tag carrying the pinned-account 503 diagnostic surface that just merged in #487 (issue #486).

## Why

Issue #486 reports a recurring `codex_pinned_account_unavailable` 503 while `codex-multi-auth doctor` shows all green. The 503 body previously omitted the runtime skip reason, so the reporter could not diagnose the cause and neither could we. PR #487 lands the structured `reason` and `account_skip_reasons` fields plus a `null`-reason desync marker; this release pushes that build to users who can reproduce.

The root cause (forecast vs runtime state desync) is **not** fixed here. Cutting a beta instead of a stable so the patch lands fast for the reporter without claiming a full fix.

## Changes

- `package.json`, `package-lock.json`, `.codex-plugin/plugin.json` bumped to `2.1.13-beta.0`
- `docs/releases/v2.1.13-beta.0.md` new release notes
- `README.md`, `docs/README.md` link the prerelease alongside current stable (v2.1.12)

## Verification

- `npm test` 4020 passed, 268 files, 0 failures
- `npm run typecheck` clean
- `npm run lint:ts` clean

## Publish plan

After merge:

```bash
git checkout main
git pull origin main
git tag v2.1.13-beta.0
git push origin v2.1.13-beta.0
npm publish --tag beta
```

`--tag beta` is critical so this does not move the `latest` dist-tag away from `v2.1.12`. Users on stable will not auto-upgrade. Only `npm i -g codex-multi-auth@beta` opts in.

## Risk Notes

- Beta-only npm publish; `latest` dist-tag stays on `v2.1.12`.
- No runtime behavior change beyond the additive 503 fields already shipped in #487.

## Follow-ups

- Once the reporter installs the beta and posts a fresh 503 body + logs against issue #486, land the root-cause patch and promote to `v2.1.13` stable.
- Followups #488 (plugins disabled after reinstall) and #489 (per-project history loss) remain open and unrelated to this prerelease.

Refs #486, #487.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

version-only prerelease bump — all three manifest files (`package.json`, `package-lock.json`, `.codex-plugin/plugin.json`) consistently move from `2.1.12` → `2.1.13-beta.0`, and the new release notes document the structured 503 diagnostic fields shipped in #487.

- version bump is internally consistent and the `--tag beta` publish plan correctly keeps `latest` pinned to `v2.1.12`.
- release notes accurately describe the changes from #487 and correctly reference `docs/reference/error-contracts.md`, which exists and contains the new fields.
- the known-gaps troubleshooting line should add a token-safety guard against `CODEX_PLUGIN_LOG_BODIES=1` and a windows log-path note.

<h3>Confidence Score: 4/5</h3>

safe to merge; this is a version bump and docs-only release preparation with no runtime code changes.

all three manifest files are consistently bumped, the publish plan correctly uses --tag beta, and the underlying runtime fix already landed in #487. the only item worth a second look is the known-gaps troubleshooting line, which guides users toward request logging without warning that enabling body logging would expose oauth tokens to disk.

docs/releases/v2.1.13-beta.0.md — the known-gaps section needs a token-safety guard and a windows log-path note before users follow it to reproduce #486.

<details open><summary><h3>Security Review</h3></summary>

- `docs/releases/v2.1.13-beta.0.md` (line 36): the troubleshooting instruction tells users to enable `ENABLE_PLUGIN_REQUEST_LOGGING=1` without explicitly warning against also setting `CODEX_PLUGIN_LOG_BODIES=1`; `SECURITY.md` classifies body logging as sensitive because raw OAuth bearer tokens pass through the runtime proxy and would be written to disk under `~/.codex/multi-auth/logs/`.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version bumped from 2.1.12 → 2.1.13-beta.0; no structural changes |
| package-lock.json | lockfile root version bumped to match package.json; no dependency changes |
| .codex-plugin/plugin.json | plugin manifest version bumped to 2.1.13-beta.0; consistent with package.json |
| docs/releases/v2.1.13-beta.0.md | new release notes for the beta; troubleshooting guidance in Known Gaps omits a token-safety warning for CODEX_PLUGIN_LOG_BODIES and lacks a Windows path note |
| README.md | prerelease link added above stable; ordering and install command are correct |
| docs/README.md | prerelease row added to the releases table; consistent with README.md change |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Proxy as Runtime Rotation Proxy
    participant AM as AccountManager

    User->>Proxy: Codex request with pinned account
    Proxy->>AM: getAccountRuntimeSkipReason(pinnedIndex)
    AM-->>Proxy: reason or null
    alt reason present
        Proxy-->>User: 503 with reason and account_skip_reasons map
    else reason null desync
        Proxy-->>Proxy: record null in status.lastError
        Proxy-->>User: 503 with explicit reason null
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22release%2Fv2.1.13-beta.0%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22release%2Fv2.1.13-beta.0%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Freleases%2Fv2.1.13-beta.0.md%3A36%0Athe%20troubleshooting%20step%20directs%20users%20to%20enable%20request%20logging%20without%20warning%20that%20%60CODEX_PLUGIN_LOG_BODIES%3D1%60%20must%20**not**%20be%20set%20alongside%20it.%20%60SECURITY.md%60%20classifies%20body%20logging%20as%20%22sensitive%22%20because%20raw%20OAuth%20payloads%20%28including%20bearer%20tokens%29%20flow%20through%20the%20proxy%3B%20a%20frustrated%20user%20chasing%20a%20503%20might%20add%20it%20for%20more%20detail%20and%20inadvertently%20persist%20tokens%20to%20disk.%20also%2C%20the%20log%20path%20uses%20%60~%2F%60%20syntax%20which%20doesn't%20work%20in%20%60cmd.exe%60%20%E2%80%94%20windows%20users%20need%20the%20%60%25USERPROFILE%25%60%20equivalent.%0A%0A%60%60%60suggestion%0A-%20The%20503%20root%20cause%20from%20issue%20%23486%20%28doctor%20reports%20all%20green%2C%20runtime%20still%20returns%20503%29%20is%20**not**%20fixed%20by%20this%20prerelease.%20Users%20who%20reproduce%20on%20this%20build%20should%20set%20%60ENABLE_PLUGIN_REQUEST_LOGGING%3D1%60%20%28**do%20not%20also%20set%20%60CODEX_PLUGIN_LOG_BODIES%3D1%60**%20%E2%80%94%20body%20logs%20capture%20raw%20OAuth%20payloads%20and%20must%20be%20treated%20as%20sensitive%20data%29%2C%20repro%2C%20and%20attach%20the%20new%20503%20body%20plus%20logs%20from%20%60~%2F.codex%2Fmulti-auth%2Flogs%2Fcodex-plugin%2F%60%20%28%60%25USERPROFILE%25%5C.codex%5Cmulti-auth%5Clogs%5Ccodex-plugin%5C%60%20on%20Windows%29%20to%20issue%20%23486.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/releases/v2.1.13-beta.0.md:36
the troubleshooting step directs users to enable request logging without warning that `CODEX_PLUGIN_LOG_BODIES=1` must **not** be set alongside it. `SECURITY.md` classifies body logging as "sensitive" because raw OAuth payloads (including bearer tokens) flow through the proxy; a frustrated user chasing a 503 might add it for more detail and inadvertently persist tokens to disk. also, the log path uses `~/` syntax which doesn't work in `cmd.exe` — windows users need the `%USERPROFILE%` equivalent.

```suggestion
- The 503 root cause from issue #486 (doctor reports all green, runtime still returns 503) is **not** fixed by this prerelease. Users who reproduce on this build should set `ENABLE_PLUGIN_REQUEST_LOGGING=1` (**do not also set `CODEX_PLUGIN_LOG_BODIES=1`** — body logs capture raw OAuth payloads and must be treated as sensitive data), repro, and attach the new 503 body plus logs from `~/.codex/multi-auth/logs/codex-plugin/` (`%USERPROFILE%\.codex\multi-auth\logs\codex-plugin\` on Windows) to issue #486.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: release v2.1.13-beta.0"](https://github.com/ndycode/codex-multi-auth/commit/d7142f645152033a249755e8a53762942a94b96b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34183140)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->