### PR TITLE
build: stop shipping JS source maps; keep declaration maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "types": [
       "node"
     ]


### PR DESCRIPTION
## Summary

Stops emitting/shipping JavaScript source maps while keeping declaration maps for library consumers — audit roadmap §4.5.1 (`docs/audits/AUDIT_2026-06-10.md`, PR #522). One-line `tsconfig.json` change.

## Impact

| Metric | Before | After |
| --- | --- | --- |
| `dist/` unpacked | 7.3 MB | 5.1 MB (−30%) |
| Packed tarball | 1,022,395 bytes | 731,570 bytes (−28%) |
| Files in tarball | 1,101 | 836 |
| `.js.map` shipped | 266 | 0 |
| `.d.ts.map` (kept) | 266 | 266 |

JS source maps were dead weight in the published package: the tarball ships `dist/` without `lib/` sources, so the maps could never resolve for consumers, and nothing in `lib/`, `scripts/`, tests, or docs references `.js.map` or `--enable-source-maps`. Declaration maps stay because go-to-definition works for monorepo/git consumers.

## Validation

- [x] `npm run build` clean; zero `.js.map` in dist, all 266 `.d.ts.map` intact
- [x] `node scripts/check-pack-budget.mjs` — Pack budget ok (731,570 bytes / 836 files)
- [x] `npx vitest run test/check-pack-budget.test.ts` — 13/13
- [x] `npm run typecheck`

## Risk / Rollback

Build-output-only change; revert the single commit to restore maps. Local debugging is unaffected (`tsc --sourceMap` or vitest's own transforms still work for development).

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

stops emitting js source maps (`sourceMap: false`) while keeping declaration maps intact — a build-output-only change that trims 266 `.js.map` files and cuts the published tarball by ~28%.

- `tsconfig.json`: `"sourceMap": true` → `"sourceMap": false`; `declarationMap` stays enabled so go-to-definition remains functional for monorepo/git consumers.
- no runtime, auth, storage, or token-handling paths are touched; the change is fully reversible with a single-commit revert.

<h3>Confidence Score: 5/5</h3>

safe to merge — single-line build config change with no effect on runtime, auth, storage, or token-handling paths.

the only file touched is tsconfig.json, and the only effect is omitting .js.map files from the compiled output. declaration maps are preserved. the pr description documents build, pack-budget, and typecheck validation, and the pack-budget vitest suite (13/13) gates the exact metric this change affects. no windows filesystem, concurrency, or token-safety concerns are in scope.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tsconfig.json | single-line change: `sourceMap` flipped from `true` to `false`; `declarationMap` remains enabled; reduces dist from 7.3 MB to 5.1 MB with no functional impact on runtime or library consumers |

</details>

<sub>Reviews (1): Last reviewed commit: ["build: stop shipping JS source maps; kee..."](https://github.com/ndycode/codex-multi-auth/commit/0cbbaedfb8a67b826ca9396629d0a16ca7bd693c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36666127)</sub>

<!-- /greptile_comment -->