### PR TITLE
chore: release v2.1.13-beta.1 (#491)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.1.13-beta.0",
+  "version": "2.1.13-beta.1",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current prerelease: [docs/releases/v2.1.13-beta.0.md](docs/releases/v2.1.13-beta.0.md) — install via `npm i -g codex-multi-auth@beta`
+- Current prerelease: [docs/releases/v2.1.13-beta.1.md](docs/releases/v2.1.13-beta.1.md) — install via `npm i -g codex-multi-auth@beta`
 - Current stable: [docs/releases/v2.1.12.md](docs/releases/v2.1.12.md)
 - Previous stable: [docs/releases/v2.1.11.md](docs/releases/v2.1.11.md)
 - Earlier stable: [docs/releases/v2.1.10.md](docs/releases/v2.1.10.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.1.13-beta.0.md](releases/v2.1.13-beta.0.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
+| [releases/v2.1.13-beta.1.md](releases/v2.1.13-beta.1.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
 | [releases/v2.1.12.md](releases/v2.1.12.md) | Current stable release notes |
 | [releases/v2.1.11.md](releases/v2.1.11.md) | Prior stable release notes |
 | [releases/v2.1.10.md](releases/v2.1.10.md) | Earlier stable release notes |

--- a/docs/releases/v2.1.13-beta.1.md
+++ b/docs/releases/v2.1.13-beta.1.md
@@ -1,0 +1,71 @@
+# v2.1.13-beta.1
+
+Beta prerelease that adds multi-workspace support for a single email: one
+OpenAI/Google account that belongs to more than one ChatGPT workspace (for
+example a personal Plus workspace and a business/team workspace), each a distinct
+quota pool keyed by its `org_id`. Ships the issue #491 work so users with such
+accounts can register, distinguish, switch, and rotate between workspaces.
+
+This is a **prerelease** and also carries the pinned-account 503 diagnostic from
+v2.1.13-beta.0. Stable `v2.1.13` will land once the issue #486 root cause is
+identified and patched.
+
+## Install
+
+```bash
+npm i -g codex-multi-auth@beta
+```
+
+## Accounts
+
+### Fixes
+
+- Account `workspaces` and `currentWorkspaceIndex` now survive a load
+  round-trip. The strict V3 storage schema (`AccountMetadataV3Schema`) did not
+  declare these fields, so Zod stripped them on every read; login captured the
+  workspaces and wrote them to disk, but the next load wiped them. This is the
+  root cause of workspace labels appearing empty after login and of two
+  same-email accounts being indistinguishable.
+- `formatAccountLabel` surfaces the active workspace name, so same-email accounts
+  in different workspaces stay distinguishable, for example
+  `Account 1 ([Personal Plus], user@gmail.com, id:g-AAAA)`. All prior label
+  formats are preserved when no workspace is tracked.
+
+### Features
+
+- `status` / `list` now list every workspace beneath an account that tracks more
+  than one, marking the active workspace and flagging disabled ones.
+- New `workspace <account> [workspace]` command: with only an account index it
+  lists that account's workspaces; with a workspace index it sets the active
+  workspace and persists it.
+- `login --org <org_id>` (and `--org=<id>`) binds a login to a specific
+  workspace/org. It reuses the `CODEX_AUTH_ACCOUNT_ID` override that every login
+  resolver already honors, scoped to the invocation and restored afterward, so a
+  second workspace can be registered on demand instead of always resolving to the
+  default org.
+
+## Release Hygiene
+
+### Tests
+
+- Schema round-trip preservation and a workspace-load regression that locks the
+  fix in place.
+- Label disambiguation coverage and `formatWorkspaceLines` output coverage
+  (active marker, disabled annotation, indentation).
+- Nine `workspace`-command cases (list, switch, persistence, already-active
+  no-op, disabled rejection, out-of-range and non-numeric indices).
+- `login --org` argument parsing and missing-value handling.
+
+## Known Gaps
+
+- The issue #486 503 root cause (doctor reports all green, runtime still returns
+  503) is **not** fixed by this prerelease.
+- Whether a real two-workspace login returns both orgs in one token or one at a
+  time is unconfirmed. Both paths are supported (the `workspace` command for the
+  former, `login --org` for the latter); a sanitized `accounts.json` from a real
+  two-workspace account would confirm which path users hit.
+
+## Refs
+
+- Issue #491 — `[feature] Support registering multiple workspaces for the same email`
+- PR #493 — `feat: support multiple workspaces for the same email (#491)`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.13-beta.0",
+	"version": "2.1.13-beta.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.1.13-beta.0",
+			"version": "2.1.13-beta.1",
 			"bundleDependencies": [
 				"@codex-ai/plugin"
 			],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.13-beta.0",
+	"version": "2.1.13-beta.1",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Prerelease `v2.1.13-beta.1`, shipping the issue #491 multi-workspace work (merged in #493) to the npm `beta` dist-tag.

Bumps `package.json`, `package-lock.json`, and `.codex-plugin/plugin.json` to `2.1.13-beta.1`, adds `docs/releases/v2.1.13-beta.1.md`, and repoints the current-prerelease links in `README.md` and `docs/README.md`.

## Contents

- Persist account `workspaces` / `currentWorkspaceIndex` (root-cause Zod-strip fix).
- Surface the active workspace name in `list` / `status` labels and list every workspace under an account.
- New `workspace <account> [workspace]` command (list + switch active workspace).
- New `login --org <org_id>` flag to bind a specific workspace on demand.
- Carries forward the pinned-503 diagnostic from `v2.1.13-beta.0`.

## Release steps after merge

- Tag `v2.1.13-beta.1` on the squash-merge commit and `gh release create` as a prerelease using the notes file.
- `npm publish --tag beta` (run separately with publish credentials).

## Notes

- Prerelease only; stable `latest` stays `2.1.12`. Stable `v2.1.13` waits on the issue #486 root cause.

## Verification

- `npm run build` - clean
- Version consistent across `package.json`, `package-lock.json`, `.codex-plugin/plugin.json` (`2.1.13-beta.1`)
- Full suite was green on the merged feature branch (`npm test` 4043 passed, 269 files)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

prerelease version bump from `v2.1.13-beta.0` → `v2.1.13-beta.1`, shipping multi-workspace support (#491/#493) to the npm `beta` dist-tag. all version fields are consistent across `package.json`, `package-lock.json`, and `.codex-plugin/plugin.json`; readme links and the new release notes file are coherent.

- bumps the three version-bearing files and adds `docs/releases/v2.1.13-beta.1.md` with full feature, fix, and known-gap notes for the multi-workspace work.
- `login --org` is documented to temporarily mutate `process.env.CODEX_AUTH_ACCOUNT_ID` and restore it afterward — a pattern worth watching for async-concurrency safety in the underlying impl.

<h3>Confidence Score: 4/5</h3>

safe to merge as a prerelease bump; the version files are consistent and the docs are accurate, but the underlying login --org env-var mutation pattern described in the notes carries a real async-concurrency and exception-safety risk in the feature code that shipped in #493.

the diff itself is mechanical — version strings and docs only — so merge risk is low. the concern is what the release notes document: login --org temporarily mutates a shared process env var without a try/finally guard visible in the notes, meaning a thrown exception or a concurrent async login call could leave CODEX_AUTH_ACCOUNT_ID set to the wrong org for the rest of the process, silently binding subsequent accounts to the wrong workspace.

docs/releases/v2.1.13-beta.1.md documents the env-var mutation pattern; the actual implementation from #493 should be verified for a try/finally restore guard and absence of concurrent call paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version bumped to 2.1.13-beta.1; no other changes |
| package-lock.json | both version entries updated to 2.1.13-beta.1, consistent with package.json |
| .codex-plugin/plugin.json | version bumped to 2.1.13-beta.1, consistent with package.json |
| docs/releases/v2.1.13-beta.1.md | new release notes file; accurately documents the Zod-strip fix, workspace features, and known gaps — but documents a process.env mutation pattern for login --org that warrants a concurrency note |
| README.md | prerelease link updated to v2.1.13-beta.1.md |
| docs/README.md | prerelease link updated to v2.1.13-beta.1.md |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant LoginResolver
    participant Storage
    participant Env as process.env

    User->>CLI: "login --org <org_id>"
    CLI->>Env: "set CODEX_AUTH_ACCOUNT_ID = org_id"
    CLI->>LoginResolver: resolve(account)
    LoginResolver->>Storage: read accounts (Zod V3 schema)
    Note over Storage: workspaces / currentWorkspaceIndex now preserved (Zod-strip fix)
    Storage-->>LoginResolver: AccountMetadataV3 with workspaces[]
    LoginResolver-->>CLI: token + workspace binding
    CLI->>Env: restore CODEX_AUTH_ACCOUNT_ID (prev value)
    CLI->>Storage: persist updated account with workspace

    User->>CLI: "workspace <account> [workspace]"
    CLI->>Storage: read account workspaces[]
    alt workspace index provided
        CLI->>Storage: set currentWorkspaceIndex, persist
        CLI-->>User: switched to workspace name
    else no index
        CLI-->>User: list workspaces (active marked, disabled flagged)
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22release%2Fv2.1.13-beta.1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22release%2Fv2.1.13-beta.1%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Freleases%2Fv2.1.13-beta.1.md%3A41-45%0A**%60login%20--org%60%20env-var%20mutation%20is%20a%20concurrency%20risk**%0A%0Athe%20notes%20say%20the%20impl%20sets%20%60process.env.CODEX_AUTH_ACCOUNT_ID%60%2C%20does%20the%20login%2C%20then%20restores%20it.%20node%20is%20single-threaded%20but%20async%20%E2%80%94%20if%20two%20%60login%20--org%60%20calls%20overlap%20on%20the%20event%20loop%20%28e.g.%20a%20cli%20invocation%20racing%20an%20in-process%20retry%29%2C%20the%20second%20call%20can%20read%20the%20first%20call's%20value%20or%20clobber%20the%20restore%2C%20assigning%20the%20wrong%20workspace%20to%20the%20wrong%20account.%20a%20scoped%20parameter%20passed%20through%20the%20call%20chain%20would%20eliminate%20the%20risk%20entirely.%20also%20worth%20checking%3A%20the%20exception%20path%20%E2%80%94%20if%20the%20login%20resolver%20throws%20before%20the%20restore%20runs%2C%20the%20env%20var%20stays%20mutated%20for%20the%20rest%20of%20the%20process%20lifetime%2C%20which%20on%20windows%20could%20also%20affect%20any%20child-process%20token%20writes%20that%20inherit%20the%20env.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Freleases%2Fv2.1.13-beta.1.md%3A50-57%0A**missing%20vitest%20coverage%20for%20env-var%20restore%20under%20failure**%0A%0Athe%20test%20list%20covers%20argument%20parsing%20and%20missing-value%20handling%20for%20%60login%20--org%60%2C%20but%20doesn't%20mention%20a%20case%20where%20the%20login%20resolver%20throws%20mid-flight%20and%20we%20verify%20%60CODEX_AUTH_ACCOUNT_ID%60%20is%20still%20restored%20to%20its%20prior%20value%20%28or%20%60undefined%60%29.%20given%20the%20mutation%20pattern%20described%20above%2C%20a%20regression%20here%20would%20silently%20corrupt%20subsequent%20logins%20in%20the%20same%20process%20without%20any%20test%20catching%20it.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/releases/v2.1.13-beta.1.md:41-45
**`login --org` env-var mutation is a concurrency risk**

the notes say the impl sets `process.env.CODEX_AUTH_ACCOUNT_ID`, does the login, then restores it. node is single-threaded but async — if two `login --org` calls overlap on the event loop (e.g. a cli invocation racing an in-process retry), the second call can read the first call's value or clobber the restore, assigning the wrong workspace to the wrong account. a scoped parameter passed through the call chain would eliminate the risk entirely. also worth checking: the exception path — if the login resolver throws before the restore runs, the env var stays mutated for the rest of the process lifetime, which on windows could also affect any child-process token writes that inherit the env.

### Issue 2 of 2
docs/releases/v2.1.13-beta.1.md:50-57
**missing vitest coverage for env-var restore under failure**

the test list covers argument parsing and missing-value handling for `login --org`, but doesn't mention a case where the login resolver throws mid-flight and we verify `CODEX_AUTH_ACCOUNT_ID` is still restored to its prior value (or `undefined`). given the mutation pattern described above, a regression here would silently corrupt subsequent logins in the same process without any test catching it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: release v2.1.13-beta.1 (#491)"](https://github.com/ndycode/codex-multi-auth/commit/a8530ba4303dca128bfd75b8eb59e290d3517efb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761815)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->