### PR TITLE
docs: fix stale command names, version drift, and duplicate doc-portal rows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,8 +27,8 @@ Describe the observed result.
 ## Environment
 
 - `codex --version`:
-- `codex auth status` output summary:
-- `codex auth rotation status` output summary, if runtime rotation is involved:
+- `codex-multi-auth status` output summary:
+- `codex-multi-auth rotation status` output summary, if runtime rotation is involved:
 - `npm ls -g codex-multi-auth`:
 - OS:
 - Node.js:
@@ -37,9 +37,9 @@ Describe the observed result.
 
 Include relevant outputs from:
 
-- `codex auth check`
-- `codex auth report --json`
-- `codex auth doctor --json`
+- `codex-multi-auth check`
+- `codex-multi-auth report --json`
+- `codex-multi-auth doctor --json`
 
 ## Logs (Optional)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Generated: 2026-04-25
 Commit: a87e005
 Branch: main
-Package version: 2.2.0
+Package version: 2.3.0-beta.1
 
 ## OVERVIEW
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 Generated: 2026-04-25
 Commit: a87e005
+Validated: 2026-06-10 against commit 98d9819 (repo audit; claims re-checked against the tree, content not regenerated)
 Branch: main
 Package version: 2.3.0-beta.1
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,17 +98,6 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 | [reference/storage-paths.md](reference/storage-paths.md) | Canonical and compatibility storage paths |
 | [reference/public-api.md](reference/public-api.md) | Public API stability and semver contract |
 | [reference/error-contracts.md](reference/error-contracts.md) | CLI, JSON, and helper error semantics |
-| [releases/v2.1.7.md](releases/v2.1.7.md) | Earlier stable release notes |
-| [releases/v2.1.6.md](releases/v2.1.6.md) | Earlier stable release notes |
-| [releases/v2.1.5.md](releases/v2.1.5.md) | Earlier stable release notes |
-| [releases/v2.1.4.md](releases/v2.1.4.md) | Earlier stable release notes |
-| [releases/v2.1.3.md](releases/v2.1.3.md) | Earlier stable release notes |
-| [releases/v2.1.2.md](releases/v2.1.2.md) | Earlier stable release notes |
-| [releases/v2.1.1.md](releases/v2.1.1.md) | Earlier stable release notes |
-| [releases/v2.1.0.md](releases/v2.1.0.md) | Earlier stable release notes |
-| [releases/v2.0.2.md](releases/v2.0.2.md) | Earlier stable release notes |
-| [releases/v2.0.1.md](releases/v2.0.1.md) | Earlier stable release notes |
-| [releases/v0.1.0-beta.0.md](releases/v0.1.0-beta.0.md) | Archived prerelease reference |
 | [Release history](#release-history) | Stable, previous, and archived release notes |
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -39,6 +39,7 @@ Compatibility forms are supported for migrations and wrapper-routed environments
 | `codex-multi-auth forecast` | Forecast best account by readiness/risk |
 | `codex-multi-auth best` | Pick and optionally sync the best account (clears any manual pin) |
 | `codex-multi-auth account ...` | Manage local account policy metadata |
+| `codex-multi-auth workspace <account> [workspace]` | List an account's tracked workspaces, or set its active workspace |
 
 > Sticky session affinity: `switch`, `unpin`, and `best` all bump an
 > `affinityGeneration` counter in storage that the runtime rotation proxy
@@ -136,6 +137,22 @@ Notes:
   runtime policy integration PR.
 - `weight` accepts values from `0` to `10`; default is `1`.
 - `tag` values are normalized to lowercase filesystem-safe labels.
+
+---
+
+## `codex-multi-auth workspace`
+
+```bash
+codex-multi-auth workspace <account>             # list the account's tracked workspaces
+codex-multi-auth workspace <account> <workspace> # set the active workspace for that account
+```
+
+Lists or sets the active workspace for one saved account. Both arguments are
+1-based indexes as shown by `codex-multi-auth list` and the workspace listing.
+With only an account index, prints the workspaces that account can rotate
+between (for example a personal Plus seat and a business/team seat under the
+same email, issue #491). With a workspace index too, persists that workspace
+as the account's active selection.
 
 ---
 

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -334,6 +334,15 @@ describe("Documentation Integrity", () => {
 			existsSync(join(projectRoot, switchPath)),
 			`${switchPath} should exist`,
 		).toBe(true);
+		const workspacePath = "lib/codex-manager/commands/workspace.ts";
+		expect(
+			existsSync(join(projectRoot, workspacePath)),
+			`${workspacePath} should exist`,
+		).toBe(true);
+		expect(commandRef).toContain(
+			"| `codex-multi-auth workspace <account> [workspace]` | List an account's tracked workspaces, or set its active workspace |",
+		);
+		expect(commandRef).toContain("## `codex-multi-auth workspace`");
 		const help = read(helpPath);
 		const switchCommand = read(switchPath);
 

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -321,7 +321,7 @@ describe("Documentation Integrity", () => {
 		expect(errorContracts).toContain("transformrequestbody");
 	});
 
-	it("keeps fix command flag docs aligned across README, reference, and CLI usage text", () => {
+	it("keeps command docs aligned across README, reference, and CLI usage text", () => {
 		const readme = read("README.md");
 		const commandRef = read("docs/reference/commands.md");
 		const helpPath = "lib/codex-manager/help.ts";


### PR DESCRIPTION
## Summary

Part 4 of the repo-wide audit (#517, #518, #519). Four documentation-accuracy fixes, each verified against the shipped CLI surface.

## Changes

1. **`.github/ISSUE_TEMPLATE/bug_report.md`** — the template asked reporters to run `codex auth status`, `codex auth rotation status`, `codex auth check`, `codex auth report --json`, and `codex auth doctor --json`. None of these are commands this package installs; reporters following the template verbatim get errors. All five now use the canonical `codex-multi-auth ...` family that README/CONTRIBUTING/`test/documentation.test.ts` establish.

2. **`AGENTS.md`** — claimed `Package version: 2.2.0` while `package.json` and `.codex-plugin/plugin.json` are both at `2.3.0-beta.1`.

3. **`docs/README.md`** — the Reference table duplicated eleven `releases/*.md` rows that the Release History section directly above already lists. Removed the duplicates; the `[Release history](#release-history)` pointer row remains.

4. **`docs/reference/commands.md`** — the shipped `codex-multi-auth workspace <account> [workspace]` command (issue #491, `lib/codex-manager/commands/workspace.ts`) was completely undocumented. Added a Daily Use table row and a detail section describing list-vs-set semantics and the 1-based indexes, matching the command's actual behavior.

## Testing

- `test/documentation.test.ts` (25 doc-integrity assertions, including command-name canonicity and release-note structure) ✅

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes four documentation accuracy issues identified during the repo-wide audit: stale `codex auth ...` command names in the bug report template, a package version mismatch in `AGENTS.md`, duplicate release rows in `docs/README.md`, and a completely undocumented `workspace` command in the command reference.

- **bug_report.md**: all five command stubs replaced with canonical `codex-multi-auth ...` forms; each was verified against the shipped cli surface (`rotation.ts`, `check.ts`, `report.ts`, and `doctor` routing in `codex-manager.ts`).
- **docs/reference/commands.md**: adds a daily-use table row and detail section for `codex-multi-auth workspace <account> [workspace]`, accurately reflecting the 1-based index semantics and list-vs-set behavior in `workspace.ts`.
- **test/documentation.test.ts**: broadens the existing alignment test to assert `workspace.ts` existence and the exact table row and section header; behavioral coverage already exists in `codex-manager-workspace-command.test.ts`.

<h3>Confidence Score: 5/5</h3>

docs-only change with no runtime code modified; all command names verified against the shipped cli surface

every corrected command name (`rotation status`, `check`, `report --json`, `doctor --json`) is confirmed present in the codebase. the workspace docs accurately reflect `workspace.ts` behavior including 1-based indexing. behavioral unit tests for the workspace command already exist in `codex-manager-workspace-command.test.ts`, and the new doc-integrity assertions match the exact strings added to `commands.md`.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug_report.md | corrects all five stale `codex auth ...` stubs to canonical `codex-multi-auth ...` equivalents; all target commands verified in the shipped cli surface |
| AGENTS.md | bumps package version from 2.2.0 to 2.3.0-beta.1 and adds a `Validated:` annotation clarifying the file was audited but not regenerated |
| docs/README.md | removes 11 duplicate release rows from the reference table; the `[Release history]` pointer row is correctly preserved |
| docs/reference/commands.md | documents the previously missing `workspace` command; table row and detail section match the actual implementation in `workspace.ts` (1-based indexes, list-vs-set semantics, disabled-workspace guard present in source but not described in docs — acceptable omission) |
| test/documentation.test.ts | broadens the alignment test with workspace source-file existence check and exact string assertions; test rename is appropriate since the test now covers more than the `fix` flag surface |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bug_report.md\nstale codex auth ... commands] -->|fixed to| B[codex-multi-auth status\ncodex-multi-auth rotation status\ncodex-multi-auth check\ncodex-multi-auth report --json\ncodex-multi-auth doctor --json]
    C[AGENTS.md\nPackage version: 2.2.0] -->|bumped to| D[2.3.0-beta.1\n+ Validated annotation]
    E[docs/README.md\nreference table with 11 duplicate\nrelease rows] -->|de-duplicated| F[pointer row kept\nRelease history section unchanged]
    G[docs/reference/commands.md\nworkspace command undocumented] -->|added| H[table row + detail section\n1-based indexes, list-vs-set semantics]
    H --> I[test/documentation.test.ts\nworkspace.ts existence check\nexact string assertions added]
```

<sub>Reviews (4): Last reviewed commit: ["test(docs): broaden stale doc-alignment ..."](https://github.com/ndycode/codex-multi-auth/commit/32d1e90f043c8ce4b936a57748b64077d174ec8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36511781)</sub>

<!-- /greptile_comment -->