### PR TITLE
refactor(request): split fetch-helpers along its natural seams

### DIFF
--- a/lib/request/error-classification.ts
+++ b/lib/request/error-classification.ts
@@ -1,0 +1,366 @@
+/**
+ * Error classification helpers for the custom fetch implementation
+ * Extracted from fetch-helpers.ts (audit roadmap §4.1.2); fetch-helpers.ts
+ * re-exports the public symbols so existing importers are unchanged.
+ */
+
+import { isRecord } from "../utils.js";
+import { HTTP_STATUS } from "../constants.js";
+
+export interface EntitlementError {
+        isEntitlement: true;
+        code: string;
+        message: string;
+}
+
+export const CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE = "model_not_supported_with_chatgpt_account";
+const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
+	/model is not supported when using codex with a chatgpt account/i;
+const NORMALIZED_UNSUPPORTED_MODEL_PATTERN =
+	/the model ['"]([^'"]+)['"] is not currently available for this chatgpt account/i;
+const MODEL_ACCESS_DENIED_PATTERN =
+	/the model [`'"]([^`'"]+)[`'"] does not exist or you do not have access to it/i;
+
+export const DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN: Record<string, string[]> = {
+	"gpt-5": ["gpt-5.5"],
+	"gpt-5-pro": ["gpt-5.5-pro"],
+	"gpt-5-chat-latest": ["gpt-5.5"],
+	"gpt-5.5": ["gpt-5.4"],
+	"gpt-5.5-pro": ["gpt-5.4"],
+	"gpt-5.5-2026-04-23": ["gpt-5.4"],
+	"gpt-5.5-pro-2026-04-23": ["gpt-5.4"],
+	"gpt-5.5-20260423": ["gpt-5.4"],
+	"gpt-5.5-pro-20260423": ["gpt-5.4"],
+	"gpt-5.3-codex-spark": ["gpt-5.3-codex", "gpt-5.2-codex"],
+	"gpt-5.3-codex": ["gpt-5.2-codex"],
+	"codex-max": ["gpt-5.3-codex"],
+	"gpt-5.1-codex-max": ["gpt-5.3-codex"],
+	"codex-mini-latest": ["gpt-5.3-codex"],
+	"gpt-5-codex-mini": ["gpt-5.3-codex"],
+	"gpt-5.1-codex-mini": ["gpt-5.3-codex"],
+	"gpt-5-codex": ["gpt-5.3-codex", "gpt-5.2-codex"],
+	"gpt-5.2-codex": ["gpt-5.3-codex"],
+	"gpt-5.1-codex": ["gpt-5.3-codex"],
+};
+
+export interface UnsupportedCodexModelInfo {
+	isUnsupported: boolean;
+	code?: string;
+	message?: string;
+	unsupportedModel?: string;
+}
+
+export interface ResolveUnsupportedCodexFallbackOptions {
+	requestedModel: string | undefined;
+	errorBody: unknown;
+	attemptedModels?: Iterable<string>;
+	fallbackOnUnsupportedCodexModel: boolean;
+	fallbackToGpt52OnUnsupportedGpt53: boolean;
+	customChain?: Record<string, string[]>;
+}
+
+function canonicalizeModelName(model: string | undefined): string | undefined {
+	if (!model) return undefined;
+	const trimmed = model.trim().toLowerCase();
+	if (!trimmed) return undefined;
+	const stripped = trimmed.includes("/")
+		? (trimmed.split("/").pop() ?? trimmed)
+		: trimmed;
+	return stripped.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
+}
+
+function normalizeFallbackChain(
+	customChain: Record<string, string[]> | undefined,
+): Record<string, string[]> {
+	const normalized: Record<string, string[]> = {};
+	for (const [key, values] of Object.entries(DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN)) {
+		const normalizedKey = canonicalizeModelName(key);
+		if (!normalizedKey) continue;
+		normalized[normalizedKey] = values
+			.map((value) => canonicalizeModelName(value))
+			.filter((value): value is string => !!value);
+	}
+
+	if (!customChain) {
+		return normalized;
+	}
+
+	for (const [key, values] of Object.entries(customChain)) {
+		const normalizedKey = canonicalizeModelName(key);
+		if (!normalizedKey || !Array.isArray(values)) continue;
+		const normalizedValues = values
+			.map((value) => canonicalizeModelName(value))
+			.filter((value): value is string => !!value);
+		if (normalizedValues.length > 0) {
+			normalized[normalizedKey] = normalizedValues;
+		}
+	}
+
+	return normalized;
+}
+
+export function extractUnsupportedCodexModelFromText(bodyText: string): string | undefined {
+	const directMatch = bodyText.match(
+		/['"]([^'"]+)['"]\s+model is not supported when using codex with a chatgpt account/i,
+	);
+	if (directMatch?.[1]) {
+		return canonicalizeModelName(directMatch[1]);
+	}
+	const normalizedMatch = bodyText.match(NORMALIZED_UNSUPPORTED_MODEL_PATTERN);
+	if (normalizedMatch?.[1]) {
+		return canonicalizeModelName(normalizedMatch[1]);
+	}
+	const accessDeniedMatch = bodyText.match(MODEL_ACCESS_DENIED_PATTERN);
+	if (accessDeniedMatch?.[1]) {
+		return canonicalizeModelName(accessDeniedMatch[1]);
+	}
+	return undefined;
+}
+
+export function isUnsupportedCodexModelForChatGpt(status: number, bodyText: string): boolean {
+	if (status !== HTTP_STATUS.BAD_REQUEST) return false;
+	if (!bodyText) return false;
+	return (
+		CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(bodyText) ||
+		NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(bodyText) ||
+		MODEL_ACCESS_DENIED_PATTERN.test(bodyText)
+	);
+}
+
+export function getUnsupportedCodexModelInfo(
+	errorBody: unknown,
+): UnsupportedCodexModelInfo {
+	if (!isRecord(errorBody)) {
+		return { isUnsupported: false };
+	}
+
+	const maybeError = errorBody.error;
+	if (!isRecord(maybeError)) {
+		// Some upstreams (e.g. the Codex quota endpoint) return the flat
+		// `{ "detail": "...model is not supported..." }` shape instead of the
+		// nested `{ "error": { "message": "..." } }` envelope. Fall back to the
+		// top-level `detail` string so model-fallback detection still works.
+		const detail = typeof errorBody.detail === "string" ? errorBody.detail : undefined;
+		if (!detail) {
+			return { isUnsupported: false };
+		}
+		const isUnsupportedDetail =
+			CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
+			NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
+			MODEL_ACCESS_DENIED_PATTERN.test(detail);
+		if (!isUnsupportedDetail) {
+			return { isUnsupported: false };
+		}
+		return {
+			isUnsupported: true,
+			message: detail,
+			unsupportedModel: extractUnsupportedCodexModelFromText(detail) ?? undefined,
+		};
+	}
+
+	const code = typeof maybeError.code === "string" ? maybeError.code : undefined;
+	const message =
+		typeof maybeError.message === "string" ? maybeError.message : undefined;
+	const unsupportedModelFromPayload =
+		typeof maybeError.unsupported_model === "string"
+			? maybeError.unsupported_model
+			: undefined;
+	const unsupportedModel = unsupportedModelFromPayload
+		? canonicalizeModelName(unsupportedModelFromPayload)
+		: extractUnsupportedCodexModelFromText(message ?? "");
+	const isUnsupported =
+		code === CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE ||
+		(message
+			? CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(message) ||
+				NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(message) ||
+				MODEL_ACCESS_DENIED_PATTERN.test(message)
+			: false);
+
+	return {
+		isUnsupported,
+		code,
+		message,
+		unsupportedModel: unsupportedModel ?? undefined,
+	};
+}
+
+export function resolveUnsupportedCodexFallbackModel(
+	options: ResolveUnsupportedCodexFallbackOptions,
+): string | undefined {
+	if (!options.fallbackOnUnsupportedCodexModel) return undefined;
+
+	const unsupported = getUnsupportedCodexModelInfo(options.errorBody);
+	if (!unsupported.isUnsupported) return undefined;
+
+	const requestedModel = canonicalizeModelName(options.requestedModel);
+	const currentModel = requestedModel ?? unsupported.unsupportedModel;
+	if (!currentModel) return undefined;
+
+	const attempted = new Set<string>();
+	for (const model of options.attemptedModels ?? []) {
+		const normalized = canonicalizeModelName(model);
+		if (normalized) attempted.add(normalized);
+	}
+
+	const chain = normalizeFallbackChain(options.customChain);
+	const targets = chain[currentModel] ?? [];
+	if (targets.length === 0) return undefined;
+
+	for (const target of targets) {
+		if (!options.fallbackToGpt52OnUnsupportedGpt53 &&
+			currentModel === "gpt-5.3-codex" &&
+			target === "gpt-5.2-codex") {
+			continue;
+		}
+		if (target === currentModel) continue;
+		if (attempted.has(target)) continue;
+		return target;
+	}
+
+	return undefined;
+}
+
+/**
+ * Returns true when the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge is available.
+ */
+export function shouldFallbackToGpt52OnUnsupportedGpt53(
+	requestedModel: string | undefined,
+	errorBody: unknown,
+): boolean {
+	if (canonicalizeModelName(requestedModel) !== "gpt-5.3-codex") {
+		return false;
+	}
+
+	return (
+		resolveUnsupportedCodexFallbackModel({
+			requestedModel,
+			errorBody,
+			// Probe whether the legacy gpt-5.2 edge is still active under current
+			// policy/toggles when the current Codex model is blocked.
+			attemptedModels: [],
+			fallbackOnUnsupportedCodexModel: true,
+			fallbackToGpt52OnUnsupportedGpt53: true,
+		}) === "gpt-5.2-codex"
+	);
+}
+
+/**
+ * Detects whether an error code or response body indicates an entitlement/subscription issue for Codex models.
+ *
+ * Entitlement errors signal that the requested feature is not included in the user's plan and should not be treated as rate limits.
+ * This function is pure and safe to call concurrently; it performs no filesystem access (including on Windows) and does not read or redact tokens — callers must avoid passing sensitive credentials in `code` or `bodyText`.
+ *
+ * @param code - The error code string returned by the service
+ * @param bodyText - The response body text to inspect for entitlement-related phrases
+ * @returns `true` if the combined `code` or `bodyText` indicates an entitlement/subscription issue, `false` otherwise
+ */
+export function isEntitlementError(code: string, bodyText: string): boolean {
+        const haystack = `${code} ${bodyText}`.toLowerCase();
+        // "usage_not_included" means the subscription doesn't include this feature
+        // This is different from "usage_limit_reached" which is a temporary quota limit
+        return /usage_not_included|not.included.in.your.plan|subscription.does.not.include/i.test(haystack);
+}
+
+/**
+ * Detects whether an error indicates the workspace/account has been disabled or expired.
+ *
+ * Workspace disabled errors signal that the current workspace is no longer accessible
+ * (expired, disabled, or removed) and the plugin should automatically switch to another account.
+ *
+ * @param status - HTTP status code
+ * @param code - The error code string returned by the service
+ * @param bodyText - The response body text to inspect for workspace-related phrases
+ * @returns `true` if the error indicates a disabled/expired workspace
+ */
+export function isWorkspaceDisabledError(
+        status: number,
+        code: unknown,
+        bodyText: string,
+): boolean {
+        const normalizedCode = typeof code === "string" ? code.trim().toLowerCase() : "";
+
+        if (status === 402) {
+                const normalizedTokens = normalizedCode
+                        .split(/[^a-z0-9_]+/i)
+                        .map((token) => token.trim())
+                        .filter((token) => token.length > 0);
+                return (
+                        normalizedTokens.includes("deactivated_workspace") ||
+                        /\bdeactivated_workspace\b/i.test(bodyText)
+                );
+        }
+
+        if (status !== 403) {
+                return false;
+        }
+
+        const haystack = `${normalizedCode} ${bodyText}`.toLowerCase();
+        const normalizedTokens = normalizedCode
+                .split(/[^a-z0-9_]+/i)
+                .map((token) => token.trim())
+                .filter((token) => token.length > 0);
+
+		const disabledPatterns = [
+				/workspace.*(?:disabled|expired|deactivated|terminated)/i,
+				/account\s+(?:has\s+been|is)\s+(?:disabled|expired|deactivated|terminated|closed)/i,
+				/(?:workspace|org(?:anization)?).*no longer.*(?:active|available|valid)/i,
+				/(?:workspace|org(?:anization)?).*has been.*(?:disabled|expired|closed)/i,
+				/workspace.*(?:access|subscription).*expired/i,
+				/org(?:anization)?.*(?:disabled|expired|inactive)/i,
+		];
+
+        for (const pattern of disabledPatterns) {
+                if (pattern.test(haystack)) {
+                        return true;
+                }
+        }
+
+        const workspaceErrorCodes = new Set([
+                "workspace_disabled",
+                "workspace_expired",
+                "workspace_terminated",
+                "account_disabled",
+                "account_expired",
+                "organization_disabled",
+        ]);
+        if (workspaceErrorCodes.has(normalizedCode)) {
+                return true;
+        }
+
+        return normalizedTokens.some((token) => workspaceErrorCodes.has(token));
+}
+
+/**
+ * Constructs a standardized 403 entitlement error Response indicating the user lacks access to Codex models.
+ *
+ * This function returns a JSON Response with an `error` payload containing a user-facing message, a
+ * `type` of `"entitlement_error"`, and a `code` of `"usage_not_included"`. The message suggests checking
+ * account/workspace access and re-authenticating with `codex-multi-auth login`.
+ *
+ * Concurrency: stateless and safe to call concurrently from multiple threads or requests.
+ * Windows filesystem behavior: none (function does not access the filesystem).
+ * Token redaction: any tokens are not included in the generated payload; do not pass sensitive tokens in `_bodyText`.
+ *
+ * @param _bodyText - Original response body text (accepted for compatibility; ignored when building the response)
+ * @returns A 403 Response with a JSON body describing the entitlement error and guidance for resolving it
+ */
+export function createEntitlementErrorResponse(_bodyText: string): Response {
+        const message = 
+                "This model is not included in your ChatGPT subscription. " +
+                "Please check that your account or workspace has access to Codex models (Plus/Pro/Business/Enterprise). " +
+                "If you recently subscribed or switched workspaces, try logging out and back in with `codex-multi-auth login`.";
+        
+        const payload = {
+                error: {
+                        message,
+                        type: "entitlement_error",
+                        code: "usage_not_included",
+                },
+        };
+
+        return new Response(JSON.stringify(payload), {
+                status: 403, // Forbidden - not a rate limit
+                statusText: "Forbidden",
+                headers: { "content-type": "application/json; charset=utf-8" },
+        });
+}

--- a/lib/request/error-classification.ts
+++ b/lib/request/error-classification.ts
@@ -13,6 +13,7 @@ export interface EntitlementError {
         message: string;
 }
 
+/** @internal Exported only for sibling lib/request modules; import via fetch-helpers.ts elsewhere. */
 export const CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE = "model_not_supported_with_chatgpt_account";
 const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
 	/model is not supported when using codex with a chatgpt account/i;
@@ -117,6 +118,7 @@ export function extractUnsupportedCodexModelFromText(bodyText: string): string |
 	return undefined;
 }
 
+/** @internal Exported only for sibling lib/request modules; import via fetch-helpers.ts elsewhere. */
 export function isUnsupportedCodexModelForChatGpt(status: number, bodyText: string): boolean {
 	if (status !== HTTP_STATUS.BAD_REQUEST) return false;
 	if (!bodyText) return false;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -3,9 +3,6 @@
  * These functions break down the complex fetch logic into manageable, testable units
  */
 
-import type { Auth, CodexClient } from "@codex-ai/sdk";
-import { ProxyAgent } from "undici";
-import { queuedRefresh } from "../refresh-queue.js";
 import { logRequest, logError, logWarn } from "../logger.js";
 import { getCodexInstructions, getModelFamily } from "../prompts/codex.js";
 import {
@@ -19,422 +16,67 @@ import {
 	convertSseToJson,
 	ensureContentType,
 } from "./response-handler.js";
-import type { UserConfig, RequestBody, TokenResult } from "../types.js";
-import { registerCleanup } from "../shutdown.js";
-import { CodexAuthError } from "../errors.js";
+import type { UserConfig, RequestBody } from "../types.js";
 import { isRecord } from "../utils.js";
 import {
-        CODEX_BASE_URL,
-        HTTP_STATUS,
-        OPENAI_HEADERS,
-        OPENAI_HEADER_VALUES,
-        URL_PATHS,
-        ERROR_MESSAGES,
-        LOG_STAGES,
+	HTTP_STATUS,
+	ERROR_MESSAGES,
+	LOG_STAGES,
 } from "../constants.js";
+import {
+	CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE,
+	createEntitlementErrorResponse,
+	extractUnsupportedCodexModelFromText,
+	isEntitlementError,
+	isUnsupportedCodexModelForChatGpt,
+} from "./error-classification.js";
+import { logDeprecationHeaders } from "./headers.js";
 
-interface CodexAuthSetter {
-	auth: {
-		set(args: {
-			path: { id: string };
-			body: {
-				type: "oauth";
-				access: string;
-				refresh: string;
-				expires: number;
-				multiAccount: boolean;
-			};
-		}): Promise<unknown>;
-	};
-}
+export { shouldRefreshToken, refreshAndUpdateToken } from "./token-refresh.js";
+export {
+	DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN,
+	extractUnsupportedCodexModelFromText,
+	getUnsupportedCodexModelInfo,
+	resolveUnsupportedCodexFallbackModel,
+	shouldFallbackToGpt52OnUnsupportedGpt53,
+	isEntitlementError,
+	isWorkspaceDisabledError,
+	createEntitlementErrorResponse,
+} from "./error-classification.js";
+export type {
+	EntitlementError,
+	UnsupportedCodexModelInfo,
+	ResolveUnsupportedCodexFallbackOptions,
+} from "./error-classification.js";
+export {
+	extractRequestUrl,
+	rewriteUrlForCodex,
+	resolveProxyUrlForRequest,
+	closeSharedProxyDispatchers,
+	applyProxyCompatibleInit,
+} from "./url-rewriting.js";
+export type { ProxyCompatibleRequestInit } from "./url-rewriting.js";
+export { createCodexHeaders } from "./headers.js";
+export type {
+	CreateCodexHeadersOptions,
+	CreateCodexHeadersParams,
+} from "./headers.js";
+
 export interface RateLimitInfo {
         retryAfterMs: number;
         code?: string;
 }
 
-export interface EntitlementError {
-        isEntitlement: true;
-        code: string;
-        message: string;
-}
-
-const CODEX_BASE_URL_OBJECT = new URL(CODEX_BASE_URL);
-const CODEX_BASE_PATH_PREFIX = CODEX_BASE_URL_OBJECT.pathname.endsWith("/")
-	? CODEX_BASE_URL_OBJECT.pathname.slice(0, -1)
-	: CODEX_BASE_URL_OBJECT.pathname;
-
-const CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE = "model_not_supported_with_chatgpt_account";
-const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
-	/model is not supported when using codex with a chatgpt account/i;
-const NORMALIZED_UNSUPPORTED_MODEL_PATTERN =
-	/the model ['"]([^'"]+)['"] is not currently available for this chatgpt account/i;
-const MODEL_ACCESS_DENIED_PATTERN =
-	/the model [`'"]([^`'"]+)[`'"] does not exist or you do not have access to it/i;
 const MAX_RATE_LIMIT_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
 const RETRY_AFTER_DURATION_PATTERN =
 	/\b(?:try|retry)\s+again\s+in\s+(\d+)\s*(second|minute|hour|day)s?\b/i;
 const RETRY_AFTER_CLOCK_TIME_PATTERN =
 	/\b(?:try|retry)\s+again\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b/i;
-const CREATE_CODEX_HEADERS_PARAM_KEYS = new Set(["init", "accountId", "accessToken", "opts"]);
-const DEFAULT_PROXY_PORTS: Record<string, number> = {
-	"http:": 80,
-	"https:": 443,
-};
-type ProxyDispatcher = NonNullable<RequestInit["dispatcher"]>;
-const sharedProxyDispatchers = new Map<string, ProxyDispatcher>();
-
-type ClosableDispatcher = ProxyDispatcher & {
-	close?: () => Promise<void> | void;
-};
-
-export const DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN: Record<string, string[]> = {
-	"gpt-5": ["gpt-5.5"],
-	"gpt-5-pro": ["gpt-5.5-pro"],
-	"gpt-5-chat-latest": ["gpt-5.5"],
-	"gpt-5.5": ["gpt-5.4"],
-	"gpt-5.5-pro": ["gpt-5.4"],
-	"gpt-5.5-2026-04-23": ["gpt-5.4"],
-	"gpt-5.5-pro-2026-04-23": ["gpt-5.4"],
-	"gpt-5.5-20260423": ["gpt-5.4"],
-	"gpt-5.5-pro-20260423": ["gpt-5.4"],
-	"gpt-5.3-codex-spark": ["gpt-5.3-codex", "gpt-5.2-codex"],
-	"gpt-5.3-codex": ["gpt-5.2-codex"],
-	"codex-max": ["gpt-5.3-codex"],
-	"gpt-5.1-codex-max": ["gpt-5.3-codex"],
-	"codex-mini-latest": ["gpt-5.3-codex"],
-	"gpt-5-codex-mini": ["gpt-5.3-codex"],
-	"gpt-5.1-codex-mini": ["gpt-5.3-codex"],
-	"gpt-5-codex": ["gpt-5.3-codex", "gpt-5.2-codex"],
-	"gpt-5.2-codex": ["gpt-5.3-codex"],
-	"gpt-5.1-codex": ["gpt-5.3-codex"],
-};
-
-export interface UnsupportedCodexModelInfo {
-	isUnsupported: boolean;
-	code?: string;
-	message?: string;
-	unsupportedModel?: string;
-}
-
-export interface ResolveUnsupportedCodexFallbackOptions {
-	requestedModel: string | undefined;
-	errorBody: unknown;
-	attemptedModels?: Iterable<string>;
-	fallbackOnUnsupportedCodexModel: boolean;
-	fallbackToGpt52OnUnsupportedGpt53: boolean;
-	customChain?: Record<string, string[]>;
-}
 
 export interface TransformRequestForCodexResult {
 	body: RequestBody;
 	updatedInit: RequestInit;
 	deferredFastSessionInputTrim?: FastSessionInputTrimPlan["trim"];
-}
-
-function canonicalizeModelName(model: string | undefined): string | undefined {
-	if (!model) return undefined;
-	const trimmed = model.trim().toLowerCase();
-	if (!trimmed) return undefined;
-	const stripped = trimmed.includes("/")
-		? (trimmed.split("/").pop() ?? trimmed)
-		: trimmed;
-	return stripped.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
-}
-
-function normalizeFallbackChain(
-	customChain: Record<string, string[]> | undefined,
-): Record<string, string[]> {
-	const normalized: Record<string, string[]> = {};
-	for (const [key, values] of Object.entries(DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN)) {
-		const normalizedKey = canonicalizeModelName(key);
-		if (!normalizedKey) continue;
-		normalized[normalizedKey] = values
-			.map((value) => canonicalizeModelName(value))
-			.filter((value): value is string => !!value);
-	}
-
-	if (!customChain) {
-		return normalized;
-	}
-
-	for (const [key, values] of Object.entries(customChain)) {
-		const normalizedKey = canonicalizeModelName(key);
-		if (!normalizedKey || !Array.isArray(values)) continue;
-		const normalizedValues = values
-			.map((value) => canonicalizeModelName(value))
-			.filter((value): value is string => !!value);
-		if (normalizedValues.length > 0) {
-			normalized[normalizedKey] = normalizedValues;
-		}
-	}
-
-	return normalized;
-}
-
-export function extractUnsupportedCodexModelFromText(bodyText: string): string | undefined {
-	const directMatch = bodyText.match(
-		/['"]([^'"]+)['"]\s+model is not supported when using codex with a chatgpt account/i,
-	);
-	if (directMatch?.[1]) {
-		return canonicalizeModelName(directMatch[1]);
-	}
-	const normalizedMatch = bodyText.match(NORMALIZED_UNSUPPORTED_MODEL_PATTERN);
-	if (normalizedMatch?.[1]) {
-		return canonicalizeModelName(normalizedMatch[1]);
-	}
-	const accessDeniedMatch = bodyText.match(MODEL_ACCESS_DENIED_PATTERN);
-	if (accessDeniedMatch?.[1]) {
-		return canonicalizeModelName(accessDeniedMatch[1]);
-	}
-	return undefined;
-}
-
-function isUnsupportedCodexModelForChatGpt(status: number, bodyText: string): boolean {
-	if (status !== HTTP_STATUS.BAD_REQUEST) return false;
-	if (!bodyText) return false;
-	return (
-		CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(bodyText) ||
-		NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(bodyText) ||
-		MODEL_ACCESS_DENIED_PATTERN.test(bodyText)
-	);
-}
-
-export function getUnsupportedCodexModelInfo(
-	errorBody: unknown,
-): UnsupportedCodexModelInfo {
-	if (!isRecord(errorBody)) {
-		return { isUnsupported: false };
-	}
-
-	const maybeError = errorBody.error;
-	if (!isRecord(maybeError)) {
-		// Some upstreams (e.g. the Codex quota endpoint) return the flat
-		// `{ "detail": "...model is not supported..." }` shape instead of the
-		// nested `{ "error": { "message": "..." } }` envelope. Fall back to the
-		// top-level `detail` string so model-fallback detection still works.
-		const detail = typeof errorBody.detail === "string" ? errorBody.detail : undefined;
-		if (!detail) {
-			return { isUnsupported: false };
-		}
-		const isUnsupportedDetail =
-			CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
-			NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
-			MODEL_ACCESS_DENIED_PATTERN.test(detail);
-		if (!isUnsupportedDetail) {
-			return { isUnsupported: false };
-		}
-		return {
-			isUnsupported: true,
-			message: detail,
-			unsupportedModel: extractUnsupportedCodexModelFromText(detail) ?? undefined,
-		};
-	}
-
-	const code = typeof maybeError.code === "string" ? maybeError.code : undefined;
-	const message =
-		typeof maybeError.message === "string" ? maybeError.message : undefined;
-	const unsupportedModelFromPayload =
-		typeof maybeError.unsupported_model === "string"
-			? maybeError.unsupported_model
-			: undefined;
-	const unsupportedModel = unsupportedModelFromPayload
-		? canonicalizeModelName(unsupportedModelFromPayload)
-		: extractUnsupportedCodexModelFromText(message ?? "");
-	const isUnsupported =
-		code === CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE ||
-		(message
-			? CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(message) ||
-				NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(message) ||
-				MODEL_ACCESS_DENIED_PATTERN.test(message)
-			: false);
-
-	return {
-		isUnsupported,
-		code,
-		message,
-		unsupportedModel: unsupportedModel ?? undefined,
-	};
-}
-
-export function resolveUnsupportedCodexFallbackModel(
-	options: ResolveUnsupportedCodexFallbackOptions,
-): string | undefined {
-	if (!options.fallbackOnUnsupportedCodexModel) return undefined;
-
-	const unsupported = getUnsupportedCodexModelInfo(options.errorBody);
-	if (!unsupported.isUnsupported) return undefined;
-
-	const requestedModel = canonicalizeModelName(options.requestedModel);
-	const currentModel = requestedModel ?? unsupported.unsupportedModel;
-	if (!currentModel) return undefined;
-
-	const attempted = new Set<string>();
-	for (const model of options.attemptedModels ?? []) {
-		const normalized = canonicalizeModelName(model);
-		if (normalized) attempted.add(normalized);
-	}
-
-	const chain = normalizeFallbackChain(options.customChain);
-	const targets = chain[currentModel] ?? [];
-	if (targets.length === 0) return undefined;
-
-	for (const target of targets) {
-		if (!options.fallbackToGpt52OnUnsupportedGpt53 &&
-			currentModel === "gpt-5.3-codex" &&
-			target === "gpt-5.2-codex") {
-			continue;
-		}
-		if (target === currentModel) continue;
-		if (attempted.has(target)) continue;
-		return target;
-	}
-
-	return undefined;
-}
-
-/**
- * Returns true when the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge is available.
- */
-export function shouldFallbackToGpt52OnUnsupportedGpt53(
-	requestedModel: string | undefined,
-	errorBody: unknown,
-): boolean {
-	if (canonicalizeModelName(requestedModel) !== "gpt-5.3-codex") {
-		return false;
-	}
-
-	return (
-		resolveUnsupportedCodexFallbackModel({
-			requestedModel,
-			errorBody,
-			// Probe whether the legacy gpt-5.2 edge is still active under current
-			// policy/toggles when the current Codex model is blocked.
-			attemptedModels: [],
-			fallbackOnUnsupportedCodexModel: true,
-			fallbackToGpt52OnUnsupportedGpt53: true,
-		}) === "gpt-5.2-codex"
-	);
-}
-
-/**
- * Detects whether an error code or response body indicates an entitlement/subscription issue for Codex models.
- *
- * Entitlement errors signal that the requested feature is not included in the user's plan and should not be treated as rate limits.
- * This function is pure and safe to call concurrently; it performs no filesystem access (including on Windows) and does not read or redact tokens — callers must avoid passing sensitive credentials in `code` or `bodyText`.
- *
- * @param code - The error code string returned by the service
- * @param bodyText - The response body text to inspect for entitlement-related phrases
- * @returns `true` if the combined `code` or `bodyText` indicates an entitlement/subscription issue, `false` otherwise
- */
-export function isEntitlementError(code: string, bodyText: string): boolean {
-        const haystack = `${code} ${bodyText}`.toLowerCase();
-        // "usage_not_included" means the subscription doesn't include this feature
-        // This is different from "usage_limit_reached" which is a temporary quota limit
-        return /usage_not_included|not.included.in.your.plan|subscription.does.not.include/i.test(haystack);
-}
-
-/**
- * Detects whether an error indicates the workspace/account has been disabled or expired.
- *
- * Workspace disabled errors signal that the current workspace is no longer accessible
- * (expired, disabled, or removed) and the plugin should automatically switch to another account.
- *
- * @param status - HTTP status code
- * @param code - The error code string returned by the service
- * @param bodyText - The response body text to inspect for workspace-related phrases
- * @returns `true` if the error indicates a disabled/expired workspace
- */
-export function isWorkspaceDisabledError(
-        status: number,
-        code: unknown,
-        bodyText: string,
-): boolean {
-        const normalizedCode = typeof code === "string" ? code.trim().toLowerCase() : "";
-
-        if (status === 402) {
-                const normalizedTokens = normalizedCode
-                        .split(/[^a-z0-9_]+/i)
-                        .map((token) => token.trim())
-                        .filter((token) => token.length > 0);
-                return (
-                        normalizedTokens.includes("deactivated_workspace") ||
-                        /\bdeactivated_workspace\b/i.test(bodyText)
-                );
-        }
-
-        if (status !== 403) {
-                return false;
-        }
-
-        const haystack = `${normalizedCode} ${bodyText}`.toLowerCase();
-        const normalizedTokens = normalizedCode
-                .split(/[^a-z0-9_]+/i)
-                .map((token) => token.trim())
-                .filter((token) => token.length > 0);
-
-		const disabledPatterns = [
-				/workspace.*(?:disabled|expired|deactivated|terminated)/i,
-				/account\s+(?:has\s+been|is)\s+(?:disabled|expired|deactivated|terminated|closed)/i,
-				/(?:workspace|org(?:anization)?).*no longer.*(?:active|available|valid)/i,
-				/(?:workspace|org(?:anization)?).*has been.*(?:disabled|expired|closed)/i,
-				/workspace.*(?:access|subscription).*expired/i,
-				/org(?:anization)?.*(?:disabled|expired|inactive)/i,
-		];
-
-        for (const pattern of disabledPatterns) {
-                if (pattern.test(haystack)) {
-                        return true;
-                }
-        }
-
-        const workspaceErrorCodes = new Set([
-                "workspace_disabled",
-                "workspace_expired",
-                "workspace_terminated",
-                "account_disabled",
-                "account_expired",
-                "organization_disabled",
-        ]);
-        if (workspaceErrorCodes.has(normalizedCode)) {
-                return true;
-        }
-
-        return normalizedTokens.some((token) => workspaceErrorCodes.has(token));
-}
-
-/**
- * Constructs a standardized 403 entitlement error Response indicating the user lacks access to Codex models.
- *
- * This function returns a JSON Response with an `error` payload containing a user-facing message, a
- * `type` of `"entitlement_error"`, and a `code` of `"usage_not_included"`. The message suggests checking
- * account/workspace access and re-authenticating with `codex-multi-auth login`.
- *
- * Concurrency: stateless and safe to call concurrently from multiple threads or requests.
- * Windows filesystem behavior: none (function does not access the filesystem).
- * Token redaction: any tokens are not included in the generated payload; do not pass sensitive tokens in `_bodyText`.
- *
- * @param _bodyText - Original response body text (accepted for compatibility; ignored when building the response)
- * @returns A 403 Response with a JSON body describing the entitlement error and guidance for resolving it
- */
-export function createEntitlementErrorResponse(_bodyText: string): Response {
-        const message = 
-                "This model is not included in your ChatGPT subscription. " +
-                "Please check that your account or workspace has access to Codex models (Plus/Pro/Business/Enterprise). " +
-                "If you recently subscribed or switched workspaces, try logging out and back in with `codex-multi-auth login`.";
-        
-        const payload = {
-                error: {
-                        message,
-                        type: "entitlement_error",
-                        code: "usage_not_included",
-                },
-        };
-
-        return new Response(JSON.stringify(payload), {
-                status: 403, // Forbidden - not a rate limit
-                statusText: "Forbidden",
-                headers: { "content-type": "application/json; charset=utf-8" },
-        });
 }
 
 export interface ErrorHandlingResult {
@@ -454,319 +96,6 @@ export interface ErrorDiagnostics {
 	correlationId?: string;
 	threadId?: string;
 	httpStatus?: number;
-}
-
-export interface CreateCodexHeadersOptions {
-	model?: string;
-	promptCacheKey?: string;
-}
-
-export interface ProxyCompatibleRequestInit extends RequestInit {
-	agent?: unknown;
-}
-
-export interface CreateCodexHeadersParams {
-	init?: RequestInit;
-	accountId: string;
-	accessToken: string;
-	opts?: CreateCodexHeadersOptions;
-}
-
-function isCreateCodexHeadersNamedParams(value: unknown): value is CreateCodexHeadersParams {
-	if (!isRecord(value)) return false;
-	if (typeof value.accountId !== "string" || typeof value.accessToken !== "string") return false;
-	return Object.keys(value).every((key) => CREATE_CODEX_HEADERS_PARAM_KEYS.has(key));
-}
-
-/**
- * Determines if the current auth token needs to be refreshed
- * @param auth - Current authentication state
- * @returns True if token is expired or invalid
- */
-export function shouldRefreshToken(auth: Auth, skewMs = 0): boolean {
-	if (auth.type !== "oauth") return true;
-	if (!auth.access) return true;
-
-	const safeSkewMs = Math.max(0, Math.floor(skewMs));
-	return auth.expires <= Date.now() + safeSkewMs;
-}
-
-function isRetryableRefreshFailure(
-	result: Extract<TokenResult, { type: "failed" }>,
-): boolean {
-	switch (result.reason) {
-		case "network_error":
-		case "unknown":
-		case "invalid_response":
-			return true;
-		case "missing_refresh":
-			return false;
-		case "http_error":
-			return !(
-				result.statusCode === HTTP_STATUS.BAD_REQUEST ||
-				result.statusCode === HTTP_STATUS.UNAUTHORIZED ||
-				result.statusCode === HTTP_STATUS.FORBIDDEN
-			);
-		default:
-			return false;
-	}
-}
-
-function isRetryableAuthSetterError(error: unknown): boolean {
-	if (!error || typeof error !== "object") {
-		return false;
-	}
-
-	const candidate = error as {
-		code?: unknown;
-		status?: unknown;
-		cause?: unknown;
-	};
-	const code =
-		typeof candidate.code === "string"
-			? candidate.code.toUpperCase()
-			: undefined;
-	if (code === "EAGAIN" || code === "EBUSY" || code === "EPERM") {
-		return true;
-	}
-
-	if (candidate.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
-		return true;
-	}
-
-	if (candidate.cause && candidate.cause !== error) {
-		return isRetryableAuthSetterError(candidate.cause);
-	}
-
-	return false;
-}
-
-/**
- * Refreshes the OAuth token and updates stored credentials
- * @param currentAuth - Current auth state
- * @param client - Codex client for updating stored credentials
- * @returns Updated auth (throws on failure)
- */
-export async function refreshAndUpdateToken(
-	currentAuth: Auth,
-	client: CodexClient,
-): Promise<Auth> {
-	const authSetter = (client as Partial<CodexAuthSetter>).auth;
-	if (!authSetter || typeof authSetter.set !== "function") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-			retryable: false,
-		});
-	}
-
-	const refreshToken = currentAuth.type === "oauth" ? currentAuth.refresh : "";
-	const refreshResult = await queuedRefresh(refreshToken);
-
-	if (refreshResult.type === "failed") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-			retryable: isRetryableRefreshFailure(refreshResult),
-			context: {
-				refreshFailureReason: refreshResult.reason,
-				statusCode: refreshResult.statusCode,
-			},
-		});
-	}
-
-	try {
-		await authSetter.set({
-			path: { id: "openai" },
-			body: {
-				type: "oauth",
-				access: refreshResult.access,
-				refresh: refreshResult.refresh,
-				expires: refreshResult.expires,
-				multiAccount: true,
-			},
-		});
-	} catch (error) {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-			retryable: isRetryableAuthSetterError(error),
-			cause: error,
-		});
-	}
-
-	// Update current auth reference if it's OAuth type
-	if (currentAuth.type === "oauth") {
-		currentAuth.access = refreshResult.access;
-		currentAuth.refresh = refreshResult.refresh;
-		currentAuth.expires = refreshResult.expires;
-	}
-
-	return currentAuth;
-}
-
-/**
- * Extracts URL string from various request input types
- * @param input - Request input (string, URL, or Request object)
- * @returns URL string
- */
-export function extractRequestUrl(input: Request | string | URL): string {
-	if (typeof input === "string") return input;
-	if (input instanceof URL) return input.toString();
-	return input.url;
-}
-
-/**
- * Rewrites OpenAI API URLs to Codex backend URLs
- * @param url - Original URL
- * @returns Rewritten URL for Codex backend
- */
-export function rewriteUrlForCodex(url: string): string {
-	const parsedUrl = new URL(url);
-	const rewrittenPath = parsedUrl.pathname.includes(URL_PATHS.RESPONSES)
-		? parsedUrl.pathname.replace(URL_PATHS.RESPONSES, URL_PATHS.CODEX_RESPONSES)
-		: parsedUrl.pathname;
-	const normalizedPath =
-		rewrittenPath === CODEX_BASE_PATH_PREFIX ||
-		rewrittenPath.startsWith(`${CODEX_BASE_PATH_PREFIX}/`)
-			? rewrittenPath
-			: `${CODEX_BASE_PATH_PREFIX}${rewrittenPath.startsWith("/") ? rewrittenPath : `/${rewrittenPath}`}`;
-
-	parsedUrl.protocol = CODEX_BASE_URL_OBJECT.protocol;
-	parsedUrl.username = "";
-	parsedUrl.password = "";
-	parsedUrl.host = CODEX_BASE_URL_OBJECT.host;
-	parsedUrl.pathname = normalizedPath;
-
-	return parsedUrl.toString();
-}
-
-function hasOwnEnvKey(env: NodeJS.ProcessEnv, key: string): boolean {
-	return Object.prototype.hasOwnProperty.call(env, key);
-}
-
-function resolveProxyEnvValue(
-	env: NodeJS.ProcessEnv,
-	lowerKey: string,
-	upperKey: string,
-): string | undefined {
-	if (hasOwnEnvKey(env, lowerKey)) {
-		const value = env[lowerKey]?.trim();
-		return value ? value : undefined;
-	}
-
-	const value = env[upperKey]?.trim();
-	return value ? value : undefined;
-}
-
-function parseNoProxyEntries(noProxyValue: string): Array<{ hostname: string; port: number }> {
-	return noProxyValue
-		.split(/[,\s]/)
-		.map((entry) => entry.trim())
-		.filter(Boolean)
-		.map((entry) => {
-			const parsed = entry.match(/^(.+):(\d+)$/);
-			const hostname = parsed?.[1] ?? entry;
-			const portText = parsed?.[2];
-			return {
-				hostname: hostname.toLowerCase(),
-				port: portText ? Number.parseInt(portText, 10) : 0,
-			};
-		});
-}
-
-function shouldBypassProxyForUrl(url: URL, noProxyValue: string | undefined): boolean {
-	if (!noProxyValue) return false;
-	if (noProxyValue === "*") return true;
-
-	const hostname = url.host.replace(/:\d*$/, "").toLowerCase();
-	const port = Number.parseInt(url.port, 10) || DEFAULT_PROXY_PORTS[url.protocol] || 0;
-
-	for (const entry of parseNoProxyEntries(noProxyValue)) {
-		if (entry.hostname === "*") return true;
-		if (entry.port && entry.port !== port) continue;
-
-		if (!/^[.*]/.test(entry.hostname)) {
-			if (hostname === entry.hostname) {
-				return true;
-			}
-			continue;
-		}
-
-		if (hostname.endsWith(entry.hostname.replace(/^\*/, ""))) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-export function resolveProxyUrlForRequest(
-	url: string,
-	env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-	const parsed = new URL(url);
-	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-		return undefined;
-	}
-
-	const httpProxy = resolveProxyEnvValue(env, "http_proxy", "HTTP_PROXY");
-	const httpsProxy = resolveProxyEnvValue(env, "https_proxy", "HTTPS_PROXY");
-	if (!httpProxy && !httpsProxy) {
-		return undefined;
-	}
-
-	const noProxy = resolveProxyEnvValue(env, "no_proxy", "NO_PROXY");
-	if (shouldBypassProxyForUrl(parsed, noProxy)) {
-		return undefined;
-	}
-
-	return parsed.protocol === "https:"
-		? (httpsProxy ?? httpProxy)
-		: httpProxy;
-}
-
-function getSharedProxyDispatcher(proxyUrl: string): ProxyDispatcher {
-	const existing = sharedProxyDispatchers.get(proxyUrl);
-	if (existing) {
-		return existing;
-	}
-
-	const dispatcher = new ProxyAgent(proxyUrl) as unknown as ProxyDispatcher;
-	sharedProxyDispatchers.set(proxyUrl, dispatcher);
-	return dispatcher;
-}
-
-export async function closeSharedProxyDispatchers(): Promise<void> {
-	while (sharedProxyDispatchers.size > 0) {
-		const dispatchers = [...sharedProxyDispatchers.values()] as ClosableDispatcher[];
-		sharedProxyDispatchers.clear();
-
-		await Promise.allSettled(
-			dispatchers.map(async (dispatcher) => {
-				if (typeof dispatcher.close === "function") {
-					await dispatcher.close();
-				}
-			}),
-		);
-	}
-}
-
-registerCleanup(closeSharedProxyDispatchers);
-
-export function applyProxyCompatibleInit(
-	url: string,
-	init?: ProxyCompatibleRequestInit,
-	env: NodeJS.ProcessEnv = process.env,
-): ProxyCompatibleRequestInit {
-	const resolvedInit = init ?? {};
-	if (resolvedInit.dispatcher || resolvedInit.agent) {
-		return resolvedInit;
-	}
-
-	const proxyUrl = resolveProxyUrlForRequest(url, env);
-	if (!proxyUrl) {
-		return resolvedInit;
-	}
-
-	return {
-		...resolvedInit,
-		dispatcher: getSharedProxyDispatcher(proxyUrl),
-	};
 }
 
 /**
@@ -888,80 +217,10 @@ export async function transformRequestForCodex(
 }
 
 /**
- * Creates headers for Codex API requests
- * @param init - Request init options
- * @param accountId - ChatGPT account ID
- * @param accessToken - OAuth access token
- * @returns Headers object with all required Codex headers
- */
-export function createCodexHeaders(
-	params: CreateCodexHeadersParams,
-): Headers;
-export function createCodexHeaders(
-    init: RequestInit | undefined,
-    accountId: string,
-    accessToken: string,
-    opts?: CreateCodexHeadersOptions,
-): Headers;
-export function createCodexHeaders(
-    initOrParams: RequestInit | undefined | CreateCodexHeadersParams,
-    accountId?: string,
-    accessToken?: string,
-    opts?: CreateCodexHeadersOptions,
-): Headers {
-	const useNamedParams =
-		typeof accountId === "undefined" &&
-		typeof accessToken === "undefined" &&
-		isCreateCodexHeadersNamedParams(initOrParams);
-	const namedParams = useNamedParams
-		? (initOrParams as CreateCodexHeadersParams)
-		: null;
-	const resolvedInit = useNamedParams
-		? namedParams?.init
-		: (initOrParams as RequestInit | undefined);
-	const resolvedAccountId = useNamedParams ? namedParams?.accountId : accountId;
-	const resolvedAccessToken = useNamedParams ? namedParams?.accessToken : accessToken;
-	const resolvedOpts = useNamedParams ? namedParams?.opts : opts;
-	if (!resolvedAccountId || !resolvedAccessToken) {
-		throw new TypeError("createCodexHeaders requires accountId and accessToken");
-	}
-	const headers = new Headers(resolvedInit?.headers ?? {});
-	headers.delete("x-api-key"); // Remove any existing API key
-	headers.set("Authorization", `Bearer ${resolvedAccessToken}`);
-	headers.set(OPENAI_HEADERS.ACCOUNT_ID, resolvedAccountId);
-	headers.set(OPENAI_HEADERS.BETA, OPENAI_HEADER_VALUES.BETA_RESPONSES);
-	headers.set(OPENAI_HEADERS.ORIGINATOR, OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
-
-    const cacheKey = resolvedOpts?.promptCacheKey;
-    if (cacheKey) {
-        headers.set(OPENAI_HEADERS.CONVERSATION_ID, cacheKey);
-        headers.set(OPENAI_HEADERS.SESSION_ID, cacheKey);
-    } else {
-        headers.delete(OPENAI_HEADERS.CONVERSATION_ID);
-        headers.delete(OPENAI_HEADERS.SESSION_ID);
-    }
-    headers.set("accept", "text/event-stream");
-    return headers;
-}
-
-/**
  * Handles error responses from the Codex API
  * @param response - Error response from API
  * @returns Original response or mapped retryable response
  */
-/**
- * Log RFC 8594 Deprecation/Sunset headers if present. Shared by the success and
- * error response handlers so a sunset notice is surfaced regardless of status
- * (request-01).
- */
-function logDeprecationHeaders(response: Response): void {
-        const deprecation = response.headers.get("Deprecation");
-        const sunset = response.headers.get("Sunset");
-        if (deprecation || sunset) {
-                logWarn(`API deprecation notice`, { deprecation, sunset });
-        }
-}
-
 export async function handleErrorResponse(
         response: Response,
         options?: ErrorHandlingOptions,

--- a/lib/request/headers.ts
+++ b/lib/request/headers.ts
@@ -1,0 +1,99 @@
+/**
+ * Header construction helpers for the custom fetch implementation
+ * Extracted from fetch-helpers.ts (audit roadmap §4.1.2); fetch-helpers.ts
+ * re-exports the public symbols so existing importers are unchanged.
+ */
+
+import { logWarn } from "../logger.js";
+import { isRecord } from "../utils.js";
+import { OPENAI_HEADERS, OPENAI_HEADER_VALUES } from "../constants.js";
+
+const CREATE_CODEX_HEADERS_PARAM_KEYS = new Set(["init", "accountId", "accessToken", "opts"]);
+
+export interface CreateCodexHeadersOptions {
+	model?: string;
+	promptCacheKey?: string;
+}
+
+export interface CreateCodexHeadersParams {
+	init?: RequestInit;
+	accountId: string;
+	accessToken: string;
+	opts?: CreateCodexHeadersOptions;
+}
+
+function isCreateCodexHeadersNamedParams(value: unknown): value is CreateCodexHeadersParams {
+	if (!isRecord(value)) return false;
+	if (typeof value.accountId !== "string" || typeof value.accessToken !== "string") return false;
+	return Object.keys(value).every((key) => CREATE_CODEX_HEADERS_PARAM_KEYS.has(key));
+}
+
+/**
+ * Creates headers for Codex API requests
+ * @param init - Request init options
+ * @param accountId - ChatGPT account ID
+ * @param accessToken - OAuth access token
+ * @returns Headers object with all required Codex headers
+ */
+export function createCodexHeaders(
+	params: CreateCodexHeadersParams,
+): Headers;
+export function createCodexHeaders(
+    init: RequestInit | undefined,
+    accountId: string,
+    accessToken: string,
+    opts?: CreateCodexHeadersOptions,
+): Headers;
+export function createCodexHeaders(
+    initOrParams: RequestInit | undefined | CreateCodexHeadersParams,
+    accountId?: string,
+    accessToken?: string,
+    opts?: CreateCodexHeadersOptions,
+): Headers {
+	const useNamedParams =
+		typeof accountId === "undefined" &&
+		typeof accessToken === "undefined" &&
+		isCreateCodexHeadersNamedParams(initOrParams);
+	const namedParams = useNamedParams
+		? (initOrParams as CreateCodexHeadersParams)
+		: null;
+	const resolvedInit = useNamedParams
+		? namedParams?.init
+		: (initOrParams as RequestInit | undefined);
+	const resolvedAccountId = useNamedParams ? namedParams?.accountId : accountId;
+	const resolvedAccessToken = useNamedParams ? namedParams?.accessToken : accessToken;
+	const resolvedOpts = useNamedParams ? namedParams?.opts : opts;
+	if (!resolvedAccountId || !resolvedAccessToken) {
+		throw new TypeError("createCodexHeaders requires accountId and accessToken");
+	}
+	const headers = new Headers(resolvedInit?.headers ?? {});
+	headers.delete("x-api-key"); // Remove any existing API key
+	headers.set("Authorization", `Bearer ${resolvedAccessToken}`);
+	headers.set(OPENAI_HEADERS.ACCOUNT_ID, resolvedAccountId);
+	headers.set(OPENAI_HEADERS.BETA, OPENAI_HEADER_VALUES.BETA_RESPONSES);
+	headers.set(OPENAI_HEADERS.ORIGINATOR, OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
+
+    const cacheKey = resolvedOpts?.promptCacheKey;
+    if (cacheKey) {
+        headers.set(OPENAI_HEADERS.CONVERSATION_ID, cacheKey);
+        headers.set(OPENAI_HEADERS.SESSION_ID, cacheKey);
+    } else {
+        headers.delete(OPENAI_HEADERS.CONVERSATION_ID);
+        headers.delete(OPENAI_HEADERS.SESSION_ID);
+    }
+    headers.set("accept", "text/event-stream");
+    return headers;
+}
+
+/**
+ * Log RFC 8594 Deprecation/Sunset headers if present. Shared by the success and
+ * error response handlers so a sunset notice is surfaced regardless of status
+ * (request-01).
+ */
+export function logDeprecationHeaders(response: Response): void {
+        const deprecation = response.headers.get("Deprecation");
+        const sunset = response.headers.get("Sunset");
+        if (deprecation || sunset) {
+                logWarn(`API deprecation notice`, { deprecation, sunset });
+        }
+}

--- a/lib/request/headers.ts
+++ b/lib/request/headers.ts
@@ -89,6 +89,8 @@ export function createCodexHeaders(
  * Log RFC 8594 Deprecation/Sunset headers if present. Shared by the success and
  * error response handlers so a sunset notice is surfaced regardless of status
  * (request-01).
+ *
+ * @internal Exported only for sibling lib/request modules; import via fetch-helpers.ts elsewhere.
  */
 export function logDeprecationHeaders(response: Response): void {
         const deprecation = response.headers.get("Deprecation");

--- a/lib/request/token-refresh.ts
+++ b/lib/request/token-refresh.ts
@@ -1,0 +1,147 @@
+/**
+ * Token refresh helpers for the custom fetch implementation
+ * Extracted from fetch-helpers.ts (audit roadmap §4.1.2); fetch-helpers.ts
+ * re-exports the public symbols so existing importers are unchanged.
+ */
+
+import type { Auth, CodexClient } from "@codex-ai/sdk";
+import { queuedRefresh } from "../refresh-queue.js";
+import type { TokenResult } from "../types.js";
+import { CodexAuthError } from "../errors.js";
+import { HTTP_STATUS, ERROR_MESSAGES } from "../constants.js";
+
+interface CodexAuthSetter {
+	auth: {
+		set(args: {
+			path: { id: string };
+			body: {
+				type: "oauth";
+				access: string;
+				refresh: string;
+				expires: number;
+				multiAccount: boolean;
+			};
+		}): Promise<unknown>;
+	};
+}
+
+/**
+ * Determines if the current auth token needs to be refreshed
+ * @param auth - Current authentication state
+ * @returns True if token is expired or invalid
+ */
+export function shouldRefreshToken(auth: Auth, skewMs = 0): boolean {
+	if (auth.type !== "oauth") return true;
+	if (!auth.access) return true;
+
+	const safeSkewMs = Math.max(0, Math.floor(skewMs));
+	return auth.expires <= Date.now() + safeSkewMs;
+}
+
+function isRetryableRefreshFailure(
+	result: Extract<TokenResult, { type: "failed" }>,
+): boolean {
+	switch (result.reason) {
+		case "network_error":
+		case "unknown":
+		case "invalid_response":
+			return true;
+		case "missing_refresh":
+			return false;
+		case "http_error":
+			return !(
+				result.statusCode === HTTP_STATUS.BAD_REQUEST ||
+				result.statusCode === HTTP_STATUS.UNAUTHORIZED ||
+				result.statusCode === HTTP_STATUS.FORBIDDEN
+			);
+		default:
+			return false;
+	}
+}
+
+function isRetryableAuthSetterError(error: unknown): boolean {
+	if (!error || typeof error !== "object") {
+		return false;
+	}
+
+	const candidate = error as {
+		code?: unknown;
+		status?: unknown;
+		cause?: unknown;
+	};
+	const code =
+		typeof candidate.code === "string"
+			? candidate.code.toUpperCase()
+			: undefined;
+	if (code === "EAGAIN" || code === "EBUSY" || code === "EPERM") {
+		return true;
+	}
+
+	if (candidate.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
+		return true;
+	}
+
+	if (candidate.cause && candidate.cause !== error) {
+		return isRetryableAuthSetterError(candidate.cause);
+	}
+
+	return false;
+}
+
+/**
+ * Refreshes the OAuth token and updates stored credentials
+ * @param currentAuth - Current auth state
+ * @param client - Codex client for updating stored credentials
+ * @returns Updated auth (throws on failure)
+ */
+export async function refreshAndUpdateToken(
+	currentAuth: Auth,
+	client: CodexClient,
+): Promise<Auth> {
+	const authSetter = (client as Partial<CodexAuthSetter>).auth;
+	if (!authSetter || typeof authSetter.set !== "function") {
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: false,
+		});
+	}
+
+	const refreshToken = currentAuth.type === "oauth" ? currentAuth.refresh : "";
+	const refreshResult = await queuedRefresh(refreshToken);
+
+	if (refreshResult.type === "failed") {
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: isRetryableRefreshFailure(refreshResult),
+			context: {
+				refreshFailureReason: refreshResult.reason,
+				statusCode: refreshResult.statusCode,
+			},
+		});
+	}
+
+	try {
+		await authSetter.set({
+			path: { id: "openai" },
+			body: {
+				type: "oauth",
+				access: refreshResult.access,
+				refresh: refreshResult.refresh,
+				expires: refreshResult.expires,
+				multiAccount: true,
+			},
+		});
+	} catch (error) {
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: isRetryableAuthSetterError(error),
+			cause: error,
+		});
+	}
+
+	// Update current auth reference if it's OAuth type
+	if (currentAuth.type === "oauth") {
+		currentAuth.access = refreshResult.access;
+		currentAuth.refresh = refreshResult.refresh;
+		currentAuth.expires = refreshResult.expires;
+	}
+
+	return currentAuth;
+}

--- a/lib/request/url-rewriting.ts
+++ b/lib/request/url-rewriting.ts
@@ -1,0 +1,199 @@
+/**
+ * URL rewriting and proxy resolution helpers for the custom fetch implementation
+ * Extracted from fetch-helpers.ts (audit roadmap §4.1.2); fetch-helpers.ts
+ * re-exports the public symbols so existing importers are unchanged.
+ */
+
+import { ProxyAgent } from "undici";
+import { registerCleanup } from "../shutdown.js";
+import { CODEX_BASE_URL, URL_PATHS } from "../constants.js";
+
+const CODEX_BASE_URL_OBJECT = new URL(CODEX_BASE_URL);
+const CODEX_BASE_PATH_PREFIX = CODEX_BASE_URL_OBJECT.pathname.endsWith("/")
+	? CODEX_BASE_URL_OBJECT.pathname.slice(0, -1)
+	: CODEX_BASE_URL_OBJECT.pathname;
+
+const DEFAULT_PROXY_PORTS: Record<string, number> = {
+	"http:": 80,
+	"https:": 443,
+};
+type ProxyDispatcher = NonNullable<RequestInit["dispatcher"]>;
+const sharedProxyDispatchers = new Map<string, ProxyDispatcher>();
+
+type ClosableDispatcher = ProxyDispatcher & {
+	close?: () => Promise<void> | void;
+};
+
+export interface ProxyCompatibleRequestInit extends RequestInit {
+	agent?: unknown;
+}
+
+/**
+ * Extracts URL string from various request input types
+ * @param input - Request input (string, URL, or Request object)
+ * @returns URL string
+ */
+export function extractRequestUrl(input: Request | string | URL): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	return input.url;
+}
+
+/**
+ * Rewrites OpenAI API URLs to Codex backend URLs
+ * @param url - Original URL
+ * @returns Rewritten URL for Codex backend
+ */
+export function rewriteUrlForCodex(url: string): string {
+	const parsedUrl = new URL(url);
+	const rewrittenPath = parsedUrl.pathname.includes(URL_PATHS.RESPONSES)
+		? parsedUrl.pathname.replace(URL_PATHS.RESPONSES, URL_PATHS.CODEX_RESPONSES)
+		: parsedUrl.pathname;
+	const normalizedPath =
+		rewrittenPath === CODEX_BASE_PATH_PREFIX ||
+		rewrittenPath.startsWith(`${CODEX_BASE_PATH_PREFIX}/`)
+			? rewrittenPath
+			: `${CODEX_BASE_PATH_PREFIX}${rewrittenPath.startsWith("/") ? rewrittenPath : `/${rewrittenPath}`}`;
+
+	parsedUrl.protocol = CODEX_BASE_URL_OBJECT.protocol;
+	parsedUrl.username = "";
+	parsedUrl.password = "";
+	parsedUrl.host = CODEX_BASE_URL_OBJECT.host;
+	parsedUrl.pathname = normalizedPath;
+
+	return parsedUrl.toString();
+}
+
+function hasOwnEnvKey(env: NodeJS.ProcessEnv, key: string): boolean {
+	return Object.prototype.hasOwnProperty.call(env, key);
+}
+
+function resolveProxyEnvValue(
+	env: NodeJS.ProcessEnv,
+	lowerKey: string,
+	upperKey: string,
+): string | undefined {
+	if (hasOwnEnvKey(env, lowerKey)) {
+		const value = env[lowerKey]?.trim();
+		return value ? value : undefined;
+	}
+
+	const value = env[upperKey]?.trim();
+	return value ? value : undefined;
+}
+
+function parseNoProxyEntries(noProxyValue: string): Array<{ hostname: string; port: number }> {
+	return noProxyValue
+		.split(/[,\s]/)
+		.map((entry) => entry.trim())
+		.filter(Boolean)
+		.map((entry) => {
+			const parsed = entry.match(/^(.+):(\d+)$/);
+			const hostname = parsed?.[1] ?? entry;
+			const portText = parsed?.[2];
+			return {
+				hostname: hostname.toLowerCase(),
+				port: portText ? Number.parseInt(portText, 10) : 0,
+			};
+		});
+}
+
+function shouldBypassProxyForUrl(url: URL, noProxyValue: string | undefined): boolean {
+	if (!noProxyValue) return false;
+	if (noProxyValue === "*") return true;
+
+	const hostname = url.host.replace(/:\d*$/, "").toLowerCase();
+	const port = Number.parseInt(url.port, 10) || DEFAULT_PROXY_PORTS[url.protocol] || 0;
+
+	for (const entry of parseNoProxyEntries(noProxyValue)) {
+		if (entry.hostname === "*") return true;
+		if (entry.port && entry.port !== port) continue;
+
+		if (!/^[.*]/.test(entry.hostname)) {
+			if (hostname === entry.hostname) {
+				return true;
+			}
+			continue;
+		}
+
+		if (hostname.endsWith(entry.hostname.replace(/^\*/, ""))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export function resolveProxyUrlForRequest(
+	url: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+	const parsed = new URL(url);
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		return undefined;
+	}
+
+	const httpProxy = resolveProxyEnvValue(env, "http_proxy", "HTTP_PROXY");
+	const httpsProxy = resolveProxyEnvValue(env, "https_proxy", "HTTPS_PROXY");
+	if (!httpProxy && !httpsProxy) {
+		return undefined;
+	}
+
+	const noProxy = resolveProxyEnvValue(env, "no_proxy", "NO_PROXY");
+	if (shouldBypassProxyForUrl(parsed, noProxy)) {
+		return undefined;
+	}
+
+	return parsed.protocol === "https:"
+		? (httpsProxy ?? httpProxy)
+		: httpProxy;
+}
+
+function getSharedProxyDispatcher(proxyUrl: string): ProxyDispatcher {
+	const existing = sharedProxyDispatchers.get(proxyUrl);
+	if (existing) {
+		return existing;
+	}
+
+	const dispatcher = new ProxyAgent(proxyUrl) as unknown as ProxyDispatcher;
+	sharedProxyDispatchers.set(proxyUrl, dispatcher);
+	return dispatcher;
+}
+
+export async function closeSharedProxyDispatchers(): Promise<void> {
+	while (sharedProxyDispatchers.size > 0) {
+		const dispatchers = [...sharedProxyDispatchers.values()] as ClosableDispatcher[];
+		sharedProxyDispatchers.clear();
+
+		await Promise.allSettled(
+			dispatchers.map(async (dispatcher) => {
+				if (typeof dispatcher.close === "function") {
+					await dispatcher.close();
+				}
+			}),
+		);
+	}
+}
+
+registerCleanup(closeSharedProxyDispatchers);
+
+export function applyProxyCompatibleInit(
+	url: string,
+	init?: ProxyCompatibleRequestInit,
+	env: NodeJS.ProcessEnv = process.env,
+): ProxyCompatibleRequestInit {
+	const resolvedInit = init ?? {};
+	if (resolvedInit.dispatcher || resolvedInit.agent) {
+		return resolvedInit;
+	}
+
+	const proxyUrl = resolveProxyUrlForRequest(url, env);
+	if (!proxyUrl) {
+		return resolvedInit;
+	}
+
+	return {
+		...resolvedInit,
+		dispatcher: getSharedProxyDispatcher(proxyUrl),
+	};
+}


### PR DESCRIPTION
## Summary

Splits `lib/request/fetch-helpers.ts` (1,497 lines, 30+ exports) along its natural seams into four focused modules, per audit roadmap §4.1.2 (`docs/audits/AUDIT_2026-06-10.md`, PR #522). All code moved verbatim; `fetch-helpers.ts` remains the re-export facade, so **no importer changes and zero behavior change**.

## Changes

| File | Lines | Contents |
| --- | --- | --- |
| `lib/request/token-refresh.ts` | 147 | `shouldRefreshToken`, `refreshAndUpdateToken` + private refresh-retry predicates |
| `lib/request/error-classification.ts` | 366 | `isEntitlementError`, `isWorkspaceDisabledError`, `EntitlementError`, full unsupported-model fallback machinery |
| `lib/request/url-rewriting.ts` | 199 | `extractRequestUrl`, `rewriteUrlForCodex`, proxy resolution, shared dispatcher cache + cleanup |
| `lib/request/headers.ts` | 99 | `createCodexHeaders` (all overloads), RFC 8594 deprecation/sunset warning logging |
| `lib/request/fetch-helpers.ts` | 1,497 → 756 | Response/error orchestration and rate-limit parsing stay (they span concerns); explicit re-exports of every previously-public symbol |

- Re-exports are explicit lists (not `export *`), so the facade's public surface did not grow.
- Three previously-private helpers gained `export` in their new homes only, for cross-module use: `CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE`, `isUnsupportedCodexModelForChatGpt`, `logDeprecationHeaders`.
- Runtime export surface compared before/after via namespace-import dump: byte-identical. No import cycles among the five request modules (madge).

## Validation

- [x] `npm run typecheck`
- [x] `npx eslint lib/request/ --max-warnings=0`
- [x] `npx vitest run` on all suites referencing fetch-helpers (`fetch-helpers`, `quota-probe`, `index`, `index-retry`, `public-api-contract`, `chaos/fault-injection`): 358/358 passed
- [x] Independently re-verified: typecheck + `fetch-helpers`/`public-api-contract` suites, 151/151

## Risk / Rollback

Mechanical move with a facade; revert the single commit to roll back. No data, config, or behavior changes.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

splits `lib/request/fetch-helpers.ts` (1,497 lines) along natural seams into four focused modules (`token-refresh`, `error-classification`, `url-rewriting`, `headers`), keeping `fetch-helpers.ts` as an explicit re-export facade with zero behavior change. all code is moved verbatim; existing tests (358/358) pass unchanged.

- four new files extract token refresh, error classification, url/proxy logic, and header construction; each is standalone with no cross-module imports among themselves.
- facade re-export lists are explicit (not `export *`), preserving the exact public surface; three helpers gain `@internal` exports in sub-modules for use by `fetch-helpers.ts` itself, but are not forwarded through the facade.
- `registerCleanup(closeSharedProxyDispatchers)` is moved to `url-rewriting.ts` module-load time; behavior is unchanged since es module singletons guarantee it fires exactly once.

<h3>Confidence Score: 5/5</h3>

mechanical extraction with a re-export facade; all code is verbatim, public surface is byte-identical, and 358 tests pass — safe to merge.

every function, constant, and interface moved verbatim; no logic changes, no import cycles, no new behavior. the only new surface is three @internal-annotated helpers accessible via sub-path imports, which the previous thread already covers. the change is structurally clean.

no files need extra scrutiny; all five files carry straightforward extractions or re-export plumbing.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/request/error-classification.ts | new file; verbatim extraction of entitlement/unsupported-model logic from fetch-helpers.ts; three @internal exports (CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE, isUnsupportedCodexModelForChatGpt) not re-exposed through facade — flagged in previous thread |
| lib/request/fetch-helpers.ts | trimmed to facade + response/rate-limit orchestration; explicit re-export lists correctly preserve every previously-public symbol |
| lib/request/headers.ts | new file; verbatim extraction of createCodexHeaders overloads + logDeprecationHeaders; logDeprecationHeaders exported @internal, not re-exposed through facade — flagged in previous thread |
| lib/request/token-refresh.ts | new file; verbatim extraction of shouldRefreshToken, refreshAndUpdateToken, and private retry predicates; EPERM/EBUSY retryability intact for windows token-file writes |
| lib/request/url-rewriting.ts | new file; verbatim extraction of proxy/URL rewrite logic; registerCleanup(closeSharedProxyDispatchers) side-effect preserved at module-load time; pre-existing double-create race in getSharedProxyDispatcher flagged in previous outside-diff comment |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    FH["fetch-helpers.ts<br/>(facade + response orchestration)"]
    EC["error-classification.ts<br/>entitlement · model fallback · workspace-disabled"]
    H["headers.ts<br/>createCodexHeaders · logDeprecationHeaders"]
    TR["token-refresh.ts<br/>shouldRefreshToken · refreshAndUpdateToken"]
    UR["url-rewriting.ts<br/>proxy resolution · URL rewrite<br/>+ registerCleanup side-effect"]

    EC -->|"re-exported via facade"| FH
    TR -->|"re-exported via facade"| FH
    UR -->|"re-exported via facade"| FH
    H  -->|"re-exported via facade"| FH

    FH -->|"internal import"| EC
    FH -->|"internal import"| H

    UR -->|"registerCleanup at load"| SD["shutdown.js"]
    TR -->|"queuedRefresh"| RQ["refresh-queue.js"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/request/url-rewriting.ts`, line 1671-1680 ([link](https://github.com/ndycode/codex-multi-auth/blob/2d5dfa1fc3c8051ce1b9520a97cd0fe4bc2bae24/lib/request/url-rewriting.ts#L1671-L1680)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **concurrency: unguarded double-create in `getSharedProxyDispatcher`**

   two concurrent callers can both observe `sharedProxyDispatchers.get(proxyUrl) === undefined`, both construct a new `ProxyAgent`, and the first agent gets silently overwritten in the map — leaving an unclosed `ProxyAgent` that is never passed to `closeSharedProxyDispatchers`. this is pre-existing code moved verbatim, but isolating it in its own module makes it the single owner of `sharedProxyDispatchers`; no other module can close the leaked agent. on windows, an abandoned `ProxyAgent` can hold an open socket handle that blocks cleanup. consider checking-after-set or using a pending promise to serialize construction.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/request/url-rewriting.ts
   Line: 1671-1680

   Comment:
   **concurrency: unguarded double-create in `getSharedProxyDispatcher`**

   two concurrent callers can both observe `sharedProxyDispatchers.get(proxyUrl) === undefined`, both construct a new `ProxyAgent`, and the first agent gets silently overwritten in the map — leaving an unclosed `ProxyAgent` that is never passed to `closeSharedProxyDispatchers`. this is pre-existing code moved verbatim, but isolating it in its own module makes it the single owner of `sharedProxyDispatchers`; no other module can close the leaked agent. on windows, an abandoned `ProxyAgent` can hold an open socket handle that blocks cleanup. consider checking-after-set or using a pending promise to serialize construction.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-06-fetch-helpers-split%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-06-fetch-helpers-split%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Frequest%2Furl-rewriting.ts%0ALine%3A%201671-1680%0A%0AComment%3A%0A**concurrency%3A%20unguarded%20double-create%20in%20%60getSharedProxyDispatcher%60**%0A%0Atwo%20concurrent%20callers%20can%20both%20observe%20%60sharedProxyDispatchers.get%28proxyUrl%29%20%3D%3D%3D%20undefined%60%2C%20both%20construct%20a%20new%20%60ProxyAgent%60%2C%20and%20the%20first%20agent%20gets%20silently%20overwritten%20in%20the%20map%20%E2%80%94%20leaving%20an%20unclosed%20%60ProxyAgent%60%20that%20is%20never%20passed%20to%20%60closeSharedProxyDispatchers%60.%20this%20is%20pre-existing%20code%20moved%20verbatim%2C%20but%20isolating%20it%20in%20its%20own%20module%20makes%20it%20the%20single%20owner%20of%20%60sharedProxyDispatchers%60%3B%20no%20other%20module%20can%20close%20the%20leaked%20agent.%20on%20windows%2C%20an%20abandoned%20%60ProxyAgent%60%20can%20hold%20an%20open%20socket%20handle%20that%20blocks%20cleanup.%20consider%20checking-after-set%20or%20using%20a%20pending%20promise%20to%20serialize%20construction.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth&pr=524&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-06-fetch-helpers-split%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-06-fetch-helpers-split%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Frequest%2Ftoken-refresh.ts%3A1-10%0A**no%20dedicated%20vitest%20test%20file%20for%20the%20four%20new%20modules**%0A%0A%60token-refresh.ts%60%2C%20%60error-classification.ts%60%2C%20%60url-rewriting.ts%60%2C%20and%20%60headers.ts%60%20have%20no%20corresponding%20test%20files.%20existing%20coverage%20flows%20entirely%20through%20the%20%60fetch-helpers.ts%60%20facade%20tests%2C%20so%20per-module%20edge%20cases%20%28e.g.%20%60isRetryableAuthSetterError%60%20returning%20%60true%60%20on%20windows%20%60EPERM%60%2C%20the%20%60registerCleanup%60%20side-effect%20firing%20at%20module%20load%20in%20%60url-rewriting.ts%60%2C%20the%20%60%40internal%60-exported%20helpers%20being%20callable%20directly%20from%20sub-paths%29%20go%20untested%20in%20isolation.%20worth%20adding%20%60test%2Ftoken-refresh.test.ts%60%20etc.%20to%20lock%20down%20the%20extracted%20seams%20independently.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=524&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/request/token-refresh.ts:1-10
**no dedicated vitest test file for the four new modules**

`token-refresh.ts`, `error-classification.ts`, `url-rewriting.ts`, and `headers.ts` have no corresponding test files. existing coverage flows entirely through the `fetch-helpers.ts` facade tests, so per-module edge cases (e.g. `isRetryableAuthSetterError` returning `true` on windows `EPERM`, the `registerCleanup` side-effect firing at module load in `url-rewriting.ts`, the `@internal`-exported helpers being callable directly from sub-paths) go untested in isolation. worth adding `test/token-refresh.test.ts` etc. to lock down the extracted seams independently.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(request): mark cross-module helpers..."](https://github.com/ndycode/codex-multi-auth/commit/52936722e4937ef11c889673a9160d48e3c7895a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36613959)</sub>

<!-- /greptile_comment -->