### PR TITLE
ci: pin all workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.x
           cache: npm
@@ -81,10 +81,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.x
           cache: npm
@@ -107,10 +107,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.x
           cache: npm
@@ -127,10 +127,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: javascript-typescript
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: javascript-typescript
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.x
           cache: npm
@@ -67,10 +67,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.x
           cache: npm
@@ -96,10 +96,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20.x
           cache: npm


### PR DESCRIPTION
## Summary

Part 3 of the repo-wide audit (#517, #518). `ci.yml`, `pr-ci.yml`, and `codeql.yml` referenced actions by **mutable tags** while `codex-plugin-scanner.yml` already used SHA pins — an inconsistent supply-chain posture. A mutable tag can be re-pointed if the upstream action repo is compromised (as happened with `tj-actions/changed-files` in 2025), which would execute attacker code with access to the CI environment.

## Changes

Every `uses:` reference is now pinned to a full commit SHA with the tag noted inline, matching the convention `codex-plugin-scanner.yml` already established:

| Action | Pin | Provenance |
|---|---|---|
| `actions/checkout@v4` | `34e11487…14f8d5` | same SHA already trusted in `codex-plugin-scanner.yml` |
| `actions/setup-node@v4` | `49933ea5…820020` | verified against the `v4` tag on github.com/actions/setup-node |
| `github/codeql-action/{init,autobuild,analyze}@v3` | `dd903d2e…32357` | `v3` → v3.36.2 tag on github.com/github/codeql-action |

No workflow logic changes — pin-only diff.

**Maintenance**: `.github/dependabot.yml` already has a `github-actions` ecosystem entry, so Dependabot will keep these SHA pins updated (it understands the `# vN` comment convention).

## Testing

YAML untouched apart from the `uses:` lines; `grep` confirms zero unpinned `uses:` references remain across all four workflows. CI on this PR itself exercises the pinned checkout/setup-node paths.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

pin-only supply-chain hardening across `ci.yml`, `pr-ci.yml`, and `codeql.yml`, replacing mutable action tags with full commit SHAs and aligning all four workflow files to the same pinning convention already established in `codex-plugin-scanner.yml`. `codeql-action` is also silently upgraded from v3 to v4 in the process, addressing the deprecation flagged in a prior review thread.

- **`ci.yml` / `pr-ci.yml`**: five jobs each now pin `actions/checkout` and `actions/setup-node` to the same SHAs used in the trusted `codex-plugin-scanner.yml` baseline.
- **`codeql.yml`**: `init`, `autobuild`, and `analyze` all pinned to `8aad20d1…1e # v4` — consistent single SHA across the three sub-actions; includes a quiet major-version bump from v3 to v4.
- no workflow logic, triggers, permissions, or step ordering changed — pure `uses:` line replacements throughout.

<h3>Confidence Score: 5/5</h3>

safe to merge — pure `uses:` line replacements with no logic, trigger, or permission changes

every changed line is a tag-to-SHA substitution; the checkout SHA matches the trusted baseline already in `codex-plugin-scanner.yml`, the codeql-action upgrade to v4 is a straightforward major-version bump with no breaking changes for javascript-typescript analysis, and dependabot is already configured to keep these pins current

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | all five jobs now pin checkout and setup-node to full commit SHAs; no logic changes |
| .github/workflows/pr-ci.yml | three jobs updated with same SHA pins as ci.yml; validate, node22-smoke, scripts-windows all consistent |
| .github/workflows/codeql.yml | checkout pinned; codeql init/autobuild/analyze pinned to v4 SHA (silently upgraded from v3, addressing prior review feedback) |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: move codeql-action pin from deprecat..."](https://github.com/ndycode/codex-multi-auth/commit/11375974f3c1f5ebc51d2c1f264d5a7e6a3a88a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36511458)</sub>

<!-- /greptile_comment -->