### PR TITLE
chore: release v2.1.13-beta.2 (#496) (#497)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.1.13-beta.1",
+  "version": "2.1.13-beta.2",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current prerelease: [docs/releases/v2.1.13-beta.1.md](docs/releases/v2.1.13-beta.1.md) — install via `npm i -g codex-multi-auth@beta`
+- Current prerelease: [docs/releases/v2.1.13-beta.2.md](docs/releases/v2.1.13-beta.2.md) — install via `npm i -g codex-multi-auth@beta`
 - Current stable: [docs/releases/v2.1.12.md](docs/releases/v2.1.12.md)
 - Previous stable: [docs/releases/v2.1.11.md](docs/releases/v2.1.11.md)
 - Earlier stable: [docs/releases/v2.1.10.md](docs/releases/v2.1.10.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.1.13-beta.1.md](releases/v2.1.13-beta.1.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
+| [releases/v2.1.13-beta.2.md](releases/v2.1.13-beta.2.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
 | [releases/v2.1.12.md](releases/v2.1.12.md) | Current stable release notes |
 | [releases/v2.1.11.md](releases/v2.1.11.md) | Prior stable release notes |
 | [releases/v2.1.10.md](releases/v2.1.10.md) | Earlier stable release notes |

--- a/docs/releases/v2.1.13-beta.2.md
+++ b/docs/releases/v2.1.13-beta.2.md
@@ -1,0 +1,80 @@
+# v2.1.13-beta.2
+
+Beta prerelease that fixes the cascade OAuth token invalidation from issue #495:
+the rotation gateway was invalidating healthy accounts one after another by
+presenting each account's OAuth token from the same IP in rapid succession,
+tripping OpenAI's anti-abuse detection. The 401 handler now detects explicit
+token-invalidation responses and stops rotating instead of cascading through
+every account.
+
+This is a **prerelease** and also carries the multi-workspace support from
+v2.1.13-beta.1 and the pinned-account 503 diagnostic from v2.1.13-beta.0. Stable
+`v2.1.13` will land once the issue #486 root cause is identified and patched.
+
+## Install
+
+```bash
+npm i -g codex-multi-auth@beta
+```
+
+## Runtime rotation
+
+### Fixes
+
+- **Detect token invalidation in 401 responses.** The 401 handler now reads the
+  response body and checks for explicit invalidation phrases (e.g.
+  `invalidated oauth token`, `authentication token has been invalidated`),
+  distinguishing them from generic expired-token 401s.
+- **Stop cascade rotation on invalidation.** When an invalidation is detected the
+  401 is returned directly to the client instead of rotating to the next account.
+  Rotating was the root cause of #495 — presenting each account's OAuth token from
+  the same IP in quick succession triggered OpenAI's anti-abuse detection and
+  invalidated the tokens in sequence. Generic 401s (expired tokens, wrong
+  credentials) continue to rotate as before.
+- **Apply a long cooldown on invalidation.** Invalidated accounts get a 5-minute
+  cooldown (`CODEX_AUTH_TOKEN_INVALIDATION_COOLDOWN_MS` /
+  `tokenInvalidationCooldownMs`) versus the generic 30-second auth-failure
+  cooldown. The cooldown is monotonic — it only extends, never shortens — so a
+  racing generic 401 cannot truncate an invalidation cooldown.
+- **Clear session affinity on invalidation.** Affinity for the affected session
+  key is cleared so the next request can pick a healthy account.
+- **Consistent client error contract.** Both invalidation exit paths
+  (refresh-failure and upstream-401) emit the same
+  `{ error: { message, code: "token_invalidated" } }` body through a single
+  shared builder, preserving the upstream human-readable message when present and
+  falling back to a stable message for non-JSON bodies.
+
+### Features
+
+- **`minRotationIntervalMs` sticky window.** A configurable sliding anchor
+  (`CODEX_AUTH_MIN_ROTATION_INTERVAL_MS` / `minRotationIntervalMs`, default 60s)
+  boosts the last-served account so back-to-back requests are less likely to
+  present a different OAuth token from the same IP within the window. The anchor
+  refreshes on every successful serve, not only on account change.
+
+## Release Hygiene
+
+### Tests
+
+- Upstream-401 invalidation returns 401 to the client, applies the ~5-minute
+  cooldown, clears affinity, and does not rotate; generic 401 still rotates
+  (regression guard); empty and HTML bodies handled.
+- Refresh-endpoint invalidation returns `code: "token_invalidated"` and routes
+  through the shared body builder.
+- Eight unit cases for the invalidation body builder cover every
+  message-extraction branch (top-level message, nested `error.message`,
+  top-level-wins priority, blank-to-nested fallback, non-JSON body, and the
+  no-usable-message fallback).
+- `minRotationIntervalMs` sliding-anchor and sticky-window coverage; schema and
+  config coverage for both new knobs (`min(0)`, allows-zero, rejects-string).
+
+## Known Gaps
+
+- The issue #486 503 root cause (doctor reports all green, runtime still returns
+  503) is **not** fixed by this prerelease; stable `v2.1.13` remains gated on it.
+
+## Refs
+
+- Issue #495 — `Rotation gateway triggers mass OAuth token invalidation across accounts`
+- PR #496 — `fix: detect token invalidation in 401 responses and stop cascade rotation`
+- PR #497 — `fix(runtime): emit consistent token_invalidated body on upstream-401 path`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.13-beta.1",
+	"version": "2.1.13-beta.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.1.13-beta.1",
+			"version": "2.1.13-beta.2",
 			"bundleDependencies": [
 				"@codex-ai/plugin"
 			],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.13-beta.1",
+	"version": "2.1.13-beta.2",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Release prerelease **v2.1.13-beta.2** to the `beta` dist-tag. Bumps from the latest published version (`2.1.13-beta.1`) and ships the cascade OAuth token-invalidation fix for issue #495 (PRs #496, #497), already merged to `main`.

Stable `latest` (`2.1.12`) is unchanged; stable `v2.1.13` remains gated on the issue #486 root cause.

## What ships

- **#496** — detect token invalidation in 401 responses and stop cascade rotation; monotonic 5-minute invalidation cooldown; session-affinity clear; `minRotationIntervalMs` sticky window.
- **#497** — consistent `{ error: { message, code: "token_invalidated" } }` body across both invalidation exit paths via a shared builder.

## Version bump (4 locations + 2 doc links)

- `package.json` / `package-lock.json` (root + `packages[""]`) → `2.1.13-beta.2`
- `.codex-plugin/plugin.json` → `2.1.13-beta.2`
- `docs/releases/v2.1.13-beta.2.md` — new release notes
- `README.md` + `docs/README.md` — prerelease links repointed

## Verification

- [x] `tsc --noEmit`: clean
- [x] `npm run build` (the `prepublishOnly` gate): clean
- [x] Full suite: **4062 tests pass** (`vitest run --maxWorkers=1`)
- [x] Version coherent across all 4 files; no stray `beta.1` references (except intentional carry-forward prose)

## Publish (after merge)

```bash
npm publish --tag beta
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

pure version bump from `2.1.13-beta.1` to `2.1.13-beta.2` shipping the cascade oauth token-invalidation fix (prs #496 and #497, already merged to `main`). all four version locations are consistent and the release notes accurately document the monotonic cooldown, session-affinity clear, shared body builder, and `minRotationIntervalMs` sticky window.

- version updated coherently across `package.json`, `package-lock.json` (both root and `packages[""]` entries), and `.codex-plugin/plugin.json` — no stray `beta.1` references in versioned fields.
- new `docs/releases/v2.1.13-beta.2.md` correctly describes the invalidation detection heuristics, the 5-minute cooldown env var (`CODEX_AUTH_TOKEN_INVALIDATION_COOLDOWN_MS`), and calls out the still-open #486 503 gap as a known limitation.

<h3>Confidence Score: 5/5</h3>

safe to merge — only version fields and documentation change; no source code, no token handling, no filesystem operations modified in this pr.

all four version locations are updated consistently, the lock file both root and packages[""] entries match, and the release notes accurately reflect the fixes already shipped in #496 and #497. nothing in this pr touches the runtime, auth flow, or any token handling path.

no files require special attention — all changes are mechanical version bumps or documentation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version bumped from 2.1.13-beta.1 to 2.1.13-beta.2; no dependency or script changes |
| package-lock.json | both root and packages[""] entries updated to 2.1.13-beta.2; consistent with package.json |
| .codex-plugin/plugin.json | version field bumped to 2.1.13-beta.2; no other changes |
| docs/releases/v2.1.13-beta.2.md | new release notes accurately documenting the cascade-invalidation fix, monotonic cooldown, session-affinity clear, minRotationIntervalMs feature, and known gaps |
| README.md | prerelease link repointed from beta.1 to beta.2; no other changes |
| docs/README.md | docs index table updated to reference v2.1.13-beta.2.md; consistent with README.md change |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant P as Rotation Proxy
    participant OAI as OpenAI API

    C->>P: POST /v1/responses (account A token)
    P->>OAI: forward with account A OAuth token
    OAI-->>P: 401 authentication token has been invalidated
    P->>P: detect invalidation phrase in body
    P->>P: apply 5-min monotonic cooldown on account A
    P->>P: clear session affinity for key
    P-->>C: "401 { error: { message, code: token_invalidated } }"
    Note over P: no cascade rotation — stops here

    C->>P: next request (new session)
    P->>P: select healthy account B (A still in cooldown)
    P->>OAI: forward with account B OAuth token
    OAI-->>P: 200 OK
    P->>P: refresh minRotationIntervalMs anchor for account B
    P-->>C: 200 OK (streamed)
```

<sub>Reviews (1): Last reviewed commit: ["chore: release v2.1.13-beta.2 (#496) (#4..."](https://github.com/ndycode/codex-multi-auth/commit/da2d33cfcc7d644d609a6c0f2b808e690e7fad05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34795979)</sub>

<!-- /greptile_comment -->