### PR TITLE
chore(hooks): run typecheck in pre-commit, drop deprecated husky bootstrap

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-npx lint-staged
-npm run typecheck
+npx lint-staged && npm run typecheck

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged
+npm run typecheck

--- a/test/precommit-hook.test.ts
+++ b/test/precommit-hook.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const projectRoot = resolve(process.cwd());
+
+describe("pre-commit hook contract", () => {
+	it("stays fail-fast when it runs multiple commands", () => {
+		const hook = readFileSync(join(projectRoot, ".husky/pre-commit"), "utf-8");
+		const commandLines = hook
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0 && !line.startsWith("#"));
+		// Plain sh runs sequential lines unconditionally and exits with the last
+		// command's status, so a multi-line hook must opt into set -e or a lint
+		// failure followed by a clean typecheck would not block the commit.
+		if (commandLines.length > 1) {
+			expect(hook, "multi-line hook must set -e to stay fail-fast").toContain(
+				"set -e",
+			);
+		}
+		// Commands on a single line must be chained with && (";" ignores the
+		// first command's failure) for the same reason.
+		for (const line of commandLines) {
+			expect(
+				line,
+				`hook line must not chain commands with ';': ${line}`,
+			).not.toContain(";");
+		}
+	});
+
+	it("does not use the deprecated husky v9 bootstrap (removed in husky v10)", () => {
+		const hook = readFileSync(join(projectRoot, ".husky/pre-commit"), "utf-8");
+		expect(hook).not.toContain("husky.sh");
+	});
+});


### PR DESCRIPTION
## Summary

Part 5 of the repo-wide audit (#517, #518, #519, #520). Two small dev-tooling fixes to `.husky/pre-commit`:

1. **Remove the deprecated husky v9 bootstrap lines** (`#!/bin/sh` + `. "$(dirname "$0")/_/husky.sh"`). Husky prints a deprecation warning on every commit today and these lines **will hard-fail in husky v10**.

2. **Add `npm run typecheck` to the pre-commit gate.** The hook previously ran only `lint-staged` (eslint), while CI requires typecheck — so type errors silently reached the PR stage. `tsc --noEmit` completes in ~5s on this codebase, cheap enough to gate every commit. (`--no-verify` remains available for emergencies, as before.)

## Testing

The hook exercised itself on this branch's own commit: lint-staged + typecheck both ran, no deprecation warning, commit succeeded.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

drops the deprecated husky v9 bootstrap shim and adds `npm run typecheck` (`tsc --noEmit`) to the pre-commit gate, chained with `&&` so a lint failure correctly blocks the commit. a new vitest contract test locks in the fail-fast invariant and the removal of the deprecated bootstrap.

- `.husky/pre-commit`: single-line `npx lint-staged && npm run typecheck` replaces the multi-line husky-v9 form; `&&` chaining propagates non-zero exit codes to git as required.
- `test/precommit-hook.test.ts`: contract test verifies no `;` chaining, no deprecated `husky.sh` shim, and that multi-line hooks carry `set -e` — adds regression coverage for both changes in this PR.

<h3>Confidence Score: 5/5</h3>

safe to merge — the hook change is correct and the test adds meaningful regression coverage

the two-file change is narrowly scoped: the hook now correctly uses `&&` so lint failures block the commit, the deprecated bootstrap is gone, and the new contract test locks both invariants in. no runtime code paths, no token handling, no windows filesystem operations are touched.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .husky/pre-commit | removes deprecated husky v9 bootstrap and chains lint-staged + typecheck with &&, correctly propagating non-zero exit codes to git |
| test/precommit-hook.test.ts | new contract test guards against multi-line hooks without set -e and semicolon chaining, but doesn't assert against || (fail-open) single-line chaining |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[git commit] --> B[pre-commit hook]
    B --> C[npx lint-staged]
    C -->|exit non-zero| D[hook exits non-zero\ngit blocks commit]
    C -->|exit 0| E[npm run typecheck\ntsc --noEmit]
    E -->|exit non-zero| D
    E -->|exit 0| F[hook exits 0\ngit proceeds with commit]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-05-precommit-typecheck%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-05-precommit-typecheck%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fprecommit-hook.test.ts%3A22-29%0Athe%20test%20guards%20against%20%60%3B%60%20chaining%20but%20not%20%60%7C%7C%60%20chaining.%20%60npx%20lint-staged%20%7C%7C%20npm%20run%20typecheck%60%20would%20pass%20every%20assertion%20here%20yet%20is%20fail-open%3A%20typecheck%20only%20runs%20when%20lint-staged%20*fails*%2C%20which%20is%20the%20opposite%20of%20the%20desired%20behaviour.%0A%0A%60%60%60suggestion%0A%09%09%2F%2F%20Commands%20on%20a%20single%20line%20must%20be%20chained%20with%20%26%26%20%28%22%3B%22%20ignores%20the%0A%09%09%2F%2F%20first%20command's%20failure%29%20for%20the%20same%20reason.%20Also%20guard%20against%20%7C%7C%0A%09%09%2F%2F%20which%20is%20fail-open%20%28second%20command%20only%20runs%20when%20the%20first%20fails%29.%0A%09%09for%20%28const%20line%20of%20commandLines%29%20%7B%0A%09%09%09expect%28%0A%09%09%09%09line%2C%0A%09%09%09%09%60hook%20line%20must%20not%20chain%20commands%20with%20'%3B'%3A%20%24%7Bline%7D%60%2C%0A%09%09%09%29.not.toContain%28%22%3B%22%29%3B%0A%09%09%09expect%28%0A%09%09%09%09line%2C%0A%09%09%09%09%60hook%20line%20must%20not%20chain%20commands%20with%20'%7C%7C'%3A%20%24%7Bline%7D%60%2C%0A%09%09%09%29.not.toContain%28%22%7C%7C%22%29%3B%0A%09%09%7D%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=521&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/precommit-hook.test.ts:22-29
the test guards against `;` chaining but not `||` chaining. `npx lint-staged || npm run typecheck` would pass every assertion here yet is fail-open: typecheck only runs when lint-staged *fails*, which is the opposite of the desired behaviour.

```suggestion
		// Commands on a single line must be chained with && (";" ignores the
		// first command's failure) for the same reason. Also guard against ||
		// which is fail-open (second command only runs when the first fails).
		for (const line of commandLines) {
			expect(
				line,
				`hook line must not chain commands with ';': ${line}`,
			).not.toContain(";");
			expect(
				line,
				`hook line must not chain commands with '||': ${line}`,
			).not.toContain("||");
		}
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test(hooks): guard pre-commit fail-fast ..."](https://github.com/ndycode/codex-multi-auth/commit/7a1c1c2c00ab469e62e8f888d00de065d4c14c16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36595562)</sub>

<!-- /greptile_comment -->