### PR TITLE
refactor(fs-retry): consolidate file-retry loops behind withRetry

### DIFF
--- a/lib/codex-manager/commands/uninstall.ts
+++ b/lib/codex-manager/commands/uninstall.ts
@@ -2,41 +2,10 @@ import { readFile, writeFile, rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
+import { withFileOperationRetry } from "../../fs-retry.js";
 import { unbindCodexAppRuntimeRotation } from "../../runtime/app-bind.js";
 
 const PLUGIN_NAME = "codex-multi-auth";
-
-const FILE_RETRY_CODES = new Set([
-	"EBUSY",
-	"EPERM",
-	"EAGAIN",
-	"ENOTEMPTY",
-	"EACCES",
-]);
-const FILE_RETRY_MAX_ATTEMPTS = 6;
-const FILE_RETRY_BASE_DELAY_MS = 25;
-const FILE_RETRY_JITTER_MS = 20;
-
-function isRetryableFsError(error: unknown): boolean {
-	if (!(error instanceof Error)) return false;
-	const code = (error as NodeJS.ErrnoException).code;
-	return typeof code === "string" && FILE_RETRY_CODES.has(code);
-}
-
-async function withFileOperationRetry<T>(operation: () => Promise<T>): Promise<T> {
-	for (let attempt = 1; ; attempt += 1) {
-		try {
-			return await operation();
-		} catch (error) {
-			if (!isRetryableFsError(error) || attempt >= FILE_RETRY_MAX_ATTEMPTS) {
-				throw error;
-			}
-			const jitter = Math.floor(Math.random() * FILE_RETRY_JITTER_MS);
-			const delayMs = FILE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1) + jitter;
-			await new Promise((resolve) => setTimeout(resolve, delayMs));
-		}
-	}
-}
 
 export function resolveUninstallPaths(
 	platform: NodeJS.Platform = process.platform,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -2,6 +2,7 @@ import { existsSync, promises as fs, readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { parseBooleanEnv } from "./env-parsing.js";
+import { withRetry, withRetrySync } from "./fs-retry.js";
 import { logWarn } from "./logger.js";
 import {
 	getCodexHomeDir,
@@ -55,34 +56,19 @@ const RETRYABLE_CONFIG_READ_CODES = new Set(["EBUSY", "EPERM", "EAGAIN"]);
  * attempts). ENOENT and SyntaxError are not retryable and propagate unchanged.
  */
 function readFileSyncWithConfigRetry(configPath: string): string {
-	const maxAttempts = 5;
-	let lastError: unknown;
-	for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-		try {
-			return readFileSync(configPath, "utf-8");
-		} catch (error) {
-			lastError = error;
-			const code = (error as NodeJS.ErrnoException | undefined)?.code;
-			if (
-				typeof code === "string" &&
-				RETRYABLE_CONFIG_READ_CODES.has(code) &&
-				attempt < maxAttempts - 1
-			) {
-				// Immediate retry — NOT a blocking sleep. loadPluginConfig() is
-				// synchronous and runs on startup, so the previous Atomics.wait froze
-				// the entire event loop for up to ~150ms on a transient Windows AV /
-				// indexer lock. An immediate re-read costs microseconds and a brief
-				// exclusive lock is typically released by the next attempt; if it
-				// genuinely persists we fail fast (the caller falls back to defaults)
-				// rather than stalling the process.
-				continue;
-			}
-			throw error;
-		}
-	}
-	// Exhausted attempts on a retryable code: surface the last error so the caller
-	// classifies it (unreadable) instead of silently returning stale/empty content.
-	throw lastError;
+	// Immediate retry (backoffMs: 0) — NOT a blocking sleep. loadPluginConfig()
+	// is synchronous and runs on startup, so the previous Atomics.wait froze the
+	// entire event loop for up to ~150ms on a transient Windows AV / indexer
+	// lock. An immediate re-read costs microseconds and a brief exclusive lock
+	// is typically released by the next attempt; if it genuinely persists we
+	// fail fast (the caller falls back to defaults) rather than stalling the
+	// process. On exhaustion the last error surfaces so the caller classifies it
+	// (unreadable) instead of silently returning stale/empty content.
+	return withRetrySync(() => readFileSync(configPath, "utf-8"), {
+		maxAttempts: 5,
+		backoffMs: 0,
+		retryableCodes: RETRYABLE_CONFIG_READ_CODES,
+	});
 }
 
 type ConfigReadState =
@@ -443,11 +429,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function isRetryableFsError(error: unknown): boolean {
-	const code = (error as NodeJS.ErrnoException | undefined)?.code;
-	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
-}
-
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -457,31 +438,26 @@ async function getConfigFileMtimeMs(filePath: string): Promise<number | null> {
 	// run on the Windows-sensitive save path, where a transient EBUSY/EPERM/EAGAIN
 	// from an AV/indexer lock on a single fs.stat would abort the entire save.
 	// Mirror readConfigRecordForSave's bounded transient-FS retry (same code set,
-	// same backoff, 5 attempts). ENOENT still returns null immediately.
-	let lastError: unknown;
-	for (let attempt = 0; attempt < 5; attempt += 1) {
-		try {
-			return (await fs.stat(filePath)).mtimeMs;
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException | undefined)?.code;
-			if (code === "ENOENT") {
-				return null;
+	// same backoff, 5 attempts). ENOENT still returns null immediately. On
+	// exhaustion the last failure surfaces so the caller treats it as a real
+	// save error rather than a phantom missing file.
+	return withRetry(
+		async () => {
+			try {
+				return (await fs.stat(filePath)).mtimeMs;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+					return null;
+				}
+				throw error;
 			}
-			lastError = error;
-			if (
-				typeof code === "string" &&
-				RETRYABLE_CONFIG_READ_CODES.has(code) &&
-				attempt < 4
-			) {
-				await sleep(10 * 2 ** attempt);
-				continue;
-			}
-			throw error;
-		}
-	}
-	// Exhausted retries on a transient code: surface the last failure so the caller
-	// treats it as a real save error rather than a phantom missing file.
-	throw lastError;
+		},
+		{
+			maxAttempts: 5,
+			backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+			retryableCodes: RETRYABLE_CONFIG_READ_CODES,
+		},
+	);
 }
 
 async function writeJsonFileAtomicWithRetry(
@@ -507,18 +483,12 @@ async function writeJsonFileAtomicWithRetry(
 				throw staleError;
 			}
 		}
-		for (let attempt = 0; attempt < 5; attempt += 1) {
-			try {
-				await fs.rename(tempPath, filePath);
-				renamed = true;
-				return;
-			} catch (error) {
-				if (!isRetryableFsError(error) || attempt >= 4) {
-					throw error;
-				}
-				await sleep(10 * 2 ** attempt);
-			}
-		}
+		await withRetry(() => fs.rename(tempPath, filePath), {
+			maxAttempts: 5,
+			backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+			retryableCodes: RETRYABLE_FS_CODES,
+		});
+		renamed = true;
 	} finally {
 		if (!renamed) {
 			try {
@@ -568,25 +538,16 @@ interface ConfigLockPayload {
 }
 
 async function unlinkConfigLockWithRetry(lockPath: string): Promise<void> {
-	for (let attempt = 0; attempt < 5; attempt += 1) {
-		try {
-			await fs.unlink(lockPath);
-			return;
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException | undefined)?.code;
-			if (code === "ENOENT") return;
-			if (
-				typeof code === "string" &&
-				RETRYABLE_FS_CODES.has(code) &&
-				attempt < 4
-			) {
-				await sleep(10 * 2 ** attempt);
-				continue;
-			}
-			// Best-effort release: a leftover lockfile is recovered as stale by the
-			// next acquirer via its expiry/mtime, so never fail the save over this.
-			return;
-		}
+	try {
+		await withRetry(() => fs.unlink(lockPath), {
+			maxAttempts: 5,
+			backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+			retryableCodes: RETRYABLE_FS_CODES,
+		});
+	} catch {
+		// ENOENT (already released) or best-effort release failure: a leftover
+		// lockfile is recovered as stale by the next acquirer via its
+		// expiry/mtime, so never fail the save over this.
 	}
 }
 
@@ -745,47 +706,42 @@ async function readConfigRecordForSave(
 		return { status: "missing" };
 	}
 
-	for (let attempt = 0; attempt < 5; attempt += 1) {
-		try {
-			const fileContent = await fs.readFile(configPath, "utf-8");
-			const normalizedFileContent = stripUtf8Bom(fileContent);
-			const parsed = JSON.parse(normalizedFileContent) as unknown;
-			if (!isRecord(parsed)) {
-				const errorMessage = `Config at ${configPath} must contain a JSON object at the root.`;
-				logConfigWarnOnce(errorMessage);
-				return { status: "invalid", errorMessage };
-			}
-			return { status: "ok", record: parsed };
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException | undefined)?.code;
-			if (code === "ENOENT") {
-				return { status: "missing" };
-			}
-			if (
-				typeof code === "string" &&
-				RETRYABLE_CONFIG_READ_CODES.has(code) &&
-				attempt < 4
-			) {
-				await sleep(10 * 2 ** attempt);
-				continue;
-			}
-			const errorMessage = `Failed to read config from ${configPath}: ${
-				error instanceof Error ? error.message : String(error)
-			}`;
-			logConfigWarnOnce(errorMessage);
-			if (error instanceof SyntaxError) {
-				return { status: "invalid", errorMessage };
-			}
-			if (typeof code === "string") {
-				return { status: "unreadable", errorMessage };
-			}
+	try {
+		return await withRetry<ConfigReadState>(
+			async () => {
+				const fileContent = await fs.readFile(configPath, "utf-8");
+				const normalizedFileContent = stripUtf8Bom(fileContent);
+				const parsed = JSON.parse(normalizedFileContent) as unknown;
+				if (!isRecord(parsed)) {
+					const errorMessage = `Config at ${configPath} must contain a JSON object at the root.`;
+					logConfigWarnOnce(errorMessage);
+					return { status: "invalid", errorMessage };
+				}
+				return { status: "ok", record: parsed };
+			},
+			{
+				maxAttempts: 5,
+				backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+				retryableCodes: RETRYABLE_CONFIG_READ_CODES,
+			},
+		);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException | undefined)?.code;
+		if (code === "ENOENT") {
+			return { status: "missing" };
+		}
+		const errorMessage = `Failed to read config from ${configPath}: ${
+			error instanceof Error ? error.message : String(error)
+		}`;
+		logConfigWarnOnce(errorMessage);
+		if (error instanceof SyntaxError) {
 			return { status: "invalid", errorMessage };
 		}
+		if (typeof code === "string") {
+			return { status: "unreadable", errorMessage };
+		}
+		return { status: "invalid", errorMessage };
 	}
-
-	const errorMessage = `Failed to read config from ${configPath}.`;
-	logConfigWarnOnce(errorMessage);
-	return { status: "unreadable", errorMessage };
 }
 
 function resolveStoredPluginConfigRecord(): {

--- a/lib/fs-retry.ts
+++ b/lib/fs-retry.ts
@@ -22,20 +22,134 @@ export function shouldRetryFileOperation(error: unknown): boolean {
 	);
 }
 
-export async function withFileOperationRetry<T>(
-	operation: () => Promise<T>,
+/**
+ * Options for {@link withRetry} / {@link withRetrySync}.
+ *
+ * The shape is deliberately wide enough to express every hand-rolled
+ * file-retry loop in the codebase without changing any call site's behavior:
+ * per-site attempt counts, exponential/linear backoff schedules, optional
+ * jitter, and per-site retryable code sets are all preserved exactly.
+ */
+export interface RetryOptions {
+	/** Total number of attempts (including the first one). Must be >= 1. */
+	maxAttempts: number;
+	/**
+	 * Delay before the next attempt, either a fixed number of milliseconds or
+	 * a function of the 1-based index of the attempt that just failed (so the
+	 * delay after the first failure is `backoffMs(1)`). A computed delay <= 0
+	 * retries immediately without scheduling a timer.
+	 */
+	backoffMs: number | ((attempt: number) => number);
+	/**
+	 * Optional jitter: adds `Math.floor(Math.random() * jitterMs)` to each
+	 * computed backoff delay.
+	 */
+	jitterMs?: number;
+	/**
+	 * Error codes considered transient. Defaults to {@link FILE_RETRY_CODES}.
+	 * An error retries only when it carries a string `code` in this set;
+	 * everything else is rethrown immediately.
+	 */
+	retryableCodes?: ReadonlySet<string> | readonly string[];
+	/** Invoked after each retryable failure, before the backoff delay. */
+	onRetry?: (error: unknown, attempt: number) => void;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+	if (typeof error !== "object" || error === null) return undefined;
+	const code = (error as { code?: unknown }).code;
+	return typeof code === "string" ? code : undefined;
+}
+
+function isRetryableError(
+	error: unknown,
+	retryableCodes: ReadonlySet<string> | readonly string[] | undefined,
+): boolean {
+	const code = getErrorCode(error);
+	if (code === undefined) return false;
+	if (retryableCodes === undefined) return FILE_RETRY_CODES.has(code);
+	return Array.isArray(retryableCodes)
+		? retryableCodes.includes(code)
+		: (retryableCodes as ReadonlySet<string>).has(code);
+}
+
+function computeDelayMs(options: RetryOptions, attempt: number): number {
+	const base =
+		typeof options.backoffMs === "function"
+			? options.backoffMs(attempt)
+			: options.backoffMs;
+	const jitter =
+		options.jitterMs !== undefined && options.jitterMs > 0
+			? Math.floor(Math.random() * options.jitterMs)
+			: 0;
+	return base + jitter;
+}
+
+/**
+ * Run `operation`, retrying on transient filesystem error codes with a
+ * per-call backoff schedule. Non-retryable errors are rethrown immediately;
+ * once `maxAttempts` is exhausted the error from the final attempt is
+ * rethrown unchanged. No delay is scheduled after the final attempt.
+ */
+export async function withRetry<T>(
+	operation: () => Promise<T> | T,
+	options: RetryOptions,
 ): Promise<T> {
 	for (let attempt = 1; ; attempt += 1) {
 		try {
 			return await operation();
 		} catch (error) {
-			if (!shouldRetryFileOperation(error) || attempt >= FILE_RETRY_MAX_ATTEMPTS) {
+			if (
+				!isRetryableError(error, options.retryableCodes) ||
+				attempt >= options.maxAttempts
+			) {
 				throw error;
 			}
-			const delayMs =
-				FILE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1) +
-				Math.floor(Math.random() * FILE_RETRY_JITTER_MS);
-			await sleep(delayMs);
+			options.onRetry?.(error, attempt);
+			const delayMs = computeDelayMs(options, attempt);
+			if (delayMs > 0) {
+				await sleep(delayMs);
+			}
 		}
 	}
+}
+
+/**
+ * Synchronous variant of {@link withRetry} for callers that cannot await
+ * (e.g. the synchronous recovery storage paths). Delays use a bounded
+ * busy-wait, so keep per-site schedules short; a computed delay <= 0 retries
+ * immediately without spinning.
+ */
+export function withRetrySync<T>(operation: () => T, options: RetryOptions): T {
+	for (let attempt = 1; ; attempt += 1) {
+		try {
+			return operation();
+		} catch (error) {
+			if (
+				!isRetryableError(error, options.retryableCodes) ||
+				attempt >= options.maxAttempts
+			) {
+				throw error;
+			}
+			options.onRetry?.(error, attempt);
+			const delayMs = computeDelayMs(options, attempt);
+			if (delayMs > 0) {
+				const waitUntil = Date.now() + delayMs;
+				while (Date.now() < waitUntil) {
+					// Busy-wait within the bounded per-attempt budget.
+				}
+			}
+		}
+	}
+}
+
+export function withFileOperationRetry<T>(
+	operation: () => Promise<T>,
+): Promise<T> {
+	return withRetry(operation, {
+		maxAttempts: FILE_RETRY_MAX_ATTEMPTS,
+		backoffMs: (attempt) => FILE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+		jitterMs: FILE_RETRY_JITTER_MS,
+		retryableCodes: FILE_RETRY_CODES,
+	});
 }

--- a/lib/quota-cache.ts
+++ b/lib/quota-cache.ts
@@ -1,8 +1,9 @@
 import { existsSync, promises as fs } from "node:fs";
 import { basename, join } from "node:path";
+import { withRetry } from "./fs-retry.js";
 import { logWarn } from "./logger.js";
 import { getCodexMultiAuthDir } from "./runtime-paths.js";
-import { isRecord, sleep } from "./utils.js";
+import { isRecord } from "./utils.js";
 
 export interface QuotaCacheWindow {
 	usedPercent?: number;
@@ -32,22 +33,7 @@ interface QuotaCacheFile {
 
 const QUOTA_CACHE_PATH = join(getCodexMultiAuthDir(), "quota-cache.json");
 const QUOTA_CACHE_LABEL = basename(QUOTA_CACHE_PATH);
-// Align with the shared FILE_RETRY_CODES taxonomy (lib/fs-retry.ts) so a
-// transient Windows lock (AV/indexer/concurrent reader) on the quota cache is
-// retried consistently with every other fs path, not just EBUSY/EPERM.
-const RETRYABLE_FS_CODES = new Set([
-	"EBUSY",
-	"EPERM",
-	"EAGAIN",
-	"ENOTEMPTY",
-	"EACCES",
-]);
 let quotaCacheWriteQueue: Promise<void> = Promise.resolve();
-
-function isRetryableFsError(error: unknown): boolean {
-	const code = (error as NodeJS.ErrnoException | undefined)?.code;
-	return typeof code === "string" && RETRYABLE_FS_CODES.has(code);
-}
 
 /**
  * Normalizes an unknown value to a finite number.
@@ -129,20 +115,14 @@ function normalizeEntryMap(value: unknown): Record<string, QuotaCacheEntry> {
 	return entries;
 }
 
-async function readCacheFileWithRetry(path: string): Promise<string> {
-	let lastError: unknown;
-	for (let attempt = 0; attempt < 5; attempt += 1) {
-		try {
-			return await fs.readFile(path, "utf8");
-		} catch (error) {
-			lastError = error;
-			if (!isRetryableFsError(error) || attempt >= 4) {
-				throw error;
-			}
-			await sleep(10 * 2 ** attempt);
-		}
-	}
-	throw lastError instanceof Error ? lastError : new Error("quota cache read retry exhausted");
+function readCacheFileWithRetry(path: string): Promise<string> {
+	// Retries the shared FILE_RETRY_CODES taxonomy (lib/fs-retry.ts) so a
+	// transient Windows lock (AV/indexer/concurrent reader) on the quota cache
+	// is retried consistently with every other fs path, not just EBUSY/EPERM.
+	return withRetry(() => fs.readFile(path, "utf8"), {
+		maxAttempts: 5,
+		backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+	});
 }
 
 /**
@@ -257,16 +237,11 @@ export async function saveQuotaCache(data: QuotaCacheData): Promise<void> {
 			});
 			let renamed = false;
 			try {
-				for (let attempt = 0; attempt < 5; attempt += 1) {
-					try {
-						await fs.rename(tempPath, QUOTA_CACHE_PATH);
-						renamed = true;
-						break;
-					} catch (error) {
-						if (!isRetryableFsError(error) || attempt >= 4) throw error;
-						await sleep(10 * 2 ** attempt);
-					}
-				}
+				await withRetry(() => fs.rename(tempPath, QUOTA_CACHE_PATH), {
+					maxAttempts: 5,
+					backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+				});
+				renamed = true;
 			} finally {
 				if (!renamed) {
 					try {

--- a/lib/recovery/storage.ts
+++ b/lib/recovery/storage.ts
@@ -14,6 +14,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { withRetrySync } from "../fs-retry.js";
 import {
 	MESSAGE_STORAGE,
 	PART_STORAGE,
@@ -184,32 +185,15 @@ const RETRYABLE_FS_CODES = new Set(["EBUSY", "EPERM", "ENOTEMPTY", "EAGAIN"]);
  * synchronous recovery code paths where async rename is not available.
  */
 function renameSyncWithRetry(source: string, target: string): void {
-	const maxAttempts = 4;
-	let lastError: unknown;
-	for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-		try {
-			renameSync(source, target);
-			return;
-		} catch (error) {
-			lastError = error;
-			const code = (error as NodeJS.ErrnoException | undefined)?.code;
-			if (!code || !RETRYABLE_FS_CODES.has(code)) {
-				throw error;
-			}
-			if (attempt === maxAttempts - 1) {
-				break;
-			}
-			// Exponential backoff: 10, 20, 40 ms before the next attempt.
-			// Synchronous wait is acceptable here because the recovery helper
-			// is already on a sync code path and retries only fire on genuine
-			// Windows lock contention.
-			const waitUntil = Date.now() + 10 * 2 ** attempt;
-			while (Date.now() < waitUntil) {
-				// busy-wait within budget (cumulative max ~70ms across attempts)
-			}
-		}
-	}
-	throw lastError as Error;
+	// Exponential backoff: 10, 20, 40 ms before the next attempt. The
+	// synchronous busy-wait inside withRetrySync is acceptable here because the
+	// recovery helper is already on a sync code path and retries only fire on
+	// genuine Windows lock contention (cumulative max ~70ms across attempts).
+	withRetrySync(() => renameSync(source, target), {
+		maxAttempts: 4,
+		backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+		retryableCodes: RETRYABLE_FS_CODES,
+	});
 }
 
 /**
@@ -252,29 +236,20 @@ function atomicWriteFileSync(
  * retries. Never throws.
  */
 function safeUnlinkWithRetry(filePath: string, maxAttempts = 4): boolean {
-	for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-		try {
-			unlinkSync(filePath);
-			return true;
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException | undefined)?.code;
-			if (code === "ENOENT") return false;
-			if (
-				!code ||
-				!RETRYABLE_FS_CODES.has(code) ||
-				attempt === maxAttempts - 1
-			) {
-				return false;
-			}
-			// Small synchronous backoff; recovery storage is not on a hot path, so
-			// a handful of milliseconds here is cheaper than leaving orphan files.
-			const waitUntil = Date.now() + 2 ** attempt * 5;
-			while (Date.now() < waitUntil) {
-				// busy-wait within budget (max ~40ms across four attempts)
-			}
-		}
+	try {
+		// Small synchronous backoff (5, 10, 20 ms); recovery storage is not on a
+		// hot path, so a handful of milliseconds here is cheaper than leaving
+		// orphan files (busy-wait budget max ~40ms across four attempts).
+		withRetrySync(() => unlinkSync(filePath), {
+			maxAttempts,
+			backoffMs: (attempt) => 2 ** (attempt - 1) * 5,
+			retryableCodes: RETRYABLE_FS_CODES,
+		});
+		return true;
+	} catch {
+		// ENOENT, a non-retryable code, or exhausted retries: best-effort delete.
+		return false;
 	}
-	return false;
 }
 
 // =============================================================================

--- a/lib/recovery/storage.ts
+++ b/lib/recovery/storage.ts
@@ -246,8 +246,12 @@ function safeUnlinkWithRetry(filePath: string, maxAttempts = 4): boolean {
 			retryableCodes: RETRYABLE_FS_CODES,
 		});
 		return true;
-	} catch {
-		// ENOENT, a non-retryable code, or exhausted retries: best-effort delete.
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException | undefined)?.code;
+		// File was already gone: nothing removed, but nothing orphaned either.
+		if (code === "ENOENT") return false;
+		// Exhausted retries or a non-retryable code (e.g. an AV lock that never
+		// released): best-effort delete, the caller cannot do better.
 		return false;
 	}
 }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -2,7 +2,7 @@ import { existsSync, promises as fs, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { ACCOUNT_LIMITS } from "./constants.js";
 import { StorageError } from "./errors.js";
-import { shouldRetryFileOperation, withFileOperationRetry } from "./fs-retry.js";
+import { withFileOperationRetry, withRetry } from "./fs-retry.js";
 import { createLogger } from "./logger.js";
 import {
 	exportNamedBackupFile,
@@ -265,51 +265,29 @@ async function copyFileWithRetry(
 	options?: { allowMissingSource?: boolean },
 ): Promise<void> {
 	const allowMissingSource = options?.allowMissingSource ?? false;
-	for (let attempt = 0; attempt < BACKUP_COPY_MAX_ATTEMPTS; attempt += 1) {
-		try {
-			await fs.copyFile(sourcePath, destinationPath);
+	try {
+		await withRetry(() => fs.copyFile(sourcePath, destinationPath), {
+			maxAttempts: BACKUP_COPY_MAX_ATTEMPTS,
+			backoffMs: (attempt) => BACKUP_COPY_BASE_DELAY_MS * 2 ** (attempt - 1),
+		});
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (allowMissingSource && code === "ENOENT") {
 			return;
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException).code;
-			if (allowMissingSource && code === "ENOENT") {
-				return;
-			}
-			const canRetry =
-				shouldRetryFileOperation(error) && attempt + 1 < BACKUP_COPY_MAX_ATTEMPTS;
-			if (canRetry) {
-				await new Promise((resolve) =>
-					setTimeout(resolve, BACKUP_COPY_BASE_DELAY_MS * 2 ** attempt),
-				);
-				continue;
-			}
-			throw error;
 		}
+		throw error;
 	}
 }
 
-async function renameFileWithRetry(
+function renameFileWithRetry(
 	sourcePath: string,
 	destinationPath: string,
 ): Promise<void> {
-	for (let attempt = 0; attempt < BACKUP_COPY_MAX_ATTEMPTS; attempt += 1) {
-		try {
-			await fs.rename(sourcePath, destinationPath);
-			return;
-		} catch (error) {
-			const canRetry =
-				shouldRetryFileOperation(error) && attempt + 1 < BACKUP_COPY_MAX_ATTEMPTS;
-			if (!canRetry) {
-				throw error;
-			}
-			const jitterMs = Math.floor(Math.random() * BACKUP_COPY_BASE_DELAY_MS);
-			await new Promise((resolve) =>
-				setTimeout(
-					resolve,
-					BACKUP_COPY_BASE_DELAY_MS * 2 ** attempt + jitterMs,
-				),
-			);
-		}
-	}
+	return withRetry(() => fs.rename(sourcePath, destinationPath), {
+		maxAttempts: BACKUP_COPY_MAX_ATTEMPTS,
+		backoffMs: (attempt) => BACKUP_COPY_BASE_DELAY_MS * 2 ** (attempt - 1),
+		jitterMs: BACKUP_COPY_BASE_DELAY_MS,
+	});
 }
 
 async function createRotatingAccountsBackup(path: string): Promise<void> {

--- a/test/fs-retry.test.ts
+++ b/test/fs-retry.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	FILE_RETRY_CODES,
+	withFileOperationRetry,
+	withRetry,
+	withRetrySync,
+} from "../lib/fs-retry.js";
+
+function makeErrnoError(code: string, message = code): NodeJS.ErrnoException {
+	const error = new Error(message) as NodeJS.ErrnoException;
+	error.code = code;
+	return error;
+}
+
+describe("withRetry", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("returns the result on first-try success without retrying", async () => {
+		const operation = vi.fn(async () => "ok");
+		await expect(
+			withRetry(operation, { maxAttempts: 5, backoffMs: 10 }),
+		).resolves.toBe("ok");
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries a retryable code and resolves once the operation succeeds", async () => {
+		const operation = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(makeErrnoError("EBUSY"))
+			.mockRejectedValueOnce(makeErrnoError("EPERM"))
+			.mockResolvedValueOnce("done");
+		await expect(
+			withRetry(operation, { maxAttempts: 5, backoffMs: 0 }),
+		).resolves.toBe("done");
+		expect(operation).toHaveBeenCalledTimes(3);
+	});
+
+	it("rethrows the last error once maxAttempts is exhausted", async () => {
+		const first = makeErrnoError("EBUSY", "first failure");
+		const last = makeErrnoError("EPERM", "last failure");
+		const operation = vi
+			.fn<() => Promise<never>>()
+			.mockRejectedValueOnce(first)
+			.mockRejectedValueOnce(makeErrnoError("EBUSY", "middle failure"))
+			.mockRejectedValue(last);
+		await expect(
+			withRetry(operation, { maxAttempts: 3, backoffMs: 0 }),
+		).rejects.toBe(last);
+		expect(operation).toHaveBeenCalledTimes(3);
+	});
+
+	it("throws immediately on a non-retryable code", async () => {
+		const error = makeErrnoError("ENOENT");
+		const operation = vi.fn<() => Promise<never>>().mockRejectedValue(error);
+		await expect(
+			withRetry(operation, { maxAttempts: 5, backoffMs: 10 }),
+		).rejects.toBe(error);
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws immediately on errors without a string code", async () => {
+		const error = new Error("no code at all");
+		const operation = vi.fn<() => Promise<never>>().mockRejectedValue(error);
+		await expect(
+			withRetry(operation, { maxAttempts: 5, backoffMs: 10 }),
+		).rejects.toBe(error);
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+
+	it("honors a custom retryableCodes array and rejects default codes", async () => {
+		const ebusy = makeErrnoError("EBUSY");
+		const operation = vi.fn<() => Promise<never>>().mockRejectedValue(ebusy);
+		await expect(
+			withRetry(operation, {
+				maxAttempts: 5,
+				backoffMs: 0,
+				retryableCodes: ["ESTALE"],
+			}),
+		).rejects.toBe(ebusy);
+		expect(operation).toHaveBeenCalledTimes(1);
+
+		const estale = makeErrnoError("ESTALE");
+		const recovers = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(estale)
+			.mockResolvedValueOnce("recovered");
+		await expect(
+			withRetry(recovers, {
+				maxAttempts: 3,
+				backoffMs: 0,
+				retryableCodes: ["ESTALE"],
+			}),
+		).resolves.toBe("recovered");
+		expect(recovers).toHaveBeenCalledTimes(2);
+	});
+
+	it("defaults retryableCodes to FILE_RETRY_CODES", async () => {
+		for (const code of FILE_RETRY_CODES) {
+			const operation = vi
+				.fn<() => Promise<string>>()
+				.mockRejectedValueOnce(makeErrnoError(code))
+				.mockResolvedValueOnce("ok");
+			await expect(
+				withRetry(operation, { maxAttempts: 2, backoffMs: 0 }),
+			).resolves.toBe("ok");
+			expect(operation).toHaveBeenCalledTimes(2);
+		}
+	});
+
+	it("honors the exponential backoff schedule between attempts", async () => {
+		vi.useFakeTimers();
+		const operation = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(makeErrnoError("EBUSY"))
+			.mockRejectedValueOnce(makeErrnoError("EBUSY"))
+			.mockRejectedValueOnce(makeErrnoError("EBUSY"))
+			.mockResolvedValueOnce("ok");
+		const pending = withRetry(operation, {
+			maxAttempts: 5,
+			backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+		});
+		// First attempt runs immediately; no timer has elapsed yet.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(operation).toHaveBeenCalledTimes(1);
+		// 9ms is one short of the first 10ms delay.
+		await vi.advanceTimersByTimeAsync(9);
+		expect(operation).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(operation).toHaveBeenCalledTimes(2);
+		// Second delay is 20ms.
+		await vi.advanceTimersByTimeAsync(19);
+		expect(operation).toHaveBeenCalledTimes(2);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(operation).toHaveBeenCalledTimes(3);
+		// Third delay is 40ms.
+		await vi.advanceTimersByTimeAsync(40);
+		expect(operation).toHaveBeenCalledTimes(4);
+		await expect(pending).resolves.toBe("ok");
+	});
+
+	it("adds jitter to the backoff delay", async () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.999);
+		const operation = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(makeErrnoError("EBUSY"))
+			.mockResolvedValueOnce("ok");
+		const pending = withRetry(operation, {
+			maxAttempts: 2,
+			backoffMs: 10,
+			jitterMs: 20,
+		});
+		// Delay is 10 + floor(0.999 * 20) = 29ms.
+		await vi.advanceTimersByTimeAsync(28);
+		expect(operation).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(operation).toHaveBeenCalledTimes(2);
+		await expect(pending).resolves.toBe("ok");
+	});
+
+	it("retries immediately without scheduling a timer when the delay is zero", async () => {
+		vi.useFakeTimers();
+		const operation = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(makeErrnoError("EBUSY"))
+			.mockResolvedValueOnce("ok");
+		// With fake timers active, a setTimeout-based sleep would hang until the
+		// clock is advanced; a zero delay must resolve without any timer.
+		await expect(
+			withRetry(operation, { maxAttempts: 2, backoffMs: 0 }),
+		).resolves.toBe("ok");
+		expect(operation).toHaveBeenCalledTimes(2);
+	});
+
+	it("invokes onRetry for each retryable failure but not for the final one", async () => {
+		const first = makeErrnoError("EBUSY", "first");
+		const second = makeErrnoError("EPERM", "second");
+		const last = makeErrnoError("EACCES", "last");
+		const operation = vi
+			.fn<() => Promise<never>>()
+			.mockRejectedValueOnce(first)
+			.mockRejectedValueOnce(second)
+			.mockRejectedValue(last);
+		const onRetry = vi.fn();
+		await expect(
+			withRetry(operation, { maxAttempts: 3, backoffMs: 0, onRetry }),
+		).rejects.toBe(last);
+		expect(onRetry).toHaveBeenCalledTimes(2);
+		expect(onRetry).toHaveBeenNthCalledWith(1, first, 1);
+		expect(onRetry).toHaveBeenNthCalledWith(2, second, 2);
+	});
+});
+
+describe("withRetrySync", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns the result on first-try success", () => {
+		const operation = vi.fn(() => 42);
+		expect(withRetrySync(operation, { maxAttempts: 4, backoffMs: 0 })).toBe(42);
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries a retryable code and returns once the operation succeeds", () => {
+		const operation = vi
+			.fn<() => string>()
+			.mockImplementationOnce(() => {
+				throw makeErrnoError("EBUSY");
+			})
+			.mockReturnValueOnce("done");
+		expect(
+			withRetrySync(operation, {
+				maxAttempts: 4,
+				backoffMs: 1,
+				retryableCodes: new Set(["EBUSY"]),
+			}),
+		).toBe("done");
+		expect(operation).toHaveBeenCalledTimes(2);
+	});
+
+	it("rethrows the last error once maxAttempts is exhausted", () => {
+		const last = makeErrnoError("EPERM", "still locked");
+		const operation = vi.fn<() => never>(() => {
+			throw last;
+		});
+		expect(() =>
+			withRetrySync(operation, { maxAttempts: 4, backoffMs: 0 }),
+		).toThrow(last);
+		expect(operation).toHaveBeenCalledTimes(4);
+	});
+
+	it("throws immediately on a non-retryable code", () => {
+		const error = makeErrnoError("ENOENT");
+		const operation = vi.fn<() => never>(() => {
+			throw error;
+		});
+		expect(() =>
+			withRetrySync(operation, { maxAttempts: 4, backoffMs: 0 }),
+		).toThrow(error);
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+
+	it("invokes onRetry with the failure and the 1-based attempt index", () => {
+		const error = makeErrnoError("EBUSY");
+		const operation = vi
+			.fn<() => string>()
+			.mockImplementationOnce(() => {
+				throw error;
+			})
+			.mockReturnValueOnce("ok");
+		const onRetry = vi.fn();
+		expect(
+			withRetrySync(operation, { maxAttempts: 2, backoffMs: 0, onRetry }),
+		).toBe("ok");
+		expect(onRetry).toHaveBeenCalledTimes(1);
+		expect(onRetry).toHaveBeenCalledWith(error, 1);
+	});
+});
+
+describe("withFileOperationRetry", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("retains the shared schedule: 6 attempts with 25ms exponential backoff plus jitter", async () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0);
+		const last = makeErrnoError("EBUSY", "always locked");
+		const operation = vi.fn<() => Promise<never>>().mockRejectedValue(last);
+		const pending = withFileOperationRetry(operation);
+		const rejection = expect(pending).rejects.toBe(last);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(operation).toHaveBeenCalledTimes(1);
+		// Delays: 25, 50, 100, 200, 400 (jitter mocked to 0).
+		for (const [index, delay] of [25, 50, 100, 200, 400].entries()) {
+			await vi.advanceTimersByTimeAsync(delay - 1);
+			expect(operation).toHaveBeenCalledTimes(index + 1);
+			await vi.advanceTimersByTimeAsync(1);
+			expect(operation).toHaveBeenCalledTimes(index + 2);
+		}
+		expect(operation).toHaveBeenCalledTimes(6);
+		await rejection;
+	});
+
+	it("throws immediately on a non-retryable code", async () => {
+		const error = makeErrnoError("ENOENT");
+		const operation = vi.fn<() => Promise<never>>().mockRejectedValue(error);
+		await expect(withFileOperationRetry(operation)).rejects.toBe(error);
+		expect(operation).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

Consolidates the divergent hand-rolled file-retry loops behind a single `withRetry` helper in `lib/fs-retry.ts` (the existing home of `FILE_RETRY_CODES`), per audit roadmap §4.2 (`docs/audits/AUDIT_2026-06-10.md`, PR #522). **Mechanical migration only** — every call site keeps its exact attempt count, backoff schedule, jitter, retryable code set, and error propagation. Tuning, if any, belongs in a follow-up PR.

## Changes

**New API in `lib/fs-retry.ts`:**

```ts
withRetry<T>(operation, { maxAttempts, backoffMs, jitterMs?, retryableCodes?, onRetry? }): Promise<T>
withRetrySync<T>(operation, options): T   // for the synchronous recovery paths
```

`backoffMs` accepts a number or a per-attempt function (covers the existing linear/exponential schedules); `retryableCodes` defaults to `FILE_RETRY_CODES`; non-retryable errors rethrow immediately; exhaustion rethrows the final error unchanged. `withFileOperationRetry` is now a thin delegate.

**14 loops migrated** across `lib/config.ts` (×5), `lib/storage.ts` (×2), `lib/quota-cache.ts` (×2, including removing a local duplicate of `FILE_RETRY_CODES`), `lib/recovery/storage.ts` (×2, sync), `lib/codex-manager/commands/uninstall.ts` (local `withFileOperationRetry` duplicate deleted in favor of the shared one), and `lib/fs-retry.ts` itself.

**3 loops deliberately skipped** (semantics don't fit attempt-bounded retry; forcing them would change behavior):
- `withConfigFileLock` acquisition — deadline-based wait with interleaved stale-lock takeover
- `savePluginConfig` ESTALE CAS loop — re-read/re-merge runs between attempts outside the retryable region
- `storage.ts` `renameTempToPath` — sleeps after the final failed attempt before rethrowing, a schedule `withRetry` intentionally cannot express

**New tests:** `test/fs-retry.test.ts` (18 cases) — first-try success, retry-then-success, exhaustion rethrow, non-retryable immediate throw, fake-timer backoff schedules (including jitter and the shared 25/50/100/200/400ms ladder), zero-delay paths, `onRetry`, and the sync variant.

## Validation

- [x] `npm run typecheck`
- [x] `npx eslint <all touched files> --max-warnings=0`
- [x] Migrated-module suites (config ×7, quota-cache, recovery-storage, recovery, uninstall ×3, fs-retry): 14 files, 375/375 passed
- [x] `test/storage.test.ts` and `test/storage-recovery-paths.test.ts`: failure lists diffed before (clean base) vs after — **identical**; all failures are the known container sandbox-EACCES environment issues documented in `docs/audits/evidence/test-baseline-2026-06-10.txt`
- [x] Independently re-verified: typecheck + fs-retry/quota-cache suites, 34/34

## Risk / Rollback

Single-commit mechanical migration; revert to roll back. The three skipped sites are unchanged on purpose and listed above for the next pass.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr consolidates 14 hand-rolled file-retry loops across 6 modules into a single `withRetry` / `withRetrySync` helper in `lib/fs-retry.ts`. the migration is mechanical: every call site's attempt count, backoff formula, retryable code set, and error-propagation contract is preserved.

- **new api** (`withRetry`, `withRetrySync`, `RetryOptions`) replaces per-module duplicates; `withFileOperationRetry` is now a thin delegate with identical behavior.
- **backoff translations** from 0-based to 1-based attempt indices are all consistent: `10 * 2 ** attempt` (0-based) ↔ `10 * 2 ** (attempt - 1)` (1-based), verified across every migrated site.
- **error-propagation semantics** — ENOENT, non-retryable codes, and exhaustion paths — are semantically equivalent in all migrated functions, including the ENOENT-inside-operation pattern in `getConfigFileMtimeMs` and the best-effort-swallow pattern in `unlinkConfigLockWithRetry`.

<h3>Confidence Score: 5/5</h3>

mechanical migration only — every backoff schedule, attempt count, retryable code set, and error-propagation contract has been faithfully preserved across all 14 migrated sites; no new logic is introduced.

all 0-based-to-1-based backoff conversions are verified correct; ENOENT and non-retryable errors still escape immediately at every call site; the three skipped sites are unchanged and explicitly documented; 375/375 migrated-module tests pass; the only open items were raised in prior review cycles and are all non-blocking.

no files require special attention; lib/fs-retry.ts is the new shared owner of retry semantics and is well covered by the new test suite.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/fs-retry.ts | new withRetry / withRetrySync / RetryOptions api added; isRetryableError helper uses a slightly wider object guard than the existing shouldRetryFileOperation (no instanceof Error check), but no practical impact since all fs errors are Error instances |
| lib/config.ts | 5 loops migrated; backoff formulas correct; ENOENT handled inside the operation for getConfigFileMtimeMs (returns null, not throws); readConfigRecordForSave exhaustion correctly produces { status: 'unreadable' } via the typeof code === 'string' guard in the outer catch |
| lib/storage.ts | 2 loops migrated; copyFileWithRetry ENOENT still handled on first throw (ENOENT not in FILE_RETRY_CODES so withRetry rethrows immediately, outer catch silences when allowMissingSource=true); jitter on renameFileWithRetry preserved via jitterMs: BACKUP_COPY_BASE_DELAY_MS |
| lib/recovery/storage.ts | 2 sync loops migrated to withRetrySync; local RETRYABLE_FS_CODES (no EACCES) correctly passed as retryableCodes so the recovery module's narrower code set is preserved; ENOENT/exhaustion share a catch block (noted in prior review) |
| lib/quota-cache.ts | local RETRYABLE_FS_CODES duplicate and isRetryableFsError helper removed; both loops now use withRetry with default FILE_RETRY_CODES, aligning with the comment already in the old code requesting this consistency |
| lib/codex-manager/commands/uninstall.ts | local withFileOperationRetry duplicate deleted; now imports from lib/fs-retry.ts; schedule (6 attempts, 25ms exponential + 20ms jitter, FILE_RETRY_CODES) is identical to what was hardcoded locally |
| test/fs-retry.test.ts | 18 test cases added; covers first-try success, retry-then-success, exhaustion rethrow, non-retryable immediate throw, fake-timer backoff/jitter verification, zero-delay path, onRetry callback, and withRetrySync basic paths; withRetrySync busy-wait with real delays (10–40ms) remains untested (noted in prior review) |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["caller: operation()"] --> B["withRetry / withRetrySync"]
    B --> C{"attempt\nsucceeds?"}
    C -- yes --> D["return result"]
    C -- no --> E{"isRetryableError?\n(code in retryableCodes)"}
    E -- no --> F["rethrow immediately"]
    E -- yes --> G{"attempt >=\nmaxAttempts?"}
    G -- yes --> F
    G -- no --> H["onRetry?.(error, attempt)"]
    H --> I["computeDelayMs\n(backoffMs + jitter)"]
    I --> J{"delayMs > 0?"}
    J -- no --> B
    J -- yes --> K["async: await sleep(ms)\nsync: busy-wait loop"]
    K --> B

    subgraph callers["migrated call sites"]
        L["lib/config.ts ×4"]
        M["lib/storage.ts ×2"]
        N["lib/quota-cache.ts ×2"]
        O["lib/recovery/storage.ts ×2"]
        P["lib/codex-manager/uninstall.ts"]
    end

    callers --> B
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `test/fs-retry.test.ts`, line 929-993 ([link](https://github.com/ndycode/codex-multi-auth/blob/57d9eb6efa07cc723299f9dd080c106a58f4bd92/test/fs-retry.test.ts#L929-L993)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`withRetrySync` busy-wait path untested**

   the `withRetrySync` suite only exercises `backoffMs: 0` and `backoffMs: 1`; neither path enters the `while (Date.now() < waitUntil)` busy-wait. on windows, `Date.now()` resolution can be ~15ms, so a test that passes `backoffMs: 10` with a spy on `Date.now()` (or a real-elapsed assertion) would give confidence that the spin loop terminates correctly and actually waits the expected budget. the production callers in `lib/recovery/storage.ts` use 10–40ms schedules, which makes this the highest-risk uncovered path in the new helper.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/fs-retry.test.ts
   Line: 929-993

   Comment:
   **`withRetrySync` busy-wait path untested**

   the `withRetrySync` suite only exercises `backoffMs: 0` and `backoffMs: 1`; neither path enters the `while (Date.now() < waitUntil)` busy-wait. on windows, `Date.now()` resolution can be ~15ms, so a test that passes `backoffMs: 10` with a spy on `Date.now()` (or a real-elapsed assertion) would give confidence that the spin loop terminates correctly and actually waits the expected budget. the production callers in `lib/recovery/storage.ts` use 10–40ms schedules, which makes this the highest-risk uncovered path in the new helper.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-07-retry-consolidation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-07-retry-consolidation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Ffs-retry.test.ts%0ALine%3A%20929-993%0A%0AComment%3A%0A**%60withRetrySync%60%20busy-wait%20path%20untested**%0A%0Athe%20%60withRetrySync%60%20suite%20only%20exercises%20%60backoffMs%3A%200%60%20and%20%60backoffMs%3A%201%60%3B%20neither%20path%20enters%20the%20%60while%20%28Date.now%28%29%20%3C%20waitUntil%29%60%20busy-wait.%20on%20windows%2C%20%60Date.now%28%29%60%20resolution%20can%20be%20~15ms%2C%20so%20a%20test%20that%20passes%20%60backoffMs%3A%2010%60%20with%20a%20spy%20on%20%60Date.now%28%29%60%20%28or%20a%20real-elapsed%20assertion%29%20would%20give%20confidence%20that%20the%20spin%20loop%20terminates%20correctly%20and%20actually%20waits%20the%20expected%20budget.%20the%20production%20callers%20in%20%60lib%2Frecovery%2Fstorage.ts%60%20use%2010%E2%80%9340ms%20schedules%2C%20which%20makes%20this%20the%20highest-risk%20uncovered%20path%20in%20the%20new%20helper.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth&pr=526&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `lib/config.ts`, line 270-310 ([link](https://github.com/ndycode/codex-multi-auth/blob/57d9eb6efa07cc723299f9dd080c106a58f4bd92/lib/config.ts#L270-L310)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **exhaustion error message format changed — not purely mechanical**

   the PR description claims "every call site keeps its exact … error propagation." in `readConfigRecordForSave`, when all 5 attempts on a retryable code (EBUSY/EPERM/EAGAIN) are exhausted and the old loop fell through, `logConfigWarnOnce` received `"Failed to read config from ${configPath}."` (no original error detail). the new catch block formats it as `"Failed to read config from ${configPath}: ${error.message}"`. this is a strictly more useful message, but it is a behavioral delta from the "mechanical only" claim and could surprise snapshot tests or log parsers that expect the old format.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/config.ts
   Line: 270-310

   Comment:
   **exhaustion error message format changed — not purely mechanical**

   the PR description claims "every call site keeps its exact … error propagation." in `readConfigRecordForSave`, when all 5 attempts on a retryable code (EBUSY/EPERM/EAGAIN) are exhausted and the old loop fell through, `logConfigWarnOnce` received `"Failed to read config from ${configPath}."` (no original error detail). the new catch block formats it as `"Failed to read config from ${configPath}: ${error.message}"`. this is a strictly more useful message, but it is a behavioral delta from the "mechanical only" claim and could surprise snapshot tests or log parsers that expect the old format.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-07-retry-consolidation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-07-retry-consolidation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fconfig.ts%0ALine%3A%20270-310%0A%0AComment%3A%0A**exhaustion%20error%20message%20format%20changed%20%E2%80%94%20not%20purely%20mechanical**%0A%0Athe%20PR%20description%20claims%20%22every%20call%20site%20keeps%20its%20exact%20%E2%80%A6%20error%20propagation.%22%20in%20%60readConfigRecordForSave%60%2C%20when%20all%205%20attempts%20on%20a%20retryable%20code%20%28EBUSY%2FEPERM%2FEAGAIN%29%20are%20exhausted%20and%20the%20old%20loop%20fell%20through%2C%20%60logConfigWarnOnce%60%20received%20%60%22Failed%20to%20read%20config%20from%20%24%7BconfigPath%7D.%22%60%20%28no%20original%20error%20detail%29.%20the%20new%20catch%20block%20formats%20it%20as%20%60%22Failed%20to%20read%20config%20from%20%24%7BconfigPath%7D%3A%20%24%7Berror.message%7D%22%60.%20this%20is%20a%20strictly%20more%20useful%20message%2C%20but%20it%20is%20a%20behavioral%20delta%20from%20the%20%22mechanical%20only%22%20claim%20and%20could%20surprise%20snapshot%20tests%20or%20log%20parsers%20that%20expect%20the%20old%20format.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth&pr=526&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(recovery): keep the ENOENT bran..."](https://github.com/ndycode/codex-multi-auth/commit/5a31ccae7b446c9843fe0860f3eb069dd1fc88df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36614785)</sub>

<!-- /greptile_comment -->