### PR TITLE
feat(rotation): sequential drain-first account scheduling mode (#509)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,7 @@ These are safe for most operators and frequently used in day-to-day workflows.
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=<ms>` | HTTP request timeout override |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=<ms>` | Stream stall timeout override |
 | `CODEX_AUTH_MIN_ROTATION_INTERVAL_MS=<ms>` | Minimum time between global account switches (default `60000`). The proxy biases selection toward the last-served account within this window to reduce the rate at which different OAuth tokens appear from the same IP. Set to `0` to disable. |
+| `CODEX_AUTH_SCHEDULING_STRATEGY=hybrid/sequential` | Account scheduling strategy (default `hybrid`). `sequential` (drain-first) keeps one active account until it is fully exhausted before advancing to the next; see [Sequential / drain-first scheduling](#sequential--drain-first-scheduling). |
 | `CODEX_AUTH_TOKEN_INVALIDATION_COOLDOWN_MS=<ms>` | Cooldown applied to an account when the upstream or token-refresh endpoint explicitly revokes its OAuth token (default `300000`, 5 minutes). Raise this if accounts continue to be re-invalidated after re-login. |
 
 ---
@@ -116,6 +117,15 @@ The proxy preserves request bodies and streaming responses, replaces outbound au
 
 - **Token-invalidation detection**: when the upstream or the token-refresh endpoint returns an explicit OAuth revocation message, the proxy returns the error directly to the client instead of rotating to the next account. The affected account receives a 5-minute cooldown (`tokenInvalidationCooldownMs`, default `300000`) instead of the generic 30-second auth-failure cooldown. Configure via `CODEX_AUTH_TOKEN_INVALIDATION_COOLDOWN_MS`.
 - **Rotation-rate throttle**: the proxy biases account selection toward the last-served account for a configurable window (default 60 seconds, `minRotationIntervalMs`). Accounts that are rate-limited or cooling down are still rotated around. Configure via `CODEX_AUTH_MIN_ROTATION_INTERVAL_MS` or set to `0` to disable.
+
+### Sequential / drain-first scheduling
+
+`schedulingStrategy` controls how the proxy picks an account for each request:
+
+- `hybrid` (default) spreads load across all available accounts using a weighted health/token/freshness score. Both accounts tend to consume quota at a similar pace.
+- `sequential` (drain-first) routes every new request to one active account and only advances to the next available account once the current one is fully exhausted (rate-limited, cooling down, or circuit-open). Because the scan wraps the pool, an earlier account that has recovered its quota window is reclaimed as soon as the current account drains. This staggers quota recovery across accounts for longer uninterrupted sessions.
+
+In `sequential` mode a manual pin (`codex-multi-auth switch <index>`) still takes precedence and is never overridden. Sequential mode intentionally ignores per-session affinity: once the active account changes, all subsequent requests follow the new active account regardless of which account originally handled a conversation. Enable it with `schedulingStrategy: "sequential"` in settings or `CODEX_AUTH_SCHEDULING_STRATEGY=sequential` for a per-process trial.
 
 Microsoft/Outlook SSO accounts may be more sensitive to proxy-mediated token use. If an Outlook-linked account is invalidated on every first request through the proxy but works normally on ChatGPT web, the root cause is likely IP or device binding on the Microsoft side. Raising `CODEX_AUTH_TOKEN_INVALIDATION_COOLDOWN_MS` and re-logging in the affected account typically resolves the cascade. If the problem persists, consider excluding the Microsoft account from the rotation pool via `codex-multi-auth switch`.
 

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -65,6 +65,7 @@ Used only for host plugin mode through the host runtime config file.
 
 | Key | Default |
 | --- | --- |
+| `schedulingStrategy` | `hybrid` |
 | `retryAllAccountsRateLimited` | `true` |
 | `retryAllAccountsMaxWaitMs` | `0` |
 | `retryAllAccountsMaxRetries` | `Infinity` |
@@ -72,6 +73,8 @@ Used only for host plugin mode through the host runtime config file.
 | `fallbackOnUnsupportedCodexModel` | `false` |
 | `fallbackToGpt52OnUnsupportedGpt53` | `true` |
 | `unsupportedCodexFallbackChain` | `{}` |
+
+`schedulingStrategy` selects how the runtime proxy picks an account per request. `hybrid` (default) keeps the weighted health/token/freshness selection that spreads load across all available accounts. `sequential` (drain-first) sticks to one active account and only advances to the next available account once the current one is fully exhausted (rate-limited / cooling down / circuit-open); earlier accounts become eligible again as soon as their quota window recovers, staggering recovery across the pool. A manual pin still overrides this, and sequential mode intentionally ignores per-session affinity so all new requests follow the single active account. Overridable per-process via `CODEX_AUTH_SCHEDULING_STRATEGY`.
 
 ### Token / Recovery
 
@@ -220,6 +223,7 @@ Upgrade note:
 | `CODEX_TUI_GLYPHS` | TUI glyph mode |
 | `CODEX_AUTH_FETCH_TIMEOUT_MS` | Request timeout override |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS` | Stream stall timeout override |
+| `CODEX_AUTH_SCHEDULING_STRATEGY` | Account scheduling strategy override (`hybrid` or `sequential`/drain-first) |
 | `CODEX_MULTI_AUTH_SYNC_CODEX_CLI` | Toggle Codex CLI state sync |
 | `CODEX_MULTI_AUTH_REAL_CODEX_BIN` | Force official Codex binary path |
 | `CODEX_MULTI_AUTH_BYPASS` | Bypass local auth handling |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -143,6 +143,7 @@ Named backup behavior:
 | Key | Default | Effect |
 | --- | --- | --- |
 | `codexRuntimeRotationProxy` | `true` | Enable the default-on localhost Responses proxy for forwarded official Codex CLI/app sessions |
+| `schedulingStrategy` | `hybrid` | Account scheduling: `hybrid` spreads load across all available accounts; `sequential` (drain-first) keeps one active account until it is fully exhausted, then advances to the next |
 | `preemptiveQuotaEnabled` | `true` | Defer requests before remaining quota is critically low |
 | `preemptiveQuotaRemainingPercent5h` | `5` | 5-hour quota threshold |
 | `preemptiveQuotaRemainingPercent7d` | `5` | 7-day quota threshold |
@@ -207,6 +208,7 @@ Maintainer/debug-focused overrides include:
 - `CODEX_MULTI_AUTH_SYNC_CODEX_CLI`
 - `CODEX_MULTI_AUTH_REAL_CODEX_BIN`
 - `CODEX_MULTI_AUTH_BYPASS`
+- `CODEX_AUTH_SCHEDULING_STRATEGY` (`hybrid` | `sequential`; opt-in drain-first scheduling without editing settings)
 - `CODEX_CLI_ACCOUNTS_PATH`
 - `CODEX_CLI_AUTH_PATH`
 - refresh lease controls (`CODEX_AUTH_REFRESH_LEASE*`)

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -805,10 +805,19 @@ export class AccountManager {
 	 * Concurrency: mutates `currentAccountIndexByFamily` / `cursorByFamily` like
 	 * the sibling selectors; callers that need serialization wrap the call in the
 	 * routing mutex (see the proxy hot path). No I/O.
+	 *
+	 * `blockedIndexes` (optional) is the request's policy block set
+	 * (`RuntimePolicyDecision.blockedAccountIndexes`: paused / drained / lacking
+	 * capability for the model). Blocked accounts are treated as NOT usable so the
+	 * selector never commits the active pointer to an account that `chooseAccount`
+	 * would immediately reject — otherwise the drain-first primary could anchor on
+	 * a permanently-blocked account and degrade every future request to the linear
+	 * scan fallback (#509 review P1).
 	 */
 	getCurrentOrNextForFamilySequential(
 		family: ModelFamily,
 		model?: string | null,
+		blockedIndexes?: ReadonlySet<number>,
 	): ManagedAccount | null {
 		const count = this.accounts.length;
 		if (count === 0) return null;
@@ -818,6 +827,7 @@ export class AccountManager {
 		): account is ManagedAccount => {
 			if (!account) return false;
 			if (account.enabled === false) return false;
+			if (blockedIndexes?.has(account.index)) return false;
 			if (!this.hasEnabledWorkspaces(account)) return false;
 			clearExpiredRateLimits(account);
 			return (

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -789,6 +789,75 @@ export class AccountManager {
 		return null;
 	}
 
+	/**
+	 * Sequential / drain-first selection (issue #509).
+	 *
+	 * Unlike the round-robin and hybrid selectors, this does NOT advance on
+	 * every pick. It sticks to the current active account for the family and
+	 * keeps returning it while it is available; only when the active account is
+	 * fully exhausted (rate-limited / cooling down / circuit-open / disabled)
+	 * does it scan forward — wrapping around the pool — for the next available
+	 * account and make THAT the new active account. Because the scan starts from
+	 * the active index and wraps, an earlier account that has recovered its
+	 * quota window becomes eligible again as soon as the current account drains,
+	 * producing the staggered-recovery pattern requested in #509.
+	 *
+	 * Concurrency: mutates `currentAccountIndexByFamily` / `cursorByFamily` like
+	 * the sibling selectors; callers that need serialization wrap the call in the
+	 * routing mutex (see the proxy hot path). No I/O.
+	 */
+	getCurrentOrNextForFamilySequential(
+		family: ModelFamily,
+		model?: string | null,
+	): ManagedAccount | null {
+		const count = this.accounts.length;
+		if (count === 0) return null;
+
+		const isUsable = (
+			account: ManagedAccount | undefined,
+		): account is ManagedAccount => {
+			if (!account) return false;
+			if (account.enabled === false) return false;
+			if (!this.hasEnabledWorkspaces(account)) return false;
+			clearExpiredRateLimits(account);
+			return (
+				!isRateLimitedForFamily(account, family, model) &&
+				!this.isAccountCoolingDown(account) &&
+				this.isCircuitAvailable(account)
+			);
+		};
+
+		// Sticky: stay on the current active account while it is still usable so
+		// we drain it fully before moving on. A negative/unset active index falls
+		// through to the forward scan below.
+		const activeIndex = this.currentAccountIndexByFamily[family];
+		if (activeIndex >= 0 && activeIndex < count) {
+			const active = this.accounts[activeIndex];
+			if (isUsable(active)) {
+				active.lastUsed = nowMs();
+				return active;
+			}
+		}
+
+		// Active account is exhausted (or none set): scan forward from the active
+		// index, wrapping, for the next usable account and pin it as the new
+		// active account. Starting at the active index (not active+1) lets a
+		// recovered earlier account reclaim the active slot on wrap-around.
+		const start = activeIndex >= 0 && activeIndex < count ? activeIndex : 0;
+		for (let i = 0; i < count; i++) {
+			const idx = (start + i) % count;
+			const account = this.accounts[idx];
+			if (!isUsable(account)) continue;
+
+			this.currentAccountIndexByFamily[family] = idx;
+			this.cursorByFamily[family] = (idx + 1) % count;
+			account.lastUsed = nowMs();
+			return account;
+		}
+
+		return null;
+	}
+
 	getCurrentOrNextForFamilyHybrid(
 		family: ModelFamily,
 		model?: string | null,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -252,6 +252,7 @@ export const DEFAULT_PLUGIN_CONFIG: PluginConfig = {
 	preemptiveQuotaRemainingPercent7d: 5,
 	preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
 	routingMutex: "legacy",
+	schedulingStrategy: "hybrid",
 };
 
 const PLUGIN_CONFIG_FIELD_SCHEMAS = PluginConfigSchema.shape;
@@ -1887,6 +1888,36 @@ export function getRoutingMutexMode(
 	);
 }
 
+const SCHEDULING_STRATEGY_MODES = new Set<string>(["hybrid", "sequential"]);
+
+/**
+ * Resolve the account scheduling strategy (issue #509).
+ *
+ * - `"hybrid"` (default) keeps the existing weighted health/token/freshness
+ *   selection that spreads load across all available accounts.
+ * - `"sequential"` (a.k.a. drain-first) sticks to one active account and only
+ *   advances to the next available account once the current one is fully
+ *   exhausted (rate-limited / cooling down / circuit-open). Earlier accounts
+ *   become eligible again as soon as their quota window recovers, producing the
+ *   staggered-recovery pattern requested in #509. A manual pin still overrides
+ *   this; sequential mode ignores per-session affinity so all new requests
+ *   follow the single active account. The `CODEX_AUTH_SCHEDULING_STRATEGY` env
+ *   var accepts the same two values for opt-in trials without editing settings.
+ *
+ * Concurrency: pure read; safe for concurrent callers. Performs no I/O and is
+ * unaffected by Windows filesystem semantics. Contains no secrets.
+ */
+export function getSchedulingStrategy(
+	pluginConfig: PluginConfig,
+): "hybrid" | "sequential" {
+	return resolveStringSetting(
+		"CODEX_AUTH_SCHEDULING_STRATEGY",
+		pluginConfig.schedulingStrategy,
+		"hybrid",
+		SCHEDULING_STRATEGY_MODES,
+	);
+}
+
 type ConfigExplainMeta = {
 	key: keyof PluginConfig;
 	envNames: string[];
@@ -2236,6 +2267,11 @@ const CONFIG_EXPLAIN_ENTRIES: ConfigExplainMeta[] = [
 		key: "routingMutex",
 		envNames: ["CODEX_AUTH_ROUTING_MUTEX"],
 		getValue: getRoutingMutexMode,
+	},
+	{
+		key: "schedulingStrategy",
+		envNames: ["CODEX_AUTH_SCHEDULING_STRATEGY"],
+		getValue: getSchedulingStrategy,
 	},
 ];
 

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -23,6 +23,7 @@ import {
 	getTokenRefreshSkewMs,
 	getPidOffsetEnabled,
 	getRoutingMutexMode,
+	getSchedulingStrategy,
 	loadPluginConfig,
 } from "./config.js";
 import {
@@ -1162,6 +1163,7 @@ export function chooseAccount(params: {
 	skipReasons?: Map<number, string>;
 	stickyBoostByAccount?: Record<number, number>;
 	pidOffsetEnabled?: boolean;
+	schedulingStrategy?: "hybrid" | "sequential";
 }): ManagedAccount | null {
 	const {
 		accountManager,
@@ -1176,6 +1178,7 @@ export function chooseAccount(params: {
 		skipReasons,
 		stickyBoostByAccount,
 		pidOffsetEnabled,
+		schedulingStrategy,
 	} = params;
 
 	// Manual pin (from `codex-multi-auth switch <n>`) overrides every other
@@ -1209,6 +1212,44 @@ export function chooseAccount(params: {
 			return null;
 		}
 		return pinned;
+	}
+
+	// Sequential / drain-first mode (issue #509): the active account governs ALL
+	// new requests, so we deliberately SKIP the per-session affinity tier — there
+	// is no per-chat stickiness, every request follows the single active account.
+	// The manual pin above still wins (handled first). When the active account is
+	// exhausted the selector advances to the next available account and earlier
+	// accounts reclaim the slot once their quota recovers.
+	if (schedulingStrategy === "sequential") {
+		const selected = accountManager.getCurrentOrNextForFamilySequential(
+			family,
+			model,
+		);
+		if (
+			selected &&
+			!attemptedIndexes.has(selected.index) &&
+			!policy?.blockedAccountIndexes.has(selected.index)
+		) {
+			const reason = accountManager.getAccountRuntimeSkipReason(
+				selected.index,
+				family,
+				model,
+			);
+			if (!reason) return selected;
+			skipReasons?.set(selected.index, reason);
+		}
+
+		// Active account was attempted/blocked/skipped this request (e.g. it just
+		// rate-limited mid-loop): fall through to the shared linear scan below to
+		// find the next eligible account.
+		return chooseLinearScanFallback({
+			accountManager,
+			family,
+			model,
+			attemptedIndexes,
+			policy,
+			skipReasons,
+		});
 	}
 
 	const preferredIndex = sessionAffinityStore?.getPreferredAccountIndex(sessionKey, now);
@@ -1258,6 +1299,35 @@ export function chooseAccount(params: {
 		if (!reason) return selected;
 		skipReasons?.set(selected.index, reason);
 	}
+
+	return chooseLinearScanFallback({
+		accountManager,
+		family,
+		model,
+		attemptedIndexes,
+		policy,
+		skipReasons,
+	});
+}
+
+/**
+ * Shared linear-scan fallback used by both the hybrid and sequential selection
+ * paths in `chooseAccount`. Walks every account in pool order and returns the
+ * first one that is not already attempted, not policy-blocked, and has no
+ * runtime skip reason (rate-limited / cooling down / circuit-open), recording a
+ * skip reason for each rejected candidate. Mutates the round-robin cursor via
+ * `markSwitched` on the winner. Returns null when no eligible account remains.
+ */
+function chooseLinearScanFallback(params: {
+	accountManager: AccountManager;
+	family: ModelFamily;
+	model: string | null;
+	attemptedIndexes: ReadonlySet<number>;
+	policy: RuntimePolicyDecision | null;
+	skipReasons?: Map<number, string>;
+}): ManagedAccount | null {
+	const { accountManager, family, model, attemptedIndexes, policy, skipReasons } =
+		params;
 
 	for (const account of accountManager.getAccountsSnapshot()) {
 		if (attemptedIndexes.has(account.index)) {
@@ -1472,6 +1542,7 @@ export async function startRuntimeRotationProxy(
 	// mutations when routingMutex="enabled". Legacy mode keeps the inline fast path.
 	const routingMutexMode = getRoutingMutexMode(pluginConfig);
 	activeAccountManager.setRoutingMutexMode(routingMutexMode);
+	const schedulingStrategy = getSchedulingStrategy(pluginConfig);
 	const fetchImpl = options.fetchImpl ?? fetch;
 	const host = options.host ?? DEFAULT_HOST;
 	// Defense in depth (runtime-proxy-01): the proxy presents managed OAuth tokens
@@ -1771,6 +1842,7 @@ export async function startRuntimeRotationProxy(
 						skipReasons: accountSkipReasons,
 						stickyBoostByAccount: rotationStickyBoost,
 						pidOffsetEnabled,
+						schedulingStrategy,
 					});
 				const selected =
 					routingMutexMode === "enabled"

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1224,6 +1224,7 @@ export function chooseAccount(params: {
 		const selected = accountManager.getCurrentOrNextForFamilySequential(
 			family,
 			model,
+			policy?.blockedAccountIndexes,
 		);
 		if (
 			selected &&

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1240,8 +1240,12 @@ export function chooseAccount(params: {
 		}
 
 		// Active account was attempted/blocked/skipped this request (e.g. it just
-		// rate-limited mid-loop): fall through to the shared linear scan below to
-		// find the next eligible account.
+		// rate-limited mid-loop): fall through to the shared linear scan to find
+		// the next eligible account to TRY. Pass advanceActivePointer=false so a
+		// transient, non-exhausting failure on the active account does not
+		// permanently move the drain-first primary — only
+		// getCurrentOrNextForFamilySequential advances it, and only on true
+		// exhaustion.
 		return chooseLinearScanFallback({
 			accountManager,
 			family,
@@ -1249,6 +1253,7 @@ export function chooseAccount(params: {
 			attemptedIndexes,
 			policy,
 			skipReasons,
+			advanceActivePointer: false,
 		});
 	}
 
@@ -1315,8 +1320,19 @@ export function chooseAccount(params: {
  * paths in `chooseAccount`. Walks every account in pool order and returns the
  * first one that is not already attempted, not policy-blocked, and has no
  * runtime skip reason (rate-limited / cooling down / circuit-open), recording a
- * skip reason for each rejected candidate. Mutates the round-robin cursor via
- * `markSwitched` on the winner. Returns null when no eligible account remains.
+ * skip reason for each rejected candidate. Returns null when no eligible
+ * account remains.
+ *
+ * `advanceActivePointer` (default `true`) controls whether the winner is
+ * committed as the new active/cursor position via `markSwitched`. The hybrid
+ * path wants this (round-robin advance). The sequential path passes `false`:
+ * its within-request fallback only needs an account to TRY this request, and
+ * must NOT move `currentAccountIndexByFamily` — otherwise a transient,
+ * non-exhausting failure on the active account (which leaves it `isUsable` but
+ * present in `attemptedIndexes`) would permanently switch the drain-first
+ * primary even though it was never exhausted (issue #509 regression caught in
+ * review). In sequential mode only `getCurrentOrNextForFamilySequential` is
+ * allowed to advance the active pointer, and only on true exhaustion.
  */
 function chooseLinearScanFallback(params: {
 	accountManager: AccountManager;
@@ -1325,9 +1341,17 @@ function chooseLinearScanFallback(params: {
 	attemptedIndexes: ReadonlySet<number>;
 	policy: RuntimePolicyDecision | null;
 	skipReasons?: Map<number, string>;
+	advanceActivePointer?: boolean;
 }): ManagedAccount | null {
-	const { accountManager, family, model, attemptedIndexes, policy, skipReasons } =
-		params;
+	const {
+		accountManager,
+		family,
+		model,
+		attemptedIndexes,
+		policy,
+		skipReasons,
+		advanceActivePointer = true,
+	} = params;
 
 	for (const account of accountManager.getAccountsSnapshot()) {
 		if (attemptedIndexes.has(account.index)) {
@@ -1347,7 +1371,11 @@ function chooseLinearScanFallback(params: {
 			const live = accountManager.getAccountByIndex(account.index);
 			if (!live) continue;
 			// L4 (deferred): unlocked cursor mutation — see chooseAccount header.
-			accountManager.markSwitched(live, "rotation", family);
+			// Skipped in sequential mode (advanceActivePointer=false) so a
+			// within-request retry never reassigns the drain-first primary.
+			if (advanceActivePointer) {
+				accountManager.markSwitched(live, "rotation", family);
+			}
 			return live;
 		}
 		skipReasons?.set(account.index, reason);
@@ -1848,12 +1876,20 @@ export async function startRuntimeRotationProxy(
 					routingMutexMode === "enabled"
 						? await withRoutingMutex(routingMutexMode, async () => {
 								const candidate = selectAccount();
-								if (candidate && pinnedIndex === null) {
+								if (
+									candidate &&
+									pinnedIndex === null &&
+									schedulingStrategy !== "sequential"
+								) {
 									// Re-commit the cursor under the held mutex. Skipped when a
 									// manual pin is active so the proxy never clobbers the pin
 									// (see #474); pinned selections are deterministic and need no
-									// cursor advance. Runs inline via reentrancy — see comment
-									// above.
+									// cursor advance. Also skipped in sequential mode: the
+									// sequential selector already committed the correct active
+									// index inside this held mutex, and re-committing `candidate`
+									// would wrongly advance the drain-first primary when the pick
+									// came from the non-advancing linear-scan fallback (#509).
+									// Runs inline via reentrancy — see comment above.
 									await accountManager.markSwitchedLocked(
 										candidate,
 										"rotation",

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -78,6 +78,7 @@ export const PluginConfigSchema = z.object({
 	preemptiveQuotaRemainingPercent7d: z.number().min(0).max(100).optional(),
 	preemptiveQuotaMaxDeferralMs: z.number().min(1_000).optional(),
 	routingMutex: z.enum(["enabled", "legacy"]).optional(),
+	schedulingStrategy: z.enum(["hybrid", "sequential"]).optional(),
 });
 
 export type PluginConfigFromSchema = z.infer<typeof PluginConfigSchema>;

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -4396,4 +4396,82 @@ describe("AccountManager", () => {
 			expect(manager.getActiveIndexForFamily("gpt-5-codex")).toBe(2);
 		});
 	});
+
+	describe("getCurrentOrNextForFamilySequential (issue #509 drain-first)", () => {
+		const makeStored = (count: number) => {
+			const now = Date.now();
+			return {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+				accounts: Array.from({ length: count }, (_, i) => ({
+					refreshToken: `token-${i}`,
+					addedAt: now,
+					lastUsed: now - i * 1000,
+				})),
+			};
+		};
+
+		it("sticks to the active account across calls while it stays available", () => {
+			const manager = new AccountManager(undefined, makeStored(2) as never);
+			manager.setActiveIndex(0);
+
+			const first = manager.getCurrentOrNextForFamilySequential("codex");
+			const second = manager.getCurrentOrNextForFamilySequential("codex");
+			const third = manager.getCurrentOrNextForFamilySequential("codex");
+
+			expect(first?.index).toBe(0);
+			expect(second?.index).toBe(0);
+			expect(third?.index).toBe(0);
+			// Cursor does NOT advance while draining the active account.
+			expect(manager.getActiveIndexForFamily("codex")).toBe(0);
+		});
+
+		it("advances to the next account only once the active one is exhausted", () => {
+			const manager = new AccountManager(undefined, makeStored(2) as never);
+			const account0 = manager.setActiveIndex(0)!;
+
+			expect(manager.getCurrentOrNextForFamilySequential("codex")?.index).toBe(0);
+
+			// Drain account 0 to 100% (rate-limited): selector must move to account 1.
+			manager.markRateLimited(account0, 60_000, "codex");
+
+			const afterDrain = manager.getCurrentOrNextForFamilySequential("codex");
+			expect(afterDrain?.index).toBe(1);
+			expect(afterDrain?.refreshToken).toBe("token-1");
+			expect(manager.getActiveIndexForFamily("codex")).toBe(1);
+
+			// And it now sticks to account 1.
+			expect(manager.getCurrentOrNextForFamilySequential("codex")?.index).toBe(1);
+		});
+
+		it("wraps back to a recovered earlier account when the current one drains", () => {
+			const manager = new AccountManager(undefined, makeStored(2) as never);
+			const account0 = manager.setActiveIndex(0)!;
+
+			// A drains -> switch to B.
+			manager.markRateLimited(account0, 60_000, "codex");
+			expect(manager.getCurrentOrNextForFamilySequential("codex")?.index).toBe(1);
+
+			// A's quota window recovers; B then drains.
+			account0.rateLimitResetTimes = {};
+			const account1 = manager.getAccountByIndex(1)!;
+			manager.markRateLimited(account1, 60_000, "codex");
+
+			// Sequential wraps forward from B (index 1) and reclaims recovered A.
+			const reclaimed = manager.getCurrentOrNextForFamilySequential("codex");
+			expect(reclaimed?.index).toBe(0);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(0);
+		});
+
+		it("returns null when every account is exhausted", () => {
+			const manager = new AccountManager(undefined, makeStored(2) as never);
+			const account0 = manager.setActiveIndex(0)!;
+			const account1 = manager.getAccountByIndex(1)!;
+			manager.markRateLimited(account0, 60_000, "codex");
+			manager.markRateLimited(account1, 60_000, "codex");
+
+			expect(manager.getCurrentOrNextForFamilySequential("codex")).toBeNull();
+		});
+	});
 });

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -4398,6 +4398,14 @@ describe("AccountManager", () => {
 	});
 
 	describe("getCurrentOrNextForFamilySequential (issue #509 drain-first)", () => {
+		// The circuit-open case below trips a breaker via recordFailure; the global
+		// beforeEach resets trackers but NOT circuit breakers, so clear them here to
+		// keep each sequential case isolated (otherwise an open breaker leaks into
+		// later cases and the selector skips a still-healthy account).
+		beforeEach(() => {
+			clearCircuitBreakers();
+		});
+
 		const makeStored = (count: number) => {
 			const now = Date.now();
 			return {
@@ -4507,6 +4515,89 @@ describe("AccountManager", () => {
 			const selected = manager.getCurrentOrNextForFamilySequential("codex");
 			expect(selected?.index).toBe(1);
 			expect(manager.getActiveIndexForFamily("codex")).toBe(1);
+		});
+
+		it("drains a 3-account pool in order and wraps to a recovered account", () => {
+			const manager = new AccountManager(undefined, makeStored(3) as never);
+			const account0 = manager.setActiveIndex(0)!;
+
+			// A is primary.
+			expect(manager.getCurrentOrNextForFamilySequential("codex")?.index).toBe(0);
+
+			// A drains -> B.
+			manager.markRateLimited(account0, 60_000, "codex");
+			expect(manager.getCurrentOrNextForFamilySequential("codex")?.index).toBe(1);
+
+			// B drains -> C (forward scan past A which is still down).
+			const account1 = manager.getAccountByIndex(1)!;
+			manager.markRateLimited(account1, 60_000, "codex");
+			expect(manager.getCurrentOrNextForFamilySequential("codex")?.index).toBe(2);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(2);
+
+			// A recovers; C drains -> wrap forward from C (index 2) past 0... A is the
+			// next usable, so it reclaims. Proves the scan wraps in a 3+ pool rather
+			// than just toggling between two accounts.
+			account0.rateLimitResetTimes = {};
+			const account2 = manager.getAccountByIndex(2)!;
+			manager.markRateLimited(account2, 60_000, "codex");
+			expect(manager.getCurrentOrNextForFamilySequential("codex")?.index).toBe(0);
+		});
+
+		it("skips a disabled active account and advances", () => {
+			const manager = new AccountManager(undefined, makeStored(2) as never);
+			manager.setActiveIndex(0);
+
+			// Disable the active account: isUsable must reject it and advance.
+			manager.setAccountEnabled(0, false);
+
+			const selected = manager.getCurrentOrNextForFamilySequential("codex");
+			expect(selected?.index).toBe(1);
+		});
+
+		it("selects the first usable account when activeIndex is unset (-1)", () => {
+			const stored = {
+				version: 3 as const,
+				activeIndex: -1,
+				activeIndexByFamily: { codex: -1 },
+				accounts: [
+					{ refreshToken: "token-0", addedAt: Date.now(), lastUsed: Date.now() },
+					{ refreshToken: "token-1", addedAt: Date.now(), lastUsed: Date.now() },
+				],
+			};
+			const manager = new AccountManager(undefined, stored as never);
+
+			// With no active account set, the forward scan starts at index 0.
+			const selected = manager.getCurrentOrNextForFamilySequential("codex");
+			expect(selected?.index).toBe(0);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(0);
+		});
+
+		it("advances each ModelFamily independently (per-family cursor)", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0, "gpt-5.1": 0 },
+				accounts: [
+					{ refreshToken: "token-0", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now - 1000 },
+				],
+			};
+			const manager = new AccountManager(undefined, stored as never);
+			const account0 = manager.getAccountByIndex(0)!;
+
+			// Exhaust account 0 for the codex family ONLY.
+			manager.markRateLimited(account0, 60_000, "codex");
+
+			// codex must advance to account 1...
+			expect(manager.getCurrentOrNextForFamilySequential("codex")?.index).toBe(1);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(1);
+
+			// ...but gpt-5.1 is unaffected and still drains account 0.
+			expect(
+				manager.getCurrentOrNextForFamilySequential("gpt-5.1")?.index,
+			).toBe(0);
+			expect(manager.getActiveIndexForFamily("gpt-5.1")).toBe(0);
 		});
 	});
 });

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -4473,5 +4473,40 @@ describe("AccountManager", () => {
 
 			expect(manager.getCurrentOrNextForFamilySequential("codex")).toBeNull();
 		});
+
+		it("advances when the active account is cooling down, then reclaims it on recovery", () => {
+			const manager = new AccountManager(undefined, makeStored(2) as never);
+			const account0 = manager.setActiveIndex(0)!;
+
+			// Cooldown is a non-rate-limit exhaustion path: selector must advance.
+			manager.markAccountCoolingDown(account0, 30_000, "auth-failure");
+			expect(manager.isAccountCoolingDown(account0)).toBe(true);
+
+			const afterCooldown = manager.getCurrentOrNextForFamilySequential("codex");
+			expect(afterCooldown?.index).toBe(1);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(1);
+
+			// Account 0 recovers; account 1 then cools down -> wrap back to 0.
+			manager.clearAccountCooldown(account0);
+			const account1 = manager.getAccountByIndex(1)!;
+			manager.markAccountCoolingDown(account1, 30_000, "network-error");
+
+			const reclaimed = manager.getCurrentOrNextForFamilySequential("codex");
+			expect(reclaimed?.index).toBe(0);
+		});
+
+		it("advances when the active account's circuit is open", () => {
+			const manager = new AccountManager(undefined, makeStored(2) as never);
+			const account0 = manager.setActiveIndex(0)!;
+
+			// Trip the circuit breaker on the active account (3 consecutive failures).
+			manager.recordFailure(account0, "codex");
+			manager.recordFailure(account0, "codex");
+			manager.recordFailure(account0, "codex");
+
+			const selected = manager.getCurrentOrNextForFamilySequential("codex");
+			expect(selected?.index).toBe(1);
+			expect(manager.getActiveIndexForFamily("codex")).toBe(1);
+		});
 	});
 });

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -4599,5 +4599,31 @@ describe("AccountManager", () => {
 			).toBe(0);
 			expect(manager.getActiveIndexForFamily("gpt-5.1")).toBe(0);
 		});
+
+		it("never anchors the active pointer on a policy-blocked account (#509 review P1)", () => {
+			const manager = new AccountManager(undefined, makeStored(2) as never);
+			const account0 = manager.setActiveIndex(0)!;
+			// Account 0 is exhausted; account 1 is otherwise usable but policy-blocked
+			// (e.g. paused/drained) for this request.
+			manager.markRateLimited(account0, 60_000, "codex");
+			const blocked = new Set([1]);
+
+			// Selector must NOT commit the active pointer to the blocked account.
+			const selected = manager.getCurrentOrNextForFamilySequential(
+				"codex",
+				null,
+				blocked,
+			);
+			expect(selected).toBeNull();
+			expect(manager.getActiveIndexForFamily("codex")).toBe(0);
+
+			// Once the block clears, account 1 becomes selectable normally.
+			const afterUnblock = manager.getCurrentOrNextForFamilySequential(
+				"codex",
+				null,
+				new Set(),
+			);
+			expect(afterUnblock?.index).toBe(1);
+		});
 	});
 });

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -168,6 +168,7 @@ describe("Plugin Configuration", () => {
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
 				routingMutex: "legacy",
+				schedulingStrategy: "hybrid",
 			});
 			// existsSync is called with multiple candidate config paths (primary + legacy fallbacks)
 			expect(mockExistsSync).toHaveBeenCalled();
@@ -241,6 +242,7 @@ describe("Plugin Configuration", () => {
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
 				routingMutex: "legacy",
+				schedulingStrategy: "hybrid",
 			});
 		});
 
@@ -670,6 +672,7 @@ describe("Plugin Configuration", () => {
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
 				routingMutex: "legacy",
+				schedulingStrategy: "hybrid",
 			});
 		});
 
@@ -744,6 +747,7 @@ describe("Plugin Configuration", () => {
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
 				routingMutex: "legacy",
+				schedulingStrategy: "hybrid",
 			});
 			expect(mockLogWarn).toHaveBeenCalled();
 		});
@@ -812,6 +816,7 @@ describe("Plugin Configuration", () => {
 				preemptiveQuotaRemainingPercent7d: 5,
 				preemptiveQuotaMaxDeferralMs: 2 * 60 * 60_000,
 				routingMutex: "legacy",
+				schedulingStrategy: "hybrid",
 			});
 			expect(mockLogWarn).toHaveBeenCalled();
 		});

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -2352,6 +2352,66 @@ describe("routing mutex serializes selection + cursor commit (issue #14 / L4)", 
 	});
 });
 
+describe("sequential mode survives the routing-mutex path (issue #509)", () => {
+	const prevMutex = process.env.CODEX_AUTH_ROUTING_MUTEX;
+	const prevStrategy = process.env.CODEX_AUTH_SCHEDULING_STRATEGY;
+
+	afterEach(() => {
+		if (prevMutex === undefined) delete process.env.CODEX_AUTH_ROUTING_MUTEX;
+		else process.env.CODEX_AUTH_ROUTING_MUTEX = prevMutex;
+		if (prevStrategy === undefined)
+			delete process.env.CODEX_AUTH_SCHEDULING_STRATEGY;
+		else process.env.CODEX_AUTH_SCHEDULING_STRATEGY = prevStrategy;
+		__resetRoutingMutexForTests();
+	});
+
+	// Regression for the P1 caught in review: under routingMutex="enabled" the hot
+	// path re-commits the selected account via markSwitchedLocked after
+	// chooseAccount. In sequential mode the sequential selector already committed
+	// the active index inside the held mutex, so the re-commit must be skipped;
+	// otherwise the drain-first primary could double-advance. This test drives the
+	// real proxy with both flags on and asserts three back-to-back requests all
+	// stick to the SAME account while it stays healthy.
+	it("keeps sticking to one account across requests under enabled mutex", async () => {
+		process.env.CODEX_AUTH_ROUTING_MUTEX = "enabled";
+		process.env.CODEX_AUTH_SCHEDULING_STRATEGY = "sequential";
+		__resetRoutingMutexForTests();
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+
+		const { calls, fetchImpl } = createRecordingFetch(async () =>
+			textEventStream("data: forwarded\n\n"),
+		);
+
+		const proxy = await startProxy({ accountManager, fetchImpl });
+		expect(accountManager.getRoutingMutexMode()).toBe("enabled");
+
+		const bodyFor = (session: string) => ({
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+			metadata: { session_id: session },
+		});
+
+		// Distinct sessions so any per-session affinity would scatter them; sequential
+		// mode must ignore affinity and keep all three on the same active account.
+		for (const session of ["s-1", "s-2", "s-3"]) {
+			const res = await postResponses(proxy, bodyFor(session));
+			expect(res.status).toBe(HTTP_STATUS.OK);
+			await res.text();
+		}
+
+		expect(calls).toHaveLength(3);
+		const servedAuth = calls.map((c) => c.headers.get("authorization"));
+		expect(servedAuth).toEqual([
+			"Bearer access-1",
+			"Bearer access-1",
+			"Bearer access-1",
+		]);
+		expect(accountManager.getActiveIndexForFamily("codex")).toBe(0);
+	});
+});
+
 describe("buildTokenInvalidationBody", () => {
 	const FALLBACK = "OAuth token has been invalidated. Please re-login.";
 	const parse = (raw: string) =>
@@ -2494,5 +2554,69 @@ describe("chooseAccount sequential mode (issue #509)", () => {
 		});
 
 		expect(selected?.index).toBe(1);
+	});
+
+	it("does not move the active primary when a healthy active account is only attempted (P1 #509)", () => {
+		const manager = makeManager(2);
+		manager.setActiveIndex(0);
+
+		// Simulate a transient, non-exhausting failure on the active account: it
+		// is still usable but already in attemptedIndexes for THIS request, so the
+		// sequential tier falls through to the linear-scan fallback.
+		const tried = chooseAccount({
+			accountManager: manager,
+			sessionAffinityStore: null,
+			sessionKey: null,
+			family: "codex",
+			model: null,
+			attemptedIndexes: new Set([0]),
+			now: Date.now(),
+			policy: null,
+			pinnedIndex: null,
+			schedulingStrategy: "sequential",
+		});
+
+		// The fallback hands account 1 to TRY this request...
+		expect(tried?.index).toBe(1);
+		// ...but the drain-first primary must NOT have advanced: account 0 was
+		// never exhausted, so the next fresh request must stick to it again.
+		expect(manager.getActiveIndexForFamily("codex")).toBe(0);
+
+		const nextRequest = chooseAccount({
+			accountManager: manager,
+			sessionAffinityStore: null,
+			sessionKey: null,
+			family: "codex",
+			model: null,
+			attemptedIndexes: new Set(),
+			now: Date.now(),
+			policy: null,
+			pinnedIndex: null,
+			schedulingStrategy: "sequential",
+		});
+		expect(nextRequest?.index).toBe(0);
+	});
+
+	it("returns null when every account is exhausted in sequential mode", () => {
+		const manager = makeManager(2);
+		const account0 = manager.setActiveIndex(0)!;
+		const account1 = manager.getAccountByIndex(1)!;
+		manager.markRateLimited(account0, 60_000, "codex");
+		manager.markRateLimited(account1, 60_000, "codex");
+
+		const selected = chooseAccount({
+			accountManager: manager,
+			sessionAffinityStore: null,
+			sessionKey: null,
+			family: "codex",
+			model: null,
+			attemptedIndexes: new Set(),
+			now: Date.now(),
+			policy: null,
+			pinnedIndex: null,
+			schedulingStrategy: "sequential",
+		});
+
+		expect(selected).toBeNull();
 	});
 });

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -5,8 +5,10 @@ import { HTTP_STATUS, OPENAI_HEADERS } from "../lib/constants.js";
 import {
 	startRuntimeRotationProxy,
 	buildTokenInvalidationBody,
+	chooseAccount,
 	type RuntimeRotationProxyServer,
 } from "../lib/runtime-rotation-proxy.js";
+import { SessionAffinityStore } from "../lib/session-affinity.js";
 import { clearCircuitBreakers } from "../lib/circuit-breaker.js";
 import {
 	__resetRoutingMutexForTests,
@@ -2404,5 +2406,93 @@ describe("buildTokenInvalidationBody", () => {
 	it("falls back to the stable message when no usable message field exists", () => {
 		const body = JSON.stringify({ error: { code: "something_else" } });
 		expect(parse(buildTokenInvalidationBody(body)).error.message).toBe(FALLBACK);
+	});
+});
+
+describe("chooseAccount sequential mode (issue #509)", () => {
+	beforeEach(() => {
+		resetTrackers();
+		clearCircuitBreakers();
+	});
+
+	const makeManager = (count: number) => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: Array.from({ length: count }, (_, i) => ({
+				refreshToken: `token-${i}`,
+				addedAt: now,
+				lastUsed: now - i * 1000,
+			})),
+		};
+		return new AccountManager(undefined, stored as never);
+	};
+
+	it("ignores session affinity and follows the active account", () => {
+		const manager = makeManager(2);
+		manager.setActiveIndex(0);
+
+		// Affinity store points this session at account 1 — sequential must NOT honor it.
+		const affinity = new SessionAffinityStore();
+		affinity.remember("session-xyz", 1);
+
+		const selected = chooseAccount({
+			accountManager: manager,
+			sessionAffinityStore: affinity,
+			sessionKey: "session-xyz",
+			family: "codex",
+			model: null,
+			attemptedIndexes: new Set(),
+			now: Date.now(),
+			policy: null,
+			pinnedIndex: null,
+			schedulingStrategy: "sequential",
+		});
+
+		expect(selected?.index).toBe(0);
+	});
+
+	it("honors a manual pin over sequential mode", () => {
+		const manager = makeManager(2);
+		manager.setActiveIndex(0);
+
+		const selected = chooseAccount({
+			accountManager: manager,
+			sessionAffinityStore: null,
+			sessionKey: null,
+			family: "codex",
+			model: null,
+			attemptedIndexes: new Set(),
+			now: Date.now(),
+			policy: null,
+			pinnedIndex: 1,
+			schedulingStrategy: "sequential",
+		});
+
+		// Pin tier runs first, so the pinned account wins regardless of the active one.
+		expect(selected?.index).toBe(1);
+	});
+
+	it("advances to the next account when the active one is exhausted", () => {
+		const manager = makeManager(2);
+		const account0 = manager.setActiveIndex(0)!;
+		manager.markRateLimited(account0, 60_000, "codex");
+
+		const selected = chooseAccount({
+			accountManager: manager,
+			sessionAffinityStore: null,
+			sessionKey: null,
+			family: "codex",
+			model: null,
+			attemptedIndexes: new Set(),
+			now: Date.now(),
+			policy: null,
+			pinnedIndex: null,
+			schedulingStrategy: "sequential",
+		});
+
+		expect(selected?.index).toBe(1);
 	});
 });

--- a/test/scheduling-strategy-config.test.ts
+++ b/test/scheduling-strategy-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { DEFAULT_PLUGIN_CONFIG, getSchedulingStrategy } from "../lib/config.js";
+import type { PluginConfig } from "../lib/types.js";
+
+describe("schedulingStrategy config flag (issue #509)", () => {
+	const ORIGINAL_ENV = process.env.CODEX_AUTH_SCHEDULING_STRATEGY;
+
+	beforeEach(() => {
+		delete process.env.CODEX_AUTH_SCHEDULING_STRATEGY;
+	});
+
+	afterEach(() => {
+		if (ORIGINAL_ENV === undefined) {
+			delete process.env.CODEX_AUTH_SCHEDULING_STRATEGY;
+		} else {
+			process.env.CODEX_AUTH_SCHEDULING_STRATEGY = ORIGINAL_ENV;
+		}
+	});
+
+	it("defaults to hybrid in DEFAULT_PLUGIN_CONFIG", () => {
+		expect(DEFAULT_PLUGIN_CONFIG.schedulingStrategy).toBe("hybrid");
+	});
+
+	it("getSchedulingStrategy returns hybrid when config is undefined", () => {
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			schedulingStrategy: undefined,
+		};
+		expect(getSchedulingStrategy(cfg)).toBe("hybrid");
+	});
+
+	it("getSchedulingStrategy respects explicit sequential in config", () => {
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			schedulingStrategy: "sequential",
+		};
+		expect(getSchedulingStrategy(cfg)).toBe("sequential");
+	});
+
+	it("env var CODEX_AUTH_SCHEDULING_STRATEGY=sequential overrides config", () => {
+		process.env.CODEX_AUTH_SCHEDULING_STRATEGY = "sequential";
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			schedulingStrategy: "hybrid",
+		};
+		expect(getSchedulingStrategy(cfg)).toBe("sequential");
+	});
+
+	it("env var CODEX_AUTH_SCHEDULING_STRATEGY=hybrid overrides config", () => {
+		process.env.CODEX_AUTH_SCHEDULING_STRATEGY = "hybrid";
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			schedulingStrategy: "sequential",
+		};
+		expect(getSchedulingStrategy(cfg)).toBe("hybrid");
+	});
+
+	it("rejects unknown env values and falls back to config", () => {
+		process.env.CODEX_AUTH_SCHEDULING_STRATEGY = "bogus-mode";
+		const cfg: PluginConfig = {
+			...DEFAULT_PLUGIN_CONFIG,
+			schedulingStrategy: "sequential",
+		};
+		expect(getSchedulingStrategy(cfg)).toBe("sequential");
+	});
+});

--- a/test/scheduling-strategy-config.test.ts
+++ b/test/scheduling-strategy-config.test.ts
@@ -63,4 +63,15 @@ describe("schedulingStrategy config flag (issue #509)", () => {
 		};
 		expect(getSchedulingStrategy(cfg)).toBe("sequential");
 	});
+
+	it("rejects an invalid persisted config value and falls back to the default", () => {
+		const cfg = {
+			...DEFAULT_PLUGIN_CONFIG,
+			schedulingStrategy: "bogus",
+		} as unknown as PluginConfig;
+		expect(getSchedulingStrategy(cfg)).toBe(
+			DEFAULT_PLUGIN_CONFIG.schedulingStrategy,
+		);
+		expect(getSchedulingStrategy(cfg)).toBe("hybrid");
+	});
 });


### PR DESCRIPTION
## Summary

Implements the optional Sequential / Drain-First scheduling mode requested in #509.

By default the runtime proxy spreads requests across all available accounts (`hybrid`), so multiple accounts drain at a similar pace and tend to hit cooldown together. This adds an opt-in `schedulingStrategy: "sequential"` that keeps one active account in use until it is fully exhausted, then advances to the next available account. Earlier accounts are reclaimed as soon as their quota window recovers, staggering recovery across the pool for longer uninterrupted sessions.

Resolves the maintainer-confirmed spec from #509:
- Switches only when the active account is 100 percent exhausted (rate-limited / cooling down / circuit-open). No soft early-switch threshold in v1.
- A single active account governs all new requests. Sequential mode intentionally ignores per-session affinity, so once the active account changes every subsequent request follows it regardless of which account started a conversation.
- A manual pin (`codex-multi-auth switch`) always takes precedence; sequential mode is ignored while a pin is active.

## Behavior

- `hybrid` (default, unchanged): weighted health/token/freshness selection across all available accounts.
- `sequential`: sticky on the current active account; scans forward (wrapping the pool) only when the active account is exhausted, and pins the next available account as the new active one.

Default is `hybrid`, so existing deployments are unaffected.

## Changes

- `lib/accounts.ts`: new `getCurrentOrNextForFamilySequential` selector. Sticky on `currentAccountIndexByFamily`; advances only on exhaustion; wraps so a recovered earlier account reclaims the active slot. Per ModelFamily, matching the rest of the selection path.
- `lib/runtime-rotation-proxy.ts`: `chooseAccount` branches on strategy. Pin tier runs first (unchanged); sequential skips the affinity tier; the linear-scan fallback is extracted into a shared helper used by both paths.
- `lib/schemas.ts` / `lib/config.ts`: `schedulingStrategy` enum (`hybrid` | `sequential`, default `hybrid`), `getSchedulingStrategy` accessor following the existing `routingMutex` pattern, `CODEX_AUTH_SCHEDULING_STRATEGY` env override, and a config-explain parity entry.
- `docs/configuration.md`, `docs/reference/settings.md`, `docs/development/CONFIG_FIELDS.md`: documented the setting and env override per the add-config-field runbook.

## Out of scope (v1)

- TUI settings picker: the backend settings hub has no enum-key type yet (existing enum strategies `routingMutex` and `fastSessionStrategy` are also config plus env only). Reachable via settings file and env var.
- Soft early-switch threshold: requester confirmed 100 percent exhaustion as the default. The accessor pattern leaves room to add a threshold later.
- In-flight drain: the proxy is stateless with respect to in-flight request counts, so "drain" means no new selections to the account, not waiting for outstanding requests to finish.

## Testing

- `npm run typecheck`: pass
- `npm run lint:ts`: pass
- `npm test`: 4387 passed, 3 skipped (pre-existing), 0 failures
- `npm run build`: pass

New tests:
- Sequential selector: sticky across calls, advances on exhaustion, wraps to a recovered earlier account, returns null when all exhausted.
- Proxy `chooseAccount`: sequential ignores session affinity, manual pin wins over sequential, advances when the active account is rate-limited.
- Config accessor: default, explicit config, env override both directions, invalid env fallback.
- Updated the five strict default-config `toEqual` assertions in `plugin-config.test.ts` for the new key.

Closes #509

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `schedulingStrategy: "sequential"` (drain-first) as an opt-in alternative to the default `hybrid` account selection mode. the sequential selector sticks to one active account per model family and only advances to the next when the active account is fully exhausted; it wraps the pool so recovered earlier accounts can reclaim the active slot.

- `lib/accounts.ts` – new `getCurrentOrNextForFamilySequential` selector with per-family sticky pointer, policy-block awareness, and wrap-around scan; `lib/runtime-rotation-proxy.ts` – `chooseAccount` branches on strategy, skips session-affinity tier in sequential mode, and `chooseLinearScanFallback` is extracted as a shared helper with an `advanceActivePointer` flag that keeps within-request retries from permanently moving the drain-first primary.
- `lib/schemas.ts` / `lib/config.ts` – `schedulingStrategy` enum field, `getSchedulingStrategy` accessor, and `CODEX_AUTH_SCHEDULING_STRATEGY` env override following the `routingMutex` pattern; three doc files updated.
- two previously-reviewed P1s are addressed: `advanceActivePointer=false` prevents transient retry failures from advancing the sequential pointer, and `blockedIndexes` is now passed into the selector so it never anchors to a policy-blocked account.

<h3>Confidence Score: 5/5</h3>

safe to merge — all three issues caught in the previous review round are fixed, the new selector and proxy branching are correct, and the test suite covers the critical edge cases including the mutex path and transient-failure non-advance regression.

the sequential selector, chooseAccount branching, and routingMutex re-commit skip have all been verified against documented invariants. advanceActivePointer=false correctly prevents within-request retries from permanently moving the drain-first primary, and the blockedIndexes guard prevents the active pointer anchoring on a policy-blocked account. test coverage is thorough across selector unit tests, chooseAccount unit tests, a real-proxy mutex integration test, and config accessor tests. no token safety or windows filesystem risks introduced.

no files require special attention — lib/runtime-rotation-proxy.ts is the most complex change but the advanceActivePointer flag and mutex skip are both well-tested.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds `getCurrentOrNextForFamilySequential` — sticky pointer, wrap-around scan, policy-block guard, and consistent `lastUsed` stamping; `isUsable` conditions align exactly with `getAccountRuntimeSkipReason`, making the outer skip-reason check in chooseAccount a safe belt-and-suspenders guard. |
| lib/runtime-rotation-proxy.ts | sequential branch inserted before session-affinity tier; `chooseLinearScanFallback` extracted with `advanceActivePointer` flag; mutex hot-path skips `markSwitchedLocked` re-commit in sequential mode — all three P1 fixes from earlier review round are present and correct. |
| lib/config.ts | new `getSchedulingStrategy` follows the same `resolveStringSetting` + known-values-set pattern as `getRoutingMutexMode`; env override and invalid-value fallback are both handled; `CONFIG_EXPLAIN_ENTRIES` entry added for parity. |
| lib/schemas.ts | adds `schedulingStrategy: z.enum(["hybrid","sequential"]).optional()` to `PluginConfigSchema`; minimal, correct change. |
| test/accounts.test.ts | 10 new sequential-selector cases covering sticky, exhaustion advance, wrap-around, cooldown, circuit-open, 3-account pool, disabled, unset active index, per-family independence, and the policy-blocked P1 regression; `clearCircuitBreakers()` in `beforeEach` prevents cross-test breaker leakage. |
| test/runtime-rotation-proxy.test.ts | adds sequential proxy tests: affinity-ignored, manual-pin-wins, advances-on-exhaustion, no-pointer-advance-on-transient-failure (P1 regression), all-exhausted; plus the mutex-path integration test driving the real proxy with `routingMutex=enabled` + `schedulingStrategy=sequential`. |
| test/scheduling-strategy-config.test.ts | new file; covers default, explicit config value, env override in both directions, invalid env fallback to config, and invalid persisted config fallback to default — fully matches the routingMutex config-test pattern. |
| test/plugin-config.test.ts | five strict `toEqual` assertions updated to include `schedulingStrategy: "hybrid"` — mechanical but necessary, no issues. |
| docs/configuration.md | added `CODEX_AUTH_SCHEDULING_STRATEGY` to stable env-override table and added the "Sequential / drain-first scheduling" section — correctly placed per the add-config-field runbook. |
| docs/reference/settings.md | added `schedulingStrategy` row to proxy settings table and `CODEX_AUTH_SCHEDULING_STRATEGY` to the env-override list — consistent with existing entries. |
| docs/development/CONFIG_FIELDS.md | added `schedulingStrategy` row to the runtime-only fields table and `CODEX_AUTH_SCHEDULING_STRATEGY` to the env var inventory — correct location and format. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(rotation): keep sequential selector ..."](https://github.com/ndycode/codex-multi-auth/commit/459c5ebc762912b699d6cbbc6dc08b86dce3f510) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35479595)</sub>

<!-- /greptile_comment -->