### PR TITLE
Fix live account checks and default probe model

### DIFF
--- a/.cr506b.py
+++ b/.cr506b.py
@@ -1,6 +1,0 @@
-import json, sys, re
-data = json.load(sys.stdin)
-for i, c in enumerate(data, 1):
-    body = re.sub(r"<details>.*?</details>", "[…]", c.get("body", ""), flags=re.S).strip()
-    print("### {}. {}:{}".format(i, c.get("path"), c.get("line")))
-    print(body[:1100]); print()

--- a/.cr506b.py
+++ b/.cr506b.py
@@ -1,0 +1,6 @@
+import json, sys, re
+data = json.load(sys.stdin)
+for i, c in enumerate(data, 1):
+    body = re.sub(r"<details>.*?</details>", "[…]", c.get("body", ""), flags=re.S).strip()
+    print("### {}. {}:{}".format(i, c.get("path"), c.get("line")))
+    print(body[:1100]); print()

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ For remote or headless shells, prefer `codex-multi-auth login --device-auth`.
 | Command | What it answers |
 | --- | --- |
 | `codex-multi-auth report --live --json` | How do I get the full machine-readable health report? |
-| `codex-multi-auth fix --live --model gpt-5.3-codex` | How do I run live repair probes with a chosen model? |
+| `codex-multi-auth fix --live --model gpt-5.5` | How do I run live repair probes with a chosen model? |
 | `codex-multi-auth why-selected --json` | Which account does the selector pick now, and why? |
 | `codex-multi-auth usage --since 24h --by project` | What local usage has been recorded recently? |
 | `codex-multi-auth monitor --json` | What is the combined usage, policy, quota, runtime, and project state? |

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -2540,7 +2540,7 @@ function parseBestArgs(args: string[]): ParsedArgsResult<BestCliOptions> {
 			continue;
 		}
 		if (arg === "--model" || arg === "-m") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -698,7 +698,7 @@ function getPersistedQuotaViewForAccount(
 	return {
 		updatedAt: cachedEntry?.updatedAt ?? now,
 		status: 429,
-		model: cachedEntry?.model ?? "gpt-5.3-codex",
+		model: cachedEntry?.model ?? "gpt-5.5",
 		planType: cachedEntry?.planType,
 		primary: {
 			...cachedEntry?.primary,
@@ -787,7 +787,8 @@ function pruneUnsafeQuotaEmailCacheEntry(
 }
 
 const DEFAULT_MENU_QUOTA_REFRESH_TTL_MS = 5 * 60_000;
-const MENU_QUOTA_REFRESH_MODEL = "gpt-5.3-codex";
+const DEFAULT_LIVE_PROBE_MODEL = "gpt-5.5";
+const MENU_QUOTA_REFRESH_MODEL = DEFAULT_LIVE_PROBE_MODEL;
 
 interface MenuQuotaProbeTarget {
 	account: AccountMetadataV3;
@@ -2181,7 +2182,7 @@ interface HealthCheckOptions {
 async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 	const forceRefresh = options.forceRefresh === true;
 	const liveProbe = options.liveProbe === true;
-	const probeModel = options.model?.trim() || "gpt-5.3-codex";
+	const probeModel = options.model?.trim() || DEFAULT_LIVE_PROBE_MODEL;
 	const modelInspection = inspectRequestedModel(probeModel);
 	const display = options.display ?? DEFAULT_DASHBOARD_DISPLAY_SETTINGS;
 	const quotaCache = liveProbe ? await loadQuotaCache() : null;
@@ -2202,6 +2203,8 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 	let ok = 0;
 	let failed = 0;
 	let warnings = 0;
+	let codexAvailable = 0;
+	let signedInOnly = 0;
 	const activeIndex = resolveActiveIndex(storage, "codex");
 	let activeAccountRefreshed = false;
 	const now = Date.now();
@@ -2236,6 +2239,7 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 				activeAccountRefreshed = true;
 			}
 			let healthDetail = "signed in and working";
+			let healthTone: "success" | "warning" = "success";
 			if (liveProbe) {
 				const currentAccessToken = account.accessToken;
 				const probeAccountId = currentAccessToken
@@ -2243,8 +2247,10 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 					: undefined;
 				if (!probeAccountId || !currentAccessToken) {
 					warnings += 1;
+					signedInOnly += 1;
+					healthTone = "warning";
 					healthDetail =
-						"signed in and working (live check skipped: missing account ID)";
+						"signed in (live check skipped: missing account ID)";
 				} else {
 					try {
 						const snapshot = await fetchCodexQuotaSnapshot({
@@ -2263,17 +2269,20 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 								) || quotaCacheChanged;
 						}
 						healthDetail = formatQuotaSnapshotForDashboard(snapshot, display);
+						codexAvailable += 1;
 					} catch (error) {
 						warnings += 1;
+						signedInOnly += 1;
+						healthTone = "warning";
 						if (isCodexUnavailableError(error)) {
 							healthDetail =
-								`signed in and working (${CODEX_UNAVAILABLE_PROBE_NOTE})`;
+								`signed in; ${CODEX_UNAVAILABLE_PROBE_NOTE}`;
 						} else {
 							const message = normalizeFailureDetail(
 								error instanceof Error ? error.message : String(error),
 								undefined,
 							);
-							healthDetail = `signed in and working (live check failed: ${message})`;
+							healthDetail = `signed in (live check failed: ${message})`;
 						}
 					}
 				}
@@ -2283,8 +2292,9 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 			}
 			ok += 1;
 			if (display.showPerAccountRows) {
+				const healthMarker = healthTone === "success" ? "✓" : "!";
 				console.log(
-					`  ${stylePromptText("✓", "success")} ${labelText} ${stylePromptText("|", "muted")} ${styleAccountDetailText(healthDetail)}`,
+					`  ${stylePromptText(healthMarker, healthTone)} ${labelText} ${stylePromptText("|", "muted")} ${styleAccountDetailText(healthDetail, healthTone)}`,
 				);
 			}
 			continue;
@@ -2340,12 +2350,15 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 			}
 			ok += 1;
 			let healthyMessage = "working now";
+			let healthyTone: "success" | "warning" = "success";
 			if (liveProbe) {
 				const probeAccountId = account.accountId ?? tokenAccountId;
 				if (!probeAccountId) {
 					warnings += 1;
+					signedInOnly += 1;
+					healthyTone = "warning";
 					healthyMessage =
-						"working now (live check skipped: missing account ID)";
+						"signed in (live check skipped: missing account ID)";
 				} else {
 					try {
 						const snapshot = await fetchCodexQuotaSnapshot({
@@ -2364,30 +2377,37 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 								) || quotaCacheChanged;
 						}
 						healthyMessage = formatQuotaSnapshotForDashboard(snapshot, display);
+						codexAvailable += 1;
 					} catch (error) {
 						warnings += 1;
+						signedInOnly += 1;
+						healthyTone = "warning";
 						if (isCodexUnavailableError(error)) {
 							healthyMessage =
-								`working now (${CODEX_UNAVAILABLE_PROBE_NOTE})`;
+								`signed in; ${CODEX_UNAVAILABLE_PROBE_NOTE}`;
 						} else {
 							const message = normalizeFailureDetail(
 								error instanceof Error ? error.message : String(error),
 								undefined,
 							);
-							healthyMessage = `working now (live check failed: ${message})`;
+							healthyMessage = `signed in (live check failed: ${message})`;
 						}
 					}
 				}
 			}
 			if (display.showPerAccountRows) {
+				const healthyMarker = healthyTone === "success" ? "✓" : "!";
 				console.log(
-					`  ${stylePromptText("✓", "success")} ${labelText} ${stylePromptText("|", "muted")} ${styleAccountDetailText(healthyMessage)}`,
+					`  ${stylePromptText(healthyMarker, healthyTone)} ${labelText} ${stylePromptText("|", "muted")} ${styleAccountDetailText(healthyMessage, healthyTone)}`,
 				);
 			}
 		} else {
 			const detail = normalizeFailureDetail(result.message, result.reason);
 			if (sessionLikelyValid) {
 				warnings += 1;
+				if (liveProbe) {
+					signedInOnly += 1;
+				}
 				if (display.showPerAccountRows) {
 					console.log(
 						`  ${stylePromptText("!", "warning")} ${labelText} ${stylePromptText("|", "muted")} ${stylePromptText(`refresh failed (${detail}) but this account still works right now`, "warning")}`,
@@ -2447,17 +2467,38 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 
 	console.log("");
 	console.log(
-		formatResultSummary([
-			{ text: `${ok} working`, tone: "success" },
-			{
-				text: `${failed} need re-login`,
-				tone: failed > 0 ? "danger" : "muted",
-			},
-			{
-				text: `${warnings} warning${warnings === 1 ? "" : "s"}`,
-				tone: warnings > 0 ? "warning" : "muted",
-			},
-		]),
+		formatResultSummary(
+			liveProbe
+				? [
+						{
+							text: `${codexAvailable} Codex available`,
+							tone: codexAvailable > 0 ? "success" : "muted",
+						},
+						{
+							text: `${signedInOnly} signed in only`,
+							tone: signedInOnly > 0 ? "warning" : "muted",
+						},
+						{
+							text: `${failed} need re-login`,
+							tone: failed > 0 ? "danger" : "muted",
+						},
+						{
+							text: `${warnings} warning${warnings === 1 ? "" : "s"}`,
+							tone: warnings > 0 ? "warning" : "muted",
+						},
+					]
+				: [
+						{ text: `${ok} working`, tone: "success" },
+						{
+							text: `${failed} need re-login`,
+							tone: failed > 0 ? "danger" : "muted",
+						},
+						{
+							text: `${warnings} warning${warnings === 1 ? "" : "s"}`,
+							tone: warnings > 0 ? "warning" : "muted",
+						},
+					],
+		),
 	);
 }
 
@@ -2474,7 +2515,7 @@ function printBestUsage(): void {
 			"Options:",
 			"  --live, -l         Probe live quota headers via Codex backend before switching",
 			"  --json, -j         Print machine-readable JSON output",
-			"  --model, -m        Probe model for live mode (default: gpt-5.3-codex)",
+			`  --model, -m        Probe model for live mode (default: ${DEFAULT_LIVE_PROBE_MODEL})`,
 			"",
 			"Behavior:",
 			"  - Chooses the healthiest account using forecast scoring",
@@ -2486,7 +2527,7 @@ function parseBestArgs(args: string[]): ParsedArgsResult<BestCliOptions> {
 	const options: BestCliOptions = {
 		live: false,
 		json: false,
-		model: "gpt-5.3-codex",
+		model: DEFAULT_LIVE_PROBE_MODEL,
 		modelProvided: false,
 	};
 

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -129,6 +129,7 @@ import {
 import { createLogger } from "./logger.js";
 import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
 import {
+	DEFAULT_MODEL,
 	getModelCapabilities,
 	getModelProfile,
 	resolveNormalizedModel,
@@ -698,7 +699,7 @@ function getPersistedQuotaViewForAccount(
 	return {
 		updatedAt: cachedEntry?.updatedAt ?? now,
 		status: 429,
-		model: cachedEntry?.model ?? "gpt-5.5",
+		model: cachedEntry?.model ?? DEFAULT_MODEL,
 		planType: cachedEntry?.planType,
 		primary: {
 			...cachedEntry?.primary,
@@ -787,7 +788,7 @@ function pruneUnsafeQuotaEmailCacheEntry(
 }
 
 const DEFAULT_MENU_QUOTA_REFRESH_TTL_MS = 5 * 60_000;
-const DEFAULT_LIVE_PROBE_MODEL = "gpt-5.5";
+const DEFAULT_LIVE_PROBE_MODEL = DEFAULT_MODEL;
 const MENU_QUOTA_REFRESH_MODEL = DEFAULT_LIVE_PROBE_MODEL;
 
 interface MenuQuotaProbeTarget {
@@ -2482,10 +2483,6 @@ async function runHealthCheck(options: HealthCheckOptions = {}): Promise<void> {
 							text: `${failed} need re-login`,
 							tone: failed > 0 ? "danger" : "muted",
 						},
-						{
-							text: `${warnings} warning${warnings === 1 ? "" : "s"}`,
-							tone: warnings > 0 ? "warning" : "muted",
-						},
 					]
 				: [
 						{ text: `${ok} working`, tone: "success" },
@@ -2544,7 +2541,7 @@ function parseBestArgs(args: string[]): ParsedArgsResult<BestCliOptions> {
 		}
 		if (arg === "--model" || arg === "-m") {
 			const value = args[i + 1];
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
@@ -2554,7 +2551,7 @@ function parseBestArgs(args: string[]): ParsedArgsResult<BestCliOptions> {
 		}
 		if (arg.startsWith("--model=")) {
 			const value = arg.slice("--model=".length).trim();
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;

--- a/lib/codex-manager/commands/best.ts
+++ b/lib/codex-manager/commands/best.ts
@@ -103,9 +103,7 @@ export async function runBestCommand(
 		return 1;
 	}
 	const options = parsedArgs.options;
-	const probeModel = resolveNormalizedModel(
-		options.model?.trim() || "gpt-5.3-codex",
-	);
+	const probeModel = resolveNormalizedModel(options.model?.trim() || "gpt-5.5");
 	if (options.modelProvided && !options.live) {
 		logError("--model requires --live for codex-multi-auth best");
 		deps.printBestUsage();

--- a/lib/codex-manager/commands/best.ts
+++ b/lib/codex-manager/commands/best.ts
@@ -1,6 +1,6 @@
 import type { ForecastAccountResult } from "../../forecast.js";
 import { type CodexQuotaSnapshot, describeCodexProbeFailure } from "../../quota-probe.js";
-import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
+import { DEFAULT_MODEL, resolveNormalizedModel } from "../../request/helpers/model-map.js";
 import type { AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 
@@ -103,7 +103,7 @@ export async function runBestCommand(
 		return 1;
 	}
 	const options = parsedArgs.options;
-	const probeModel = resolveNormalizedModel(options.model?.trim() || "gpt-5.5");
+	const probeModel = resolveNormalizedModel(options.model?.trim() || DEFAULT_MODEL);
 	if (options.modelProvided && !options.live) {
 		logError("--model requires --live for codex-multi-auth best");
 		deps.printBestUsage();

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -14,7 +14,7 @@ import {
 } from "../forecast-report-shared.js";
 import type { QuotaCacheData } from "../../quota-cache.js";
 import { type CodexQuotaSnapshot, describeCodexProbeFailure } from "../../quota-probe.js";
-import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
+import { DEFAULT_MODEL, resolveNormalizedModel } from "../../request/helpers/model-map.js";
 import { type AccountMetadataV3, type AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 
@@ -149,7 +149,7 @@ function parseForecastArgs(
 		live: false,
 		json: false,
 		explain: false,
-		model: "gpt-5.5",
+		model: DEFAULT_MODEL,
 		runtimeOverlay: true,
 	};
 
@@ -174,14 +174,18 @@ function parseForecastArgs(
 		}
 		if (arg === "--model" || arg === "-m") {
 			const value = args[i + 1];
-			if (!value) return { ok: false, message: "Missing value for --model" };
+			if (!value || value.startsWith("-")) {
+				return { ok: false, message: "Missing value for --model" };
+			}
 			options.model = value;
 			i += 1;
 			continue;
 		}
 		if (arg.startsWith("--model=")) {
 			const value = arg.slice("--model=".length).trim();
-			if (!value) return { ok: false, message: "Missing value for --model" };
+			if (!value || value.startsWith("-")) {
+				return { ok: false, message: "Missing value for --model" };
+			}
 			options.model = value;
 			continue;
 		}
@@ -211,7 +215,7 @@ export async function runForecastCommand(
 		return 1;
 	}
 	const options = parsedArgs.options;
-	const requestedModel = options.model?.trim() || "gpt-5.5";
+	const requestedModel = options.model?.trim() || DEFAULT_MODEL;
 	const probeModel = resolveNormalizedModel(requestedModel);
 	const display = deps.loadDashboardDisplaySettings
 		? (await deps.loadDashboardDisplaySettings().catch(() => null)) ??

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -136,7 +136,7 @@ function printForecastUsage(logInfo: (message: string) => void): void {
 			"  --live, -l         Probe live quota headers via Codex backend",
 			"  --json, -j         Print machine-readable JSON output",
 			"  --explain          Include structured recommendation reasoning",
-			"  --model, -m        Probe model for live mode (default: gpt-5.3-codex)",
+			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
 			"  --no-runtime-overlay  Ignore persisted runtime skip diagnostics",
 		].join("\n"),
 	);
@@ -149,7 +149,7 @@ function parseForecastArgs(
 		live: false,
 		json: false,
 		explain: false,
-		model: "gpt-5.3-codex",
+		model: "gpt-5.5",
 		runtimeOverlay: true,
 	};
 
@@ -211,7 +211,7 @@ export async function runForecastCommand(
 		return 1;
 	}
 	const options = parsedArgs.options;
-	const requestedModel = options.model?.trim() || "gpt-5.3-codex";
+	const requestedModel = options.model?.trim() || "gpt-5.5";
 	const probeModel = resolveNormalizedModel(requestedModel);
 	const display = deps.loadDashboardDisplaySettings
 		? (await deps.loadDashboardDisplaySettings().catch(() => null)) ??

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -173,7 +173,7 @@ function parseForecastArgs(
 			continue;
 		}
 		if (arg === "--model" || arg === "-m") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -136,7 +136,7 @@ function printForecastUsage(logInfo: (message: string) => void): void {
 			"  --live, -l         Probe live quota headers via Codex backend",
 			"  --json, -j         Print machine-readable JSON output",
 			"  --explain          Include structured recommendation reasoning",
-			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
+			`  --model, -m        Probe model for live mode (default: ${DEFAULT_MODEL})`,
 			"  --no-runtime-overlay  Ignore persisted runtime skip diagnostics",
 		].join("\n"),
 	);

--- a/lib/codex-manager/commands/integrations.ts
+++ b/lib/codex-manager/commands/integrations.ts
@@ -69,7 +69,7 @@ export function runIntegrationsCommand(
 		}
 		if (arg === "--model") {
 			const value = args[i + 1];
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				logError("Missing value for --model");
 				return 1;
 			}

--- a/lib/codex-manager/commands/integrations.ts
+++ b/lib/codex-manager/commands/integrations.ts
@@ -68,7 +68,7 @@ export function runIntegrationsCommand(
 			continue;
 		}
 		if (arg === "--model") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				logError("Missing value for --model");
 				return 1;

--- a/lib/codex-manager/commands/models.ts
+++ b/lib/codex-manager/commands/models.ts
@@ -43,7 +43,7 @@ export async function runModelsCommand(
 			continue;
 		}
 		if (arg === "--model") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				logError("Missing value for --model");
 				return 1;

--- a/lib/codex-manager/commands/models.ts
+++ b/lib/codex-manager/commands/models.ts
@@ -44,7 +44,7 @@ export async function runModelsCommand(
 		}
 		if (arg === "--model") {
 			const value = args[i + 1];
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				logError("Missing value for --model");
 				return 1;
 			}
@@ -54,7 +54,7 @@ export async function runModelsCommand(
 		}
 		if (arg?.startsWith("--model=")) {
 			const value = arg.slice("--model=".length).trim();
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				logError("Missing value for --model");
 				return 1;
 			}

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -127,7 +127,7 @@ function printReportUsage(logInfo: (message: string) => void): void {
 			"  --live, -l         Probe live quota headers via Codex backend",
 			"  --json, -j         Print machine-readable JSON output",
 			"  --explain          Print per-account reasoning in text mode",
-			"  --model, -m        Probe model for live mode (default: gpt-5.3-codex)",
+			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
 			"  --max-accounts N   Limit how many enabled accounts live mode can consider",
 			"  --max-probes N     Limit how many live quota probes can run",
 			"  --cached-only      Skip refreshes and only use already-usable access tokens",
@@ -141,7 +141,7 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 		live: false,
 		json: false,
 		explain: false,
-		model: "gpt-5.3-codex",
+		model: "gpt-5.5",
 		cachedOnly: false,
 	};
 
@@ -305,7 +305,7 @@ export async function runReportCommand(
 		return 1;
 	}
 	const options = parsedArgs.options;
-	const requestedModel = options.model?.trim() || "gpt-5.3-codex";
+	const requestedModel = options.model?.trim() || "gpt-5.5";
 	const modelInspection = inspectRequestedModel(requestedModel);
 
 	deps.setStoragePath(null);

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -166,7 +166,7 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 			continue;
 		}
 		if (arg === "--model" || arg === "-m") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -128,7 +128,7 @@ function printReportUsage(logInfo: (message: string) => void): void {
 			"  --live, -l         Probe live quota headers via Codex backend",
 			"  --json, -j         Print machine-readable JSON output",
 			"  --explain          Print per-account reasoning in text mode",
-			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
+			`  --model, -m        Probe model for live mode (default: ${DEFAULT_MODEL})`,
 			"  --max-accounts N   Limit how many enabled accounts live mode can consider",
 			"  --max-probes N     Limit how many live quota probes can run",
 			"  --cached-only      Skip refreshes and only use already-usable access tokens",

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -25,6 +25,7 @@ import {
 } from "../../quota-probe.js";
 import { type ModelFamily } from "../../prompts/codex.js";
 import {
+	DEFAULT_MODEL,
 	getModelCapabilities,
 	getModelProfile,
 	resolveNormalizedModel,
@@ -141,7 +142,7 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 		live: false,
 		json: false,
 		explain: false,
-		model: "gpt-5.5",
+		model: DEFAULT_MODEL,
 		cachedOnly: false,
 	};
 
@@ -166,14 +167,18 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 		}
 		if (arg === "--model" || arg === "-m") {
 			const value = args[i + 1];
-			if (!value) return { ok: false, message: "Missing value for --model" };
+			if (!value || value.startsWith("-")) {
+				return { ok: false, message: "Missing value for --model" };
+			}
 			options.model = value;
 			i += 1;
 			continue;
 		}
 		if (arg.startsWith("--model=")) {
 			const value = arg.slice("--model=".length).trim();
-			if (!value) return { ok: false, message: "Missing value for --model" };
+			if (!value || value.startsWith("-")) {
+				return { ok: false, message: "Missing value for --model" };
+			}
 			options.model = value;
 			continue;
 		}
@@ -305,7 +310,7 @@ export async function runReportCommand(
 		return 1;
 	}
 	const options = parsedArgs.options;
-	const requestedModel = options.model?.trim() || "gpt-5.5";
+	const requestedModel = options.model?.trim() || DEFAULT_MODEL;
 	const modelInspection = inspectRequestedModel(requestedModel);
 
 	deps.setStoragePath(null);

--- a/lib/codex-manager/forecast-report-commands.ts
+++ b/lib/codex-manager/forecast-report-commands.ts
@@ -143,7 +143,7 @@ export function parseForecastArgs(args: string[]): ParsedArgsResult<ForecastCliO
 			continue;
 		}
 		if (arg === "--model" || arg === "-m") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
@@ -184,7 +184,7 @@ export function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptio
 			continue;
 		}
 		if (arg === "--model" || arg === "-m") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}

--- a/lib/codex-manager/forecast-report-commands.ts
+++ b/lib/codex-manager/forecast-report-commands.ts
@@ -19,6 +19,7 @@ import {
 	describeCodexProbeFailure,
 } from "../quota-probe.js";
 import { queuedRefresh } from "../refresh-queue.js";
+import { DEFAULT_MODEL } from "../request/helpers/model-map.js";
 import {
 	getStoragePath,
 	loadAccounts,
@@ -127,7 +128,7 @@ export function parseForecastArgs(args: string[]): ParsedArgsResult<ForecastCliO
 	const options: ForecastCliOptions = {
 		live: false,
 		json: false,
-		model: "gpt-5.5",
+		model: DEFAULT_MODEL,
 	};
 
 	for (let i = 0; i < args.length; i += 1) {
@@ -143,7 +144,7 @@ export function parseForecastArgs(args: string[]): ParsedArgsResult<ForecastCliO
 		}
 		if (arg === "--model" || arg === "-m") {
 			const value = args[i + 1];
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
@@ -152,7 +153,7 @@ export function parseForecastArgs(args: string[]): ParsedArgsResult<ForecastCliO
 		}
 		if (arg.startsWith("--model=")) {
 			const value = arg.slice("--model=".length).trim();
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
@@ -168,7 +169,7 @@ export function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptio
 	const options: ReportCliOptions = {
 		live: false,
 		json: false,
-		model: "gpt-5.5",
+		model: DEFAULT_MODEL,
 	};
 
 	for (let i = 0; i < args.length; i += 1) {
@@ -184,7 +185,7 @@ export function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptio
 		}
 		if (arg === "--model" || arg === "-m") {
 			const value = args[i + 1];
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
@@ -193,7 +194,7 @@ export function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptio
 		}
 		if (arg.startsWith("--model=")) {
 			const value = arg.slice("--model=".length).trim();
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;

--- a/lib/codex-manager/forecast-report-commands.ts
+++ b/lib/codex-manager/forecast-report-commands.ts
@@ -104,7 +104,7 @@ export function printForecastUsage(): void {
 			"Options:",
 			"  --live, -l         Probe live quota headers via Codex backend",
 			"  --json, -j         Print machine-readable JSON output",
-			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
+			`  --model, -m        Probe model for live mode (default: ${DEFAULT_MODEL})`,
 		].join("\n"),
 	);
 }
@@ -118,7 +118,7 @@ export function printReportUsage(): void {
 			"Options:",
 			"  --live, -l         Probe live quota headers via Codex backend",
 			"  --json, -j         Print machine-readable JSON output",
-			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
+			`  --model, -m        Probe model for live mode (default: ${DEFAULT_MODEL})`,
 			"  --out              Write JSON report to a file path",
 		].join("\n"),
 	);

--- a/lib/codex-manager/forecast-report-commands.ts
+++ b/lib/codex-manager/forecast-report-commands.ts
@@ -103,7 +103,7 @@ export function printForecastUsage(): void {
 			"Options:",
 			"  --live, -l         Probe live quota headers via Codex backend",
 			"  --json, -j         Print machine-readable JSON output",
-			"  --model, -m        Probe model for live mode (default: gpt-5.3-codex)",
+			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
 		].join("\n"),
 	);
 }
@@ -117,7 +117,7 @@ export function printReportUsage(): void {
 			"Options:",
 			"  --live, -l         Probe live quota headers via Codex backend",
 			"  --json, -j         Print machine-readable JSON output",
-			"  --model, -m        Probe model for live mode (default: gpt-5.3-codex)",
+			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
 			"  --out              Write JSON report to a file path",
 		].join("\n"),
 	);
@@ -127,7 +127,7 @@ export function parseForecastArgs(args: string[]): ParsedArgsResult<ForecastCliO
 	const options: ForecastCliOptions = {
 		live: false,
 		json: false,
-		model: "gpt-5.3-codex",
+		model: "gpt-5.5",
 	};
 
 	for (let i = 0; i < args.length; i += 1) {
@@ -168,7 +168,7 @@ export function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptio
 	const options: ReportCliOptions = {
 		live: false,
 		json: false,
-		model: "gpt-5.3-codex",
+		model: "gpt-5.5",
 	};
 
 	for (let i = 0; i < args.length; i += 1) {

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -1,4 +1,6 @@
-const DEFAULT_LIVE_PROBE_MODEL = "gpt-5.5";
+import { DEFAULT_MODEL } from "../request/helpers/model-map.js";
+
+const DEFAULT_LIVE_PROBE_MODEL = DEFAULT_MODEL;
 
 export function printUsage(): void {
 	console.log(

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -1,3 +1,5 @@
+const DEFAULT_LIVE_PROBE_MODEL = "gpt-5.5";
+
 export function printUsage(): void {
 	console.log(
 		[
@@ -147,7 +149,7 @@ export function printBestUsage(): void {
 			"Options:",
 			"  --live, -l         Probe live quota headers via Codex backend before switching",
 			"  --json, -j         Print machine-readable JSON output",
-			"  --model, -m        Probe model for live mode (default: gpt-5.3-codex)",
+			`  --model, -m        Probe model for live mode (default: ${DEFAULT_LIVE_PROBE_MODEL})`,
 			"",
 			"Behavior:",
 			"  - Chooses the healthiest account using forecast scoring",
@@ -160,7 +162,7 @@ export function parseBestArgs(args: string[]): ParsedBestArgs {
 	const options: BestCliOptions = {
 		live: false,
 		json: false,
-		model: "gpt-5.3-codex",
+		model: DEFAULT_LIVE_PROBE_MODEL,
 		modelProvided: false,
 	};
 

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -183,7 +183,7 @@ export function parseBestArgs(args: string[]): ParsedBestArgs {
 			continue;
 		}
 		if (arg === "--model" || arg === "-m") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				return {
 					ok: false,

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -184,7 +184,7 @@ export function parseBestArgs(args: string[]): ParsedBestArgs {
 		}
 		if (arg === "--model" || arg === "-m") {
 			const value = args[i + 1];
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return {
 					ok: false,
 					reason: "error",
@@ -198,7 +198,7 @@ export function parseBestArgs(args: string[]): ParsedBestArgs {
 		}
 		if (arg.startsWith("--model=")) {
 			const value = arg.slice("--model=".length).trim();
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return {
 					ok: false,
 					reason: "error",

--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -213,7 +213,7 @@ export function parseFixArgs(args: string[]): ParsedArgsResult<FixCliOptions> {
 			continue;
 		}
 		if (argValue === "--model" || argValue === "-m") {
-			const value = args[i + 1];
+			const value = args[i + 1]?.trim();
 			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}

--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -142,7 +142,7 @@ export function printFixUsage(): void {
 			"  --dry-run, -n      Preview changes without writing storage",
 			"  --json, -j         Print machine-readable JSON output",
 			"  --live, -l         Run live session probe before deciding health",
-			"  --model, -m        Probe model for live mode (default: gpt-5.3-codex)",
+			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
 			"",
 			"Behavior:",
 			"  - Refreshes tokens for enabled accounts",
@@ -194,7 +194,7 @@ export function parseFixArgs(args: string[]): ParsedArgsResult<FixCliOptions> {
 		dryRun: false,
 		json: false,
 		live: false,
-		model: "gpt-5.3-codex",
+		model: "gpt-5.5",
 	};
 
 	for (let i = 0; i < args.length; i += 1) {
@@ -1197,7 +1197,7 @@ export async function runFix(
 		return 1;
 	}
 	const options = parsedArgs.options;
-	const probeModel = resolveNormalizedModel(options.model.trim() || "gpt-5.3-codex");
+	const probeModel = resolveNormalizedModel(options.model.trim() || "gpt-5.5");
 	const display = DEFAULT_DASHBOARD_DISPLAY_SETTINGS;
 	const quotaCache = options.live ? await loadQuotaCache() : null;
 	const workingQuotaCache = quotaCache ? deps.cloneQuotaCacheData(quotaCache) : null;

--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -214,7 +214,7 @@ export function parseFixArgs(args: string[]): ParsedArgsResult<FixCliOptions> {
 		}
 		if (argValue === "--model" || argValue === "-m") {
 			const value = args[i + 1];
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
@@ -223,7 +223,7 @@ export function parseFixArgs(args: string[]): ParsedArgsResult<FixCliOptions> {
 		}
 		if (argValue.startsWith("--model=")) {
 			const value = argValue.slice("--model=".length).trim();
-			if (!value) {
+			if (!value || value.startsWith("-")) {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;

--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -40,7 +40,7 @@ import {
 } from "../codex-cli/state.js";
 import { setCodexCliActiveSelection } from "../codex-cli/writer.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
-import { resolveNormalizedModel } from "../request/helpers/model-map.js";
+import { DEFAULT_MODEL, resolveNormalizedModel } from "../request/helpers/model-map.js";
 import { loadPersistedRuntimeObservabilitySnapshot } from "../runtime/runtime-observability.js";
 import type { AccountIdSource, TokenFailure, TokenResult } from "../types.js";
 
@@ -194,7 +194,7 @@ export function parseFixArgs(args: string[]): ParsedArgsResult<FixCliOptions> {
 		dryRun: false,
 		json: false,
 		live: false,
-		model: "gpt-5.5",
+		model: DEFAULT_MODEL,
 	};
 
 	for (let i = 0; i < args.length; i += 1) {
@@ -1197,7 +1197,7 @@ export async function runFix(
 		return 1;
 	}
 	const options = parsedArgs.options;
-	const probeModel = resolveNormalizedModel(options.model.trim() || "gpt-5.5");
+	const probeModel = resolveNormalizedModel(options.model.trim() || DEFAULT_MODEL);
 	const display = DEFAULT_DASHBOARD_DISPLAY_SETTINGS;
 	const quotaCache = options.live ? await loadQuotaCache() : null;
 	const workingQuotaCache = quotaCache ? deps.cloneQuotaCacheData(quotaCache) : null;

--- a/lib/codex-manager/repair-commands.ts
+++ b/lib/codex-manager/repair-commands.ts
@@ -142,7 +142,7 @@ export function printFixUsage(): void {
 			"  --dry-run, -n      Preview changes without writing storage",
 			"  --json, -j         Print machine-readable JSON output",
 			"  --live, -l         Run live session probe before deciding health",
-			"  --model, -m        Probe model for live mode (default: gpt-5.5)",
+			`  --model, -m        Probe model for live mode (default: ${DEFAULT_MODEL})`,
 			"",
 			"Behavior:",
 			"  - Refreshes tokens for enabled accounts",

--- a/lib/integration-generators.ts
+++ b/lib/integration-generators.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_MODEL } from "./request/helpers/model-map.js";
+
 export type IntegrationSnippetKind = "opencode" | "openclaw" | "python" | "curl" | "env";
 
 export interface IntegrationSnippetInput {
@@ -13,7 +15,6 @@ export interface IntegrationSnippet {
 }
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:1456/v1";
-const DEFAULT_MODEL = "gpt-5.3-codex";
 const DEFAULT_ENV_VAR = "CODEX_MULTI_AUTH_LOCAL_KEY";
 
 function normalizeInput(input: IntegrationSnippetInput = {}): Required<IntegrationSnippetInput> {

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
 import type { CacheMetadata, GitHubRelease } from "../types.js";
 import { logWarn, logError, logDebug } from "../logger.js";
 import { getCodexCacheDir } from "../runtime-paths.js";
-import { getModelProfile, type PromptModelFamily } from "../request/helpers/model-map.js";
+import { DEFAULT_MODEL, getModelProfile, type PromptModelFamily } from "../request/helpers/model-map.js";
 import { fetchWithTimeout, readBodyTextGuarded, withBodyTimeout } from "./fetch-utils.js";
 import { withFileOperationRetry } from "../fs-retry.js";
 
@@ -234,11 +234,11 @@ async function getLatestReleaseTag(): Promise<string> {
  *
  * Rate limit protection: Only checks GitHub if cache is older than 15 minutes
  *
- * @param normalizedModel - The normalized model name (optional, defaults to "gpt-5.3-codex")
+ * @param normalizedModel - The normalized model name (optional, defaults to DEFAULT_MODEL)
  * @returns Codex instructions for the specified model family
  */
 export async function getCodexInstructions(
-	normalizedModel = "gpt-5.3-codex",
+	normalizedModel = DEFAULT_MODEL,
 ): Promise<string> {
 	const modelFamily = getModelFamily(normalizedModel);
 	const now = Date.now();
@@ -466,7 +466,7 @@ function refreshInstructionsInBackground(
  * Prewarm instruction caches for the provided models/families.
  */
 export function prewarmCodexInstructions(models: string[] = []): void {
-	const candidates = models.length > 0 ? models : ["gpt-5.3-codex", "gpt-5.5", "gpt-5.1"];
+	const candidates = models.length > 0 ? models : [DEFAULT_MODEL, "gpt-5.3-codex", "gpt-5.1"];
 	const prewarmTargets = new Map<string, string>();
 	for (const model of candidates) {
 		const promptFamily = getModelFamily(model);

--- a/lib/quota-probe.ts
+++ b/lib/quota-probe.ts
@@ -1,6 +1,6 @@
 import { CODEX_BASE_URL } from "./constants.js";
 import { createCodexHeaders, getUnsupportedCodexModelInfo } from "./request/fetch-helpers.js";
-import { DEFAULT_MODEL } from "./request/helpers/model-map.js";
+import { QUOTA_PROBE_MODEL_CHAIN } from "./request/helpers/model-map.js";
 import { CodexUnavailableError, isCodexUnavailableError } from "./errors.js";
 import { getCodexInstructions } from "./prompts/codex.js";
 import { mutateRuntimeObservabilitySnapshot } from "./runtime/runtime-observability.js";
@@ -54,13 +54,7 @@ export interface CodexQuotaSnapshot {
 	model: string;
 }
 
-const DEFAULT_QUOTA_PROBE_MODELS = [
-	DEFAULT_MODEL,
-	"gpt-5.4",
-	"gpt-5.3-codex",
-	"gpt-5.2-codex",
-	"gpt-5-codex",
-] as const;
+const DEFAULT_QUOTA_PROBE_MODELS = QUOTA_PROBE_MODEL_CHAIN;
 
 /**
  * Parse an HTTP header value and return it as a finite number.

--- a/lib/quota-probe.ts
+++ b/lib/quota-probe.ts
@@ -1,5 +1,6 @@
 import { CODEX_BASE_URL } from "./constants.js";
 import { createCodexHeaders, getUnsupportedCodexModelInfo } from "./request/fetch-helpers.js";
+import { DEFAULT_MODEL } from "./request/helpers/model-map.js";
 import { CodexUnavailableError, isCodexUnavailableError } from "./errors.js";
 import { getCodexInstructions } from "./prompts/codex.js";
 import { mutateRuntimeObservabilitySnapshot } from "./runtime/runtime-observability.js";
@@ -54,7 +55,7 @@ export interface CodexQuotaSnapshot {
 }
 
 const DEFAULT_QUOTA_PROBE_MODELS = [
-	"gpt-5.5",
+	DEFAULT_MODEL,
 	"gpt-5.4",
 	"gpt-5.3-codex",
 	"gpt-5.2-codex",

--- a/lib/quota-probe.ts
+++ b/lib/quota-probe.ts
@@ -53,7 +53,13 @@ export interface CodexQuotaSnapshot {
 	model: string;
 }
 
-const DEFAULT_QUOTA_PROBE_MODELS = ["gpt-5.3-codex", "gpt-5.2-codex", "gpt-5-codex"] as const;
+const DEFAULT_QUOTA_PROBE_MODELS = [
+	"gpt-5.5",
+	"gpt-5.4",
+	"gpt-5.3-codex",
+	"gpt-5.2-codex",
+	"gpt-5-codex",
+] as const;
 
 /**
  * Parse an HTTP header value and return it as a finite number.

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -81,6 +81,18 @@ const TOOL_CAPABILITIES = {
 
 export const CURRENT_CODEX_MODEL = "gpt-5.3-codex";
 export const DEFAULT_MODEL = "gpt-5.5";
+
+// Single source of truth for the live/quota probe fallback chain. Both the
+// manager probe (lib/quota-probe.ts) and the runtime probe (lib/runtime/quota-probe.ts)
+// import this so the ordered candidate list cannot drift between them.
+export const QUOTA_PROBE_MODEL_CHAIN = [
+	DEFAULT_MODEL,
+	"gpt-5.4",
+	"gpt-5.3-codex",
+	"gpt-5.2-codex",
+	"gpt-5-codex",
+] as const;
+
 const LEGACY_CODEX_MODEL = "gpt-5-codex";
 const GPT_5_5_CANONICAL_MODEL = "gpt-5.5";
 const GPT_5_5_PRO_CANONICAL_MODEL = "gpt-5.5-pro";

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -33,6 +33,7 @@ import {
 	URL_PATHS,
 } from "./constants.js";
 import { getModelFamily, type ModelFamily } from "./prompts/codex.js";
+import { DEFAULT_MODEL } from "./request/helpers/model-map.js";
 import { queuedRefresh } from "./refresh-queue.js";
 import {
 	mutateRuntimeObservabilitySnapshot,
@@ -725,7 +726,7 @@ function buildResponsesRequestContext(
 		method: "POST",
 		upstreamPath: URL_PATHS.CODEX_RESPONSES,
 		model,
-		family: getModelFamily(model ?? "gpt-5.3-codex"),
+		family: getModelFamily(model ?? DEFAULT_MODEL),
 		stream: parsedBody?.stream === true,
 		sessionKey: resolveSessionKey(headers, parsedBody),
 	};

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -33,7 +33,7 @@ import {
 	URL_PATHS,
 } from "./constants.js";
 import { getModelFamily, type ModelFamily } from "./prompts/codex.js";
-import { DEFAULT_MODEL } from "./request/helpers/model-map.js";
+import { CURRENT_CODEX_MODEL } from "./request/helpers/model-map.js";
 import { queuedRefresh } from "./refresh-queue.js";
 import {
 	mutateRuntimeObservabilitySnapshot,
@@ -726,7 +726,11 @@ function buildResponsesRequestContext(
 		method: "POST",
 		upstreamPath: URL_PATHS.CODEX_RESPONSES,
 		model,
-		family: getModelFamily(model ?? DEFAULT_MODEL),
+		// The /codex/responses path is codex-family. A model-less request must
+		// bucket into the codex family (rotation/cooldown/budget), so fall back to
+		// the current codex model — NOT the general DEFAULT_MODEL (gpt-5.5), whose
+		// family is gpt-5.2 and would mis-account a pass-through codex request.
+		family: getModelFamily(model ?? CURRENT_CODEX_MODEL),
 		stream: parsedBody?.stream === true,
 		sessionKey: resolveSessionKey(headers, parsedBody),
 	};

--- a/lib/runtime/quota-probe.ts
+++ b/lib/runtime/quota-probe.ts
@@ -1,9 +1,10 @@
 import type { RequestBody } from "../types.js";
 import type { CodexQuotaSnapshot } from "../quota-probe.js";
 import type { ParsedCodexQuotaSnapshot } from "./quota-headers.js";
+import { DEFAULT_MODEL } from "../request/helpers/model-map.js";
 
 const QUOTA_PROBE_MODELS = [
-	"gpt-5.5",
+	DEFAULT_MODEL,
 	"gpt-5.4",
 	"gpt-5.3-codex",
 	"gpt-5.2-codex",

--- a/lib/runtime/quota-probe.ts
+++ b/lib/runtime/quota-probe.ts
@@ -1,15 +1,9 @@
 import type { RequestBody } from "../types.js";
 import type { CodexQuotaSnapshot } from "../quota-probe.js";
 import type { ParsedCodexQuotaSnapshot } from "./quota-headers.js";
-import { DEFAULT_MODEL } from "../request/helpers/model-map.js";
+import { QUOTA_PROBE_MODEL_CHAIN } from "../request/helpers/model-map.js";
 
-const QUOTA_PROBE_MODELS = [
-	DEFAULT_MODEL,
-	"gpt-5.4",
-	"gpt-5.3-codex",
-	"gpt-5.2-codex",
-	"gpt-5-codex",
-] as const;
+const QUOTA_PROBE_MODELS = QUOTA_PROBE_MODEL_CHAIN;
 
 export async function fetchRuntimeCodexQuotaSnapshot(params: {
 	accountId: string;

--- a/lib/runtime/quota-probe.ts
+++ b/lib/runtime/quota-probe.ts
@@ -3,6 +3,8 @@ import type { CodexQuotaSnapshot } from "../quota-probe.js";
 import type { ParsedCodexQuotaSnapshot } from "./quota-headers.js";
 
 const QUOTA_PROBE_MODELS = [
+	"gpt-5.5",
+	"gpt-5.4",
 	"gpt-5.3-codex",
 	"gpt-5.2-codex",
 	"gpt-5-codex",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
 		"codex-multi-auth": "scripts/codex-multi-auth.js"
 	},
 	"files": [
+		".codex-plugin/plugin.json",
 		"dist/",
 		"assets/",
 		"config/",

--- a/scripts/check-pack-budget-lib.js
+++ b/scripts/check-pack-budget-lib.js
@@ -14,6 +14,7 @@ const execAsync = promisify(exec);
 
 export const MAX_PACKAGE_SIZE = 8 * 1024 * 1024;
 export const REQUIRED_PREFIXES = [
+	".codex-plugin/plugin.json",
 	"dist/",
 	"assets/",
 	"config/",

--- a/scripts/check-pack-budget-lib.js
+++ b/scripts/check-pack-budget-lib.js
@@ -13,16 +13,21 @@ import { promisify } from "node:util";
 const execAsync = promisify(exec);
 
 export const MAX_PACKAGE_SIZE = 8 * 1024 * 1024;
-export const REQUIRED_PREFIXES = [
+// Exact files that must be present (matched by full path equality, so a sibling
+// like ".codex-plugin/plugin.json.bak" or "README.md.bak" cannot satisfy them).
+export const REQUIRED_FILES = [
 	".codex-plugin/plugin.json",
+	"README.md",
+	"LICENSE",
+];
+// Directory prefixes that must contribute at least one packed file.
+export const REQUIRED_PREFIXES = [
 	"dist/",
 	"assets/",
 	"config/",
 	"scripts/",
 	"vendor/codex-ai-plugin/",
 	"vendor/codex-ai-sdk/",
-	"README.md",
-	"LICENSE",
 ];
 
 export const FORBIDDEN_PREFIXES = [
@@ -97,6 +102,14 @@ export function validatePackMetadata({ packageSize, paths }) {
 		);
 		if (leaked) {
 			throw new Error(`Forbidden file leaked into package: ${leaked}`);
+		}
+	}
+
+	for (const requiredFile of REQUIRED_FILES) {
+		if (!paths.includes(requiredFile)) {
+			throw new Error(
+				`Required package file missing from npm pack output: ${requiredFile}`,
+			);
 		}
 	}
 

--- a/test/check-pack-budget.test.ts
+++ b/test/check-pack-budget.test.ts
@@ -127,6 +127,27 @@ describe("validatePackMetadata", () => {
 		).toThrow(/\.codex-plugin\/plugin\.json/);
 	});
 
+	it("does not accept a .bak sibling as the plugin manifest (exact-file match)", () => {
+		// A prefix match would let ".codex-plugin/plugin.json.bak" satisfy the gate
+		// while the real manifest is missing — the exact-file check must reject it.
+		expect(() =>
+			validatePackMetadata({
+				packageSize: 123,
+				paths: [
+					".codex-plugin/plugin.json.bak",
+					"dist/index.js",
+					"assets/logo.svg",
+					"config/default.json",
+					"scripts/codex.js",
+					"vendor/codex-ai-plugin/index.js",
+					"vendor/codex-ai-sdk/index.js",
+					"README.md",
+					"LICENSE",
+				],
+			}),
+		).toThrow(/\.codex-plugin\/plugin\.json/);
+	});
+
 	it("rejects forbidden lib sources in the packed file list", () => {
 		expect(() =>
 			validatePackMetadata({

--- a/test/check-pack-budget.test.ts
+++ b/test/check-pack-budget.test.ts
@@ -96,6 +96,7 @@ describe("validatePackMetadata", () => {
 			validatePackMetadata({
 				packageSize: 123,
 				paths: [
+					".codex-plugin/plugin.json",
 					"dist/index.js",
 					"assets/logo.svg",
 					"config/default.json",
@@ -107,11 +108,31 @@ describe("validatePackMetadata", () => {
 			}),
 		).toThrow(/vendor\/codex-ai-sdk/);
 	});
+
+	it("rejects packages missing the Codex plugin image manifest", () => {
+		expect(() =>
+			validatePackMetadata({
+				packageSize: 123,
+				paths: [
+					"dist/index.js",
+					"assets/logo.svg",
+					"config/default.json",
+					"scripts/codex.js",
+					"vendor/codex-ai-plugin/index.js",
+					"vendor/codex-ai-sdk/index.js",
+					"README.md",
+					"LICENSE",
+				],
+			}),
+		).toThrow(/\.codex-plugin\/plugin\.json/);
+	});
+
 	it("rejects forbidden lib sources in the packed file list", () => {
 		expect(() =>
 			validatePackMetadata({
 				packageSize: 123,
 				paths: [
+					".codex-plugin/plugin.json",
 					"dist/index.js",
 					"assets/logo.svg",
 					"config/default.json",
@@ -137,6 +158,7 @@ describe("runPackBudgetCheck", () => {
 						{
 							size: 321,
 							files: [
+								{ path: ".codex-plugin/plugin.json" },
 								{ path: "dist/index.js" },
 								{ path: "assets/logo.svg" },
 								{ path: "config/default.json" },
@@ -151,7 +173,7 @@ describe("runPackBudgetCheck", () => {
 				})),
 				log,
 			}),
-		).resolves.toBe("Pack budget ok: 321 bytes across 8 files");
-		expect(log).toHaveBeenCalledWith("Pack budget ok: 321 bytes across 8 files");
+		).resolves.toBe("Pack budget ok: 321 bytes across 9 files");
+		expect(log).toHaveBeenCalledWith("Pack budget ok: 321 bytes across 9 files");
 	});
 });

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -745,7 +745,7 @@ describe("codex manager cli commands", () => {
 		confirmMock.mockResolvedValue(true);
 		fetchCodexQuotaSnapshotMock.mockResolvedValue({
 			status: 200,
-			model: "gpt-5.3-codex",
+			model: "gpt-5.5",
 			primary: {},
 			secondary: {},
 		});
@@ -1772,7 +1772,7 @@ describe("codex manager cli commands", () => {
 				acc_forecast: {
 					updatedAt: expect.any(Number),
 					status: 200,
-					model: "gpt-5.3-codex",
+					model: "gpt-5.5",
 					planType: undefined,
 					primary: {
 						usedPercent: undefined,
@@ -2969,7 +2969,7 @@ describe("codex manager cli commands", () => {
 				"owner@example.com": {
 					updatedAt: now - 5_000,
 					status: 200,
-					model: "gpt-5.3-codex",
+					model: "gpt-5.5",
 					primary: {
 						usedPercent: 95,
 						windowMinutes: 300,
@@ -3055,7 +3055,7 @@ describe("codex manager cli commands", () => {
 			expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
 			expect(
 				logSpy.mock.calls.some((call) =>
-					String(call[0]).includes("Result: 2 working"),
+					String(call[0]).includes("Result: 2 Codex available"),
 				),
 			).toBe(true);
 		} finally {
@@ -3101,7 +3101,7 @@ describe("codex manager cli commands", () => {
 				"alpha@example.com": {
 					updatedAt: now - 10_000,
 					status: 200,
-					model: "gpt-5.3-codex",
+					model: "gpt-5.5",
 					primary: {
 						usedPercent: 15,
 						windowMinutes: 300,
@@ -3245,12 +3245,88 @@ describe("codex manager cli commands", () => {
 		expect(queuedRefreshMock).not.toHaveBeenCalled();
 		expect(saveAccountsMock).not.toHaveBeenCalled();
 		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(1);
+		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledWith(
+			expect.objectContaining({ model: "gpt-5.5" }),
+		);
 		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
 		expect(
 			logSpy.mock.calls.some((call) =>
 				String(call[0]).includes("live session OK"),
 			),
 		).toBe(true);
+	});
+
+	it("does not label Codex-unavailable live checks as working now", async () => {
+		const now = Date.now();
+		loadAccountsMock.mockResolvedValueOnce({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					accountId: "acc_fresh_unavailable",
+					email: "fresh-unavailable@example.com",
+					refreshToken: "refresh-fresh-unavailable",
+					accessToken: "access-fresh-unavailable",
+					expiresAt: now + 60 * 60 * 1000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+				{
+					accountId: "acc_refreshed_unavailable",
+					email: "refreshed-unavailable@example.com",
+					refreshToken: "refresh-refreshed-unavailable",
+					accessToken: "access-refreshed-unavailable-old",
+					expiresAt: now - 1_000,
+					addedAt: now - 2_000,
+					lastUsed: now - 2_000,
+					enabled: true,
+				},
+			],
+		});
+		queuedRefreshMock.mockResolvedValueOnce({
+			type: "success",
+			access: "access-refreshed-unavailable-next",
+			refresh: "refresh-refreshed-unavailable-next",
+			expires: now + 60 * 60 * 1000,
+			idToken: "id-refreshed-unavailable-next",
+		});
+		fetchCodexQuotaSnapshotMock
+			.mockRejectedValueOnce(
+				new CodexUnavailableError(
+					"The requested Codex model is not available for this account.",
+				),
+			)
+			.mockRejectedValueOnce(
+				new CodexUnavailableError(
+					"The requested Codex model is not available for this account.",
+				),
+			);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+
+		const exitCode = await runCodexMultiAuthCli(["auth", "check"]);
+
+		expect(exitCode).toBe(0);
+		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
+		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
+		const output = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+		const unavailableRows = output
+			.split("\n")
+			.filter((line) => line.includes(CODEX_UNAVAILABLE_PROBE_NOTE_LITERAL));
+		expect(unavailableRows).toHaveLength(2);
+		expect(unavailableRows.every((line) => line.includes("signed in;"))).toBe(
+			true,
+		);
+		expect(output).not.toContain(
+			`signed in and working (${CODEX_UNAVAILABLE_PROBE_NOTE_LITERAL})`,
+		);
+		expect(output).not.toContain(
+			`working now (${CODEX_UNAVAILABLE_PROBE_NOTE_LITERAL})`,
+		);
+		expect(output).toContain("Result: 0 Codex available | 2 signed in only");
+		expect(output).not.toContain("Result: 2 working");
 	});
 
 	it("does not mutate loaded quota cache when live check account save fails", async () => {
@@ -3302,7 +3378,7 @@ describe("codex manager cli commands", () => {
 				acc_live: {
 					updatedAt: expect.any(Number),
 					status: 200,
-					model: "gpt-5.3-codex",
+					model: "gpt-5.5",
 					planType: undefined,
 					primary: {
 						usedPercent: undefined,
@@ -7050,7 +7126,7 @@ describe("codex manager cli commands", () => {
 				acc_a: {
 					updatedAt: expect.any(Number),
 					status: 200,
-					model: "gpt-5.3-codex",
+					model: "gpt-5.5",
 					planType: undefined,
 					primary: {
 						usedPercent: undefined,
@@ -7263,12 +7339,12 @@ describe("codex manager cli commands", () => {
 		expect(fetchCodexQuotaSnapshotMock).toHaveBeenNthCalledWith(1, {
 			accountId: "workspace-alpha",
 			accessToken: "access-alpha",
-			model: "gpt-5.3-codex",
+			model: "gpt-5.5",
 		});
 		expect(fetchCodexQuotaSnapshotMock).toHaveBeenNthCalledWith(2, {
 			accountId: "workspace-beta",
 			accessToken: "access-beta",
-			model: "gpt-5.3-codex",
+			model: "gpt-5.5",
 		});
 		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
 		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
@@ -9830,14 +9906,14 @@ describe("codex manager cli commands", () => {
 		expect(payload.accounts.enabled).toBe(1);
 		expect(payload.accounts.disabled).toBe(1);
 		expect(payload.modelSelection).toEqual({
-			requested: "gpt-5.3-codex",
-			normalized: "gpt-5.3-codex",
+			requested: "gpt-5.5",
+			normalized: "gpt-5.5",
 			remapped: false,
-			promptFamily: "gpt-5-codex",
+			promptFamily: "gpt-5.2",
 			capabilities: {
-				toolSearch: false,
-				computerUse: false,
-				compaction: false,
+				toolSearch: true,
+				computerUse: true,
+				compaction: true,
 			},
 		});
 	});

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -2006,6 +2006,26 @@ describe("codex manager cli commands", () => {
 		expect(logSpy.mock.calls[0]?.[0]).toContain("codex-multi-auth best");
 	});
 
+	it("rejects a flag-like value after best --model instead of consuming it", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+
+		// "--model --live" must NOT swallow --live as the model value.
+		const exitCode = await runCodexMultiAuthCli([
+			"auth",
+			"best",
+			"--model",
+			"--live",
+		]);
+
+		expect(exitCode).toBe(1);
+		expect(errorSpy).toHaveBeenCalledWith("Missing value for --model");
+		expect(loadAccountsMock).not.toHaveBeenCalled();
+		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(logSpy.mock.calls[0]?.[0]).toContain("codex-multi-auth best");
+	});
+
 	it("rejects unknown best args before switching accounts", async () => {
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -7020,6 +7020,55 @@ describe("codex manager cli commands", () => {
 		).toBe(true);
 	});
 
+	it("deep-check counts a refresh failure with a still-valid session as signed-in-only", async () => {
+		// forceRefresh + liveProbe + queuedRefresh failure while the session token is
+		// still usable must take the "refresh failed but works right now" path and
+		// land in the live summary as "signed in only", not "need re-login".
+		const now = Date.now();
+		const storage = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "a@example.com",
+					accountId: "acc_a",
+					refreshToken: "refresh-a",
+					accessToken: "access-a",
+					// Unexpired access token => hasUsableAccessToken() true =>
+					// sessionLikelyValid true.
+					expiresAt: now + 3_600_000,
+					addedAt: now - 1_000,
+					lastUsed: now - 1_000,
+					enabled: true,
+				},
+			],
+		};
+		loadAccountsMock.mockResolvedValue(storage);
+		promptLoginModeMock
+			.mockResolvedValueOnce({ mode: "deep-check" })
+			.mockResolvedValueOnce({ mode: "cancel" });
+		// Refresh fails transiently (NOT a hard/revoked failure) so the session
+		// stays valid and the account is signed-in-only, not need-re-login.
+		queuedRefreshMock.mockResolvedValueOnce({
+			type: "error",
+			reason: "network",
+			message: "temporary network failure",
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+
+		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
+		expect(exitCode).toBe(0);
+		const output = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+		// Per-account warning row.
+		expect(output).toContain("refresh failed");
+		expect(output).toContain("but this account still works right now");
+		// Live summary: signed-in-only, not need-re-login.
+		expect(output).toContain("signed in only");
+		expect(output).not.toContain("1 need re-login");
+	});
+
 	it("runs quick check from login menu with live probe", async () => {
 		const now = Date.now();
 		const storage = {

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexUnavailableError } from "../lib/errors.js";
+import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
 // quota-probe is mocked below; reference the note as a literal to avoid a
 // top-level import racing the hoisted vi.mock factory.
 const CODEX_UNAVAILABLE_PROBE_NOTE_LITERAL = "Codex not available for this account";
@@ -745,7 +746,7 @@ describe("codex manager cli commands", () => {
 		confirmMock.mockResolvedValue(true);
 		fetchCodexQuotaSnapshotMock.mockResolvedValue({
 			status: 200,
-			model: "gpt-5.5",
+			model: DEFAULT_MODEL,
 			primary: {},
 			secondary: {},
 		});
@@ -1772,7 +1773,7 @@ describe("codex manager cli commands", () => {
 				acc_forecast: {
 					updatedAt: expect.any(Number),
 					status: 200,
-					model: "gpt-5.5",
+					model: DEFAULT_MODEL,
 					planType: undefined,
 					primary: {
 						usedPercent: undefined,
@@ -3266,7 +3267,7 @@ describe("codex manager cli commands", () => {
 		expect(saveAccountsMock).not.toHaveBeenCalled();
 		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(1);
 		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledWith(
-			expect.objectContaining({ model: "gpt-5.5" }),
+			expect.objectContaining({ model: DEFAULT_MODEL }),
 		);
 		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
 		expect(
@@ -3398,7 +3399,7 @@ describe("codex manager cli commands", () => {
 				acc_live: {
 					updatedAt: expect.any(Number),
 					status: 200,
-					model: "gpt-5.5",
+					model: DEFAULT_MODEL,
 					planType: undefined,
 					primary: {
 						usedPercent: undefined,
@@ -7195,7 +7196,7 @@ describe("codex manager cli commands", () => {
 				acc_a: {
 					updatedAt: expect.any(Number),
 					status: 200,
-					model: "gpt-5.5",
+					model: DEFAULT_MODEL,
 					planType: undefined,
 					primary: {
 						usedPercent: undefined,
@@ -7408,12 +7409,12 @@ describe("codex manager cli commands", () => {
 		expect(fetchCodexQuotaSnapshotMock).toHaveBeenNthCalledWith(1, {
 			accountId: "workspace-alpha",
 			accessToken: "access-alpha",
-			model: "gpt-5.5",
+			model: DEFAULT_MODEL,
 		});
 		expect(fetchCodexQuotaSnapshotMock).toHaveBeenNthCalledWith(2, {
 			accountId: "workspace-beta",
 			accessToken: "access-beta",
-			model: "gpt-5.5",
+			model: DEFAULT_MODEL,
 		});
 		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
 		expect(saveQuotaCacheMock).toHaveBeenCalledWith({

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -149,6 +149,13 @@ describe("runForecastCommand", () => {
 		expect(deps.logError).toHaveBeenCalledWith("Missing value for --model");
 	});
 
+	it("rejects a whitespace-only --model value", async () => {
+		const deps = createDeps();
+		const result = await runForecastCommand(["--model", "   "], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith("Missing value for --model");
+	});
+
 	it("prints json output for populated storage", async () => {
 		const deps = createDeps();
 		const result = await runForecastCommand(["--json"], deps);

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -134,6 +134,21 @@ describe("runForecastCommand", () => {
 		expect(deps.logError).toHaveBeenCalledWith("Unknown option: --bogus");
 	});
 
+	it("rejects a flag-like value after --model instead of consuming it", async () => {
+		// "--model --json" must NOT swallow --json as the model value.
+		const deps = createDeps();
+		const result = await runForecastCommand(["--model", "--json"], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith("Missing value for --model");
+	});
+
+	it("rejects an empty flag-like --model= value", async () => {
+		const deps = createDeps();
+		const result = await runForecastCommand(["--model=--json"], deps);
+		expect(result).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith("Missing value for --model");
+	});
+
 	it("prints json output for populated storage", async () => {
 		const deps = createDeps();
 		const result = await runForecastCommand(["--json"], deps);

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../lib/codex-manager/commands/forecast.js";
 import { CodexUnavailableError } from "../lib/errors.js";
 import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../lib/quota-probe.js";
+import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 
 function createStorage(): AccountStorageV3 {
@@ -124,6 +125,9 @@ describe("runForecastCommand", () => {
 		expect(result).toBe(0);
 		expect(deps.logInfo).toHaveBeenCalledWith(
 			expect.stringContaining("codex-multi-auth forecast"),
+		);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			expect.stringContaining(`(default: ${DEFAULT_MODEL})`),
 		);
 	});
 

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -143,5 +143,12 @@ describe("codex-manager help parsers", () => {
 			reason: "error",
 			message: "Missing value for --model",
 		});
+		// The short -m alias is first-class too.
+		expect(parseBestArgs(["-m", "--json"])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Missing value for --model",
+		});
+		expect(parseBestArgs(["-m", "gpt-5.5"]).ok).toBe(true);
 	});
 });

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -89,6 +89,15 @@ describe("codex-manager help parsers", () => {
 	});
 
 	it("parses best args and treats help as a first-class result", () => {
+		expect(parseBestArgs([])).toEqual({
+			ok: true,
+			options: {
+				live: false,
+				json: false,
+				model: "gpt-5.5",
+				modelProvided: false,
+			},
+		});
 		expect(parseBestArgs(["--live", "--json", "--model", "gpt-5"])).toEqual({
 			ok: true,
 			options: {

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -125,4 +125,23 @@ describe("codex-manager help parsers", () => {
 			message: "Unknown option: --bogus",
 		});
 	});
+
+	it("rejects a flag-like value after --model instead of consuming it", () => {
+		// "best --model --json" / "--model --live" must not swallow the next flag.
+		expect(parseBestArgs(["--model", "--json"])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Missing value for --model",
+		});
+		expect(parseBestArgs(["--model", "--live"])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Missing value for --model",
+		});
+		expect(parseBestArgs(["--model=--json"])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Missing value for --model",
+		});
+	});
 });

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -143,6 +143,12 @@ describe("codex-manager help parsers", () => {
 			reason: "error",
 			message: "Missing value for --model",
 		});
+		// A whitespace-only value trims to empty and must be rejected too.
+		expect(parseBestArgs(["--model", "   "])).toEqual({
+			ok: false,
+			reason: "error",
+			message: "Missing value for --model",
+		});
 		// The short -m alias is first-class too.
 		expect(parseBestArgs(["-m", "--json"])).toEqual({
 			ok: false,

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	parseAuthLoginArgs,
 	parseBestArgs,
+	printBestUsage,
 } from "../lib/codex-manager/help.js";
+import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
 
 describe("codex-manager help parsers", () => {
 	it("parses login flags without printing usage", () => {
@@ -94,7 +96,7 @@ describe("codex-manager help parsers", () => {
 			options: {
 				live: false,
 				json: false,
-				model: "gpt-5.5",
+				model: DEFAULT_MODEL,
 				modelProvided: false,
 			},
 		});
@@ -111,6 +113,17 @@ describe("codex-manager help parsers", () => {
 			ok: false,
 			reason: "help",
 		});
+	});
+
+	it("renders the default probe model from DEFAULT_MODEL in best usage", () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		printBestUsage();
+
+		expect(logSpy).toHaveBeenCalledTimes(1);
+		const usage = String(logSpy.mock.calls[0]?.[0]);
+		expect(usage).toContain(`(default: ${DEFAULT_MODEL})`);
+		logSpy.mockRestore();
 	});
 
 	it("reports missing model values and unknown flags", () => {

--- a/test/codex-manager-integrations-command.test.ts
+++ b/test/codex-manager-integrations-command.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { runIntegrationsCommand } from "../lib/codex-manager/commands/integrations.js";
+import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
 
 describe("integrations command", () => {
 	it("prints selected json snippets", async () => {
@@ -15,7 +16,7 @@ describe("integrations command", () => {
 		expect(payload.snippets).toHaveLength(1);
 		expect(payload.snippets[0]?.kind).toBe("python");
 		expect(payload.snippets[0]?.body).toContain("client.responses.create");
-		expect(payload.snippets[0]?.body).toContain('model="gpt-5.5"');
+		expect(payload.snippets[0]?.body).toContain(`model="${DEFAULT_MODEL}"`);
 		expect(payload.snippets[0]?.body).toContain("CODEX_MULTI_AUTH_LOCAL_KEY");
 	});
 

--- a/test/codex-manager-integrations-command.test.ts
+++ b/test/codex-manager-integrations-command.test.ts
@@ -28,4 +28,24 @@ describe("integrations command", () => {
 		expect(exitCode).toBe(1);
 		expect(String(logError.mock.calls[0]?.[0])).toContain("invalid value");
 	});
+
+	it("rejects a flag-like value after --model instead of consuming it", async () => {
+		const logError = vi.fn();
+		const exitCode = await runIntegrationsCommand(["--model", "-x"], {
+			logInfo: vi.fn(),
+			logError,
+		});
+		expect(exitCode).toBe(1);
+		expect(logError).toHaveBeenCalledWith("Missing value for --model");
+	});
+
+	it("rejects a whitespace-only --model value", async () => {
+		const logError = vi.fn();
+		const exitCode = await runIntegrationsCommand(["--model", "   "], {
+			logInfo: vi.fn(),
+			logError,
+		});
+		expect(exitCode).toBe(1);
+		expect(logError).toHaveBeenCalledWith("Missing value for --model");
+	});
 });

--- a/test/codex-manager-integrations-command.test.ts
+++ b/test/codex-manager-integrations-command.test.ts
@@ -15,6 +15,7 @@ describe("integrations command", () => {
 		expect(payload.snippets).toHaveLength(1);
 		expect(payload.snippets[0]?.kind).toBe("python");
 		expect(payload.snippets[0]?.body).toContain("client.responses.create");
+		expect(payload.snippets[0]?.body).toContain('model="gpt-5.5"');
 		expect(payload.snippets[0]?.body).toContain("CODEX_MULTI_AUTH_LOCAL_KEY");
 	});
 

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -520,7 +520,7 @@ describe("runReportCommand", () => {
 		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledWith({
 			accountId: "acct-live",
 			accessToken: "access-token-1",
-			model: "gpt-5.3-codex",
+			model: "gpt-5.5",
 		});
 	});
 

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -92,6 +92,17 @@ describe("runReportCommand", () => {
 		expect(deps.logError).toHaveBeenCalledWith("Unknown option: --bogus");
 	});
 
+	it("rejects a flag-like or whitespace-only --model value instead of consuming it", async () => {
+		// Split-arg form trims before validating, so "  -x" / "   " can't slip
+		// through and silently fall back to the default model.
+		for (const bad of ["--json", "  -x", "   "]) {
+			const deps = createDeps();
+			const result = await runReportCommand(["--model", bad], deps);
+			expect(result).toBe(1);
+			expect(deps.logError).toHaveBeenCalledWith("Missing value for --model");
+		}
+	});
+
 	it("rejects invalid live probe budget values", async () => {
 		const deps = createDeps();
 

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -4,6 +4,7 @@ import {
 	runReportCommand,
 } from "../lib/codex-manager/commands/report.js";
 import { CodexUnavailableError } from "../lib/errors.js";
+import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
 import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../lib/quota-probe.js";
 import type { AccountStorageV3, StorageHealthSummary } from "../lib/storage.js";
 
@@ -531,7 +532,7 @@ describe("runReportCommand", () => {
 		expect(deps.fetchCodexQuotaSnapshot).toHaveBeenCalledWith({
 			accountId: "acct-live",
 			accessToken: "access-token-1",
-			model: "gpt-5.5",
+			model: DEFAULT_MODEL,
 		});
 	});
 

--- a/test/codex-prompts.test.ts
+++ b/test/codex-prompts.test.ts
@@ -118,6 +118,37 @@ describe("Codex Prompts Module", () => {
 	});
 
 	describe("getCodexInstructions", () => {
+		it("uses gpt-5.5 prompt family by default", async () => {
+			mockedReadFile.mockRejectedValue(new Error("ENOENT"));
+			mockFetch.mockImplementation((input) => {
+				if (typeof input === "string" && input.includes("api.github.com")) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ tag_name: "rust-v0.120.0" }),
+					});
+				}
+				return Promise.resolve({
+					ok: true,
+					text: () => Promise.resolve("default model instructions"),
+					headers: { get: () => "etag" },
+				});
+			});
+			mockedMkdir.mockResolvedValue(undefined);
+			mockedWriteFile.mockResolvedValue(undefined);
+
+			const result = await getCodexInstructions();
+
+			expect(result).toBe("default model instructions");
+			const rawUrls = mockFetch.mock.calls
+				.map((call) => call[0])
+				.filter(
+					(url): url is string =>
+						typeof url === "string" && url.includes("raw.githubusercontent.com"),
+				);
+			expect(rawUrls.some((url) => url.includes("gpt_5_2_prompt.md"))).toBe(true);
+			expect(rawUrls.some((url) => url.includes("gpt_5_codex_prompt.md"))).toBe(false);
+		});
+
 		describe("Memory cache behavior", () => {
 			it("should return cached content within TTL", async () => {
 				const recentTimestamp = Date.now() - 5 * 60 * 1000;

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -336,7 +336,7 @@ describe("Documentation Integrity", () => {
 		const help = read(helpPath);
 		const switchCommand = read(switchPath);
 
-		expect(readme).toContain("codex-multi-auth fix --live --model gpt-5.3-codex");
+		expect(readme).toContain("codex-multi-auth fix --live --model gpt-5.5");
 		expect(commandRef).toContain(
 			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle |",
 		);

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { UI_COPY } from "../lib/ui/copy.js";
+import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
 
 const projectRoot = resolve(process.cwd());
 
@@ -336,7 +337,9 @@ describe("Documentation Integrity", () => {
 		const help = read(helpPath);
 		const switchCommand = read(switchPath);
 
-		expect(readme).toContain("codex-multi-auth fix --live --model gpt-5.5");
+		expect(readme).toContain(
+			`codex-multi-auth fix --live --model ${DEFAULT_MODEL}`,
+		);
 		expect(commandRef).toContain(
 			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle |",
 		);

--- a/test/package-bin.test.ts
+++ b/test/package-bin.test.ts
@@ -14,7 +14,13 @@ describe("package bin entries", () => {
 		expect(pkg.bin?.["codex-multi-auth-app-launcher"]).toBe("scripts/codex-app-launcher.js");
 		expect(pkg.bin?.["codex-multi-auth"]).toBe("scripts/codex-multi-auth.js");
 		expect(pkg.bin?.["codex-multi-auth-opencode-install"]).toBeUndefined();
-		expect(pkg.files).toEqual(expect.arrayContaining(["vendor/codex-ai-plugin/", "vendor/codex-ai-sdk/"]));
+		expect(pkg.files).toEqual(
+			expect.arrayContaining([
+				".codex-plugin/plugin.json",
+				"vendor/codex-ai-plugin/",
+				"vendor/codex-ai-sdk/",
+			]),
+		);
 		expect(pkg.bundleDependencies).toEqual(expect.arrayContaining(["@codex-ai/plugin"]));
 	});
 

--- a/test/quota-probe.test.ts
+++ b/test/quota-probe.test.ts
@@ -30,6 +30,7 @@ import {
 	CODEX_UNAVAILABLE_PROBE_NOTE,
 } from "../lib/quota-probe.js";
 import { CodexUnavailableError } from "../lib/errors.js";
+import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
 
 function makeQuotaHeaders(overrides: Record<string, string> = {}): Headers {
 	const headers = new Headers({
@@ -95,9 +96,51 @@ describe("quota-probe", () => {
 			accessToken: "token-1",
 		});
 
-		expect(snapshot.model).toBe("gpt-5.5");
-		expect(getCodexInstructionsMock).toHaveBeenCalledWith("gpt-5.5");
+		expect(snapshot.model).toBe(DEFAULT_MODEL);
+		expect(getCodexInstructionsMock).toHaveBeenCalledWith(DEFAULT_MODEL);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back from the default model to gpt-5.4 when the default is unsupported", async () => {
+		// The default probe chain leads with DEFAULT_MODEL; if the account cannot
+		// use it, the next candidate (gpt-5.4) must be tried before any codex model.
+		const unsupported = new Response(
+			JSON.stringify({
+				error: {
+					message: `Model ${DEFAULT_MODEL} unsupported`,
+					type: "invalid_request_error",
+				},
+			}),
+			{ status: 400, headers: new Headers({ "content-type": "application/json" }) },
+		);
+		const ok = new Response("", {
+			status: 200,
+			headers: makeQuotaHeaders({ "x-codex-primary-used-percent": "11" }),
+		});
+		const fetchMock = vi.fn().mockResolvedValueOnce(unsupported).mockResolvedValueOnce(ok);
+		vi.stubGlobal("fetch", fetchMock);
+
+		getUnsupportedCodexModelInfoMock
+			.mockReturnValueOnce({
+				isUnsupported: true,
+				unsupportedModel: DEFAULT_MODEL,
+				message: "unsupported",
+			})
+			.mockReturnValue({
+				isUnsupported: false,
+				unsupportedModel: undefined,
+				message: undefined,
+			});
+
+		const snapshot = await fetchCodexQuotaSnapshot({
+			accountId: "acc-1",
+			accessToken: "token-1",
+		});
+
+		expect(snapshot.model).toBe("gpt-5.4");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(getCodexInstructionsMock).toHaveBeenNthCalledWith(1, DEFAULT_MODEL);
+		expect(getCodexInstructionsMock).toHaveBeenNthCalledWith(2, "gpt-5.4");
 	});
 
 	it("falls back to next model when first model is unsupported", async () => {

--- a/test/quota-probe.test.ts
+++ b/test/quota-probe.test.ts
@@ -84,6 +84,22 @@ describe("quota-probe", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
+	it("uses gpt-5.5 as the default quota probe model", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response("", { status: 200, headers: makeQuotaHeaders() }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const snapshot = await fetchCodexQuotaSnapshot({
+			accountId: "acc-1",
+			accessToken: "token-1",
+		});
+
+		expect(snapshot.model).toBe("gpt-5.5");
+		expect(getCodexInstructionsMock).toHaveBeenCalledWith("gpt-5.5");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("falls back to next model when first model is unsupported", async () => {
 		const unsupported = new Response(
 			JSON.stringify({

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -114,6 +114,7 @@ const {
 	runDoctor,
 	runFix,
 	runVerifyFlagged,
+	parseFixArgs,
 } = await import("../lib/codex-manager/repair-commands.js");
 
 function createDeps(
@@ -159,6 +160,25 @@ describe("repair-commands direct deps coverage", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	it("parseFixArgs rejects a flag-like value after --model instead of consuming it", () => {
+		// "fix --model --json" / "--model --live" must not swallow the next flag.
+		expect(parseFixArgs(["--model", "--json"])).toEqual({
+			ok: false,
+			message: "Missing value for --model",
+		});
+		expect(parseFixArgs(["--model", "--live"])).toEqual({
+			ok: false,
+			message: "Missing value for --model",
+		});
+		expect(parseFixArgs(["--model=--json"])).toEqual({
+			ok: false,
+			message: "Missing value for --model",
+		});
+		// A real model value is still accepted.
+		const okParse = parseFixArgs(["--model", "gpt-5.5"]);
+		expect(okParse.ok).toBe(true);
 	});
 
 	it("runVerifyFlagged uses the injected identity resolver in the direct no-restore flow", async () => {

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -176,9 +176,14 @@ describe("repair-commands direct deps coverage", () => {
 			ok: false,
 			message: "Missing value for --model",
 		});
-		// A real model value is still accepted.
-		const okParse = parseFixArgs(["--model", "gpt-5.5"]);
-		expect(okParse.ok).toBe(true);
+		// The short -m form is first-class too and must reject flag-like values.
+		expect(parseFixArgs(["-m", "--json"])).toEqual({
+			ok: false,
+			message: "Missing value for --model",
+		});
+		// A real model value is still accepted (both long and short forms).
+		expect(parseFixArgs(["--model", "gpt-5.5"]).ok).toBe(true);
+		expect(parseFixArgs(["-m", "gpt-5.5"]).ok).toBe(true);
 	});
 
 	it("runVerifyFlagged uses the injected identity resolver in the direct no-restore flow", async () => {

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -176,6 +176,11 @@ describe("repair-commands direct deps coverage", () => {
 			ok: false,
 			message: "Missing value for --model",
 		});
+		// A whitespace-only value trims to empty and must be rejected too.
+		expect(parseFixArgs(["--model", "   "])).toEqual({
+			ok: false,
+			message: "Missing value for --model",
+		});
 		// The short -m form is first-class too and must reject flag-like values.
 		expect(parseFixArgs(["-m", "--json"])).toEqual({
 			ok: false,

--- a/test/runtime-quota-probe.test.ts
+++ b/test/runtime-quota-probe.test.ts
@@ -42,7 +42,7 @@ describe("fetchRuntimeCodexQuotaSnapshot", () => {
 			getUnsupportedCodexModelInfo: () => ({ isUnsupported: false }),
 		});
 
-		expect(snapshot.model).toBe("gpt-5.3-codex");
+		expect(snapshot.model).toBe("gpt-5.5");
 		expect(snapshot.planType).toBe("plus");
 		expect(parseCodexQuotaSnapshot).toHaveBeenCalledOnce();
 	});
@@ -90,7 +90,7 @@ describe("fetchRuntimeCodexQuotaSnapshot", () => {
 			}),
 		});
 
-		expect(snapshot.model).toBe("gpt-5.2-codex");
+		expect(snapshot.model).toBe("gpt-5.4");
 		expect(fetchImpl).toHaveBeenCalledTimes(2);
 	});
 });

--- a/test/runtime-quota-probe.test.ts
+++ b/test/runtime-quota-probe.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { fetchRuntimeCodexQuotaSnapshot } from "../lib/runtime/quota-probe.js";
+import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
 
 function makeQuotaHeaders(overrides: Record<string, string> = {}): Headers {
 	return new Headers({
@@ -42,7 +43,7 @@ describe("fetchRuntimeCodexQuotaSnapshot", () => {
 			getUnsupportedCodexModelInfo: () => ({ isUnsupported: false }),
 		});
 
-		expect(snapshot.model).toBe("gpt-5.5");
+		expect(snapshot.model).toBe(DEFAULT_MODEL);
 		expect(snapshot.planType).toBe("plus");
 		expect(parseCodexQuotaSnapshot).toHaveBeenCalledOnce();
 	});


### PR DESCRIPTION
## Summary
- set `gpt-5.5` as the default live/quota probe model, while keeping legacy Codex fallback compatibility
- report Codex-unavailable accounts as signed-in only instead of working
- include the Codex plugin manifest in the packed package and keep icon packaging covered by tests
- update integrations/default prompt handling and README examples to match the new default

## Verification
- `npm test -- --run test/codex-manager-cli.test.ts test/codex-manager-help.test.ts test/quota-probe.test.ts test/codex-manager-integrations-command.test.ts`
- `npm test -- --run test/codex-prompts.test.ts test/documentation.test.ts test/runtime-rotation-proxy.test.ts`
- `npm test -- --run test/runtime-quota-probe.test.ts test/runtime-account-check.test.ts test/repair-commands.test.ts test/package-bin.test.ts test/check-pack-budget.test.ts test/plugin-manifest.test.ts`
- `npm run typecheck`
- `npm run pack:check`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr promotes `gpt-5.5` as the default live/quota probe model, unifies both the manager and runtime probe fallback chains into a single `QUOTA_PROBE_MODEL_CHAIN` constant, corrects the misleading "signed in and working" label for codex-unavailable accounts, adds exact-file validation for the plugin manifest in npm pack budgets, and hardens `--model` flag parsing across all command modules to reject flag-like next-arg values.

- **default probe model + chain unification**: `DEFAULT_MODEL = \"gpt-5.5\"` and `QUOTA_PROBE_MODEL_CHAIN = [gpt-5.5, gpt-5.4, gpt-5.3-codex, ...]` exported from `model-map.ts`; both `lib/quota-probe.ts` and `lib/runtime/quota-probe.ts` now import the same list, eliminating drift between the manager and runtime probe paths.
- **live account status semantics**: `CodexUnavailableError` and probe-skip paths now land in `signedInOnly` (not `ok`), and the live summary shows `codexAvailable | signed in only | need re-login` instead of a single \"working\" bucket, making plan-access failures visible at a glance.
- **pack budget + plugin manifest**: `.codex-plugin/plugin.json` added to `package.json` files field and to `REQUIRED_FILES` (exact-path check); `README.md` and `LICENSE` migrated from prefix-match to exact-match, closing a bug where `README.md.bak` could satisfy the README requirement.

<h3>Confidence Score: 5/5</h3>

safe to merge; all changed paths have corresponding test coverage and the runtime-rotation fallback model logic is correctly preserved

the logic change is well-contained — a constant rename, a label correction, and a pack-budget exact-file gate. the probe chain unification eliminates an existing drift risk. the two minor observations (dead `ok` tracking in live mode, missing absence-tests for README/LICENSE) don't affect runtime correctness

lib/codex-manager.ts (dead `ok` counter in live path) and test/check-pack-budget.test.ts (no test for absent README.md or LICENSE)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/helpers/model-map.ts | adds DEFAULT_MODEL = gpt-5.5 and QUOTA_PROBE_MODEL_CHAIN as single source of truth for the ordered probe fallback list; clean change |
| lib/codex-manager.ts | live summary switched to codexAvailable/signedInOnly/failed counters; ok variable is still incremented in live mode but never displayed or used in the live path |
| lib/quota-probe.ts | switches DEFAULT_QUOTA_PROBE_MODELS to import QUOTA_PROBE_MODEL_CHAIN; probe now leads with gpt-5.5 and includes gpt-5.4 before legacy codex models |
| lib/runtime/quota-probe.ts | QUOTA_PROBE_MODELS unified with manager probe via shared QUOTA_PROBE_MODEL_CHAIN; eliminates drift between runtime and manager probe chains |
| lib/runtime-rotation-proxy.ts | model-less /codex/responses requests correctly fall back to CURRENT_CODEX_MODEL (gpt-5.3-codex) rather than DEFAULT_MODEL to preserve codex family bucketing; comment explains the rationale |
| scripts/check-pack-budget-lib.js | adds REQUIRED_FILES array with exact-path matching for plugin.json, README.md, and LICENSE; fixes a prior bug where README.md.bak could satisfy README.md via prefix matching |
| test/check-pack-budget.test.ts | adds tests for exact-file match enforcement for plugin.json and the .bak-sibling corner case; README.md and LICENSE absence paths remain untested under the new exact-file logic |
| lib/integration-generators.ts | removes local DEFAULT_MODEL = gpt-5.3-codex constant; imports shared DEFAULT_MODEL (gpt-5.5) from model-map instead |
| package.json | adds .codex-plugin/plugin.json to the files array so the plugin manifest is included in npm pack output |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runHealthCheck liveProbe=true] --> B{usable token?}
    B -- yes --> C{accountId present?}
    B -- no --> D[queuedRefresh]
    D -- success --> C
    D -- fail + sessionValid --> E[warnings++ signedInOnly++]
    D -- fail session dead --> F[failed++]
    C -- no --> G[ok++ warnings++ signedInOnly++ tone=warning]
    C -- yes --> H[fetchCodexQuotaSnapshot via QUOTA_PROBE_MODEL_CHAIN]
    H --> I{probe result}
    I -- success --> J[ok++ codexAvailable++ tone=success]
    I -- CodexUnavailableError --> K[ok++ warnings++ signedInOnly++ tone=warning]
    I -- other error --> K
    E --> M[live summary]
    F --> M
    J --> M
    K --> M
    G --> M
    M --> N[codexAvailable - signed in only - need re-login]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/codex-manager.ts:2204-2207
**`ok` counter is dead code in live probe mode**

in live mode the result summary uses `codexAvailable`, `signedInOnly`, and `failed` exclusively — `ok` is still incremented but never read or displayed in that path. the variable isn't harmful, but it adds cognitive load when tracing the live-mode counter semantics. consider dropping `ok += 1` from the fresh-token and refresh-success branches when `liveProbe` is true, or adding a brief comment that `ok` is only meaningful in non-live mode.

### Issue 2 of 2
test/check-pack-budget.test.ts:857-873
**missing vitest coverage for absent README.md and LICENSE under new exact-match logic**

`README.md` and `LICENSE` moved from `REQUIRED_PREFIXES` (prefix match) to `REQUIRED_FILES` (exact `Array.includes`). the new tests only cover `.codex-plugin/plugin.json` absence and the `.bak`-sibling edge case. there are no cases that drop `README.md` or `LICENSE` from the paths list and assert the validation throws — so a regression that silently drops them from `REQUIRED_FILES` wouldn't be caught.

`````

</details>

<sub>Reviews (10): Last reviewed commit: ["refactor(#506): single probe-chain const..."](https://github.com/ndycode/codex-multi-auth/commit/3239f7194284d53fb9d2cb01418825b49b647943) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35311578)</sub>

<!-- /greptile_comment -->