### PR TITLE
feat: support multiple workspaces for the same email (#491)

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1799,6 +1799,36 @@ export function formatAccountLabel(
 	return `Account ${index + 1} (${segments.join(", ")})`;
 }
 
+/**
+ * One display line per workspace tracked on an account, with the active one
+ * marked. Lets `status`/`list` and the `workspace` command show every workspace
+ * a same-email account can rotate between (issue #491). Callers decide when to
+ * render these (e.g. only when more than one workspace exists) and supply the
+ * leading indent.
+ */
+export function formatWorkspaceLines(
+	account:
+		| { workspaces?: Workspace[]; currentWorkspaceIndex?: number }
+		| undefined,
+	indent = "   ",
+): string[] {
+	const workspaces = account?.workspaces;
+	if (!workspaces || workspaces.length === 0) return [];
+	const activeIndex = account?.currentWorkspaceIndex ?? 0;
+	return workspaces.map((workspace, idx) => {
+		const isActive = idx === activeIndex;
+		const name = workspace.name?.trim() || "(unnamed)";
+		const id = workspace.id?.trim() ?? "";
+		const idSuffix = id.length > 6 ? id.slice(-6) : id;
+		const tags: string[] = [];
+		if (isActive) tags.push("active");
+		if (workspace.enabled === false) tags.push("disabled");
+		const tagLabel = tags.length > 0 ? ` (${tags.join(", ")})` : "";
+		const idLabel = idSuffix ? ` id:${idSuffix}` : "";
+		return `${indent}${isActive ? "*" : "-"} ${idx + 1}. [${name}]${idLabel}${tagLabel}`;
+	});
+}
+
 export function formatCooldown(
 	account: { coolingDownUntil?: number; cooldownReason?: string },
 	now = nowMs(),

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1741,13 +1741,37 @@ export class AccountManager {
 	}
 }
 
+/**
+ * Name of the account's currently-selected workspace, if any. Lets same-email
+ * accounts that live in different workspaces (personal Plus vs business/team)
+ * stay distinguishable in `list`/`status` output. See issue #491.
+ */
+function activeWorkspaceName(
+	account:
+		| { workspaces?: Workspace[]; currentWorkspaceIndex?: number }
+		| undefined,
+): string | undefined {
+	const workspaces = account?.workspaces;
+	if (!workspaces || workspaces.length === 0) return undefined;
+	const idx = account?.currentWorkspaceIndex ?? 0;
+	const workspace = workspaces[idx] ?? workspaces[0];
+	return workspace?.name?.trim() || undefined;
+}
+
 export function formatAccountLabel(
 	account:
-		| { email?: string; accountId?: string; accountLabel?: string }
+		| {
+				email?: string;
+				accountId?: string;
+				accountLabel?: string;
+				workspaces?: Workspace[];
+				currentWorkspaceIndex?: number;
+		  }
 		| undefined,
 	index: number,
 ): string {
 	const accountLabel = account?.accountLabel?.trim();
+	const workspaceName = activeWorkspaceName(account);
 	const email = account?.email?.trim();
 	const accountId = account?.accountId?.trim();
 	const idSuffix = accountId
@@ -1756,19 +1780,23 @@ export function formatAccountLabel(
 			: accountId
 		: null;
 
-	if (accountLabel && email && idSuffix) {
-		return `Account ${index + 1} (${accountLabel}, ${email}, id:${idSuffix})`;
+	const segments: string[] = [];
+	if (accountLabel) segments.push(accountLabel);
+	// Surface the active workspace so two same-email accounts in different
+	// workspaces remain distinguishable; skip it when it would just repeat the
+	// manual account label.
+	if (workspaceName && workspaceName !== accountLabel) {
+		segments.push(`[${workspaceName}]`);
 	}
-	if (accountLabel && email)
-		return `Account ${index + 1} (${accountLabel}, ${email})`;
-	if (accountLabel && idSuffix)
-		return `Account ${index + 1} (${accountLabel}, id:${idSuffix})`;
-	if (accountLabel) return `Account ${index + 1} (${accountLabel})`;
-	if (email && idSuffix)
-		return `Account ${index + 1} (${email}, id:${idSuffix})`;
-	if (email) return `Account ${index + 1} (${email})`;
-	if (idSuffix) return `Account ${index + 1} (${idSuffix})`;
-	return `Account ${index + 1}`;
+	if (email) segments.push(email);
+	// A bare id stands alone (e.g. "Account 1 (123456)"); once any other
+	// segment precedes it, prefix with "id:" for clarity.
+	if (idSuffix) {
+		segments.push(segments.length > 0 ? `id:${idSuffix}` : idSuffix);
+	}
+
+	if (segments.length === 0) return `Account ${index + 1}`;
+	return `Account ${index + 1} (${segments.join(", ")})`;
 }
 
 export function formatCooldown(

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -90,7 +90,11 @@ import { runSwitchCommand } from "./codex-manager/commands/switch.js";
 import { runUnpinCommand } from "./codex-manager/commands/unpin.js";
 import { runWorkspaceCommand } from "./codex-manager/commands/workspace.js";
 import { runUsageCommand } from "./codex-manager/commands/usage.js";
-import { parseAuthLoginArgs, printUsage } from "./codex-manager/help.js";
+import {
+	type AuthLoginOptions,
+	parseAuthLoginArgs,
+	printUsage,
+} from "./codex-manager/help.js";
 import {
 	applyUiThemeFromDashboardSettings,
 	configureUnifiedSettings,
@@ -2786,13 +2790,30 @@ async function runAuthLogin(args: string[]): Promise<number> {
 	const loginOptions = parsedArgs.options;
 	// `--org <id>` binds this login to a specific workspace/org so the same
 	// email's personal vs business/team workspace can be registered on demand
-	// (issue #491). It reuses the CODEX_AUTH_ACCOUNT_ID override, which every
-	// login resolver already honors, and takes precedence over any inherited
-	// env value for this invocation.
-	if (loginOptions.org) {
-		process.env.CODEX_AUTH_ACCOUNT_ID = loginOptions.org;
-		console.log(`Binding this login to workspace org id: ${loginOptions.org}`);
+	// (issue #491). It reuses the CODEX_AUTH_ACCOUNT_ID override that every login
+	// resolver already honors. Scope it to this invocation and restore the prior
+	// value in a finally so a later login in the same process (menu re-entry, a
+	// reused test worker) is never silently bound to a stale org.
+	if (!loginOptions.org) {
+		return runAuthLoginFlow(loginOptions);
 	}
+	const previousAccountIdOverride = process.env.CODEX_AUTH_ACCOUNT_ID;
+	process.env.CODEX_AUTH_ACCOUNT_ID = loginOptions.org;
+	console.log(`Binding this login to workspace org id: ${loginOptions.org}`);
+	try {
+		return await runAuthLoginFlow(loginOptions);
+	} finally {
+		if (previousAccountIdOverride === undefined) {
+			delete process.env.CODEX_AUTH_ACCOUNT_ID;
+		} else {
+			process.env.CODEX_AUTH_ACCOUNT_ID = previousAccountIdOverride;
+		}
+	}
+}
+
+async function runAuthLoginFlow(
+	loginOptions: AuthLoginOptions,
+): Promise<number> {
 	setStoragePath(null);
 	let pendingMenuQuotaRefresh: Promise<void> | null = null;
 	let menuQuotaRefreshStatus: string | undefined;

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -2784,6 +2784,15 @@ async function runAuthLogin(args: string[]): Promise<number> {
 	}
 
 	const loginOptions = parsedArgs.options;
+	// `--org <id>` binds this login to a specific workspace/org so the same
+	// email's personal vs business/team workspace can be registered on demand
+	// (issue #491). It reuses the CODEX_AUTH_ACCOUNT_ID override, which every
+	// login resolver already honors, and takes precedence over any inherited
+	// env value for this invocation.
+	if (loginOptions.org) {
+		process.env.CODEX_AUTH_ACCOUNT_ID = loginOptions.org;
+		console.log(`Binding this login to workspace org id: ${loginOptions.org}`);
+	}
 	setStoragePath(null);
 	let pendingMenuQuotaRefresh: Promise<void> | null = null;
 	let menuQuotaRefreshStatus: string | undefined;

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -88,6 +88,7 @@ import {
 import { loadPersistedRuntimeObservabilitySnapshot } from "./runtime/runtime-observability.js";
 import { runSwitchCommand } from "./codex-manager/commands/switch.js";
 import { runUnpinCommand } from "./codex-manager/commands/unpin.js";
+import { runWorkspaceCommand } from "./codex-manager/commands/workspace.js";
 import { runUsageCommand } from "./codex-manager/commands/usage.js";
 import { parseAuthLoginArgs, printUsage } from "./codex-manager/help.js";
 import {
@@ -202,6 +203,7 @@ const ACCOUNT_MANAGER_COMMANDS = new Set([
 	"status",
 	"switch",
 	"unpin",
+	"workspace",
 	"best",
 	"check",
 	"features",
@@ -3556,6 +3558,13 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 			loadAccounts,
 			saveAccounts,
 			getStoragePath,
+		});
+	}
+	if (command === "workspace") {
+		return runWorkspaceCommand(rest, {
+			setStoragePath,
+			loadAccounts,
+			saveAccounts,
 		});
 	}
 	if (command === "check") {

--- a/lib/codex-manager/commands/status.ts
+++ b/lib/codex-manager/commands/status.ts
@@ -2,6 +2,7 @@ import {
 	formatAccountLabel,
 	formatCooldown,
 	formatWaitTime,
+	formatWorkspaceLines,
 } from "../../accounts.js";
 import {
 	evaluateForecastAccounts,
@@ -241,6 +242,14 @@ export async function runStatusCommand(
 		const primaryReason = forecastResults[i]?.reasons[0];
 		if (primaryReason) {
 			logInfo(`   reason: ${primaryReason}`);
+		}
+		// Surface every workspace a same-email account can rotate between, so
+		// personal Plus vs business/team stay visible at once (issue #491).
+		if ((account.workspaces?.length ?? 0) > 1) {
+			logInfo("   workspaces:");
+			for (const workspaceLine of formatWorkspaceLines(account, "     ")) {
+				logInfo(workspaceLine);
+			}
 		}
 	}
 

--- a/lib/codex-manager/commands/workspace.ts
+++ b/lib/codex-manager/commands/workspace.ts
@@ -122,8 +122,10 @@ export async function runWorkspaceCommand(
 	account.currentWorkspaceIndex = workspaceIndex;
 	await saveAccountsWithRetry(storage, deps.saveAccounts);
 
-	const idSuffix =
-		target.id.length > 6 ? target.id.slice(-6) : target.id;
+	// Guard a possibly-undefined id the same way formatWorkspaceLines does, in
+	// case on-disk data does not conform to the Workspace interface.
+	const id = target.id?.trim() ?? "";
+	const idSuffix = id.length > 6 ? id.slice(-6) : id;
 	logInfo(
 		`Account ${parsedAccount} now using workspace ${parsedWorkspace}: [${targetName}]${idSuffix ? ` (id:${idSuffix})` : ""}.`,
 	);

--- a/lib/codex-manager/commands/workspace.ts
+++ b/lib/codex-manager/commands/workspace.ts
@@ -1,0 +1,131 @@
+import {
+	formatAccountLabel,
+	formatWorkspaceLines,
+} from "../../accounts.js";
+import type { AccountStorageV3 } from "../../storage.js";
+import { saveAccountsWithRetry } from "../forecast-report-shared.js";
+
+type LoadedStorage = AccountStorageV3 | null;
+
+export interface WorkspaceCommandDeps {
+	setStoragePath: (path: string | null) => void;
+	loadAccounts: () => Promise<LoadedStorage>;
+	saveAccounts: (storage: AccountStorageV3) => Promise<void>;
+	logError?: (message: string) => void;
+	logInfo?: (message: string) => void;
+}
+
+/**
+ * `codex-multi-auth workspace <account> [workspace]`
+ *
+ * With only an account index, lists the workspaces that account can rotate
+ * between (personal Plus vs business/team under one email, issue #491). With a
+ * workspace index too, sets it as the active workspace for that account.
+ */
+export async function runWorkspaceCommand(
+	args: string[],
+	deps: WorkspaceCommandDeps,
+): Promise<number> {
+	deps.setStoragePath(null);
+	const logError = deps.logError ?? console.error;
+	const logInfo = deps.logInfo ?? console.log;
+
+	const storage = await deps.loadAccounts();
+	if (!storage || storage.accounts.length === 0) {
+		logError("No accounts configured.");
+		return 1;
+	}
+
+	const accountArg = args[0];
+	if (!accountArg) {
+		logError(
+			"Missing account index. Usage: codex-multi-auth workspace <account> [workspace]",
+		);
+		return 1;
+	}
+
+	const parsedAccount = Number.parseInt(accountArg, 10);
+	if (!Number.isFinite(parsedAccount) || parsedAccount < 1) {
+		logError(`Invalid account index: ${accountArg}`);
+		return 1;
+	}
+
+	const accountIndex = parsedAccount - 1;
+	if (accountIndex >= storage.accounts.length) {
+		logError(
+			`Account index out of range. Valid range: 1-${storage.accounts.length}`,
+		);
+		return 1;
+	}
+
+	const account = storage.accounts[accountIndex];
+	if (!account) {
+		logError(`Account ${parsedAccount} not found.`);
+		return 1;
+	}
+
+	const workspaces = account.workspaces ?? [];
+	if (workspaces.length === 0) {
+		logInfo(
+			`Account ${parsedAccount} (${formatAccountLabel(account, accountIndex)}) has no tracked workspaces.`,
+		);
+		return 0;
+	}
+
+	const workspaceArg = args[1];
+	if (!workspaceArg) {
+		logInfo(`Account ${parsedAccount}: ${formatAccountLabel(account, accountIndex)}`);
+		for (const line of formatWorkspaceLines(account, "  ")) {
+			logInfo(line);
+		}
+		logInfo("");
+		logInfo(
+			`Switch with: codex-multi-auth workspace ${parsedAccount} <workspace-number>`,
+		);
+		return 0;
+	}
+
+	const parsedWorkspace = Number.parseInt(workspaceArg, 10);
+	if (
+		!Number.isFinite(parsedWorkspace) ||
+		parsedWorkspace < 1 ||
+		parsedWorkspace > workspaces.length
+	) {
+		logError(
+			`Invalid workspace index. Valid range: 1-${workspaces.length}`,
+		);
+		return 1;
+	}
+
+	const workspaceIndex = parsedWorkspace - 1;
+	const target = workspaces[workspaceIndex];
+	if (!target) {
+		logError(`Workspace ${parsedWorkspace} not found.`);
+		return 1;
+	}
+
+	const targetName = target.name?.trim() || "(unnamed)";
+	if (target.enabled === false) {
+		logError(
+			`Workspace ${parsedWorkspace} ([${targetName}]) is disabled and cannot be selected.`,
+		);
+		return 1;
+	}
+
+	if (account.currentWorkspaceIndex === workspaceIndex) {
+		logInfo(
+			`Account ${parsedAccount} is already using workspace ${parsedWorkspace}: [${targetName}].`,
+		);
+		return 0;
+	}
+
+	account.currentWorkspaceIndex = workspaceIndex;
+	await saveAccountsWithRetry(storage, deps.saveAccounts);
+
+	const idSuffix =
+		target.id.length > 6 ? target.id.slice(-6) : target.id;
+	logInfo(
+		`Account ${parsedAccount} now using workspace ${parsedWorkspace}: [${targetName}]${idSuffix ? ` (id:${idSuffix})` : ""}.`,
+	);
+	return 0;
+}

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -12,6 +12,7 @@ export function printUsage(): void {
 			"  codex-multi-auth list",
 			"  codex-multi-auth switch <index>   (pins the account for runtime routing)",
 			"  codex-multi-auth unpin            (clears the manual pin set by switch)",
+			"  codex-multi-auth workspace <account> [workspace]   (list or switch an account's workspaces)",
 			"  codex-multi-auth best [--live] [--json] [--model <model>]   (clears any manual pin set by switch)",
 			"  codex-multi-auth forecast [--live] [--json] [--model <model>]",
 			"  codex-multi-auth account tag|untag|weight|pause|unpause|drain|undrain|note ...",

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -4,7 +4,7 @@ export function printUsage(): void {
 			"Codex Multi-Auth CLI",
 			"",
 			"Start here:",
-			"  codex-multi-auth login [--device-auth|--manual|--no-browser]",
+			"  codex-multi-auth login [--device-auth|--manual|--no-browser] [--org <org_id>]",
 			"  codex-multi-auth status",
 			"  codex-multi-auth check",
 			"",
@@ -52,6 +52,7 @@ export function printUsage(): void {
 export type AuthLoginOptions = {
 	manual: boolean;
 	deviceAuth: boolean;
+	org?: string;
 };
 
 export type ParsedAuthLoginArgs =
@@ -66,7 +67,8 @@ export function parseAuthLoginArgs(args: string[]): ParsedAuthLoginArgs {
 	};
 	const manualFlags: string[] = [];
 
-	for (const arg of args) {
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
 		if (arg === "--manual" || arg === "--no-browser") {
 			options.manual = true;
 			if (!manualFlags.includes(arg)) {
@@ -76,6 +78,29 @@ export function parseAuthLoginArgs(args: string[]): ParsedAuthLoginArgs {
 		}
 		if (arg === "--device-auth") {
 			options.deviceAuth = true;
+			continue;
+		}
+		if (arg === "--org" || arg?.startsWith("--org=")) {
+			// Bind this login to a specific workspace/org id (issue #491). Reuses
+			// the CODEX_AUTH_ACCOUNT_ID override mechanism so the same email's
+			// personal vs business/team workspace can be registered on demand.
+			let value: string | undefined;
+			if (arg === "--org") {
+				value = args[i + 1];
+				i += 1;
+			} else {
+				value = arg.slice("--org=".length);
+			}
+			const trimmed = value?.trim();
+			if (!trimmed || trimmed.startsWith("--")) {
+				return {
+					ok: false,
+					reason: "error",
+					message:
+						"Missing value for --org. Usage: codex-multi-auth login --org <org_id>",
+				};
+			}
+			options.org = trimmed;
 			continue;
 		}
 		if (arg === "--help" || arg === "-h") {

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -147,6 +147,22 @@ export const RateLimitStateV3Schema = z.record(
 export type RateLimitStateV3FromSchema = z.infer<typeof RateLimitStateV3Schema>;
 
 /**
+ * Workspace entry within an account. Supports a single OpenAI/Google account
+ * that belongs to multiple ChatGPT workspaces (e.g. personal Plus + a
+ * business/team workspace), each a distinct quota pool keyed by its org_id
+ * (`id`). Mirrors the `Workspace` TS interface in `lib/accounts.ts`. See #491.
+ */
+export const WorkspaceSchema = z.object({
+	id: z.string(),
+	name: z.string().optional(),
+	enabled: z.boolean(),
+	disabledAt: z.number().optional(),
+	isDefault: z.boolean().optional(),
+});
+
+export type WorkspaceFromSchema = z.infer<typeof WorkspaceSchema>;
+
+/**
  * Account metadata V3 - current storage format.
  */
 export const AccountMetadataV3Schema = z.object({
@@ -164,6 +180,11 @@ export const AccountMetadataV3Schema = z.object({
 	rateLimitResetTimes: RateLimitStateV3Schema.optional(),
 	coolingDownUntil: z.number().optional(),
 	cooldownReason: CooldownReasonSchema.optional(),
+	// Multi-workspace support (#491): without these here, the strict z.object
+	// strips workspace tracking on every load, so login-captured workspaces
+	// silently vanish after one read/write round-trip.
+	workspaces: z.array(WorkspaceSchema).optional(),
+	currentWorkspaceIndex: z.number().optional(),
 });
 
 export type AccountMetadataV3FromSchema = z.infer<

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -3,6 +3,7 @@ import {
 	AccountManager,
 	extractAccountEmail,
 	formatAccountLabel,
+	formatWorkspaceLines,
 	parseRateLimitReason,
 	sanitizeEmail,
 	formatWaitTime,
@@ -846,6 +847,43 @@ describe("AccountManager", () => {
 				0,
 			),
 		).toBe("Account 1 (user@gmail.com)");
+	});
+
+	it("lists workspaces with the active one marked (#491)", () => {
+		const lines = formatWorkspaceLines({
+			workspaces: [
+				{ id: "org-AAAA", name: "Personal Plus", enabled: true },
+				{ id: "org-BBBB", name: "GkTech Business", enabled: true },
+			],
+			currentWorkspaceIndex: 1,
+		});
+		expect(lines).toEqual([
+			"   - 1. [Personal Plus] id:g-AAAA",
+			"   * 2. [GkTech Business] id:g-BBBB (active)",
+		]);
+	});
+
+	it("marks disabled workspaces and honors a custom indent (#491)", () => {
+		const lines = formatWorkspaceLines(
+			{
+				workspaces: [
+					{ id: "org-AAAA", name: "Personal Plus", enabled: true },
+					{ id: "org-BBBB", enabled: false, disabledAt: 1 },
+				],
+				currentWorkspaceIndex: 0,
+			},
+			"  ",
+		);
+		expect(lines).toEqual([
+			"  * 1. [Personal Plus] id:g-AAAA (active)",
+			"  - 2. [(unnamed)] id:g-BBBB (disabled)",
+		]);
+	});
+
+	it("returns no workspace lines when none are tracked (#491)", () => {
+		expect(formatWorkspaceLines(undefined)).toEqual([]);
+		expect(formatWorkspaceLines({})).toEqual([]);
+		expect(formatWorkspaceLines({ workspaces: [] })).toEqual([]);
 	});
 
 	it("performs true round-robin rotation across multiple requests", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -776,6 +776,78 @@ describe("AccountManager", () => {
 		);
 	});
 
+	it("surfaces the active workspace to distinguish same-email accounts (#491)", () => {
+		const personal = {
+			email: "user@gmail.com",
+			accountId: "org-AAAA",
+			workspaces: [{ id: "org-AAAA", name: "Personal Plus", enabled: true }],
+			currentWorkspaceIndex: 0,
+		};
+		const business = {
+			email: "user@gmail.com",
+			accountId: "org-BBBB",
+			workspaces: [{ id: "org-BBBB", name: "GkTech Business", enabled: true }],
+			currentWorkspaceIndex: 0,
+		};
+		expect(formatAccountLabel(personal, 0)).toBe(
+			"Account 1 ([Personal Plus], user@gmail.com, id:g-AAAA)",
+		);
+		expect(formatAccountLabel(business, 1)).toBe(
+			"Account 2 ([GkTech Business], user@gmail.com, id:g-BBBB)",
+		);
+	});
+
+	it("follows currentWorkspaceIndex when picking the workspace tag (#491)", () => {
+		expect(
+			formatAccountLabel(
+				{
+					email: "user@gmail.com",
+					workspaces: [
+						{ id: "org-AAAA", name: "Personal Plus", enabled: true },
+						{ id: "org-BBBB", name: "GkTech Business", enabled: true },
+					],
+					currentWorkspaceIndex: 1,
+				},
+				0,
+			),
+		).toBe("Account 1 ([GkTech Business], user@gmail.com)");
+	});
+
+	it("omits the workspace tag when it duplicates the account label (#491)", () => {
+		expect(
+			formatAccountLabel(
+				{
+					accountLabel: "Personal Plus",
+					email: "user@gmail.com",
+					workspaces: [
+						{ id: "org-AAAA", name: "Personal Plus", enabled: true },
+					],
+					currentWorkspaceIndex: 0,
+				},
+				0,
+			),
+		).toBe("Account 1 (Personal Plus, user@gmail.com)");
+	});
+
+	it("ignores empty or unnamed workspaces in the label (#491)", () => {
+		expect(
+			formatAccountLabel(
+				{
+					email: "user@gmail.com",
+					workspaces: [{ id: "org-AAAA", enabled: true }],
+					currentWorkspaceIndex: 0,
+				},
+				0,
+			),
+		).toBe("Account 1 (user@gmail.com)");
+		expect(
+			formatAccountLabel(
+				{ email: "user@gmail.com", workspaces: [], currentWorkspaceIndex: 0 },
+				0,
+			),
+		).toBe("Account 1 (user@gmail.com)");
+	});
+
 	it("performs true round-robin rotation across multiple requests", () => {
 		const now = Date.now();
 		const stored = {

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -28,6 +28,36 @@ describe("codex-manager help parsers", () => {
 		logSpy.mockRestore();
 	});
 
+	it("parses --org to bind a workspace (#491)", () => {
+		expect(parseAuthLoginArgs(["--org", "org-BBBB"])).toEqual({
+			ok: true,
+			options: { manual: false, deviceAuth: false, org: "org-BBBB" },
+		});
+		expect(parseAuthLoginArgs(["--org=org-AAAA"])).toEqual({
+			ok: true,
+			options: { manual: false, deviceAuth: false, org: "org-AAAA" },
+		});
+		expect(parseAuthLoginArgs(["--manual", "--org", "org-BBBB"])).toEqual({
+			ok: true,
+			options: { manual: true, deviceAuth: false, org: "org-BBBB" },
+		});
+	});
+
+	it("reports a missing --org value (#491)", () => {
+		expect(parseAuthLoginArgs(["--org"])).toEqual({
+			ok: false,
+			reason: "error",
+			message:
+				"Missing value for --org. Usage: codex-multi-auth login --org <org_id>",
+		});
+		expect(parseAuthLoginArgs(["--org", "--manual"])).toEqual({
+			ok: false,
+			reason: "error",
+			message:
+				"Missing value for --org. Usage: codex-multi-auth login --org <org_id>",
+		});
+	});
+
 	it("reports login parser errors explicitly", () => {
 		expect(parseAuthLoginArgs(["--bogus"])).toEqual({
 			ok: false,

--- a/test/codex-manager-workspace-command.test.ts
+++ b/test/codex-manager-workspace-command.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	runWorkspaceCommand,
+	type WorkspaceCommandDeps,
+} from "../lib/codex-manager/commands/workspace.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+function createStorage(): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { codex: 0 },
+		accounts: [
+			{
+				email: "user@gmail.com",
+				refreshToken: "refresh-token-1",
+				addedAt: 1,
+				lastUsed: 1,
+				accountId: "org-AAAA",
+				workspaces: [
+					{ id: "org-AAAA", name: "Personal Plus", enabled: true },
+					{ id: "org-BBBB", name: "GkTech Business", enabled: true },
+				],
+				currentWorkspaceIndex: 0,
+			},
+			{
+				email: "solo@example.com",
+				refreshToken: "refresh-token-2",
+				addedAt: 2,
+				lastUsed: 2,
+			},
+		],
+	};
+}
+
+function createDeps(
+	overrides: Partial<WorkspaceCommandDeps> = {},
+): WorkspaceCommandDeps {
+	return {
+		setStoragePath: vi.fn(),
+		loadAccounts: vi.fn(async () => createStorage()),
+		saveAccounts: vi.fn(async () => {}),
+		logError: vi.fn(),
+		logInfo: vi.fn(),
+		...overrides,
+	};
+}
+
+describe("runWorkspaceCommand", () => {
+	it("errors when no accounts are configured", async () => {
+		const deps = createDeps({ loadAccounts: vi.fn(async () => null) });
+		const result = await runWorkspaceCommand(["1"], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith("No accounts configured.");
+	});
+
+	it("errors when the account index is missing", async () => {
+		const deps = createDeps();
+		const result = await runWorkspaceCommand([], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith(
+			"Missing account index. Usage: codex-multi-auth workspace <account> [workspace]",
+		);
+	});
+
+	it("errors when the account index is out of range", async () => {
+		const deps = createDeps();
+		const result = await runWorkspaceCommand(["5"], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith(
+			"Account index out of range. Valid range: 1-2",
+		);
+	});
+
+	it("lists workspaces with the active one marked when no workspace arg", async () => {
+		const deps = createDeps();
+		const result = await runWorkspaceCommand(["1"], deps);
+		expect(result).toBe(0);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			"  * 1. [Personal Plus] id:g-AAAA (active)",
+		);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			"  - 2. [GkTech Business] id:g-BBBB",
+		);
+		expect(deps.saveAccounts).not.toHaveBeenCalled();
+	});
+
+	it("reports when an account has no tracked workspaces", async () => {
+		const deps = createDeps();
+		const result = await runWorkspaceCommand(["2"], deps);
+		expect(result).toBe(0);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			expect.stringContaining("has no tracked workspaces"),
+		);
+		expect(deps.saveAccounts).not.toHaveBeenCalled();
+	});
+
+	it("switches the active workspace and persists it", async () => {
+		let saved: AccountStorageV3 | undefined;
+		const deps = createDeps({
+			saveAccounts: vi.fn(async (storage: AccountStorageV3) => {
+				saved = storage;
+			}),
+		});
+		const result = await runWorkspaceCommand(["1", "2"], deps);
+		expect(result).toBe(0);
+		expect(saved?.accounts[0]?.currentWorkspaceIndex).toBe(1);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			"Account 1 now using workspace 2: [GkTech Business] (id:g-BBBB).",
+		);
+	});
+
+	it("rejects an out-of-range workspace index", async () => {
+		const deps = createDeps();
+		const result = await runWorkspaceCommand(["1", "9"], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith(
+			"Invalid workspace index. Valid range: 1-2",
+		);
+		expect(deps.saveAccounts).not.toHaveBeenCalled();
+	});
+
+	it("refuses to select a disabled workspace", async () => {
+		const deps = createDeps({
+			loadAccounts: vi.fn(async () => {
+				const storage = createStorage();
+				const workspace = storage.accounts[0]?.workspaces?.[1];
+				if (workspace) workspace.enabled = false;
+				return storage;
+			}),
+		});
+		const result = await runWorkspaceCommand(["1", "2"], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith(
+			"Workspace 2 ([GkTech Business]) is disabled and cannot be selected.",
+		);
+		expect(deps.saveAccounts).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op when the workspace is already active", async () => {
+		const deps = createDeps();
+		const result = await runWorkspaceCommand(["1", "1"], deps);
+		expect(result).toBe(0);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			"Account 1 is already using workspace 1: [Personal Plus].",
+		);
+		expect(deps.saveAccounts).not.toHaveBeenCalled();
+	});
+});

--- a/test/codex-manager-workspace-command.test.ts
+++ b/test/codex-manager-workspace-command.test.ts
@@ -72,6 +72,14 @@ describe("runWorkspaceCommand", () => {
 		);
 	});
 
+	it("errors when the account index is non-numeric", async () => {
+		const deps = createDeps();
+		const result = await runWorkspaceCommand(["abc"], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith("Invalid account index: abc");
+		expect(deps.saveAccounts).not.toHaveBeenCalled();
+	});
+
 	it("lists workspaces with the active one marked when no workspace arg", async () => {
 		const deps = createDeps();
 		const result = await runWorkspaceCommand(["1"], deps);
@@ -113,6 +121,16 @@ describe("runWorkspaceCommand", () => {
 	it("rejects an out-of-range workspace index", async () => {
 		const deps = createDeps();
 		const result = await runWorkspaceCommand(["1", "9"], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith(
+			"Invalid workspace index. Valid range: 1-2",
+		);
+		expect(deps.saveAccounts).not.toHaveBeenCalled();
+	});
+
+	it("rejects a non-numeric workspace index", async () => {
+		const deps = createDeps();
+		const result = await runWorkspaceCommand(["1", "xyz"], deps);
 		expect(result).toBe(1);
 		expect(deps.logError).toHaveBeenCalledWith(
 			"Invalid workspace index. Valid range: 1-2",

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -232,6 +232,43 @@ describe("AccountMetadataV3Schema", () => {
 		});
 		expect(result.success).toBe(false);
 	});
+
+	it("preserves workspaces and currentWorkspaceIndex (#491)", () => {
+		const account = {
+			...validAccount,
+			workspaces: [
+				{
+					id: "org-AAAA",
+					name: "Personal Plus",
+					enabled: true,
+					isDefault: true,
+				},
+				{
+					id: "org-BBBB",
+					name: "GkTech Business",
+					enabled: false,
+					disabledAt: 123,
+				},
+			],
+			currentWorkspaceIndex: 1,
+		};
+		const result = AccountMetadataV3Schema.safeParse(account);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.workspaces).toHaveLength(2);
+			expect(result.data.workspaces?.[0]?.name).toBe("Personal Plus");
+			expect(result.data.workspaces?.[1]?.enabled).toBe(false);
+			expect(result.data.currentWorkspaceIndex).toBe(1);
+		}
+	});
+
+	it("rejects a workspace missing its id (#491)", () => {
+		const result = AccountMetadataV3Schema.safeParse({
+			...validAccount,
+			workspaces: [{ name: "Personal Plus", enabled: true }],
+		});
+		expect(result.success).toBe(false);
+	});
 });
 
 describe("AccountStorageV3Schema", () => {
@@ -778,6 +815,37 @@ describe("safeParseJson", () => {
 		);
 		expect(result).not.toBeNull();
 		expect(result?.version).toBe(3);
+	});
+
+	it("keeps workspaces through the load round-trip (#491)", () => {
+		// Regression: the strict z.object used to strip workspace tracking on
+		// every load, so login-captured workspaces vanished after one reload.
+		const raw = JSON.stringify({
+			version: 3,
+			accounts: [
+				{
+					refreshToken: "rt",
+					addedAt: 1,
+					lastUsed: 1,
+					accountId: "org-AAAA",
+					email: "user@gmail.com",
+					workspaces: [{ id: "org-AAAA", name: "Personal Plus", enabled: true }],
+					currentWorkspaceIndex: 0,
+				},
+			],
+			activeIndex: 0,
+		});
+		const result = safeParseJson(raw, AnyAccountStorageSchema, "test.workspaces");
+		expect(result).not.toBeNull();
+		const account = result?.accounts?.[0] as
+			| {
+					workspaces?: Array<{ name?: string }>;
+					currentWorkspaceIndex?: number;
+			  }
+			| undefined;
+		expect(account?.workspaces).toHaveLength(1);
+		expect(account?.workspaces?.[0]?.name).toBe("Personal Plus");
+		expect(account?.currentWorkspaceIndex).toBe(0);
 	});
 });
 


### PR DESCRIPTION
## Summary

Closes #491.

A single OpenAI/Google account can belong to multiple ChatGPT workspaces
(personal Plus vs business/team), each a distinct quota pool keyed by its
`org_id`. This PR makes such workspaces persist, be visible, be switchable, and
be registrable on demand.

Root cause: the login path already captures every workspace from the token
(`getAccountIdCandidates`) into one account's `workspaces[]`, and
`promptAccountSelection` lets the user pick which binds. But the strict
`AccountMetadataV3Schema` (`z.object`) did not declare `workspaces` /
`currentWorkspaceIndex`, so Zod stripped them on every load. Login wrote them to
disk; the next read wiped them. That is the reported "workspaceName always empty
even after login", and it also left `list` unable to distinguish two same-email
accounts.

## Changes

Persistence + labels
- `lib/schemas.ts`: add `WorkspaceSchema` and declare `workspaces` /
  `currentWorkspaceIndex` on `AccountMetadataV3Schema` so workspace tracking
  survives the load round-trip.
- `lib/accounts.ts`: surface the active workspace name in `formatAccountLabel`
  (for example `Account 1 ([Personal Plus], user@gmail.com, id:g-AAAA)`),
  preserving every existing label format.

Visibility + switching
- `lib/accounts.ts`: add `formatWorkspaceLines` (one line per workspace, active
  marked with `*`, disabled flagged).
- `lib/codex-manager/commands/status.ts`: under `status` / `list`, list every
  workspace beneath an account that tracks more than one.
- `lib/codex-manager/commands/workspace.ts` (new) `workspace <account> [workspace]`:
  list an account's workspaces, or set the active one and persist it. Wired into
  the command registry, dispatch, and help.

On-demand registration
- `lib/codex-manager/help.ts` + `lib/codex-manager.ts`: add `login --org <org_id>`
  (and `--org=<id>`). It reuses the `CODEX_AUTH_ACCOUNT_ID` override that every
  login resolver already honors, so a specific workspace can be bound at login
  even when selection would otherwise pick the default org.

Tests
- schema round-trip preservation and load regression, label disambiguation,
  `formatWorkspaceLines`, nine `workspace`-command cases, and `--org` parsing.

## Example

```
2. Account 2 ([Personal Plus], user@gmail.com, id:g-AAAA) used 1m ago
   workspaces:
     * 1. [Personal Plus] id:g-AAAA (active)
     - 2. [GkTech Business] id:g-BBBB

codex-multi-auth workspace 2 2
Account 2 now using workspace 2: [GkTech Business] (id:g-BBBB).

codex-multi-auth login --org org-BBBB
Binding this login to workspace org id: org-BBBB
```

## Risk notes

- `formatAccountLabel` is behavior-preserving when no workspaces are tracked;
  all prior outputs are unchanged.
- Schema change is additive and optional; no migration required.
- Nested display renders only when an account tracks more than one workspace.
- `--org` does not change the auth resolvers; it sets the existing override env
  var for the invocation, so all three login paths honor it without new wiring.

## Verification

- `npm run typecheck` - clean
- `npm run lint` - clean
- `npm run build` - clean
- `npm test` - 4041 passed (269 files)

## Follow-up to confirm

Whether a real two-workspace login returns both orgs in one token (then the
`workspace` command alone covers switching) or one at a time (then `--org` is
the path to add the second). Both are now supported; a sanitized `accounts.json`
from a real two-workspace account would confirm which path users hit.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes the root cause of workspace data loss (strict `z.object` stripping `workspaces`/`currentWorkspaceIndex` on every load) and builds the full workspace ux on top: persistent schema fields, label disambiguation for same-email accounts, `status`/`list` sub-display, a new `workspace` command for listing and switching, and `login --org` for on-demand workspace registration.

- `lib/schemas.ts`: adds `WorkspaceSchema` and declares `workspaces`/`currentWorkspaceIndex` on `AccountMetadataV3Schema` — additive, no migration needed; `currentWorkspaceIndex` uses `z.number()` without int/min(0) constraints, which can cause split-brain display if a float or negative lands on disk.
- `lib/codex-manager.ts`: `--org` uses a `try/finally` to scope `CODEX_AUTH_ACCOUNT_ID` to the invocation and restore it afterward — correct, but the finally-path restore has no vitest coverage.
- `lib/codex-manager/commands/workspace.ts`: new command with full validation, disabled-workspace guard, and already-active no-op; inherits the TOCTOU/EBUSY concerns already flagged in the previous review round.

<h3>Confidence Score: 5/5</h3>

safe to merge; changes are additive and behavior-preserving for accounts without workspaces

the schema fix is a straightforward additive field declaration; the workspace command and --org flag are well-guarded; the try/finally env-restore pattern in codex-manager.ts is correct; remaining gaps are test coverage and a minor schema constraint

lib/schemas.ts (currentWorkspaceIndex constraint) and lib/codex-manager.ts (--org env-restore test coverage)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/schemas.ts | adds WorkspaceSchema and declares workspaces/currentWorkspaceIndex on AccountMetadataV3Schema — fixes the root-cause stripping bug; currentWorkspaceIndex uses z.number() without int/min(0) constraints |
| lib/accounts.ts | adds activeWorkspaceName, refactors formatAccountLabel to segment-based building (behavior-preserving), and exports formatWorkspaceLines — logic correct, fallback to workspaces[0] on OOB index is safe |
| lib/codex-manager.ts | adds --org flag with try/finally env-restore, wires workspace command into dispatch — env restore logic is correct but lacks test coverage for the finally path |
| lib/codex-manager/commands/workspace.ts | new workspace command with list/switch logic, disabled-workspace guard, already-active no-op — input validation and save path look correct; TOCTOU and EBUSY coverage already called out in previous threads |
| lib/codex-manager/commands/status.ts | adds workspace sub-list under accounts with more than one workspace; intentionally skips single-workspace accounts per PR spec |
| lib/codex-manager/help.ts | adds --org parsing with --org=value and --org value forms, validates empty/flag-looking values, updates usage string |
| test/schemas.test.ts | adds round-trip preservation test and missing-id rejection test for WorkspaceSchema — covers the root-cause regression directly |
| test/codex-manager-workspace-command.test.ts | nine cases covering list, switch, disabled-workspace reject, no-op, and error paths — no EBUSY/EPERM save-retry test (already noted in previous thread) |
| test/accounts.test.ts | adds label disambiguation, currentWorkspaceIndex tracking, workspace-tag dedup, empty/unnamed workspace, and formatWorkspaceLines tests |
| test/codex-manager-help.test.ts | adds --org parse tests covering both syntax forms and missing-value error — no test for the runAuthLogin env-restore behavior itself |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[codex-multi-auth login --org org-X] --> B[parseAuthLoginArgs]
    B --> C{org present?}
    C -- yes --> D[save prev CODEX_AUTH_ACCOUNT_ID]
    D --> E[set env var to org-X]
    E --> F[runAuthLoginFlow]
    F --> G{success / throw}
    G --> H[finally: restore/delete env var]
    C -- no --> I[runAuthLoginFlow directly]

    J[codex-multi-auth workspace N] --> K[loadAccounts]
    K --> L{workspaces.length > 0?}
    L -- no --> M[log: no tracked workspaces]
    L -- yes --> N{workspace arg?}
    N -- no --> O[formatWorkspaceLines list]
    N -- yes --> P{valid index?}
    P -- no --> Q[error: out of range]
    P -- yes --> R{enabled?}
    R -- no --> S[error: disabled]
    R -- yes --> T{already active?}
    T -- yes --> U[no-op log]
    T -- no --> V[set currentWorkspaceIndex saveAccountsWithRetry]

    W[status / list] --> X[formatAccountLabel with workspaceName]
    X --> Y{workspaces.length > 1?}
    Y -- yes --> Z[formatWorkspaceLines sub-display]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fissue-491-workspace-display%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fissue-491-workspace-display%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fschemas.ts%3A187%0A**%60currentWorkspaceIndex%60%20accepts%20floats%20and%20negatives%20from%20disk**%0A%0A%60z.number%28%29%60%20allows%20values%20like%20%601.5%60%20or%20%60-1%60%20to%20survive%20the%20load%20round-trip.%20When%20a%20float%20lands%20on%20disk%20%28e.g.%2C%20via%20manual%20editing%20or%20a%20future%20code%20path%29%2C%20%60formatWorkspaceLines%60%20would%20show%20no%20%60*%60%20active%20marker%20%28since%20%60idx%20%3D%3D%3D%201.5%60%20is%20always%20false%29%2C%20while%20%60activeWorkspaceName%60%20silently%20falls%20back%20to%20%60workspaces%5B0%5D%60%20via%20the%20%60%3F%3F%20workspaces%5B0%5D%60%20guard%20%E2%80%94%20split-brain%20between%20the%20label%20and%20the%20workspace%20list.%20%60z.number%28%29.int%28%29.min%280%29%60%20would%20catch%20this%20on%20load%20and%20prevent%20the%20mismatch%20before%20it%20reaches%20any%20display%20path.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fcodex-manager.ts%3A2803-2811%0A**%60--org%60%20env-restore%20path%20has%20no%20vitest%20coverage**%0A%0AThe%20%60try%2Ffinally%60%20that%20deletes%20or%20restores%20%60CODEX_AUTH_ACCOUNT_ID%60%20is%20untested.%20two%20cases%20need%20coverage%3A%20%28a%29%20the%20var%20is%20deleted%20after%20a%20successful%20%60--org%60%20run%20when%20no%20prior%20value%20existed%2C%20and%20%28b%29%20a%20pre-existing%20value%20is%20restored%20after%20the%20login%20flow%20completes%20or%20throws.%20this%20is%20especially%20worth%20testing%20on%20windows%2C%20where%20env%20mutation%20across%20async%20boundaries%20can%20behave%20unexpectedly.%20without%20a%20test%2C%20a%20regression%20here%20would%20silently%20bind%20every%20subsequent%20login%20in%20the%20same%20process%20to%20the%20stale%20org.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/schemas.ts:187
**`currentWorkspaceIndex` accepts floats and negatives from disk**

`z.number()` allows values like `1.5` or `-1` to survive the load round-trip. When a float lands on disk (e.g., via manual editing or a future code path), `formatWorkspaceLines` would show no `*` active marker (since `idx === 1.5` is always false), while `activeWorkspaceName` silently falls back to `workspaces[0]` via the `?? workspaces[0]` guard — split-brain between the label and the workspace list. `z.number().int().min(0)` would catch this on load and prevent the mismatch before it reaches any display path.

### Issue 2 of 2
lib/codex-manager.ts:2803-2811
**`--org` env-restore path has no vitest coverage**

The `try/finally` that deletes or restores `CODEX_AUTH_ACCOUNT_ID` is untested. two cases need coverage: (a) the var is deleted after a successful `--org` run when no prior value existed, and (b) a pre-existing value is restored after the login flow completes or throws. this is especially worth testing on windows, where env mutation across async boundaries can behave unexpectedly. without a test, a regression here would silently bind every subsequent login in the same process to the stale org.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(login): scope --org override and res..."](https://github.com/ndycode/codex-multi-auth/commit/7be686a2aadc688dfb8b40b8912f9bc0779fc9bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34736037)</sub>

<!-- /greptile_comment -->