### PR TITLE
fix(forecast): ignore stale time-bounded runtime overlay reasons (#507)

### DIFF
--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -258,11 +258,36 @@ export function evaluateForecastAccount(
 		overlay?.accountSkipReasons?.[String(index)] ??
 		overlay?.lastPoolExhaustionSkipReasons?.[String(index)] ??
 		null;
+	// Time-bounded overlay reasons ("rate-limited", "cooling-down:...") are
+	// persisted to runtime-observability.json on pool exhaustion and only ever
+	// cleared by an explicit runtime reset, never on a subsequent successful
+	// request. That leaves a stale reason on disk after the underlying window
+	// expires, so the forecast would keep marking a working account as
+	// unavailable. Cross-reference the time-aware disk state before applying:
+	// drop the overlay reason when the condition it describes is no longer
+	// active. Each reason validates only against its own backing disk state
+	// ("rate-limited" -> rateLimitResetTimes, "cooling-down" -> coolingDownUntil)
+	// so we never substitute a misleading reason string. Non-time-bounded
+	// reasons ("circuit-open", "token-exhausted", "policy-blocked") have no disk
+	// expiry to check and are always applied.
+	const coolingDownActive =
+		typeof account.coolingDownUntil === "number" &&
+		account.coolingDownUntil > now;
+	const isStaleOverlayReason =
+		overlayReason === "rate-limited"
+			? rateLimitResetAt === null
+			: overlayReason?.startsWith("cooling-down")
+				? !coolingDownActive
+				: false;
 	if (overlay?.policyBlockedIndexes?.includes(index)) {
 		availability = "unavailable";
 		riskScore += 95;
 		reasons.push("runtime policy blocked account");
-	} else if (overlayReason && overlayReason !== "already-attempted") {
+	} else if (
+		overlayReason &&
+		overlayReason !== "already-attempted" &&
+		!isStaleOverlayReason
+	) {
 		availability = "unavailable";
 		riskScore +=
 			overlayReason === "circuit-open"

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -229,6 +229,29 @@ describe("forecast helpers", () => {
 		expect(result.reasons).not.toContain("runtime skip: rate-limited");
 	});
 
+	it("ignores a stale rate-limited overlay when rateLimitResetTimes is absent", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+			// No rateLimitResetTimes field at all: the limit was cleared (runtime
+			// reset or a successful request) after the overlay was written.
+		};
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "rate-limited" },
+			},
+		});
+
+		expect(result.availability).toBe("ready");
+		expect(result.reasons).not.toContain("runtime skip: rate-limited");
+	});
+
 	it("applies a rate-limited overlay when the rate limit is still active on disk", () => {
 		const now = 1_700_000_000_000;
 		const result = evaluateForecastAccount({
@@ -282,6 +305,30 @@ describe("forecast helpers", () => {
 				addedAt: now - 10_000,
 				lastUsed: now - 10_000,
 				coolingDownUntil: now - 1,
+			},
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "cooling-down:server-error" },
+			},
+		});
+
+		expect(result.availability).toBe("ready");
+		expect(result.reasons).not.toContain(
+			"runtime skip: cooling-down:server-error",
+		);
+	});
+
+	it("ignores a stale cooling-down overlay when coolingDownUntil is absent", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				// No coolingDownUntil field at all: cooldown cleared after the
+				// overlay was written.
 			},
 			runtimeOverlay: {
 				lastPoolExhaustionSkipReasons: { "0": "cooling-down:server-error" },

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -182,8 +182,8 @@ describe("forecast helpers", () => {
 		expect(overlaid.reasons).toContain("runtime skip: circuit-open");
 	});
 
-	it.each(["rate-limited", "cooling-down:server-error", "workspace-disabled"])(
-		"marks runtime skip reason %s as unavailable",
+	it.each(["circuit-open", "token-exhausted", "workspace-disabled"])(
+		"marks non-time-bounded runtime skip reason %s as unavailable",
 		(reason) => {
 			const now = 1_700_000_000_000;
 			const result = evaluateForecastAccount({
@@ -204,6 +204,116 @@ describe("forecast helpers", () => {
 			expect(result.reasons).toContain(`runtime skip: ${reason}`);
 		},
 	);
+
+	it("ignores a stale rate-limited overlay when no rate limit is active on disk", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+			// Expired entry: clearExpiredRateLimits-equivalent semantics mean this
+			// is no longer an active rate limit.
+			rateLimitResetTimes: { codex: now - 30_000 },
+		};
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "rate-limited" },
+			},
+		});
+
+		expect(result.availability).toBe("ready");
+		expect(result.reasons).not.toContain("runtime skip: rate-limited");
+	});
+
+	it("applies a rate-limited overlay when the rate limit is still active on disk", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				rateLimitResetTimes: { codex: now + 30_000 },
+			},
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "rate-limited" },
+			},
+		});
+
+		expect(result.availability).toBe("unavailable");
+		expect(result.reasons).toContain("runtime skip: rate-limited");
+	});
+
+	it("applies a rate-limited overlay when a model-scoped limit is active on disk", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				rateLimitResetTimes: { "codex:5h": now + 30_000 },
+			},
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "rate-limited" },
+			},
+		});
+
+		expect(result.availability).toBe("unavailable");
+		expect(result.reasons).toContain("runtime skip: rate-limited");
+	});
+
+	it("ignores a stale cooling-down overlay when cooldown has elapsed on disk", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				coolingDownUntil: now - 1,
+			},
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "cooling-down:server-error" },
+			},
+		});
+
+		expect(result.availability).toBe("ready");
+		expect(result.reasons).not.toContain(
+			"runtime skip: cooling-down:server-error",
+		);
+	});
+
+	it("applies a cooling-down overlay when cooldown is still active on disk", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				coolingDownUntil: now + 60_000,
+			},
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "cooling-down:server-error" },
+			},
+		});
+
+		expect(result.availability).toBe("unavailable");
+		expect(result.reasons).toContain("runtime skip: cooling-down:server-error");
+	});
 
 	it("recommends the best ready account", () => {
 		const now = 1_700_000_000_000;

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -252,6 +252,55 @@ describe("forecast helpers", () => {
 		expect(result.reasons).not.toContain("runtime skip: rate-limited");
 	});
 
+	it("ignores a stale overlay reason resolved from accountSkipReasons (precedence path)", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				// No active rate limit or cooldown on disk.
+			},
+			runtimeOverlay: {
+				// accountSkipReasons takes precedence over
+				// lastPoolExhaustionSkipReasons in the resolver; the staleness guard
+				// must apply to whichever key wins.
+				accountSkipReasons: { "0": "rate-limited" },
+				lastPoolExhaustionSkipReasons: { "0": "cooling-down:server-error" },
+			},
+		});
+
+		expect(result.availability).toBe("ready");
+		expect(result.reasons).not.toContain("runtime skip: rate-limited");
+		expect(result.reasons).not.toContain(
+			"runtime skip: cooling-down:server-error",
+		);
+	});
+
+	it("applies an active overlay reason resolved from accountSkipReasons (precedence path)", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				rateLimitResetTimes: { codex: now + 30_000 },
+			},
+			runtimeOverlay: {
+				accountSkipReasons: { "0": "rate-limited" },
+			},
+		});
+
+		expect(result.availability).toBe("unavailable");
+		expect(result.reasons).toContain("runtime skip: rate-limited");
+	});
+
 	it("applies a rate-limited overlay when the rate limit is still active on disk", () => {
 		const now = 1_700_000_000_000;
 		const result = evaluateForecastAccount({


### PR DESCRIPTION
## Summary

Fixes #507. `forecast --live` reported both accounts as `unavailable` (`runtime skip: rate-limited`) while Codex kept executing prompts successfully.

Root cause: the runtime overlay in `runtime-observability.json` persists a per-account skip reason on pool exhaustion and is only cleared by an explicit runtime reset, never on a subsequent successful request. Once the underlying window expired, the stale reason kept `lib/forecast.ts` marking the account `unavailable`. The proxy was unaffected because it rebuilds skip reasons fresh per request (`getAccountRuntimeSkipReason` -> `isRateLimitedForFamily`), which is why Codex still worked. `doctor`'s `forecast-runtime-alignment` warning surfaced the same stale state through the shared `evaluateForecastAccounts` call.

## Fix

In the overlay-application block of `evaluateForecastAccount`, validate time-bounded overlay reasons against the time-aware disk state before applying them:

- `rate-limited` is ignored when `getRateLimitResetTimeForFamily(account, now, "codex")` returns `null` (no active reset on disk, including model-scoped keys like `codex:5h`).
- `cooling-down:...` is ignored when `coolingDownUntil` is absent or `<= now`.

Each reason validates only against its own backing disk state, so the displayed reason string is never substituted with a misleading one. Non-time-bounded reasons (`circuit-open`, `token-exhausted`, `policy-blocked`) have no disk expiry and remain unconditional. The guard reuses the `rateLimitResetAt` value and the single `now` timestamp already computed in the function, so no extra disk read or clock skew is introduced.

## Tests

- Split the parametrized runtime-skip test into non-time-bounded reasons (still applied unconditionally).
- Added: stale `rate-limited` overlay with expired disk entry -> account ready, reason dropped.
- Added: active `rate-limited` overlay (`codex` and `codex:5h` future reset) -> account unavailable.
- Added: stale `cooling-down` overlay (elapsed `coolingDownUntil`) -> reason dropped.
- Added: active `cooling-down` overlay -> account unavailable.

## Verification

- `npx tsc --noEmit`: clean.
- `npx vitest run test/forecast.test.ts`: 31 passed.
- `npx vitest run` (full suite): 4365 passed, 6 skipped, 0 failed.

## Notes / follow-up

- `token-exhausted` shares the same overlay-staleness class but has no disk-backed reset time to validate against, so it is intentionally left unconditional. Fully clearing it would require clearing the skip reason on a successful proxy request (CodeRabbit design-choice option 2); out of scope for this bug. Worth a tracking issue.
- Possible duplicate of #479 (noted by CodeRabbit issue enrichment); this PR addresses the #507 report directly.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

fixes stale time-bounded runtime overlay reasons persisting in `runtime-observability.json` long after the underlying rate-limit window or cooldown expires, causing `forecast --live` to incorrectly report working accounts as `unavailable`.

- `lib/forecast.ts`: adds `isStaleOverlayReason` computed from the already-available `rateLimitResetAt` and `coolingDownActive` values; ignores `rate-limited` overlay when `getRateLimitResetTimeForFamily` returns `null`, and `cooling-down:…` overlay when `coolingDownUntil` is absent or elapsed. non-time-bounded reasons (`circuit-open`, `token-exhausted`, `policy-blocked`) are applied unconditionally.
- `test/forecast.test.ts`: nine new vitest cases cover expired and absent disk entries, both overlay-source precedence paths (`accountSkipReasons` vs `lastPoolExhaustionSkipReasons`), active boundaries, and model-scoped rate-limit keys (`codex:5h`); the `it.each` is narrowed to the three genuinely unconditional reasons.

<h3>Confidence Score: 5/5</h3>

the staleness guard is tightly scoped, reuses already-computed values, and all nine new tests pass; no functional regressions introduced.

the fix reads no extra disk state and introduces no new async paths; the ternary correctly short-circuits for null overlayReason and the policyBlockedIndexes branch is unaffected. test coverage spans both staleness sources, both time-bounded reason types, active/expired/absent disk state, and model-scoped keys.

no files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/forecast.ts | adds isStaleOverlayReason guard that cross-references live disk state before applying time-bounded overlay reasons; logic is correct and tightly scoped |
| test/forecast.test.ts | comprehensive new staleness tests covering both overlay sources, both time-bounded reasons, absent disk state, active/expired boundaries, and model-scoped keys; previous thread gap addressed |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[evaluateForecastAccount] --> B[resolve overlayReason\naccountSkipReasons ?? lastPoolExhaustionSkipReasons]
    B --> C{overlayReason type?}
    C -->|rate-limited| D[rateLimitResetAt === null?]
    C -->|cooling-down:...| E[coolingDownUntil absent or <= now?]
    C -->|other non-time-bounded| F[isStaleOverlayReason = false]
    D -->|yes - stale| G[drop reason, account stays ready]
    D -->|no - active| H[apply: availability=unavailable]
    E -->|yes - stale| G
    E -->|no - active| H
    F --> H
    H --> I[reasons.push: runtime skip: ...]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/forecast.test.ts`, line 208-321 ([link](https://github.com/ndycode/codex-multi-auth/blob/ff9c9f40f1d9e593662cf6b11684b24134fc442e/test/forecast.test.ts#L208-L321)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **missing coverage: stale overlay via `accountSkipReasons` source**

   `overlayReason` is resolved from `accountSkipReasons` first, then `lastPoolExhaustionSkipReasons`. all five new staleness tests exclusively use `lastPoolExhaustionSkipReasons`. if `accountSkipReasons` ever had a stale `"rate-limited"` or `"cooling-down:..."` entry the guard would fire identically, but there's no test confirming that — so a refactor of the resolution order or short-circuit logic would silently pass vitest.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/forecast.test.ts
   Line: 208-321

   Comment:
   **missing coverage: stale overlay via `accountSkipReasons` source**

   `overlayReason` is resolved from `accountSkipReasons` first, then `lastPoolExhaustionSkipReasons`. all five new staleness tests exclusively use `lastPoolExhaustionSkipReasons`. if `accountSkipReasons` ever had a stale `"rate-limited"` or `"cooling-down:..."` entry the guard would fire identically, but there's no test confirming that — so a refactor of the resolution order or short-circuit logic would silently pass vitest.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2F507-stale-runtime-overlay%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F507-stale-runtime-overlay%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fforecast.test.ts%0ALine%3A%20208-321%0A%0AComment%3A%0A**missing%20coverage%3A%20stale%20overlay%20via%20%60accountSkipReasons%60%20source**%0A%0A%60overlayReason%60%20is%20resolved%20from%20%60accountSkipReasons%60%20first%2C%20then%20%60lastPoolExhaustionSkipReasons%60.%20all%20five%20new%20staleness%20tests%20exclusively%20use%20%60lastPoolExhaustionSkipReasons%60.%20if%20%60accountSkipReasons%60%20ever%20had%20a%20stale%20%60%22rate-limited%22%60%20or%20%60%22cooling-down%3A...%22%60%20entry%20the%20guard%20would%20fire%20identically%2C%20but%20there's%20no%20test%20confirming%20that%20%E2%80%94%20so%20a%20refactor%20of%20the%20resolution%20order%20or%20short-circuit%20logic%20would%20silently%20pass%20vitest.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test(forecast): cover accountSkipReasons..."](https://github.com/ndycode/codex-multi-auth/commit/c547ff851057970c29ece9e91eb7b1f476ad403d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35379295)</sub>

<!-- /greptile_comment -->