### PR TITLE
fix(deps): bump hono 4.12.18 → 4.12.21 (resolves 4 Dependabot advisories)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current prerelease: [docs/releases/v2.3.0-beta.0.md](docs/releases/v2.3.0-beta.0.md) — install via `npm i -g codex-multi-auth@beta`
+- Current prerelease: [docs/releases/v2.3.0-beta.1.md](docs/releases/v2.3.0-beta.1.md) — install via `npm i -g codex-multi-auth@beta`
 - Current stable: [docs/releases/v2.2.2.md](docs/releases/v2.2.2.md) — install via `npm i -g codex-multi-auth`
 - Previous stable: [docs/releases/v2.2.1.md](docs/releases/v2.2.1.md)
 - Previous stable: [docs/releases/v2.2.0.md](docs/releases/v2.2.0.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,7 +79,7 @@ The following are not treated as vulnerabilities in this repository:
 
 Security override rationale (`package.json` -> `overrides`):
 
-- `hono`: pinned to `4.12.18` to keep builds out of the vulnerable `4.12.0-4.12.1` range reported in `GHSA-xh87-mx6m-69f3` (authentication bypass advisory).
+- `hono`: pinned to `4.12.21` to keep builds out of the vulnerable `<4.12.21` range reported in `GHSA-3hrh-pfw6-9m5x`, `GHSA-2gcr-mfcq-wcc3`, `GHSA-xrhx-7g5j-rcj5`, and `GHSA-f577-qrjj-4474` (Set-Cookie injection, `app.mount()` path-decoding, IPv6 IP-restriction bypass, and JWT scheme-acceptance advisories).
 - `rollup`: pinned to `^4.59.0` to keep the Vite and Vitest transitive graph above the vulnerable `<4.59.0` range surfaced by `npm audit`.
 
 Before release and after dependency changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 				"@codex-ai/sdk": "file:vendor/codex-ai-sdk",
 				"@openauthjs/openauth": "^0.4.3",
-				"hono": "4.12.18",
+				"hono": "4.12.21",
 				"undici": "6.25.0",
 				"zod": "4.4.3"
 			},
@@ -1832,9 +1832,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2428,9 +2428,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.18",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-			"integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+			"version": "4.12.21",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+			"integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -176,12 +176,12 @@
 		"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 		"@codex-ai/sdk": "file:vendor/codex-ai-sdk",
 		"@openauthjs/openauth": "^0.4.3",
-		"hono": "4.12.18",
+		"hono": "4.12.21",
 		"undici": "6.25.0",
 		"zod": "4.4.3"
 	},
 	"overrides": {
-		"hono": "4.12.18",
+		"hono": "4.12.21",
 		"flatted": "3.4.2",
 		"minimatch": "10.2.4",
 		"picomatch": "4.0.4",


### PR DESCRIPTION
## Summary

Resolves all **4 open Dependabot alerts** shown in the repo's Security & quality view. All four are the same root cause: `hono` pinned below `4.12.21`. A single patch-level bump fixes every one.

| Alert | Severity | Advisory | Issue |
|------|----------|----------|-------|
| #47 | MEDIUM | `GHSA-3hrh-pfw6-9m5x` (CVE-2026-47675) | Cookie helper does not sanitize `sameSite`/`priority` → Set-Cookie injection |
| #45 | MEDIUM | `GHSA-2gcr-mfcq-wcc3` (CVE-2026-47676) | `app.mount()` strips mount prefix using undecoded path |
| #43 | MEDIUM | `GHSA-xrhx-7g5j-rcj5` (CVE-2026-47674) | IP-restriction bypass for non-canonical IPv6 deny rules |
| #41 | MEDIUM | `GHSA-f577-qrjj-4474` (CVE-2026-47673) | JWT middleware accepts any `Authorization` scheme, not only `Bearer` |

## Changes

- **`package.json`** — bump `hono` `4.12.18` → `4.12.21` in both `dependencies` and `overrides`. Patch within `4.12.x`, non-breaking (`engines` unchanged).
- **`package-lock.json`** — regenerated. Also bumps dev-only `brace-expansion` `5.0.5` → `5.0.6` (via `npm audit fix`, `GHSA-jxxr-4gwj-5jf2`). `npm audit` now reports **0 vulnerabilities**.
- **`SECURITY.md`** — override rationale updated to cite `4.12.21` and the four new advisories (enforced by `test/documentation.test.ts` docs-supplychain-03, which would otherwise fail on drift).
- **`README.md`** — corrected the "Current prerelease" link to `v2.3.0-beta.1` (it had drifted to `v2.3.0-beta.0` at the last release; this was a pre-existing doc-test failure on `main`, fixed here while the suite was green).

## Exposure note

The loopback bridge (`lib/local-bridge.ts`) uses only core Hono routing — none of the affected middleware (cookie helper, JWT, IP-restriction, `app.mount()`). So this is dependency hygiene rather than an exploitable path in this codebase, but it clears the alerts and keeps the supply chain clean.

## Verification

- `npm run build` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ — **4428 passed, 0 failed, 3 skipped**
- `npm audit --omit=dev --audit-level=high` ✅ — 0 vulnerabilities
- `npm audit` (full) ✅ — 0 vulnerabilities

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

patch-level bump of `hono` from `4.12.18` to `4.12.21`, resolving four medium-severity dependabot advisories (Set-Cookie injection, `app.mount()` path-decoding, IPv6 IP-restriction bypass, jwt scheme acceptance). also bumps dev-only `brace-expansion` `5.0.5` → `5.0.6` and corrects two documentation files.

- **`package.json` / `package-lock.json`**: `hono` pinned consistently in both `dependencies` and `overrides`; `brace-expansion` dev bump flows through lockfile only, no override needed since `npm audit --omit=dev` is clean.
- **`SECURITY.md`**: override rationale updated to `4.12.21` and lists the four new advisories; drops the original `GHSA-xh87-mx6m-69f3` authentication-bypass reference that first motivated the pin.
- **`README.md`**: prerelease link corrected from `v2.3.0-beta.0` → `v2.3.0-beta.1`; target file confirmed present in `docs/releases/`.

<h3>Confidence Score: 4/5</h3>

safe to merge — focused patch-level version bump with no logic changes; affected hono middleware is not exercised by lib/local-bridge.ts

all four changed files are correct and consistent. the one minor gap is that SECURITY.md drops the original GHSA-xh87-mx6m-69f3 authentication-bypass advisory from its documented history, which could confuse a future auditor tracing why the override was first introduced.

SECURITY.md — missing historical advisory reference; all other files are clean

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | bumps hono 4.12.18 → 4.12.21 in both dependencies and overrides; both fields stay in sync |
| package-lock.json | regenerated lockfile; hono and brace-expansion (dev-only) both bumped, integrity hashes updated correctly |
| SECURITY.md | override rationale updated to 4.12.21 and lists 4 new advisories; original GHSA-xh87-mx6m-69f3 authentication-bypass advisory is dropped from the documented history |
| README.md | prerelease link corrected from v2.3.0-beta.0 to v2.3.0-beta.1; target file exists in docs/releases/ |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm install] --> B{resolve hono}
    B -->|dependencies| C[hono 4.12.21]
    B -->|overrides| C
    C --> D{advisories fixed}
    D --> E[GHSA-3hrh-pfw6-9m5x\nSet-Cookie injection]
    D --> F[GHSA-2gcr-mfcq-wcc3\napp.mount path-decoding]
    D --> G[GHSA-xrhx-7g5j-rcj5\nIPv6 IP-restriction bypass]
    D --> H[GHSA-f577-qrjj-4474\nJWT scheme acceptance]
    A --> I{resolve brace-expansion}
    I -->|dev only| J[brace-expansion 5.0.6\nGHSA-jxxr-4gwj-5jf2 fixed]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fhono-4.12.21-security%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhono-4.12.21-security%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASECURITY.md%3A82%0Athe%20original%20%60GHSA-xh87-mx6m-69f3%60%20authentication-bypass%20advisory%20%28which%20first%20justified%20pinning%20hono%29%20is%20no%20longer%20cited%20anywhere%20in%20the%20rationale.%20while%20%60%3C4.12.21%60%20implicitly%20covers%20it%2C%20dropping%20the%20reference%20breaks%20the%20audit%20trail%20%E2%80%94%20a%20future%20reader%20won't%20know%20the%20pin%20predates%20these%20four%20new%20advisories%20or%20why%20it%20was%20introduced%20originally.%0A%0A%60%60%60suggestion%0A-%20%60hono%60%3A%20pinned%20to%20%604.12.21%60%20to%20keep%20builds%20out%20of%20the%20vulnerable%20%60%3C4.12.21%60%20range%20reported%20in%20%60GHSA-xh87-mx6m-69f3%60%20%28authentication%20bypass%29%2C%20%60GHSA-3hrh-pfw6-9m5x%60%2C%20%60GHSA-2gcr-mfcq-wcc3%60%2C%20%60GHSA-xrhx-7g5j-rcj5%60%2C%20and%20%60GHSA-f577-qrjj-4474%60%20%28Set-Cookie%20injection%2C%20%60app.mount%28%29%60%20path-decoding%2C%20IPv6%20IP-restriction%20bypass%2C%20and%20JWT%20scheme-acceptance%20advisories%29.%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=515&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
SECURITY.md:82
the original `GHSA-xh87-mx6m-69f3` authentication-bypass advisory (which first justified pinning hono) is no longer cited anywhere in the rationale. while `<4.12.21` implicitly covers it, dropping the reference breaks the audit trail — a future reader won't know the pin predates these four new advisories or why it was introduced originally.

```suggestion
- `hono`: pinned to `4.12.21` to keep builds out of the vulnerable `<4.12.21` range reported in `GHSA-xh87-mx6m-69f3` (authentication bypass), `GHSA-3hrh-pfw6-9m5x`, `GHSA-2gcr-mfcq-wcc3`, `GHSA-xrhx-7g5j-rcj5`, and `GHSA-f577-qrjj-4474` (Set-Cookie injection, `app.mount()` path-decoding, IPv6 IP-restriction bypass, and JWT scheme-acceptance advisories).
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): bump hono 4.12.18 -&gt; 4.12.21 ..."](https://github.com/ndycode/codex-multi-auth/commit/3c35571f4dcc33967c1028674b56c02880d176d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36100775)</sub>

<!-- /greptile_comment -->