### PR TITLE
chore: release v2.3.0-beta.0 (sequential drain-first, #509)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.2.2",
+  "version": "2.3.0-beta.0",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
+- Current prerelease: [docs/releases/v2.3.0-beta.0.md](docs/releases/v2.3.0-beta.0.md) — install via `npm i -g codex-multi-auth@beta`
 - Current stable: [docs/releases/v2.2.2.md](docs/releases/v2.2.2.md) — install via `npm i -g codex-multi-auth`
 - Previous stable: [docs/releases/v2.2.1.md](docs/releases/v2.2.1.md)
 - Previous stable: [docs/releases/v2.2.0.md](docs/releases/v2.2.0.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
+| [releases/v2.3.0-beta.0.md](releases/v2.3.0-beta.0.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
 | [releases/v2.2.2.md](releases/v2.2.2.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
 | [releases/v2.2.1.md](releases/v2.2.1.md) | Prior stable release notes |
 | [releases/v2.2.0.md](releases/v2.2.0.md) | Prior stable release notes |

--- a/docs/releases/v2.3.0-beta.0.md
+++ b/docs/releases/v2.3.0-beta.0.md
@@ -1,0 +1,42 @@
+## Runtime Rotation
+
+### Features
+
+- **Sequential / drain-first account scheduling (opt-in).** A new
+  `schedulingStrategy` setting (`CODEX_AUTH_SCHEDULING_STRATEGY` /
+  `schedulingStrategy`, default `hybrid`) adds a `sequential` mode that drains one
+  account fully before moving to the next, instead of spreading load across the
+  pool. Set it to `sequential` to keep every new request on the current active
+  account until that account is exhausted (rate-limited, cooling down, circuit-open,
+  or disabled), then advance to the next usable account. When an earlier account's
+  quota window recovers it reclaims the active slot on the next forward scan, so the
+  pool's quota windows stagger over time rather than resetting together — longer
+  uninterrupted sessions across a multi-account pool (issue #509).
+- **Default behavior is unchanged.** `hybrid` remains the default and keeps the
+  existing weighted health/token/freshness selection plus per-session affinity.
+  `sequential` is fully opt-in; pools that do not set it behave exactly as before.
+- **Manual pin still wins.** A `switch <n>` pin overrides scheduling in both modes.
+  In `sequential` mode per-session affinity is intentionally bypassed — every
+  request follows the single active account, not a per-chat sticky account.
+
+## Release Hygiene
+
+### Tests
+
+- Selector coverage for the drain-first path: sticky-while-usable, advance-on-
+  exhaustion, wrap-to-recovered-earlier-account, returns-null when the whole pool is
+  exhausted, cooldown/circuit-open/disabled failover, per-family cursor isolation,
+  and the policy-blocked-anchor guard.
+- Proxy-level coverage: affinity is ignored, manual pin takes precedence, the active
+  pointer advances only on true exhaustion (not on a transient attempted-this-request
+  skip), and the mode survives the routing-mutex select+commit path without double-
+  advancing the cursor.
+- Config coverage for `schedulingStrategy`: default, explicit value, env override in
+  both directions, and invalid env/persisted values falling back safely.
+
+### Notes
+
+- Prerelease published under the `beta` dist-tag
+  (`npm i -g codex-multi-auth@beta`). Whether drain-first delivers longer
+  uninterrupted sessions depends on each pool's real quota-window timing, which is
+  why this ships as a beta for validation on real accounts before a stable cut.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.2.0",
+	"version": "2.3.0-beta.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.2.0",
+			"version": "2.3.0-beta.0",
 			"bundleDependencies": [
 				"@codex-ai/plugin",
 				"@codex-ai/sdk"
@@ -25,7 +25,7 @@
 				"codex-multi-auth": "scripts/codex-multi-auth.js",
 				"codex-multi-auth-app-launcher": "scripts/codex-app-launcher.js",
 				"codex-multi-auth-codex": "scripts/codex.js",
-				"mcodex": "scripts/mcodex"
+				"mcodex": "scripts/mcodex.js"
 			},
 			"devDependencies": {
 				"@fast-check/vitest": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.2.2",
+	"version": "2.3.0-beta.0",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Release prep for the opt-in **sequential / drain-first** account scheduling mode (issue #509), already merged to main as the feature commit (#510). This PR carries the version bump to `2.3.0-beta.0` plus the release notes and portal wiring. Published to npm under the `beta` dist-tag.

## What ships
- `schedulingStrategy=sequential` (env `CODEX_AUTH_SCHEDULING_STRATEGY=sequential`): drains one account fully before advancing to the next, so quota windows stagger across the pool for longer uninterrupted sessions.
- Default `hybrid` behavior unchanged; the mode is fully opt-in.
- Manual pin still wins; per-session affinity is bypassed in sequential mode.

## Files
- `package.json`, `package-lock.json`, `.codex-plugin/plugin.json`: version -> 2.3.0-beta.0
- `docs/releases/v2.3.0-beta.0.md`: prerelease notes (area-first format)
- `README.md`, `docs/README.md`: add Current prerelease links

## Verification
- Full suite: 280 files / 4398 tests pass, exit 0 (`vitest run --maxWorkers=1`)
- Build + typecheck + lint: all clean
- Live drain-first harness (real proxy, real timers, real quota path): drain -> failover -> wrap-reclaim verified
- E2E smoke on the BUILT dist artifact with `schedulingStrategy=sequential`, isolated sandbox: all phases pass
- Built CLI `config explain` surfaces `schedulingStrategy = "hybrid" (default) [CODEX_AUTH_SCHEDULING_STRATEGY]`

## Notes
- Beta is not logged in the top-level CHANGELOG, matching prior `v2.1.13-beta.*` convention (prerelease notes live in `docs/releases/`).
- Whether drain-first delivers longer sessions depends on each pool's real quota-window timing, which is why this ships as a beta for validation before a stable cut.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

release prep for `v2.3.0-beta.0`, wiring in the sequential / drain-first scheduling mode (#510) with a version bump across `package.json`, `package-lock.json`, and `.codex-plugin/plugin.json`, plus prerelease notes and portal links.

- **version bump**: all three manifests aligned to `2.3.0-beta.0`; `package-lock.json` was silently stale by two patch versions (was `2.2.0`) and its `mcodex` bin entry was corrected from `scripts/mcodex` → `scripts/mcodex.js`, neither of which is noted in the release notes.
- **release notes** (`docs/releases/v2.3.0-beta.0.md`): covers drain-first logic, selector/proxy/config test inventory, and beta rationale; no mention of windows filesystem retry behavior or token-safety checks on the sequential failover path, both of which `AGENTS.md` flags as standing requirements.
- **readme/docs portal**: prerelease row inserted correctly above the stable row with the right dist-tag install command.

<h3>Confidence Score: 4/5</h3>

safe to merge as a release-prep PR; the actual feature logic landed in a prior commit and is not touched here.

the changes are version bumps and documentation only. the lockfile carried a two-patch-version lag and a missing `.js` extension on the `mcodex` bin entry — both corrected here but not surfaced in the release notes, which makes the published artifact history slightly harder to audit. the release notes' test inventory is solid for logic coverage but omits explicit confirmation of windows filesystem retry behavior and token-safety checks on the sequential failover path, two areas `AGENTS.md` calls out as standing requirements for this codebase.

`package-lock.json` — carries the silent bin-path fix and version correction worth noting in the changelog; `docs/releases/v2.3.0-beta.0.md` — worth adding a notes bullet on windows retry and token-header scrubbing coverage.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version bumped from 2.2.2 to 2.3.0-beta.0; bin entry for mcodex already correctly points to scripts/mcodex.js; no dependency changes |
| package-lock.json | lockfile was stale by two patch versions (2.2.0 vs package.json 2.2.2) before this bump; mcodex bin path fixed from scripts/mcodex to scripts/mcodex.js — fix not mentioned in release notes |
| docs/releases/v2.3.0-beta.0.md | good test inventory for drain-first logic; missing explicit mention of windows filesystem retry coverage and token-safety verification on sequential failover |
| .codex-plugin/plugin.json | version bumped from 2.2.2 to 2.3.0-beta.0; no other changes |
| README.md | prerelease link added above current stable entry; correct dist-tag install command |
| docs/README.md | release table updated with prerelease row; link and install command are correct |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client Request
    participant P as Runtime Proxy
    participant S as Scheduler (sequential)
    participant A1 as Account[0]
    participant A2 as Account[1]

    C->>P: request
    P->>S: selectAccount()
    S->>A1: is usable?
    A1-->>S: yes (not exhausted)
    S-->>P: Account[0]
    P->>A1: forward request
    A1-->>P: response
    P-->>C: response

    C->>P: next request
    P->>S: selectAccount()
    S->>A1: is usable?
    A1-->>S: no (rate-limited / cooldown)
    S->>A2: is usable?
    A2-->>S: yes
    S-->>P: Account[1] (cursor advances)
    P->>A2: forward request
    A2-->>P: response
    P-->>C: response

    Note over S: on next scan, if Account[0] quota window recovered → reclaims active slot
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22release%2Fv2.3.0-beta.0%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22release%2Fv2.3.0-beta.0%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackage-lock.json%3A27%0A**silent%20bin-path%20fix%20bundled%20into%20version%20bump**%0A%0Athe%20%60mcodex%60%20bin%20entry%20changed%20from%20%60scripts%2Fmcodex%60%20%28no%20extension%29%20to%20%60scripts%2Fmcodex.js%60%20%E2%80%94%20a%20real%20correctness%20fix%20that%20isn't%20called%20out%20in%20the%20PR%20description%20or%20release%20notes.%20separately%2C%20the%20lockfile%20was%20at%20%602.2.0%60%20while%20%60package.json%60%20was%20already%20at%20%602.2.2%60%2C%20meaning%20two%20patch%20releases%20shipped%20without%20regenerating%20the%20lockfile.%20neither%20issue%20appears%20in%20the%20release%20notes%2C%20so%20anyone%20auditing%20v2.2.x%20published%20artifacts%20won't%20find%20a%20trace%20of%20the%20bin-path%20discrepancy%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Freleases%2Fv2.3.0-beta.0.md%3A26-35%0A**no%20windows%20filesystem%20or%20token-safety%20coverage%20noted%20for%20sequential%20drain%20path**%0A%0Athe%20test%20inventory%20is%20thorough%20for%20the%20happy-path%20and%20logic%20branches%2C%20but%20%60AGENTS.md%60%20explicitly%20flags%20windows%20filesystem%20safety%20%28%60EBUSY%60%2F%60EPERM%60%2F%60ENOTEMPTY%60%20retries%29%20and%20prohibits%20exposing%20tokens%20in%20proxy%20response%20headers%2Flogs.%20the%20sequential%20cursor%20is%20mutable%20shared%20state%20%E2%80%94%20write%20failures%20mid-advance%20on%20windows%20could%20leave%20the%20cursor%20corrupt%20or%20unadvanced%2C%20and%20a%20failover%20that%20surfaces%20a%20fresh%20token%20during%20drain%20isn't%20ruled%20out%20by%20the%20listed%20test%20cases.%20worth%20documenting%20whether%20the%20routing-mutex%20commit%20path%20has%20windows-retry%20coverage%20and%20whether%20token%20headers%20are%20scrubbed%20on%20sequential%20failover%2C%20even%20if%20only%20as%20a%20notes%20bullet.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
package-lock.json:27
**silent bin-path fix bundled into version bump**

the `mcodex` bin entry changed from `scripts/mcodex` (no extension) to `scripts/mcodex.js` — a real correctness fix that isn't called out in the PR description or release notes. separately, the lockfile was at `2.2.0` while `package.json` was already at `2.2.2`, meaning two patch releases shipped without regenerating the lockfile. neither issue appears in the release notes, so anyone auditing v2.2.x published artifacts won't find a trace of the bin-path discrepancy here.

### Issue 2 of 2
docs/releases/v2.3.0-beta.0.md:26-35
**no windows filesystem or token-safety coverage noted for sequential drain path**

the test inventory is thorough for the happy-path and logic branches, but `AGENTS.md` explicitly flags windows filesystem safety (`EBUSY`/`EPERM`/`ENOTEMPTY` retries) and prohibits exposing tokens in proxy response headers/logs. the sequential cursor is mutable shared state — write failures mid-advance on windows could leave the cursor corrupt or unadvanced, and a failover that surfaces a fresh token during drain isn't ruled out by the listed test cases. worth documenting whether the routing-mutex commit path has windows-retry coverage and whether token headers are scrubbed on sequential failover, even if only as a notes bullet.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: release v2.3.0-beta.0 (#509 seque..."](https://github.com/ndycode/codex-multi-auth/commit/66af21f18be84cbbc38a8e65a0c2832955bd27a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35610014)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->