### PR TITLE
chore: release v2.3.0-beta.1 (#512 login workspace + manual-callback fixes)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.3.0-beta.0",
+  "version": "2.3.0-beta.1",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,8 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.3.0-beta.0.md](releases/v2.3.0-beta.0.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
+| [releases/v2.3.0-beta.1.md](releases/v2.3.0-beta.1.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
+| [releases/v2.3.0-beta.0.md](releases/v2.3.0-beta.0.md) | Prior prerelease notes |
 | [releases/v2.2.2.md](releases/v2.2.2.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
 | [releases/v2.2.1.md](releases/v2.2.1.md) | Prior stable release notes |
 | [releases/v2.2.0.md](releases/v2.2.0.md) | Prior stable release notes |

--- a/docs/releases/v2.3.0-beta.1.md
+++ b/docs/releases/v2.3.0-beta.1.md
@@ -1,0 +1,62 @@
+## Account Login
+
+### Bugfixes
+
+- Stopped `codex-multi-auth login` from always printing `Added account` when a
+  same-email / different-workspace login folded onto an existing saved entry.
+  The CLI login path used local copies of `resolveAccountSelection` and
+  `persistAccountPool` in `lib/codex-manager.ts` that had drifted from the
+  workspace-aware versions in `lib/runtime/` (added for #491 and used only by
+  the runtime proxy); the CLI copies never persisted `workspaces` and
+  unconditionally reported `Added account`. The login flow now reports the real
+  outcome — `Added account`, `Updated existing account`, or
+  `Rebound workspace for existing account` — based on whether the write
+  inserted a new entry, refreshed an existing one, or surfaced a
+  previously-untracked workspace (issue #512).
+- Persisted token-derived workspaces on the saved account so
+  `codex-multi-auth workspace <account>` is usable after a same-email
+  multi-workspace login. Rows no longer save with `workspaces: null`;
+  per-workspace `enabled`/`disabledAt` state is preserved across re-logins, and
+  the explicit `login --org <id>` binding now tracks workspaces too (previously
+  the override path returned before workspace discovery).
+- Classified the first workspace-aware re-login of a pre-#491 account (one with
+  no tracked workspaces yet) as `Updated existing account` rather than
+  `Rebound workspace`, so quiet first-time enrichment is not mislabeled as a
+  rebind.
+
+### Manual sign-in
+
+- Surfaced real validation errors from `codex-multi-auth login --manual`
+  instead of reporting every failure as `Cancelled.`. The manual callback
+  reader returned `null` for a genuine user cancel, a callback URL missing the
+  code/state parameter, and an OAuth state mismatch alike, and the caller
+  treated all three as a cancellation. A new pure classifier
+  (`classifyManualCallbackInput`) distinguishes `code` / `cancelled` /
+  `invalid` / `state-mismatch`; `invalid` and `state-mismatch` now exit non-zero
+  with a specific, actionable message (`callbackInvalid` /
+  `callbackStateMismatch`), while a genuine cancellation is unchanged
+  (issue #512 follow-up).
+
+## Release Hygiene
+
+### Tests
+
+- Extracted the account-pool fold (dedup → insert/update/rebound →
+  workspace-tracking → active-index) into pure helpers
+  (`applyAccountPoolResults`, `buildInsertedAccount`, `buildUpdatedAccount`,
+  `mergeAccountWorkspaces`, `resolveCurrentWorkspaceIndex`) and covered them with
+  unit tests, including an end-to-end reproduction of the same-email
+  multi-workspace scenario driven through the real `findMatchingAccountIndex`
+  dedup strategy.
+- Added CLI regressions: `login --org <id>` persists workspace tracking, a
+  mismatched manual-callback state exits non-zero with the state-mismatch
+  message, and a malformed manual-callback URL exits non-zero with the
+  `callbackInvalid` message — none of which persist an account.
+- Full classifier coverage for the manual-callback contract, including the
+  reporter's "pasted a localhost callback URL but still saw Cancelled" case.
+
+### Notes
+
+- Prerelease published under the `beta` dist-tag
+  (`npm i -g codex-multi-auth@beta`). This is a bugfix beta on the 2.3.0 line;
+  the #509 sequential drain-first feature from `2.3.0-beta.0` is unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.3.0-beta.0",
+	"version": "2.3.0-beta.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.3.0-beta.0",
+			"version": "2.3.0-beta.1",
 			"bundleDependencies": [
 				"@codex-ai/plugin",
 				"@codex-ai/sdk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.3.0-beta.0",
+	"version": "2.3.0-beta.1",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## Release: v2.3.0-beta.1

Bugfix beta on the 2.3.0 line, shipping the #512 fixes merged in #513. No code changes beyond the version bump and release docs — the fixes are already on `main`.

### What's in this release
- `codex-multi-auth login` now reports the true outcome — **Added account / Updated existing account / Rebound workspace for existing account** — instead of always printing "Added account" for same-email / different-workspace logins.
- Token-derived **workspaces are persisted** on the saved account (including the `login --org <id>` path), so `codex-multi-auth workspace <account>` works for same-email multi-workspace accounts. Rows no longer save with `workspaces: null`.
- First-time workspace enrichment of a pre-#491 row is reported as `Updated`, not `Rebound`.
- `login --manual` **surfaces real callback validation errors** (`invalid` / `state-mismatch`) with specific messages and a non-zero exit, instead of reporting them as "Cancelled.".

The #509 sequential drain-first feature from `2.3.0-beta.0` is unchanged.

### Version touchpoints bumped to `2.3.0-beta.1`
- `package.json`, `package-lock.json`, `.codex-plugin/plugin.json`
- `docs/releases/v2.3.0-beta.1.md` (new) + `docs/README.md` index updated

### Verification (on merged `main` + this bump)
- Full suite: **4428 passed / 0 failing**
- `npm run build` (tsc + copy-oauth-success): clean, version stamps as `2.3.0-beta.1`
- `npm run lint`: clean

### Publish
**Not performed here.** No `npm publish` and no git tag were run — this PR only prepares the release artifacts. Publish to the `beta` dist-tag (`npm publish --tag beta`) after merge, per your release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

pure release-prep pr — version bump from `2.3.0-beta.0` to `2.3.0-beta.1` across `package.json`, `package-lock.json`, and `.codex-plugin/plugin.json`, plus new release notes and an updated docs index. no production code changes; the underlying `#512` fixes (workspace persistence, manual-callback error classification) are already on `main`.

- version is consistent across all three manifest files; `package-lock.json` correctly bumps both root and `packages[\"\"]` entries.
- release notes in `docs/releases/v2.3.0-beta.1.md` accurately describe the login outcome reporting, workspace persistence, and `--manual` callback classifier fixes, and note the new vitest coverage — but the notes section incorrectly states the package is already published when `npm publish` hasn't been run yet.

<h3>Confidence Score: 4/5</h3>

safe to merge — all changes are version manifest bumps and documentation; no production logic is touched.

the three manifest files are internally consistent and the docs index is correct. the only rough edge is in the release notes: the notes say the package is already published when the PR description is explicit that `npm publish` hasn't been run. that's a docs inaccuracy that could confuse someone checking install status right after merge, but it carries no risk to the codebase or token safety.

docs/releases/v2.3.0-beta.1.md — the publish-status wording in the Notes section should be reconciled with the actual post-merge publish step.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version bumped from 2.3.0-beta.0 to 2.3.0-beta.1; no other changes |
| package-lock.json | version bumped in both root and packages[""] entries; lockfileVersion and dependency tree untouched |
| .codex-plugin/plugin.json | plugin version bumped to 2.3.0-beta.1; consistent with package.json |
| docs/README.md | release index updated: v2.3.0-beta.1 promoted to current prerelease, v2.3.0-beta.0 moved to prior; no broken links |
| docs/releases/v2.3.0-beta.1.md | new release notes accurately describe the #512 fixes and test coverage, but the Notes section incorrectly states the package is already published when npm publish hasn't been run yet |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR merges to main\nversion bump beta.0 to beta.1] --> B[manifest files updated\npackage.json, package-lock.json\nplugin.json]
    A --> C[release notes created\ndocs/releases/v2.3.0-beta.1.md]
    A --> D[docs index updated\ndocs/README.md]
    B --> E[npm run build\ntsc plus copy-oauth-success]
    E --> F{build clean?}
    F -- yes --> G[npm publish tag beta\npost-merge manual step]
    F -- no --> H[fix build errors]
    G --> I[codex-multi-auth at beta available]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22release%2Fv2.3.0-beta.1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22release%2Fv2.3.0-beta.1%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Freleases%2Fv2.3.0-beta.1.md%3A60-62%0A**release%20notes%20claim%20publish%20already%20happened%2C%20but%20it%20hasn't**%0A%0Athe%20notes%20say%20%22Prerelease%20published%20under%20the%20%60beta%60%20dist-tag%22%20in%20past%20tense%2C%20but%20the%20PR%20description%20is%20explicit%20that%20%60npm%20publish%60%20was%20*not*%20run%20and%20will%20only%20happen%20post-merge.%20once%20this%20file%20lands%20on%20%60main%60%2C%20anyone%20reading%20it%20will%20incorrectly%20believe%20the%20package%20is%20already%20live%20on%20the%20%60beta%60%20dist-tag.%20suggest%20wording%20like%20%22Will%20be%20published%20under%20the%20%60beta%60%20dist-tag%20after%20merge%20%28%60npm%20publish%20--tag%20beta%60%29.%22%20to%20match%20the%20actual%20release%20process.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=514&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/releases/v2.3.0-beta.1.md:60-62
**release notes claim publish already happened, but it hasn't**

the notes say "Prerelease published under the `beta` dist-tag" in past tense, but the PR description is explicit that `npm publish` was *not* run and will only happen post-merge. once this file lands on `main`, anyone reading it will incorrectly believe the package is already live on the `beta` dist-tag. suggest wording like "Will be published under the `beta` dist-tag after merge (`npm publish --tag beta`)." to match the actual release process.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: release v2.3.0-beta.1 (#512 login..."](https://github.com/ndycode/codex-multi-auth/commit/62dd2d6212db2f17b4ce92854f3ee1cc9c1f3dab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36067246)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->