### PR TITLE
fix(quota): detect unsupported Codex model from detail shape (#501)

### DIFF
--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -163,6 +163,7 @@ import {
 	fetchCodexQuotaSnapshot,
 	formatQuotaSnapshotLine,
 } from "./quota-probe.js";
+import { isCodexUnavailableError } from "./errors.js";
 import { queuedRefresh } from "./refresh-queue.js";
 import {
 	type AccountMetadataV3,
@@ -2266,12 +2267,17 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 						}
 						healthDetail = formatQuotaSnapshotForDashboard(snapshot, display);
 					} catch (error) {
-						const message = normalizeFailureDetail(
-							error instanceof Error ? error.message : String(error),
-							undefined,
-						);
 						warnings += 1;
-						healthDetail = `signed in and working (live check failed: ${message})`;
+						if (isCodexUnavailableError(error)) {
+							healthDetail =
+								"signed in and working (Codex not available for this account)";
+						} else {
+							const message = normalizeFailureDetail(
+								error instanceof Error ? error.message : String(error),
+								undefined,
+							);
+							healthDetail = `signed in and working (live check failed: ${message})`;
+						}
 					}
 				}
 			}
@@ -2362,12 +2368,17 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 						}
 						healthyMessage = formatQuotaSnapshotForDashboard(snapshot, display);
 					} catch (error) {
-						const message = normalizeFailureDetail(
-							error instanceof Error ? error.message : String(error),
-							undefined,
-						);
 						warnings += 1;
-						healthyMessage = `working now (live check failed: ${message})`;
+						if (isCodexUnavailableError(error)) {
+							healthyMessage =
+								"working now (Codex not available for this account)";
+						} else {
+							const message = normalizeFailureDetail(
+								error instanceof Error ? error.message : String(error),
+								undefined,
+							);
+							healthyMessage = `working now (live check failed: ${message})`;
+						}
 					}
 				}
 			}

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -450,7 +450,7 @@ function styleAccountDetailText(
 				? "success"
 				: fallbackTone;
 		const suffixTone: PromptTone =
-			/re-login|stale|warning|retry|fallback/i.test(suffix)
+			/re-login|stale|warning|retry|fallback|unavailable|not available/i.test(suffix)
 				? "warning"
 				: /failed|error/i.test(suffix)
 					? "danger"
@@ -464,7 +464,7 @@ function styleAccountDetailText(
 	}
 
 	if (/rate-limited/i.test(compact)) return stylePromptText(compact, "danger");
-	if (/re-login|stale|warning|fallback/i.test(compact))
+	if (/re-login|stale|warning|fallback|unavailable|not available/i.test(compact))
 		return stylePromptText(compact, "warning");
 	if (/failed|error/i.test(compact)) return stylePromptText(compact, "danger");
 	if (/ok|working|succeeded|valid/i.test(compact))

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -162,6 +162,7 @@ import {
 	type CodexQuotaSnapshot,
 	fetchCodexQuotaSnapshot,
 	formatQuotaSnapshotLine,
+	CODEX_UNAVAILABLE_PROBE_NOTE,
 } from "./quota-probe.js";
 import { isCodexUnavailableError } from "./errors.js";
 import { queuedRefresh } from "./refresh-queue.js";
@@ -2270,7 +2271,7 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 						warnings += 1;
 						if (isCodexUnavailableError(error)) {
 							healthDetail =
-								"signed in and working (Codex not available for this account)";
+								`signed in and working (${CODEX_UNAVAILABLE_PROBE_NOTE})`;
 						} else {
 							const message = normalizeFailureDetail(
 								error instanceof Error ? error.message : String(error),
@@ -2371,7 +2372,7 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 						warnings += 1;
 						if (isCodexUnavailableError(error)) {
 							healthyMessage =
-								"working now (Codex not available for this account)";
+								`working now (${CODEX_UNAVAILABLE_PROBE_NOTE})`;
 						} else {
 							const message = normalizeFailureDetail(
 								error instanceof Error ? error.message : String(error),

--- a/lib/codex-manager/commands/best.ts
+++ b/lib/codex-manager/commands/best.ts
@@ -1,5 +1,5 @@
 import type { ForecastAccountResult } from "../../forecast.js";
-import type { CodexQuotaSnapshot } from "../../quota-probe.js";
+import { type CodexQuotaSnapshot, describeCodexProbeFailure } from "../../quota-probe.js";
 import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
 import type { AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
@@ -208,9 +208,8 @@ export async function runBestCommand(
 			});
 			liveQuotaByIndex.set(i, liveQuota);
 		} catch (error) {
-			const message = deps.normalizeFailureDetail(
-				error instanceof Error ? error.message : String(error),
-				undefined,
+			const message = describeCodexProbeFailure(error, (raw) =>
+				deps.normalizeFailureDetail(raw, undefined),
 			);
 			probeErrors.push(`${deps.formatAccountLabel(account, i)}: ${message}`);
 		}

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -13,7 +13,7 @@ import {
 	type RefreshedAccountPatch,
 } from "../forecast-report-shared.js";
 import type { QuotaCacheData } from "../../quota-cache.js";
-import type { CodexQuotaSnapshot } from "../../quota-probe.js";
+import { type CodexQuotaSnapshot, describeCodexProbeFailure } from "../../quota-probe.js";
 import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
 import { type AccountMetadataV3, type AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
@@ -347,9 +347,8 @@ export async function runForecastCommand(
 				}
 			}
 		} catch (error) {
-			const message = deps.normalizeFailureDetail(
-				error instanceof Error ? error.message : String(error),
-				undefined,
+			const message = describeCodexProbeFailure(error, (raw) =>
+				deps.normalizeFailureDetail(raw, undefined),
 			);
 			probeErrors.push(`${deps.formatAccountLabel(account, i)}: ${message}`);
 		}

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -21,6 +21,7 @@ import {
 import {
 	type CodexQuotaSnapshot,
 	formatQuotaSnapshotLine,
+	describeCodexProbeFailure,
 } from "../../quota-probe.js";
 import { type ModelFamily } from "../../prompts/codex.js";
 import {
@@ -447,9 +448,8 @@ export async function runReportCommand(
 				});
 				liveQuotaByIndex.set(i, liveQuota);
 			} catch (error) {
-				const message = deps.normalizeFailureDetail(
-					error instanceof Error ? error.message : String(error),
-					undefined,
+				const message = describeCodexProbeFailure(error, (raw) =>
+					deps.normalizeFailureDetail(raw, undefined),
 				);
 				probeErrors.push(`${formatAccountLabel(account, i)}: ${message}`);
 			}

--- a/lib/codex-manager/forecast-report-commands.ts
+++ b/lib/codex-manager/forecast-report-commands.ts
@@ -13,7 +13,11 @@ import {
 	type ForecastAccountResult,
 } from "../forecast.js";
 import { loadQuotaCache, saveQuotaCache, type QuotaCacheData } from "../quota-cache.js";
-import { fetchCodexQuotaSnapshot, formatQuotaSnapshotLine } from "../quota-probe.js";
+import {
+	fetchCodexQuotaSnapshot,
+	formatQuotaSnapshotLine,
+	describeCodexProbeFailure,
+} from "../quota-probe.js";
 import { queuedRefresh } from "../refresh-queue.js";
 import {
 	getStoragePath,
@@ -349,9 +353,8 @@ export async function runForecast(
 				}
 			}
 		} catch (error) {
-			const message = deps.normalizeFailureDetail(
-				error instanceof Error ? error.message : String(error),
-				undefined,
+			const message = describeCodexProbeFailure(error, (raw) =>
+				deps.normalizeFailureDetail(raw, undefined),
 			);
 			probeErrors.push(`${formatAccountLabel(account, i)}: ${message}`);
 		}
@@ -523,9 +526,8 @@ export async function runReport(
 				});
 				liveQuotaByIndex.set(i, liveQuota);
 			} catch (error) {
-				const message = deps.normalizeFailureDetail(
-					error instanceof Error ? error.message : String(error),
-					undefined,
+				const message = describeCodexProbeFailure(error, (raw) =>
+					deps.normalizeFailureDetail(raw, undefined),
 				);
 				probeErrors.push(`${formatAccountLabel(account, i)}: ${message}`);
 			}

--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -13,7 +13,11 @@ import {
 	sanitizeEmail,
 } from "../accounts.js";
 import { loadQuotaCache, saveQuotaCache, type QuotaCacheData } from "../quota-cache.js";
-import { fetchCodexQuotaSnapshot } from "../quota-probe.js";
+import {
+	fetchCodexQuotaSnapshot,
+	CODEX_UNAVAILABLE_PROBE_NOTE,
+} from "../quota-probe.js";
+import { isCodexUnavailableError } from "../errors.js";
 import { queuedRefresh } from "../refresh-queue.js";
 import {
 	findMatchingAccountIndex,
@@ -1386,6 +1390,15 @@ export async function runFix(
 						});
 						continue;
 					} catch (error) {
+						if (isCodexUnavailableError(error)) {
+							reports.push({
+								index: i,
+								label,
+								outcome: "warning-soft-failure",
+								message: `refresh succeeded (${CODEX_UNAVAILABLE_PROBE_NOTE})`,
+							});
+							continue;
+						}
 						const message = deps.normalizeFailureDetail(
 							error instanceof Error ? error.message : String(error),
 							undefined,

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -13,6 +13,7 @@ export const ErrorCode = {
 	VALIDATION_ERROR: "CODEX_VALIDATION_ERROR",
 	RATE_LIMIT: "CODEX_RATE_LIMIT",
 	TIMEOUT: "CODEX_TIMEOUT",
+	CODEX_UNAVAILABLE: "CODEX_UNAVAILABLE",
 } as const;
 
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
@@ -184,4 +185,30 @@ export class StorageError extends CodexError {
 		this.path = path;
 		this.hint = hint;
 	}
+}
+
+/**
+ * Raised when every probe model is rejected because the account/workspace has no
+ * Codex entitlement (e.g. the API answers `model is not supported when using
+ * Codex with a ChatGPT account` for all candidates). The account is otherwise
+ * signed in and working; callers should surface this as a warning, not a failure.
+ */
+export class CodexUnavailableError extends CodexError {
+	override readonly name = "CodexUnavailableError";
+
+	constructor(message: string, options?: CodexErrorOptions) {
+		super(message, { ...options, code: options?.code ?? ErrorCode.CODEX_UNAVAILABLE });
+	}
+}
+
+/**
+ * Type guard for `CodexUnavailableError` that survives cross-realm/duplicate-module
+ * boundaries by also matching on the structural `code` marker.
+ */
+export function isCodexUnavailableError(error: unknown): error is CodexUnavailableError {
+	if (error instanceof CodexUnavailableError) return true;
+	return (
+		error instanceof Error &&
+		(error as { code?: unknown }).code === ErrorCode.CODEX_UNAVAILABLE
+	);
 }

--- a/lib/quota-probe.ts
+++ b/lib/quota-probe.ts
@@ -1,10 +1,42 @@
 import { CODEX_BASE_URL } from "./constants.js";
 import { createCodexHeaders, getUnsupportedCodexModelInfo } from "./request/fetch-helpers.js";
-import { CodexUnavailableError } from "./errors.js";
+import { CodexUnavailableError, isCodexUnavailableError } from "./errors.js";
 import { getCodexInstructions } from "./prompts/codex.js";
 import { mutateRuntimeObservabilitySnapshot } from "./runtime/runtime-observability.js";
 import type { RequestBody } from "./types.js";
 import { isRecord } from "./utils.js";
+
+/**
+ * Human-readable note shown when a live probe fails solely because the account
+ * lacks Codex entitlement (see {@link CodexUnavailableError}). Centralized so
+ * every check/forecast/repair surface renders the same wording instead of
+ * leaking the raw upstream "model is not supported..." message (issue #501).
+ */
+export const CODEX_UNAVAILABLE_PROBE_NOTE = "Codex not available for this account";
+
+/**
+ * Turn a live-probe failure into a display string. When the failure is a
+ * {@link CodexUnavailableError} (every probe model rejected for lack of Codex
+ * entitlement), returns the friendly {@link CODEX_UNAVAILABLE_PROBE_NOTE};
+ * otherwise falls back to the normalized error message.
+ *
+ * Pure and side-effect free; safe for concurrent use and performs no I/O.
+ *
+ * @param error - The thrown probe error.
+ * @param normalize - Optional normalizer applied to non-unavailable messages
+ *   (e.g. `normalizeFailureDetail`); defaults to the raw error message.
+ * @returns A display-ready failure description.
+ */
+export function describeCodexProbeFailure(
+	error: unknown,
+	normalize?: (message: string) => string,
+): string {
+	if (isCodexUnavailableError(error)) {
+		return CODEX_UNAVAILABLE_PROBE_NOTE;
+	}
+	const raw = error instanceof Error ? error.message : String(error);
+	return normalize ? normalize(raw) : raw;
+}
 
 export interface CodexQuotaWindow {
 	usedPercent?: number;

--- a/lib/quota-probe.ts
+++ b/lib/quota-probe.ts
@@ -1,5 +1,6 @@
 import { CODEX_BASE_URL } from "./constants.js";
 import { createCodexHeaders, getUnsupportedCodexModelInfo } from "./request/fetch-helpers.js";
+import { CodexUnavailableError } from "./errors.js";
 import { getCodexInstructions } from "./prompts/codex.js";
 import { mutateRuntimeObservabilitySnapshot } from "./runtime/runtime-observability.js";
 import type { RequestBody } from "./types.js";
@@ -330,8 +331,12 @@ export async function fetchCodexQuotaSnapshot(
 	const models = normalizeProbeModels(options.model, options.fallbackModels);
 	const timeoutMs = Math.max(1_000, Math.min(options.timeoutMs ?? 15_000, 60_000));
 	let lastError: Error | null = null;
+	let attemptedAnyModel = false;
+	let sawUnsupportedModel = false;
+	let sawOtherFailure = false;
 
 	for (const model of models) {
+		attemptedAnyModel = true;
 		try {
 			const instructions = await getCodexInstructions(model);
 			const probeBody: RequestBody = {
@@ -395,12 +400,14 @@ export async function fetchCodexQuotaSnapshot(
 
 				const unsupportedInfo = getUnsupportedCodexModelInfo(errorBody);
 				if (unsupportedInfo.isUnsupported) {
+					sawUnsupportedModel = true;
 					lastError = new Error(
 						unsupportedInfo.message ?? `Model '${model}' unsupported for this account`,
 					);
 					continue;
 				}
 
+				sawOtherFailure = true;
 				throw new Error(extractErrorMessage(bodyText, response.status));
 			}
 
@@ -409,10 +416,19 @@ export async function fetchCodexQuotaSnapshot(
 			} catch {
 				// Best effort cancellation.
 			}
+			sawOtherFailure = true;
 			lastError = new Error("Codex response did not include quota headers");
 		} catch (error) {
+			sawOtherFailure = true;
 			lastError = error instanceof Error ? error : new Error(String(error));
 		}
+	}
+
+	if (attemptedAnyModel && sawUnsupportedModel && !sawOtherFailure) {
+		throw new CodexUnavailableError(
+			lastError?.message ?? "Codex is not available for this account",
+			{ cause: lastError ?? undefined },
+		);
 	}
 
 	throw lastError ?? new Error("Failed to fetch quotas");

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -207,7 +207,25 @@ export function getUnsupportedCodexModelInfo(
 
 	const maybeError = errorBody.error;
 	if (!isRecord(maybeError)) {
-		return { isUnsupported: false };
+		// Some upstreams (e.g. the Codex quota endpoint) return the flat
+		// `{ "detail": "...model is not supported..." }` shape instead of the
+		// nested `{ "error": { "message": "..." } }` envelope. Fall back to the
+		// top-level `detail` string so model-fallback detection still works.
+		const detail = typeof errorBody.detail === "string" ? errorBody.detail : undefined;
+		if (!detail) {
+			return { isUnsupported: false };
+		}
+		const isUnsupportedDetail =
+			CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
+			MODEL_ACCESS_DENIED_PATTERN.test(detail);
+		if (!isUnsupportedDetail) {
+			return { isUnsupported: false };
+		}
+		return {
+			isUnsupported: true,
+			message: detail,
+			unsupportedModel: extractUnsupportedCodexModelFromText(detail) ?? undefined,
+		};
 	}
 
 	const code = typeof maybeError.code === "string" ? maybeError.code : undefined;

--- a/lib/runtime/account-check-types.ts
+++ b/lib/runtime/account-check-types.ts
@@ -5,6 +5,7 @@ export type AccountCheckWorkingState = {
 	flaggedChanged: boolean;
 	ok: number;
 	errors: number;
+	warnings: number;
 	disabled: number;
 	removeFromActive: Set<string>;
 	flaggedStorage: { version: 1; accounts: FlaggedAccountMetadataV1[] };
@@ -19,6 +20,7 @@ export function createAccountCheckWorkingState(flaggedStorage: {
 		flaggedChanged: false,
 		ok: 0,
 		errors: 0,
+		warnings: 0,
 		disabled: 0,
 		removeFromActive: new Set<string>(),
 		flaggedStorage,

--- a/lib/runtime/account-check.ts
+++ b/lib/runtime/account-check.ts
@@ -296,15 +296,19 @@ export async function runRuntimeAccountCheck(
 					`[${i + 1}/${total}] ${label}: ${deps.formatCodexQuotaLine(snapshot)}`,
 				);
 			} catch (error) {
-				state.errors += 1;
-				const message = isCodexUnavailableError(error)
-					? CODEX_UNAVAILABLE_PROBE_NOTE
-					: error instanceof Error
-						? error.message
-						: String(error);
-				deps.showLine(
-					`[${i + 1}/${total}] ${label}: ERROR (${message.slice(0, 160)})`,
-				);
+				if (isCodexUnavailableError(error)) {
+					state.warnings += 1;
+					state.ok += 1;
+					deps.showLine(
+						`[${i + 1}/${total}] ${label}: ${CODEX_UNAVAILABLE_PROBE_NOTE}`,
+					);
+				} else {
+					state.errors += 1;
+					const message = error instanceof Error ? error.message : String(error);
+					deps.showLine(
+						`[${i + 1}/${total}] ${label}: ERROR (${message.slice(0, 160)})`,
+					);
+				}
 			}
 		} catch (error) {
 			state.errors += 1;
@@ -344,7 +348,9 @@ export async function runRuntimeAccountCheck(
 
 	deps.showLine("");
 	deps.showLine(
-		`Results: ${state.ok} ok, ${state.errors} error, ${state.disabled} disabled`,
+		state.warnings > 0
+			? `Results: ${state.ok} ok, ${state.warnings} warning, ${state.errors} error, ${state.disabled} disabled`
+			: `Results: ${state.ok} ok, ${state.errors} error, ${state.disabled} disabled`,
 	);
 	if (state.removeFromActive.size > 0) {
 		deps.showLine(

--- a/lib/runtime/account-check.ts
+++ b/lib/runtime/account-check.ts
@@ -1,4 +1,6 @@
 import { maskEmail } from "../logger.js";
+import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../quota-probe.js";
+import { isCodexUnavailableError } from "../errors.js";
 import type { ModelFamily } from "../prompts/codex.js";
 import type { AccountStorageV3, FlaggedAccountMetadataV1 } from "../storage.js";
 import type { AccountIdSource, TokenResult } from "../types.js";
@@ -295,7 +297,11 @@ export async function runRuntimeAccountCheck(
 				);
 			} catch (error) {
 				state.errors += 1;
-				const message = error instanceof Error ? error.message : String(error);
+				const message = isCodexUnavailableError(error)
+					? CODEX_UNAVAILABLE_PROBE_NOTE
+					: error instanceof Error
+						? error.message
+						: String(error);
 				deps.showLine(
 					`[${i + 1}/${total}] ${label}: ERROR (${message.slice(0, 160)})`,
 				);

--- a/test/codex-manager-best-command.test.ts
+++ b/test/codex-manager-best-command.test.ts
@@ -4,6 +4,8 @@ import {
 	type BestCommandDeps,
 	runBestCommand,
 } from "../lib/codex-manager/commands/best.js";
+import { CodexUnavailableError } from "../lib/errors.js";
+import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../lib/quota-probe.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 
 function createAccount(
@@ -367,5 +369,71 @@ describe("runBestCommand", () => {
 				switchReason: "best",
 			}),
 		);
+	});
+
+	it("surfaces the friendly note for codex-unavailable live probe failures", async () => {
+		const deps = createDeps({
+			parseBestArgs: vi.fn(() => ({
+				ok: true,
+				options: {
+					live: true,
+					json: true,
+					model: "gpt-5-codex",
+					modelProvided: false,
+				} satisfies BestCliOptions,
+			})),
+			fetchCodexQuotaSnapshot: vi.fn(async () => {
+				throw new CodexUnavailableError(
+					"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+				);
+			}),
+		});
+
+		const result = await runBestCommand(["--live"], deps);
+
+		expect(result).toBe(0);
+		const jsonCall = (deps.logInfo as ReturnType<typeof vi.fn>).mock.calls
+			.map((call) => String(call[0]))
+			.find((line) => line.includes("probeErrors"));
+		expect(jsonCall).toBeDefined();
+		const payload = JSON.parse(jsonCall as string) as {
+			probeErrors?: string[];
+		};
+		expect(payload.probeErrors).toBeDefined();
+		expect(payload.probeErrors?.some((e) => e.includes(CODEX_UNAVAILABLE_PROBE_NOTE))).toBe(true);
+		// must not leak the raw upstream error
+		expect(jsonCall).not.toContain("is not supported when using Codex");
+	});
+
+	it("normalizes non-codex-unavailable probe failures without leaking raw detail", async () => {
+		const deps = createDeps({
+			parseBestArgs: vi.fn(() => ({
+				ok: true,
+				options: {
+					live: true,
+					json: true,
+					model: "gpt-5-codex",
+					modelProvided: false,
+				} satisfies BestCliOptions,
+			})),
+			normalizeFailureDetail: vi.fn(() => "rate limited; retry later"),
+			fetchCodexQuotaSnapshot: vi.fn(async () => {
+				throw new Error(
+					'{"error":{"message":"token sk-secret leaked"}} HTTP 429',
+				);
+			}),
+		});
+
+		const result = await runBestCommand(["--live"], deps);
+
+		expect(result).toBe(0);
+		const jsonCall = (deps.logInfo as ReturnType<typeof vi.fn>).mock.calls
+			.map((call) => String(call[0]))
+			.find((line) => line.includes("probeErrors"));
+		const payload = JSON.parse(jsonCall as string) as {
+			probeErrors?: string[];
+		};
+		expect(payload.probeErrors?.some((e) => e.includes("rate limited; retry later"))).toBe(true);
+		expect(jsonCall).not.toContain("sk-secret");
 	});
 });

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CodexUnavailableError } from "../lib/errors.js";
+// quota-probe is mocked below; reference the note as a literal to avoid a
+// top-level import racing the hoisted vi.mock factory.
+const CODEX_UNAVAILABLE_PROBE_NOTE_LITERAL = "Codex not available for this account";
 
 const loadAccountsMock = vi.fn();
 const loadFlaggedAccountsMock = vi.fn();
@@ -4051,6 +4055,45 @@ describe("codex manager cli commands", () => {
 				String(call[0]).includes("network timeout"),
 			),
 		).toBe(true);
+	});
+
+	it("prints the friendly codex-unavailable note instead of raw probe detail", async () => {
+		const now = Date.now();
+		loadAccountsMock.mockResolvedValueOnce({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "best@example.com",
+					accountId: "acc_best",
+					refreshToken: "refresh-best",
+					accessToken: "access-best",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		});
+		fetchCodexQuotaSnapshotMock.mockRejectedValueOnce(
+			new CodexUnavailableError(
+				"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+			),
+		);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+
+		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--live"]);
+
+		expect(exitCode).toBe(0);
+		const lines = logSpy.mock.calls.map((call) => String(call[0]));
+		expect(
+			lines.some((l) => l.includes(CODEX_UNAVAILABLE_PROBE_NOTE_LITERAL)),
+		).toBe(true);
+		// the raw upstream error / JSON must not leak to the user
+		expect(lines.join("\n")).not.toContain("is not supported when using Codex");
+		expect(lines.join("\n")).not.toContain('"detail"');
 	});
 
 	it("reuses the queued refresh result across concurrent live best runs", async () => {

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -219,7 +219,8 @@ vi.mock("../lib/codex-cli/state.js", () => ({
 	loadCodexCliState: loadCodexCliStateMock,
 }));
 
-vi.mock("../lib/quota-probe.js", () => ({
+vi.mock("../lib/quota-probe.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/quota-probe.js")>()),
 	fetchCodexQuotaSnapshot: fetchCodexQuotaSnapshotMock,
 	formatQuotaSnapshotLine: vi.fn(() => "probe-ok"),
 }));

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -3,6 +3,8 @@ import {
 	type ForecastCommandDeps,
 	runForecastCommand,
 } from "../lib/codex-manager/commands/forecast.js";
+import { CodexUnavailableError } from "../lib/errors.js";
+import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../lib/quota-probe.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 
 function createStorage(): AccountStorageV3 {
@@ -347,5 +349,32 @@ describe("runForecastCommand", () => {
 		expect(deps.logInfo).toHaveBeenCalledWith(
 			'<accent>1.</accent> <accent>1. forecast@example.com [current]</accent> <muted>|</muted> <success>ready</success><muted> | </muted><success>low risk (0)</success>',
 		);
+	});
+
+	it("includes the codex-unavailable note in json probeErrors without leaking raw detail", async () => {
+		const deps = createDeps({
+			fetchCodexQuotaSnapshot: vi.fn(async () => {
+				throw new CodexUnavailableError(
+					"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+				);
+			}),
+		});
+
+		const result = await runForecastCommand(["--json", "--live"], deps);
+
+		expect(result).toBe(0);
+		const jsonLine = (deps.logInfo as ReturnType<typeof vi.fn>).mock.calls
+			.map((call) => String(call[0]))
+			.find((line) => line.includes('"command": "forecast"'));
+		expect(jsonLine).toBeDefined();
+		const payload = JSON.parse(jsonLine as string) as { probeErrors?: string[] };
+		expect(
+			payload.probeErrors?.some(
+				(e) =>
+					e.includes(CODEX_UNAVAILABLE_PROBE_NOTE) &&
+					e.includes("forecast@example.com"),
+			),
+		).toBe(true);
+		expect(jsonLine).not.toContain("is not supported when using Codex");
 	});
 });

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -3,6 +3,8 @@ import {
 	type ReportCommandDeps,
 	runReportCommand,
 } from "../lib/codex-manager/commands/report.js";
+import { CodexUnavailableError } from "../lib/errors.js";
+import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../lib/quota-probe.js";
 import type { AccountStorageV3, StorageHealthSummary } from "../lib/storage.js";
 
 function createStorage(
@@ -774,5 +776,47 @@ describe("runReportCommand", () => {
 		await expect(
 			runReportCommand(["--json", "--out", "report.json"], deps),
 		).rejects.toThrow("disk full");
+	});
+
+	it("reports codex-unavailable probe failures via forecast.probeErrors without leaking raw detail", async () => {
+		const deps = createDeps({
+			loadAccounts: vi.fn(async () =>
+				createStorage([
+					{
+						email: "one@example.com",
+						accountId: "acc-report-1",
+						refreshToken: "refresh-token-1",
+						accessToken: "access-token-1",
+						expiresAt: Date.now() + 600_000,
+						addedAt: 1,
+						lastUsed: 1,
+						enabled: true,
+					},
+				]),
+			),
+			hasUsableAccessToken: vi.fn(() => true),
+			fetchCodexQuotaSnapshot: vi.fn(async () => {
+				throw new CodexUnavailableError(
+					"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+				);
+			}),
+		});
+
+		const result = await runReportCommand(["--json", "--live"], deps);
+
+		expect(result).toBe(0);
+		const jsonOutput = JSON.parse(
+			(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? "{}",
+		) as { forecast: { probeErrors: string[] } };
+		expect(
+			jsonOutput.forecast.probeErrors.some((e) =>
+				e.includes(CODEX_UNAVAILABLE_PROBE_NOTE),
+			),
+		).toBe(true);
+		expect(
+			jsonOutput.forecast.probeErrors.some((e) =>
+				e.includes("is not supported when using Codex"),
+			),
+		).toBe(false);
 	});
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -7,6 +7,8 @@ import {
 	CodexNetworkError,
 	CodexValidationError,
 	CodexRateLimitError,
+	CodexUnavailableError,
+	isCodexUnavailableError,
 } from '../lib/errors.js';
 
 describe('Errors Module', () => {
@@ -259,6 +261,37 @@ describe('Errors Module', () => {
 
 			expect(networkError).toBeInstanceOf(CodexNetworkError);
 			expect(networkError).not.toBeInstanceOf(CodexApiError);
+		});
+	});
+
+	describe('CodexUnavailableError', () => {
+		it('exposes the CODEX_UNAVAILABLE code and preserves cause', () => {
+			const cause = new Error('all models unsupported');
+			const error = new CodexUnavailableError('Codex not available', { cause });
+
+			expect(error).toBeInstanceOf(CodexUnavailableError);
+			expect(error).toBeInstanceOf(CodexError);
+			expect(error.name).toBe('CodexUnavailableError');
+			expect(error.code).toBe(ErrorCode.CODEX_UNAVAILABLE);
+			expect(error.message).toBe('Codex not available');
+			expect(error.cause).toBe(cause);
+		});
+
+		it('isCodexUnavailableError matches instances and structural code marker', () => {
+			expect(isCodexUnavailableError(new CodexUnavailableError('x'))).toBe(true);
+
+			// Cross-realm / duplicate-module guard: a plain Error carrying the code.
+			const structural = Object.assign(new Error('x'), {
+				code: ErrorCode.CODEX_UNAVAILABLE,
+			});
+			expect(isCodexUnavailableError(structural)).toBe(true);
+		});
+
+		it('isCodexUnavailableError rejects unrelated errors and non-errors', () => {
+			expect(isCodexUnavailableError(new CodexApiError('x', { status: 400 }))).toBe(false);
+			expect(isCodexUnavailableError(new Error('x'))).toBe(false);
+			expect(isCodexUnavailableError(undefined)).toBe(false);
+			expect(isCodexUnavailableError({ code: ErrorCode.CODEX_UNAVAILABLE })).toBe(false);
 		});
 	});
 });

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -1664,6 +1664,46 @@ describe('createEntitlementErrorResponse', () => {
 			expect(info.isUnsupported).toBe(false);
 		});
 
+		it("detects unsupported model from flat `detail` payload (issue #501)", () => {
+			const info = getUnsupportedCodexModelInfo({
+				detail:
+					"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+			});
+			expect(info.isUnsupported).toBe(true);
+			expect(info.message).toContain("gpt-5-codex");
+			expect(info.unsupportedModel).toBe("gpt-5-codex");
+		});
+
+		it("detects unsupported model from `detail` even when `error` is null", () => {
+			const info = getUnsupportedCodexModelInfo({
+				error: null,
+				detail:
+					"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+			});
+			expect(info.isUnsupported).toBe(true);
+			expect(info.unsupportedModel).toBe("gpt-5.3-codex");
+		});
+
+		it("uses `detail` access-denied wording and leaves model undefined when absent", () => {
+			const info = getUnsupportedCodexModelInfo({
+				detail:
+					"model is not supported when using Codex with a ChatGPT account",
+			});
+			expect(info.isUnsupported).toBe(true);
+			expect(info.unsupportedModel).toBeUndefined();
+		});
+
+		it("ignores unrelated `detail` strings", () => {
+			expect(
+				getUnsupportedCodexModelInfo({ detail: "you are not authorized" })
+					.isUnsupported,
+			).toBe(false);
+			expect(
+				getUnsupportedCodexModelInfo({ detail: 42 as unknown as string })
+					.isUnsupported,
+			).toBe(false);
+		});
+
 		it("resolves unsupported-model fallbacks with custom chains and canonicalization", () => {
 			const fallback = resolveUnsupportedCodexFallbackModel({
 				requestedModel: "org/gpt-5.3-codex-high",

--- a/test/quota-probe.test.ts
+++ b/test/quota-probe.test.ts
@@ -23,7 +23,12 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 	getUnsupportedCodexModelInfo: getUnsupportedCodexModelInfoMock,
 }));
 
-import { fetchCodexQuotaSnapshot, formatQuotaSnapshotLine } from "../lib/quota-probe.js";
+import {
+	fetchCodexQuotaSnapshot,
+	formatQuotaSnapshotLine,
+	describeCodexProbeFailure,
+	CODEX_UNAVAILABLE_PROBE_NOTE,
+} from "../lib/quota-probe.js";
 import { CodexUnavailableError } from "../lib/errors.js";
 
 function makeQuotaHeaders(overrides: Record<string, string> = {}): Headers {
@@ -482,5 +487,28 @@ describe("quota-probe", () => {
 		expect(line).not.toContain("resets");
 		expect(line).not.toContain("plan:");
 		expect(line).not.toContain("active:");
+	});
+
+	describe("describeCodexProbeFailure", () => {
+		it("returns the friendly note for CodexUnavailableError (issue #501)", () => {
+			const error = new CodexUnavailableError(
+				"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+			);
+			expect(describeCodexProbeFailure(error)).toBe(CODEX_UNAVAILABLE_PROBE_NOTE);
+			expect(describeCodexProbeFailure(error, (raw) => `norm:${raw}`)).toBe(
+				CODEX_UNAVAILABLE_PROBE_NOTE,
+			);
+		});
+
+		it("falls back to the raw message for other errors", () => {
+			expect(describeCodexProbeFailure(new Error("boom"))).toBe("boom");
+			expect(describeCodexProbeFailure("plain string")).toBe("plain string");
+		});
+
+		it("applies the normalizer to non-unavailable errors when provided", () => {
+			expect(
+				describeCodexProbeFailure(new Error("  messy  "), (raw) => raw.trim()),
+			).toBe("messy");
+		});
 	});
 });

--- a/test/quota-probe.test.ts
+++ b/test/quota-probe.test.ts
@@ -24,6 +24,7 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 }));
 
 import { fetchCodexQuotaSnapshot, formatQuotaSnapshotLine } from "../lib/quota-probe.js";
+import { CodexUnavailableError } from "../lib/errors.js";
 
 function makeQuotaHeaders(overrides: Record<string, string> = {}): Headers {
 	const headers = new Headers({
@@ -306,6 +307,81 @@ describe("quota-probe", () => {
 				fallbackModels: [],
 			}),
 		).rejects.toThrow("Model 'gpt-5-codex' unsupported for this account");
+	});
+
+	it("throws CodexUnavailableError when every model is unsupported (issue #501)", async () => {
+		const detailBody = () =>
+			new Response(
+				JSON.stringify({
+					detail:
+						"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+				}),
+				{ status: 400, headers: new Headers({ "content-type": "application/json" }) },
+			);
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(detailBody())
+			.mockResolvedValueOnce(detailBody());
+		vi.stubGlobal("fetch", fetchMock);
+
+		getUnsupportedCodexModelInfoMock.mockReturnValue({
+			isUnsupported: true,
+			unsupportedModel: "gpt-5-codex",
+			message:
+				"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+		});
+
+		const promise = fetchCodexQuotaSnapshot({
+			accountId: "acc-detail",
+			accessToken: "token-detail",
+			model: "gpt-5.3-codex",
+			fallbackModels: ["gpt-5.2-codex"],
+		});
+
+		await expect(promise).rejects.toBeInstanceOf(CodexUnavailableError);
+		await expect(promise).rejects.toThrow(/not supported when using Codex/i);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not throw CodexUnavailableError when a non-unsupported failure is mixed in", async () => {
+		const unsupported = new Response(
+			JSON.stringify({
+				detail:
+					"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+			}),
+			{ status: 400, headers: new Headers({ "content-type": "application/json" }) },
+		);
+		const serverError = new Response(JSON.stringify({ error: { message: "boom" } }), {
+			status: 500,
+			headers: new Headers({ "content-type": "application/json" }),
+		});
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(unsupported)
+			.mockResolvedValueOnce(serverError);
+		vi.stubGlobal("fetch", fetchMock);
+
+		getUnsupportedCodexModelInfoMock
+			.mockReturnValueOnce({
+				isUnsupported: true,
+				unsupportedModel: "gpt-5.3-codex",
+				message: "unsupported",
+			})
+			.mockReturnValue({
+				isUnsupported: false,
+				unsupportedModel: undefined,
+				message: undefined,
+			});
+
+		const promise = fetchCodexQuotaSnapshot({
+			accountId: "acc-mixed",
+			accessToken: "token-mixed",
+			model: "gpt-5.3-codex",
+			fallbackModels: ["gpt-5.2-codex"],
+		});
+
+		await expect(promise).rejects.not.toBeInstanceOf(CodexUnavailableError);
+		await expect(promise).rejects.toThrow("boom");
 	});
 
 	it("throws generic failure when no normalized probe models are available", async () => {

--- a/test/quota-probe.test.ts
+++ b/test/quota-probe.test.ts
@@ -389,6 +389,42 @@ describe("quota-probe", () => {
 		await expect(promise).rejects.toThrow("boom");
 	});
 
+	it("does not mask an instruction-fetch failure on a later model as CodexUnavailableError", async () => {
+		// First model: unsupported (sawUnsupportedModel = true).
+		const unsupported = new Response(
+			JSON.stringify({
+				detail:
+					"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+			}),
+			{ status: 400, headers: new Headers({ "content-type": "application/json" }) },
+		);
+		const fetchMock = vi.fn().mockResolvedValueOnce(unsupported);
+		vi.stubGlobal("fetch", fetchMock);
+
+		getUnsupportedCodexModelInfoMock.mockReturnValue({
+			isUnsupported: true,
+			unsupportedModel: "gpt-5.3-codex",
+			message: "unsupported",
+		});
+
+		// Second model: getCodexInstructions rejects -> outer catch -> sawOtherFailure.
+		getCodexInstructionsMock
+			.mockResolvedValueOnce("instructions:gpt-5.3-codex")
+			.mockRejectedValueOnce(new Error("instruction fetch failed"));
+
+		const promise = fetchCodexQuotaSnapshot({
+			accountId: "acc-instr",
+			accessToken: "token-instr",
+			model: "gpt-5.3-codex",
+			fallbackModels: ["gpt-5.2-codex"],
+		});
+
+		// A transient instruction error must surface, not be swallowed into CodexUnavailableError.
+		await expect(promise).rejects.not.toBeInstanceOf(CodexUnavailableError);
+		await expect(promise).rejects.toThrow("instruction fetch failed");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("throws generic failure when no normalized probe models are available", async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -67,7 +67,8 @@ vi.mock("../lib/quota-cache.js", () => ({
 	saveQuotaCache: saveQuotaCacheMock,
 }));
 
-vi.mock("../lib/quota-probe.js", () => ({
+vi.mock("../lib/quota-probe.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/quota-probe.js")>()),
 	fetchCodexQuotaSnapshot: fetchCodexQuotaSnapshotMock,
 }));
 

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { RepairCommandDeps } from "../lib/codex-manager/repair-commands.js";
+import { CodexUnavailableError } from "../lib/errors.js";
+// Note: do not statically import from ../lib/quota-probe.js here — it is mocked
+// below via vi.mock and a top-level import would race the hoisted factory.
+const CODEX_UNAVAILABLE_PROBE_NOTE = "Codex not available for this account";
 
 const existsSyncMock = vi.fn();
 const statMock = vi.fn();
@@ -689,6 +693,62 @@ describe("repair-commands direct deps coverage", () => {
 		expect(payload.summary).toMatchObject({ healthy: 1, warnings: 0 });
 		expect(payload.reports).toHaveLength(1);
 		expect(payload.reports[0]).toMatchObject({ outcome: "healthy" });
+	});
+
+	it("runFix marks codex-unavailable live probe as a soft warning and keeps the account enabled", async () => {
+		loadQuotaCacheMock.mockResolvedValueOnce({ byAccountId: {}, byEmail: {} });
+		const storage = {
+			version: 3 as const,
+			accounts: [
+				{
+					email: "unavailable@example.com",
+					refreshToken: "refresh-unavailable",
+					accessToken: "access-expired",
+					expiresAt: 0,
+					accountId: "unavailable-account",
+					accountIdSource: "manual" as const,
+					enabled: true,
+				},
+			],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		};
+		loadAccountsMock.mockResolvedValue(storage);
+		queuedRefreshMock.mockResolvedValueOnce({
+			type: "success",
+			access: "access-unavailable-next",
+			refresh: "refresh-unavailable-next",
+			expires: Date.now() + 120_000,
+			idToken: "id-token-unavailable",
+		});
+		fetchCodexQuotaSnapshotMock.mockRejectedValue(
+			new CodexUnavailableError(
+				"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+			),
+		);
+		extractAccountEmailMock.mockReturnValue("unavailable@example.com");
+		extractAccountIdMock.mockReturnValue("unavailable-account");
+		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const exitCode = await runFix(
+			["--json", "--live"],
+			createDeps({ hasUsableAccessToken: () => false }),
+		);
+
+		expect(exitCode).toBe(0);
+		const payload = JSON.parse(
+			String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}"),
+		) as {
+			summary: { warnings: number };
+			reports: Array<{ outcome: string; message: string }>;
+		};
+		expect(payload.reports).toHaveLength(1);
+		expect(payload.reports[0]?.outcome).toBe("warning-soft-failure");
+		expect(payload.reports[0]?.message).toContain(CODEX_UNAVAILABLE_PROBE_NOTE);
+		// raw upstream error must not leak
+		expect(payload.reports[0]?.message).not.toContain(
+			"is not supported when using Codex",
+		);
 	});
 
 	it("runDoctor uses the injected refresh-token validator in JSON diagnostics", async () => {

--- a/test/runtime-account-check.test.ts
+++ b/test/runtime-account-check.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { runRuntimeAccountCheck } from "../lib/runtime/account-check.js";
+import { CodexUnavailableError } from "../lib/errors.js";
+import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../lib/quota-probe.js";
 
 describe("runRuntimeAccountCheck", () => {
 	it("reports when there are no accounts to check", async () => {
@@ -380,5 +382,78 @@ describe("runRuntimeAccountCheck", () => {
 		expect(saveFlaggedAccounts).toHaveBeenCalledTimes(1);
 		expect(saveAccounts).toHaveBeenCalledTimes(1);
 		expect(saveFlaggedAccounts.mock.invocationCallOrder[0]).toBeLessThan(saveAccounts.mock.invocationCallOrder[0]);
+	});
+
+	it("treats a codex-unavailable quota probe as a warning, not a hard error", async () => {
+		const showLine = vi.fn();
+		const state = {
+			flaggedStorage: { version: 1 as const, accounts: [] },
+			removeFromActive: new Set<string>(),
+			storageChanged: false,
+			flaggedChanged: false,
+			ok: 0,
+			errors: 0,
+			warnings: 0,
+			disabled: 0,
+		};
+		await runRuntimeAccountCheck(false, {
+			hydrateEmails: async (storage) => storage,
+			loadAccounts: async () => ({
+				version: 3,
+				accounts: [
+					{
+						email: "nocodex@example.com",
+						refreshToken: "fresh-refresh-nocodex",
+						accessToken: "usable-access",
+						accountId: "nocodex-account",
+						accountIdSource: "manual",
+						expiresAt: 9_999_999,
+						addedAt: 1,
+						lastUsed: 1,
+						enabled: true,
+					},
+				],
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+			}),
+			createEmptyStorage: () => ({ version: 3, accounts: [], activeIndex: 0, activeIndexByFamily: {} }),
+			loadFlaggedAccounts: async () => ({ version: 1, accounts: [] }),
+			createAccountCheckWorkingState: () => state,
+			lookupCodexCliTokensByEmail: async () => null,
+			extractAccountId: () => "nocodex-account",
+			shouldUpdateAccountIdFromToken: () => false,
+			sanitizeEmail: (email) => email,
+			extractAccountEmail: () => undefined,
+			queuedRefresh: vi.fn(async () => ({ type: "failed" as const, reason: "invalid_grant" })),
+			isRuntimeFlaggableFailure: () => false,
+			fetchCodexQuotaSnapshot: async () => {
+				throw new CodexUnavailableError(
+					"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+				);
+			},
+			resolveRequestAccountId: () => "nocodex-account",
+			formatCodexQuotaLine: () => "quota ok",
+			clampRuntimeActiveIndices: vi.fn(),
+			MODEL_FAMILIES: ["codex"],
+			saveAccounts: vi.fn(async () => {}),
+			invalidateAccountManagerCache: vi.fn(),
+			saveFlaggedAccounts: vi.fn(async () => {}),
+			now: () => 10_000,
+			showLine,
+		});
+
+		// counted as a warning + ok, not an error
+		expect(state.warnings).toBe(1);
+		expect(state.errors).toBe(0);
+		expect(state.ok).toBe(1);
+
+		const lines = showLine.mock.calls.map((call) => String(call[0]));
+		// friendly note is shown without an ERROR prefix or raw JSON
+		const noteLine = lines.find((l) => l.includes(CODEX_UNAVAILABLE_PROBE_NOTE));
+		expect(noteLine).toBeDefined();
+		expect(noteLine).not.toContain("ERROR");
+		expect(lines.join("\n")).not.toContain("is not supported when using Codex");
+		// summary reflects the warning bucket
+		expect(lines.some((l) => /Results:.*1 warning/.test(l))).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

`codex-multi-auth check` (and `best`, `forecast`, `report`, `fix`, deep-check) reported `live check failed: {"detail": "The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account."}` for accounts without Codex entitlement (issue #501).

Root cause: the Codex quota endpoint now returns model-not-supported errors as a flat `{"detail": "..."}` body instead of the nested `{"error": {"message": "..."}}` envelope. `getUnsupportedCodexModelInfo` only inspected `errorBody.error`, so detection returned `isUnsupported: false`, the model-fallback loop in `fetchCodexQuotaSnapshot` stopped continuing, and the raw JSON leaked into the probe error message that every live-probe surface renders.

## Changes

Detection and probe core:
- `lib/request/fetch-helpers.ts`: when `errorBody.error` is absent or not a record, fall back to the top-level `detail` string, reusing the existing unsupported-model and access-denied patterns and `extractUnsupportedCodexModelFromText`.
- `lib/quota-probe.ts`: track whether every probed model failed solely due to missing Codex entitlement; when so, throw a typed `CodexUnavailableError`. Mixed or other failures keep the previous behavior. Add `CODEX_UNAVAILABLE_PROBE_NOTE` and `describeCodexProbeFailure()` to centralize the user-facing wording and the unavailable-error check.
- `lib/errors.ts`: add `CodexUnavailableError` (code `CODEX_UNAVAILABLE`) and an `isCodexUnavailableError` guard that also matches the structural `code` marker across duplicate-module boundaries.

Surfaces (every consumer of `fetchCodexQuotaSnapshot` that rendered the raw error):
- `lib/codex-manager.ts`: both `runHealthCheck` branches (`check` / deep-check) render `signed in and working (Codex not available for this account)` / `working now (...)` via the shared constant.
- `lib/codex-manager/commands/best.ts`, `forecast.ts`, `report.ts`, `forecast-report-commands.ts`: live-probe catch blocks route through `describeCodexProbeFailure`. Persist-patch catch blocks were intentionally left untouched.
- `lib/codex-manager/repair-commands.ts` (`fix`): emit `refresh succeeded (Codex not available for this account)` instead of `live probe failed: ...` for the unavailable case.
- `lib/runtime/account-check.ts`: same note for the runtime deep-check probe path.

The proxy request path was already correct (it matches the raw body text via regex); only the quota-probe consumers parsed the body and read `error.message`.

## Tests

- `test/fetch-helpers.test.ts`: detection from the flat `detail` shape, the `{"error": null, "detail": "..."}` edge case, generic-wording detail, and rejection of unrelated detail strings.
- `test/quota-probe.test.ts`: all-models-unsupported throws `CodexUnavailableError`; a mixed failure does not and propagates the original error; `describeCodexProbeFailure` unit cases.
- `test/errors.test.ts`: `CodexUnavailableError` shape and `isCodexUnavailableError` instance / structural / negative cases.
- `test/codex-manager-cli.test.ts`, `test/repair-commands.test.ts`: partial `quota-probe` mocks now spread `importOriginal` so the new exports resolve.

No existing assertion depended on the exact `live check failed` string.

## Verification

- `npm run typecheck`: clean
- `npx eslint` on all changed files: clean
- `npm test`: 4074 passed across 269 files
- End-to-end check against the built `dist`: detail-shape detection, friendly-note rendering (no JSON leak), and structural guard all pass. `check` and deep-check confirmed live before the local test account was reset.

Fixes #501

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes the root cause of issue #501: the codex quota endpoint now returns unsupported-model rejections as a flat `{\"detail\":\"...\"}` body, which the old `getUnsupportedCodexModelInfo` missed because it only inspected `errorBody.error`. the leak of raw json into every live-probe surface is fixed end-to-end.

- `fetch-helpers.ts` gains a `detail` fallback path; `quota-probe.ts` tracks `sawUnsupportedModel`/`sawOtherFailure` per iteration and promotes an all-unsupported outcome to a typed `CodexUnavailableError` so callers don't have to guess.
- every consumer (`check`, `best`, `forecast`, `report`, `fix`, runtime deep-check) is updated to render the centralized `CODEX_UNAVAILABLE_PROBE_NOTE` string instead of leaking the upstream message.
- the previously flagged instruction-fetch mid-loop regression test and the `AccountCheckWorkingState.warnings` field (noted in earlier review threads) are both addressed in this pr.

<h3>Confidence Score: 5/5</h3>

safe to merge — all changed probe paths are covered by tests and the new error type is isolated with a structural guard for cross-realm safety.

the core detection logic in fetch-helpers.ts is a narrow, well-tested addition that reuses existing patterns and cannot regress the nested-error path. the sawUnsupportedModel/sawOtherFailure flags in quota-probe.ts correctly gate the new error type, and the instruction-fetch edge case now has explicit coverage. surface updates are mechanical and consistent. no token exposure or filesystem paths are touched.

lib/runtime/account-check.ts — the state.ok increment alongside state.warnings for unavailable accounts causes Results totals to exceed the checked-account count.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/fetch-helpers.ts | core fix: falls back to top-level `detail` string for unsupported-model detection when `error` is absent or non-record; reuses existing patterns and extractor cleanly |
| lib/quota-probe.ts | adds sawUnsupportedModel/sawOtherFailure tracking and throws CodexUnavailableError only when every model fails solely due to missing entitlement; mixed/other failures preserve previous behavior |
| lib/errors.ts | adds CodexUnavailableError and structural isCodexUnavailableError guard; follows existing error class pattern |
| lib/runtime/account-check.ts | routes CodexUnavailableError to warnings; increments both state.warnings and state.ok for a single unavailable account, making Results totals exceed the account count |
| lib/codex-manager.ts | both health-check branches now route CodexUnavailableError to CODEX_UNAVAILABLE_PROBE_NOTE; regex extended for unavailable/not available warning styling |
| test/quota-probe.test.ts | adds all-models-unsupported, mixed-failure, and instruction-fetch-failure cases; describeCodexProbeFailure unit tests included |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetchCodexQuotaSnapshot] --> B{for each model}
    B --> C[getCodexInstructions]
    C -->|throws| K[outer catch sawOtherFailure=true]
    C --> D[fetch /codex/responses]
    D --> E{parseQuotaSnapshotBase from headers}
    E -->|found| F[return snapshot]
    E -->|missing| G{response.ok?}
    G -->|yes| H[sawOtherFailure=true]
    G -->|no| I[getUnsupportedCodexModelInfo detail+error fallback]
    I -->|isUnsupported| J[sawUnsupportedModel=true continue]
    I -->|other| L[sawOtherFailure=true throw]
    K --> B
    H --> B
    J --> B
    B -->|exhausted| M{sawUnsupportedModel and not sawOtherFailure?}
    M -->|yes| N[throw CodexUnavailableError]
    M -->|no| O[throw lastError]
    N --> P[describeCodexProbeFailure]
    P --> Q[CODEX_UNAVAILABLE_PROBE_NOTE]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2F501-codex-quota-detail-detection%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F501-codex-quota-detail-detection%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fruntime%2Faccount-check.ts%3A299-303%0A**ok%20%2B%20warnings%20double-counts%20the%20same%20account**%0A%0A%60state.ok%20%2B%3D%201%60%20alongside%20%60state.warnings%20%2B%3D%201%60%20means%20the%20Results%20summary%20totals%20exceed%20the%20number%20of%20accounts%20checked.%20for%20a%20single%20Codex-unavailable%20account%3A%20%60Results%3A%201%20ok%2C%201%20warning%2C%200%20error%2C%200%20disabled%60%20%E2%80%94%20two%20entries%20for%20one%20account.%20if%20%60ok%60%20is%20intended%20to%20mean%20%22authenticated%20successfully%22%20%28and%20unavailable%20is%20a%20sub-category%29%2C%20that's%20fine%2C%20but%20any%20script%20that%20sums%20%60ok%20%2B%20warning%20%2B%20error%20%2B%20disabled%60%20to%20recover%20the%20total%20count%20will%20be%20off.%20consider%20dropping%20the%20%60ok%60%20increment%20here%20and%20adjusting%20the%20results%20line%20label%20so%20the%20semantics%20are%20explicit.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/runtime/account-check.ts:299-303
**ok + warnings double-counts the same account**

`state.ok += 1` alongside `state.warnings += 1` means the Results summary totals exceed the number of accounts checked. for a single Codex-unavailable account: `Results: 1 ok, 1 warning, 0 error, 0 disabled` — two entries for one account. if `ok` is intended to mean "authenticated successfully" (and unavailable is a sub-category), that's fine, but any script that sums `ok + warning + error + disabled` to recover the total count will be off. consider dropping the `ok` increment here and adjusting the results line label so the semantics are explicit.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(quota): treat codex-unavailable as w..."](https://github.com/ndycode/codex-multi-auth/commit/b92b497314a9bc828090e76afb7b66348f36ad78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35066059)</sub>

<!-- /greptile_comment -->