### PR TITLE
release: v2.2.0 stable + post-audit hardening

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.1.13-beta.3",
+  "version": "2.2.0",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ test-results.md
 # local env files
 .env
 .env.local
+
+# OMC session scratch (never publish)
+.omc/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Generated: 2026-04-25
 Commit: a87e005
 Branch: main
-Package version: 2.1.13-beta.3
+Package version: 2.2.0
 
 ## OVERVIEW
 

--- a/README.md
+++ b/README.md
@@ -383,9 +383,9 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current prerelease: [docs/releases/v2.1.13-beta.3.md](docs/releases/v2.1.13-beta.3.md) — install via `npm i -g codex-multi-auth@beta`
-- Current stable: [docs/releases/v2.1.12.md](docs/releases/v2.1.12.md)
-- Previous stable: [docs/releases/v2.1.11.md](docs/releases/v2.1.11.md)
+- Current stable: [docs/releases/v2.2.0.md](docs/releases/v2.2.0.md) — install via `npm i -g codex-multi-auth`
+- Previous stable: [docs/releases/v2.1.12.md](docs/releases/v2.1.12.md)
+- Earlier stable: [docs/releases/v2.1.11.md](docs/releases/v2.1.11.md)
 - Earlier stable: [docs/releases/v2.1.10.md](docs/releases/v2.1.10.md)
 - Earlier stable: [docs/releases/v2.1.8.md](docs/releases/v2.1.8.md)
 - Earlier stable: [docs/releases/v2.1.7.md](docs/releases/v2.1.7.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,8 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.1.13-beta.3.md](releases/v2.1.13-beta.3.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
-| [releases/v2.1.12.md](releases/v2.1.12.md) | Current stable release notes |
+| [releases/v2.2.0.md](releases/v2.2.0.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
+| [releases/v2.1.12.md](releases/v2.1.12.md) | Prior stable release notes |
 | [releases/v2.1.11.md](releases/v2.1.11.md) | Prior stable release notes |
 | [releases/v2.1.10.md](releases/v2.1.10.md) | Earlier stable release notes |
 | [releases/v2.1.9.md](releases/v2.1.9.md) | Earlier stable release notes |

--- a/docs/releases/v2.2.0.md
+++ b/docs/releases/v2.2.0.md
@@ -1,19 +1,17 @@
-# v2.1.13-beta.3
+# v2.2.0
 
-Beta prerelease that lands the Phase 1 correctness/security audit (#499), the new
-`mcodex` launcher + cached statusline (#500), and a round of pre-release
-hardening surfaced by a whole-tree stress test (#503). It carries forward the
-cascade OAuth token-invalidation fix from v2.1.13-beta.2, the multi-workspace
-support from v2.1.13-beta.1, and the pinned-account 503 diagnostic from
-v2.1.13-beta.0.
-
-This is a **prerelease**. Stable `v2.1.13` will land once the issue #486 root
-cause is identified and patched.
+Stable release. Promotes the v2.1.13-beta line to stable and adds the `mcodex`
+launcher. It bundles the Phase 1 correctness/security audit (#499), the new
+`mcodex` launcher + cached statusline (#500), the quota unsupported-model
+detail-shape detection (#501/#502), and the hardening surfaced by a whole-tree
+stress test (#503). It also carries the cascade OAuth token-invalidation fix, the
+multi-workspace support, and the pinned-account 503 diagnostic that shipped
+across v2.1.13-beta.0–beta.3.
 
 ## Install
 
 ```bash
-npm i -g codex-multi-auth@beta
+npm i -g codex-multi-auth
 ```
 
 ## mcodex launcher (#500)
@@ -94,11 +92,22 @@ Security and correctness hardening across the runtime, storage, and prompt layer
 - `codex-multi-auth status` / `list` gained `--json` for machine-readable output,
   with a stable shape whether or not accounts are configured.
 
-## Pre-release hardening (#503)
+## Quota detection (#501/#502)
+
+- Detect an unsupported Codex model from the upstream error `detail` shape (not
+  just the nested `error` envelope), so a Codex-gated account surfaces a friendly
+  "Codex unavailable" note across the `best` / `forecast` / `report` / live-check
+  surfaces instead of leaking the raw upstream "model is not supported" text.
+- A genuine transient failure mixed into the probe still surfaces as the real
+  error (never masked behind the friendly note), so a real outage is not hidden.
+
+## Post-audit hardening (#503 + follow-ups)
 
 - Strip inbound `cookie` / `proxy-authorization` on both egress paths.
 - Bound the proxy's upstream error-body read (previously unbounded on 4xx/5xx).
 - Persist `runtime-observability.json` owner-only (`0o600` / dir `0o700`) on POSIX.
+- Reject NUL-byte paths in `resolvePath` (defense in depth) and require a strict
+  integer for `switch <index>` (no silent float truncation).
 - Bump `vitest` to `^4.1.8` (dev-only) to clear GHSA-5xrq-8626-4rwp.
 
 ## Verification

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -422,10 +422,13 @@ function styleAccountDetailText(
 				? "success"
 				: fallbackTone;
 		const suffixTone: PromptTone =
-			/re-login|stale|warning|retry|fallback|unavailable|not available/i.test(suffix)
-				? "warning"
-				: /failed|error/i.test(suffix)
-					? "danger"
+			// danger wins first: a real failure whose text happens to contain
+			// "unavailable"/"not available" (e.g. a 5xx "service not available")
+			// must render red, not be downgraded to a yellow warning.
+			/failed|error/i.test(suffix)
+				? "danger"
+				: /re-login|stale|warning|retry|fallback|unavailable|not available/i.test(suffix)
+					? "warning"
 					: "muted";
 
 		const chunks: string[] = [];
@@ -436,9 +439,9 @@ function styleAccountDetailText(
 	}
 
 	if (/rate-limited/i.test(compact)) return stylePromptText(compact, "danger");
+	if (/failed|error/i.test(compact)) return stylePromptText(compact, "danger");
 	if (/re-login|stale|warning|fallback|unavailable|not available/i.test(compact))
 		return stylePromptText(compact, "warning");
-	if (/failed|error/i.test(compact)) return stylePromptText(compact, "danger");
 	if (/ok|working|succeeded|valid/i.test(compact))
 		return stylePromptText(compact, "success");
 	return stylePromptText(compact, fallbackTone);

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -403,7 +403,10 @@ function styleQuotaSummary(summary: string): string {
 	return joinStyledSegments(rendered);
 }
 
-function styleAccountDetailText(
+// Exported for unit tests: tone precedence (danger before warning) is
+// security/UX-relevant — a failure whose text contains "unavailable" must
+// render red, not be downgraded to yellow. See test/codex-manager-detail-tone.test.ts.
+export function styleAccountDetailText(
 	detail: string,
 	fallbackTone: PromptTone = "muted",
 ): string {

--- a/lib/codex-manager/commands/switch.ts
+++ b/lib/codex-manager/commands/switch.ts
@@ -36,6 +36,13 @@ export async function runSwitchCommand(
 		return 1;
 	}
 
+	// Require a plain positive integer. Number.parseInt would silently truncate
+	// "1.5" -> 1 (or "2abc" -> 2), selecting a real account from malformed input;
+	// reject anything that isn't all digits so the index is unambiguous.
+	if (!/^\d+$/.test(indexArg.trim())) {
+		(deps.logError ?? console.error)(`Invalid index: ${indexArg}`);
+		return 1;
+	}
 	const parsed = Number.parseInt(indexArg, 10);
 	if (!Number.isFinite(parsed) || parsed < 1) {
 		(deps.logError ?? console.error)(`Invalid index: ${indexArg}`);

--- a/lib/storage/paths.ts
+++ b/lib/storage/paths.ts
@@ -442,6 +442,12 @@ function canonicalizeExistingPrefix(targetPath: string): string {
 }
 
 export function resolvePath(filePath: string): string {
+	// Reject NUL bytes up front (defense in depth): a poison byte cannot traverse
+	// out of an approved root, but it must never reach the fs layer — fail here
+	// with a clear error rather than letting Node throw deep in a later read/write.
+	if (filePath.includes(String.fromCharCode(0))) {
+		throw new Error("Invalid path: contains a NUL byte");
+	}
 	let resolved: string;
 	if (filePath.startsWith("~")) {
 		resolved = join(homedir(), filePath.slice(1));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.13-beta.2",
+	"version": "2.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.1.13-beta.2",
+			"version": "2.2.0",
 			"bundleDependencies": [
 				"@codex-ai/plugin",
 				"@codex-ai/sdk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.1.13-beta.3",
+	"version": "2.2.0",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/test/codex-manager-detail-tone.test.ts
+++ b/test/codex-manager-detail-tone.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { styleAccountDetailText } from "../lib/codex-manager.js";
+import { ANSI } from "../lib/ui/ansi.js";
+import { resetUiRuntimeOptions, setUiRuntimeOptions } from "../lib/ui/runtime.js";
+
+// styleAccountDetailText colors a one-line account detail by tone. The
+// security/UX-relevant invariant is precedence: a real failure whose text also
+// contains "unavailable"/"not available" (e.g. a 5xx "service not available")
+// MUST render danger (red), never be downgraded to a warning (yellow). These
+// tests pin that the /failed|error/i check wins over the unavailable regex on
+// both the compact path and the quota-suffix path.
+//
+// To make tone assertions deterministic we force the legacy ANSI renderer
+// (v2 off) and an interactive stdout, so danger => ANSI.red and
+// warning => ANSI.yellow exactly.
+
+describe("styleAccountDetailText tone precedence", () => {
+	const stdoutIsTTYDescriptor = Object.getOwnPropertyDescriptor(
+		process.stdout,
+		"isTTY",
+	);
+
+	beforeEach(() => {
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: true,
+			configurable: true,
+		});
+		setUiRuntimeOptions({ v2Enabled: false });
+	});
+
+	afterEach(() => {
+		resetUiRuntimeOptions();
+		if (stdoutIsTTYDescriptor) {
+			Object.defineProperty(process.stdout, "isTTY", stdoutIsTTYDescriptor);
+		} else {
+			delete (process.stdout as unknown as { isTTY?: boolean }).isTTY;
+		}
+	});
+
+	it("renders danger (red), not warning (yellow), when a failure detail also says 'unavailable'", () => {
+		const styled = styleAccountDetailText("refresh failed: service unavailable");
+		expect(styled).toContain(ANSI.red);
+		expect(styled).not.toContain(ANSI.yellow);
+	});
+
+	it("treats 'not available' the same — danger wins over the warning keyword", () => {
+		const styled = styleAccountDetailText("token error (not available)");
+		// "(not available)" has no percent sign, so this stays on the compact path.
+		expect(styled).toContain(ANSI.red);
+		expect(styled).not.toContain(ANSI.yellow);
+	});
+
+	it("normalizes whitespace/newlines before matching tone keywords", () => {
+		const styled = styleAccountDetailText("  probe   failed\n  — endpoint unavailable  ");
+		expect(styled).toContain(ANSI.red);
+		expect(styled).not.toContain(ANSI.yellow);
+	});
+
+	it("still renders warning (yellow) when only an unavailable keyword is present", () => {
+		const styled = styleAccountDetailText("Codex not available for this account");
+		expect(styled).toContain(ANSI.yellow);
+		expect(styled).not.toContain(ANSI.red);
+	});
+
+	it("applies danger precedence to the quota suffix when it contains both keywords", () => {
+		// Quota-bearing prefix routes through the (NN%) branch; the suffix carries
+		// the failure text and must render red despite containing "unavailable".
+		const styled = styleAccountDetailText("acct (12%) — refresh failed, now unavailable");
+		expect(styled).toContain(ANSI.red);
+		expect(styled).not.toContain(ANSI.yellow);
+	});
+});

--- a/test/codex-manager-switch-command.test.ts
+++ b/test/codex-manager-switch-command.test.ts
@@ -67,6 +67,18 @@ describe("runSwitchCommand", () => {
 		);
 	});
 
+	it.each(["1.5", "2.9", "2abc", "0x2", "1e0", "+1", "-1"])(
+		"rejects a non-integer index %p instead of truncating it",
+		async (arg) => {
+			const deps = createDeps();
+			const result = await runSwitchCommand([arg], deps);
+			expect(result).toBe(1);
+			expect(deps.logError).toHaveBeenCalledWith(`Invalid index: ${arg}`);
+			// A rejected index must never persist a selection.
+			expect(deps.persistAndSyncSelectedAccount).not.toHaveBeenCalled();
+		},
+	);
+
 	it("persists and reports the selected account", async () => {
 		const deps = createDeps({
 			persistAndSyncSelectedAccount: vi.fn(async () => ({

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -772,6 +772,14 @@ describe("Storage Paths Module", () => {
 	});
 
 	describe("resolvePath", () => {
+		it("rejects a path containing a NUL byte", () => {
+			// Defense in depth: a poison byte must be refused here, not deep in fs.
+			expect(() => resolvePath(`~/.codex/${String.fromCharCode(0)}evil.json`)).toThrow(
+				/NUL byte/i,
+			);
+			expect(() => resolvePath(`${String.fromCharCode(0)}`)).toThrow(/NUL byte/i);
+		});
+
 		it("should expand tilde to home directory", () => {
 			const result = resolvePath("~/.codex/config.json");
 			expect(result).toBe(path.join(homedir(), ".codex/config.json"));


### PR DESCRIPTION
## Summary

Cuts the **v2.2.0 stable release** (promoting the v2.1.13-beta line) and folds in the remaining LOW findings from the deep post-merge audit of `main`.

Per the maintainer decision, this is a **minor stable** release → npm `latest` (drops the `-beta` prerelease tag).

## Release
- Version `2.1.13-beta.3` → **`2.2.0`** across `package.json`, `.codex-plugin/plugin.json`, `AGENTS.md`, `package-lock.json`.
- `docs/releases/v2.1.13-beta.3.md` → **`v2.2.0.md`**, rewritten as a stable release (`npm i -g codex-multi-auth`, no `@beta`), with a #501/#502 quota section + post-audit hardening notes. Docs-portal + README pointers moved from "current prerelease (beta)" → "current stable" v2.2.0.
- Added `.omc/` to `.gitignore` (session scratch, never published).

## Fixes (deep-audit LOW findings)
- **`styleAccountDetailText`** (codex-manager.ts): test `failed|error` (danger) **before** `unavailable|not available` (warning) in both the suffix and compact paths — a real failure whose text contains "not available" now renders red, not a soft yellow warning.
- **`resolvePath`** (storage/paths.ts): reject a NUL-byte path up front (defense in depth) instead of letting it reach the fs layer.
- **`switch <index>`**: require a strict integer — `1.5` / `2abc` no longer silently truncate to a valid account; they error.

Tests: strict-index rejection for `switch`, NUL-byte rejection for `resolvePath`.

## Deliberately NOT changed
The quota-probe transient-vs-unsupported precedence (a CodeRabbit LOW suggestion) was left as-is: existing tests ("does not throw CodexUnavailableError when a non-unsupported failure is mixed in" / "does not mask an instruction-fetch failure") intentionally keep a real transient surfacing rather than masking a possible outage behind the friendly "Codex unavailable" note. Changing it would regress that safety contract.

## Audit confidence (this release)
Deep multi-arm audit of merged `main` (the basis for 2.2.0):
- **Packaging/supply-chain**: SHIP — prod audit 0 vulns, `audit:ci` exit 0 (vitest GHSA cleared), vendor verified, no secrets in tarball, all 4 bins present, Node-18 clean, version parity.
- **Runtime/fuzz**: no crashes/hangs/leaks across adversarial CLI args, wrapper passthrough, mcodex injection, 400-way save concurrency, 120k×2 fuzz (display-width + resolvePath), 22-command hang sweep.
- **Code audit** (#499/#500/#503 areas + the #502 quota code): 0 CRITICAL/HIGH; only the LOW items fixed here.

## Verification
typecheck + lint + `audit:ci` clean · full suite **4278 passed / 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

promotes the v2.1.13-beta line to a stable 2.2.0 release and folds in the remaining LOW audit findings: tone-precedence fix in `styleAccountDetailText`, NUL-byte rejection in `resolvePath`, and strict-integer guard in `switch`. all three fixes ship with targeted vitest coverage (the previously-noted gap for the tone fix is now closed by `test/codex-manager-detail-tone.test.ts`).

- **`styleAccountDetailText`** (`lib/codex-manager.ts`): `failed|error` now checked before `unavailable|not available` on both the compact path and the quota-suffix path, so a 5xx "service not available" renders danger (red) instead of warning (yellow). exported for direct unit testing.
- **`resolvePath`** (`lib/storage/paths.ts`): NUL-byte (`\x00`) check added as the very first guard, before tilde expansion or `path.resolve`, giving a clear error rather than a deep fs-layer throw on windows or posix.
- **`switch <index>`** (`lib/codex-manager/commands/switch.ts`): `^\d+$` regex rejects floats (`1.5`), scientific notation (`1e0`), hex (`0x2`), and sign-prefixed strings (`+1`, `-1`) before `parseInt` is called, preventing silent truncation to a valid account index.

<h3>Confidence Score: 5/5</h3>

all three code changes are narrow, well-scoped hardening fixes with direct vitest coverage; version bump and docs are mechanical.

the tone-precedence fix, NUL-byte guard, and strict-integer check each have no side-effects beyond the intended behavior change, and each is pinned by new tests. the previous audit gap (missing tone test) is now closed. no concurrency-sensitive paths are touched, no token or filesystem safety regressions are introduced.

no files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/codex-manager.ts | exports styleAccountDetailText and reorders tone precedence — danger before warning — on both the compact and quota-suffix paths; logic is correct and now covered by the new tone test. |
| lib/codex-manager/commands/switch.ts | adds ^\d+$ guard before parseInt to reject floats, hex, scientific-notation, and sign-prefixed strings; early return prevents loadAccounts and persistAndSyncSelectedAccount from ever being called on invalid input. |
| lib/storage/paths.ts | NUL-byte rejection added as the very first check in resolvePath, before any tilde expansion or path.resolve call; correct on both POSIX and Windows. |
| test/codex-manager-detail-tone.test.ts | new test file covering both the compact path and quota-suffix path for tone precedence; uses isTTY override and v2Enabled:false to make ANSI color assertions deterministic. |
| test/codex-manager-switch-command.test.ts | adds it.each over seven non-integer inputs verifying exit code 1, correct error message, and no side-effects (persistAndSyncSelectedAccount not called). |
| test/paths.test.ts | adds two NUL-byte rejection cases for resolvePath matching /NUL byte/i; straightforward and sufficient. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["switch index arg"] --> B{"^\\d+$ test on trimmed arg"}
    B -- fail --> E["logError: Invalid index\nreturn 1"]
    B -- pass --> C{"isFinite && >= 1"}
    C -- fail --> E
    C -- pass --> F["loadAccounts()"]
    F --> G{"targetIndex in range?"}
    G -- no --> H["logError: out of range\nreturn 1"]
    G -- yes --> I["persistAndSyncSelectedAccount()"]
    I --> J["return 0"]

    R["resolvePath(filePath)"] --> R1{"contains NUL byte?"}
    R1 -- yes --> R2["throw: Invalid path: contains a NUL byte"]
    R1 -- no --> R3["tilde expand / path.resolve"]
    R3 --> R4["lookalike-sibling + root checks"]
    R4 --> R5["return resolved path"]

    S["styleAccountDetailText(detail)"] --> S1{"quota pattern match?"}
    S1 -- yes --> S2{"suffix: /failed|error/?"}
    S2 -- yes --> SD["danger (red)"]
    S2 -- no --> S3{"suffix: unavailable/stale?"}
    S3 -- yes --> SW["warning (yellow)"]
    S3 -- no --> SM["muted"]
    S1 -- no --> S4{"compact: /rate-limited/?"}
    S4 -- yes --> SD2["danger"]
    S4 -- no --> S5{"compact: /failed|error/?"}
    S5 -- yes --> SD3["danger"]
    S5 -- no --> S6{"compact: unavailable/stale?"}
    S6 -- yes --> SW2["warning"]
    S6 -- no --> SF["fallback tone"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/codex-manager.ts`, line 424-448 ([link](https://github.com/ndycode/codex-multi-auth/blob/d8f714c45e4e6e7104ffb9cfb64c461618e57bf7/lib/codex-manager.ts#L424-L448)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **missing vitest coverage for `styleAccountDetailText` priority fix**

   the priority-swap is the core correctness fix in this PR, but there's no unit test verifying the new ordering. `styleAccountDetailText` is only referenced in tests via a pass-through mock in `repair-commands.test.ts` — so a regression (e.g. the suffix branch reverting to the old order) would pass the full suite undetected. a targeted test for a suffix like `"service not available – error"` asserting `"danger"` output would close this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/codex-manager.ts
   Line: 424-448

   Comment:
   **missing vitest coverage for `styleAccountDetailText` priority fix**

   the priority-swap is the core correctness fix in this PR, but there's no unit test verifying the new ordering. `styleAccountDetailText` is only referenced in tests via a pass-through mock in `repair-commands.test.ts` — so a regression (e.g. the suffix branch reverting to the old order) would pass the full suite undetected. a targeted test for a suffix like `"service not available – error"` asserting `"danger"` output would close this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fpost-merge-audit-lows%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpost-merge-audit-lows%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fcodex-manager.ts%0ALine%3A%20424-448%0A%0AComment%3A%0A**missing%20vitest%20coverage%20for%20%60styleAccountDetailText%60%20priority%20fix**%0A%0Athe%20priority-swap%20is%20the%20core%20correctness%20fix%20in%20this%20PR%2C%20but%20there's%20no%20unit%20test%20verifying%20the%20new%20ordering.%20%60styleAccountDetailText%60%20is%20only%20referenced%20in%20tests%20via%20a%20pass-through%20mock%20in%20%60repair-commands.test.ts%60%20%E2%80%94%20so%20a%20regression%20%28e.g.%20the%20suffix%20branch%20reverting%20to%20the%20old%20order%29%20would%20pass%20the%20full%20suite%20undetected.%20a%20targeted%20test%20for%20a%20suffix%20like%20%60%22service%20not%20available%20%E2%80%93%20error%22%60%20asserting%20%60%22danger%22%60%20output%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(codex-manager): pin danger&gt;warning ..."](https://github.com/ndycode/codex-multi-auth/commit/51d9a06dea2de138a227daf85fcb82e83ec2aa59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35118267)</sub>

<!-- /greptile_comment -->