### PR TITLE
fix: correctness bugs in flagged-storage, recovery, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current prerelease: [docs/releases/v2.3.0-beta.0.md](docs/releases/v2.3.0-beta.0.md) — install via `npm i -g codex-multi-auth@beta`
+- Current prerelease: [docs/releases/v2.3.0-beta.1.md](docs/releases/v2.3.0-beta.1.md) — install via `npm i -g codex-multi-auth@beta`
 - Current stable: [docs/releases/v2.2.2.md](docs/releases/v2.2.2.md) — install via `npm i -g codex-multi-auth`
 - Previous stable: [docs/releases/v2.2.1.md](docs/releases/v2.2.1.md)
 - Previous stable: [docs/releases/v2.2.0.md](docs/releases/v2.2.0.md)

--- a/lib/recovery/storage.ts
+++ b/lib/recovery/storage.ts
@@ -672,7 +672,7 @@ export function findEmptyMessageByIndex(
 		if (idx < 0 || idx >= messages.length) continue;
 
 		const targetMsg = messages[idx];
-		if (!targetMsg) continue;
+		if (!targetMsg || targetMsg.role !== "assistant") continue;
 
 		if (!messageHasContent(targetMsg.id)) {
 			return targetMsg.id;

--- a/lib/rotation.ts
+++ b/lib/rotation.ts
@@ -385,7 +385,7 @@ export interface HybridSelectionConfig {
 	healthWeight: number;
 	/** Weight for token count (default: 5) */
 	tokenWeight: number;
-	/** Weight for freshness/last used (default: 0.1) */
+	/** Weight for freshness/last used (default: 2) */
 	freshnessWeight: number;
 }
 

--- a/lib/storage/flagged-storage.ts
+++ b/lib/storage/flagged-storage.ts
@@ -46,12 +46,14 @@ export function normalizeFlaggedStorage(
 			value === "initial" ||
 			value === "rotation" ||
 			value === "best" ||
-			value === "restore";
+			value === "restore" ||
+			value === "manual";
 		const isCooldownReason = (
 			value: unknown,
 		): value is AccountMetadataV3["cooldownReason"] =>
 			value === "auth-failure" ||
 			value === "network-error" ||
+			value === "server-error" ||
 			value === "rate-limit";
 
 		let rateLimitResetTimes:

--- a/test/flagged-storage.test.ts
+++ b/test/flagged-storage.test.ts
@@ -28,4 +28,40 @@ describe("flagged storage helper", () => {
 		expect(result.accounts[0]?.refreshToken).toBe("token-1");
 		expect(result.accounts[0]?.lastError).toBe("oops");
 	});
+
+	it("preserves the 'manual' last switch reason on round-trip", () => {
+		const result = normalizeFlaggedStorage(
+			{
+				version: 1,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						flaggedAt: 10,
+						lastSwitchReason: "manual",
+					},
+				],
+			},
+			{ isRecord, now: () => 99 },
+		);
+
+		expect(result.accounts[0]?.lastSwitchReason).toBe("manual");
+	});
+
+	it("preserves the 'server-error' cooldown reason on round-trip", () => {
+		const result = normalizeFlaggedStorage(
+			{
+				version: 1,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						flaggedAt: 10,
+						cooldownReason: "server-error",
+					},
+				],
+			},
+			{ isRecord, now: () => 99 },
+		);
+
+		expect(result.accounts[0]?.cooldownReason).toBe("server-error");
+	});
 });

--- a/test/fs-retry.test.ts
+++ b/test/fs-retry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+	FILE_RETRY_CODES,
+	shouldRetryFileOperation,
+} from "../lib/fs-retry.js";
+
+function errnoError(code: string): NodeJS.ErrnoException {
+	const error = new Error(code) as NodeJS.ErrnoException;
+	error.code = code;
+	return error;
+}
+
+describe("shouldRetryFileOperation", () => {
+	it("treats every transient lock code as retryable", () => {
+		for (const code of ["EBUSY", "EPERM", "EAGAIN", "ENOTEMPTY", "EACCES"]) {
+			expect(shouldRetryFileOperation(errnoError(code)), code).toBe(true);
+			expect(FILE_RETRY_CODES.has(code), code).toBe(true);
+		}
+	});
+
+	it("does not retry non-transient errors", () => {
+		for (const code of ["ENOENT", "EISDIR", "EINVAL", "EROFS"]) {
+			expect(shouldRetryFileOperation(errnoError(code)), code).toBe(false);
+		}
+	});
+
+	it("returns false for non-errors and errors without a code", () => {
+		expect(shouldRetryFileOperation(undefined)).toBe(false);
+		expect(shouldRetryFileOperation(null)).toBe(false);
+		expect(shouldRetryFileOperation("EACCES")).toBe(false);
+		expect(shouldRetryFileOperation(new Error("no code"))).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

A parallel multi-agent review sweep over the `lib/` tree (rotation/proxy, accounts/storage/recovery, request/auth/refresh, config/manager/usage). I fixed **only high-confidence defects with observable wrong behavior**, added regression tests, and deliberately left several findings alone after verifying they were false positives or by-design (documented below).

## Fixes

### 1. Flagged-storage silently drops valid enum values (data loss) — `lib/storage/flagged-storage.ts`
`normalizeFlaggedStorage`'s type guards omitted two members that are part of the type, the Zod schema, and produced at runtime:
- `lastSwitchReason: "manual"` (set by the CLI `switch` command)
- `cooldownReason: "server-error"` (produced by `failure-policy.ts` / `runtime-rotation-proxy.ts`)

On any load → normalize → save round-trip, these were coerced to `undefined`, erasing switch/cooldown provenance from flagged records. **+2 regression tests.**

### 2. Recovery message-repair could target the wrong message — `lib/recovery/storage.ts`
`findEmptyMessageByIndex` probed `targetIndex, -1, -2` and returned the first empty message **without a role check**, unlike its sibling `findMessageByIndexNeedingThinking` which requires `role === "assistant"`. Added the matching guard so it can't select an unrelated user message. (Export-only/no live caller today — hardening against misuse.)

### 3. Misleading JSDoc default — `lib/rotation.ts`
`HybridSelectionConfig.freshnessWeight` doc said `default: 0.1`; the actual default is `2.0`. A consumer wiring a custom config from the doc would under-weight freshness 20×. Doc corrected.

### 4. README prerelease link drift — `README.md`
"Current prerelease" still pointed at `v2.3.0-beta.0` after the `v2.3.0-beta.1` release. Fixed (asserted by `test/documentation.test.ts`).

### 5. New test coverage — `test/fs-retry.test.ts`
Covers `shouldRetryFileOperation` across the full `FILE_RETRY_CODES` set and rejection of non-transient / code-less errors (this predicate had no direct test).

## Findings deliberately NOT changed (verified, not bugs)

- **`renameTempToPath` only retries EPERM/EBUSY** (`lib/storage.ts`): a reviewer flagged this as inconsistent with the module's broader retry set. It is **by-design and explicitly tested** — `storage.test.ts > "throws immediately on non-EPERM/EBUSY errors"` asserts `EACCES` on the final atomic commit-rename fails fast (a real permissions problem, not a transient lock). I made this change, it broke 7 tests, and I reverted it.
- **`lastGlobalSwitchAt` stamped on every successful request** (`runtime-rotation-proxy.ts`): plausibly intentional "drain-until-exhausted" stickiness, consistent with the recent sequential drain-first feature. Changing it alters core rotation semantics — needs maintainer intent, not a blind fix.
- **Import counts / `activeIndex` re-clamp** (`import-export.ts`): "skipped vs updated" count semantics are a product judgment encoded in existing tests; the activeIndex concern is masked by load-time `normalizeAccountStorage`. No observable defect.

## Verification

- `npm run build` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ — **4433 passed, 0 failed, 3 skipped** (5 new tests vs. baseline)

## Note
Independent of the hono security bump in #515 — that PR can merge separately.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes three correctness bugs found in a multi-agent sweep: silent data loss in `normalizeFlaggedStorage` (two missing enum members caused valid `lastSwitchReason` and `cooldownReason` values to be coerced to `undefined` on every save round-trip), a wrong-message selection risk in `findEmptyMessageByIndex` (no role guard, unlike its sibling), and a 20x wrong `freshnessWeight` default in the jsdoc.

- **flagged-storage fix**: adds `\"manual\"` to `isSwitchReason` and `\"server-error\"` to `isCooldownReason`, aligning both guards with the full `CooldownReason` union and `AccountMetadataV3` type; two regression tests included.
- **recovery guard**: `findEmptyMessageByIndex` now requires `role === \"assistant\"` before returning a message id, preventing accidental repair of a user message; no live caller today but no test covers the new branch.
- **docs/tests**: corrects jsdoc default for `freshnessWeight` (0.1 to 2), bumps readme prerelease link, and adds first direct tests for `shouldRetryFileOperation` across the full `FILE_RETRY_CODES` set.

<h3>Confidence Score: 4/5</h3>

safe to merge — all three code changes are narrow, well-scoped fixes with no altered control flow on production-active paths

the flagged-storage and rotation changes are clearly correct and well-tested. the recovery guard is sound but lacks a test for the new branch, and the fs-retry test hardcodes codes instead of iterating the exported set — both are minor coverage gaps that would be cheap to fill.

lib/recovery/storage.ts and test/fs-retry.test.ts would benefit from a second look on test completeness

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage/flagged-storage.ts | adds "manual" to isSwitchReason and "server-error" to isCooldownReason, aligning the guards with the full CooldownReason union and AccountMetadataV3 type — genuine data-loss fix with regression tests |
| lib/recovery/storage.ts | adds role === "assistant" guard to findEmptyMessageByIndex, matching the sibling function; no live caller today but correct defensive hardening — no test added for the new guard path |
| lib/rotation.ts | corrects freshnessWeight JSDoc from 0.1 to 2, matching DEFAULT_HYBRID_SELECTION_CONFIG.freshnessWeight = 2.0 — trivial doc-only fix, no logic change |
| test/flagged-storage.test.ts | adds two round-trip regression tests for "manual" and "server-error" enum values; both tests are correct and cover the fixed code paths |
| test/fs-retry.test.ts | new test file for shouldRetryFileOperation; hardcodes retry codes rather than iterating FILE_RETRY_CODES, so future additions to the set won't be automatically exercised |
| README.md | bumps prerelease doc link from v2.3.0-beta.0 to v2.3.0-beta.1; trivial, correct |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[load flagged-storage JSON] --> B[normalizeFlaggedStorage]
    B --> C{isSwitchReason?}
    C -->|rate-limit / initial / rotation / best / restore / manual| D[preserve lastSwitchReason]
    C -->|unknown value| E[coerce to undefined]
    B --> F{isCooldownReason?}
    F -->|auth-failure / network-error / server-error / rate-limit| G[preserve cooldownReason]
    F -->|unknown value| H[coerce to undefined]
    D & G --> I[save normalized record]
    J[findEmptyMessageByIndex] --> K[probe targetIndex -1 -2]
    K --> L{role === assistant?}
    L -->|no| M[skip not a repair target]
    L -->|yes| N{messageHasContent?}
    N -->|empty| O[return message id]
    N -->|has content| P[continue probe]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fbug-sweep%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fbug-sweep%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Ffs-retry.test.ts%3A14-19%0Athe%20test%20hardcodes%20retry%20codes%20instead%20of%20deriving%20them%20from%20%60FILE_RETRY_CODES%60.%20if%20a%20new%20code%20is%20added%20to%20the%20set%2C%20%60shouldRetryFileOperation%60%20will%20accept%20it%20but%20this%20test%20won't%20cover%20it.%20iterating%20directly%20over%20the%20exported%20set%20makes%20the%20test%20self-updating%20and%20also%20validates%20the%20set's%20size%20implicitly.%0A%0A%60%60%60suggestion%0A%09it%28%22treats%20every%20transient%20lock%20code%20as%20retryable%22%2C%20%28%29%20%3D%3E%20%7B%0A%09%09for%20%28const%20code%20of%20FILE_RETRY_CODES%29%20%7B%0A%09%09%09expect%28shouldRetryFileOperation%28errnoError%28code%29%29%2C%20code%29.toBe%28true%29%3B%0A%09%09%7D%0A%09%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Frecovery%2Fstorage.ts%3A662-683%0A**missing%20vitest%20coverage%20for%20new%20role%20guard**%0A%0A%60findEmptyMessageByIndex%60%20now%20skips%20user%20messages%20via%20%60role%20!%3D%3D%20%22assistant%22%60%2C%20but%20no%20test%20exercises%20that%20branch.%20the%20existing%20%60test%2Frecovery-storage.test.ts%60%20has%20no%20case%20where%20a%20user%20message%20sits%20at%20or%20near%20%60targetIndex%60.%20if%20the%20guard%20were%20accidentally%20reverted%20or%20the%20role%20string%20changed%2C%20no%20test%20would%20catch%20it.%20worth%20adding%20at%20least%20one%20case%3A%20a%20messages%20array%20where%20%60targetIndex%60%20lands%20on%20an%20empty%20user%20message%20to%20verify%20%60null%60%20is%20returned%20rather%20than%20the%20user%20message%20id.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=516&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/fs-retry.test.ts:14-19
the test hardcodes retry codes instead of deriving them from `FILE_RETRY_CODES`. if a new code is added to the set, `shouldRetryFileOperation` will accept it but this test won't cover it. iterating directly over the exported set makes the test self-updating and also validates the set's size implicitly.

```suggestion
	it("treats every transient lock code as retryable", () => {
		for (const code of FILE_RETRY_CODES) {
			expect(shouldRetryFileOperation(errnoError(code)), code).toBe(true);
		}
	});
```

### Issue 2 of 2
lib/recovery/storage.ts:662-683
**missing vitest coverage for new role guard**

`findEmptyMessageByIndex` now skips user messages via `role !== "assistant"`, but no test exercises that branch. the existing `test/recovery-storage.test.ts` has no case where a user message sits at or near `targetIndex`. if the guard were accidentally reverted or the role string changed, no test would catch it. worth adding at least one case: a messages array where `targetIndex` lands on an empty user message to verify `null` is returned rather than the user message id.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: correctness bugs in flagged-storage..."](https://github.com/ndycode/codex-multi-auth/commit/1a792b343dde30e67c4c5b77598ae579354b9925) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36103985)</sub>

<!-- /greptile_comment -->