### PR TITLE
chore(deps): pin @types/node to the supported runtime floor major

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 			},
 			"devDependencies": {
 				"@fast-check/vitest": "^0.2.4",
-				"@types/node": "^25.3.0",
+				"@types/node": "^20.19.42",
 				"@typescript-eslint/eslint-plugin": "^8.56.0",
 				"@typescript-eslint/parser": "^8.56.0",
 				"@vitest/coverage-v8": "^4.1.8",
@@ -921,9 +921,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -938,9 +935,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -955,9 +949,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -972,9 +963,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -989,9 +977,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1006,9 +991,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1023,9 +1005,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1040,9 +1019,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1057,9 +1033,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1074,9 +1047,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1091,9 +1061,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1108,9 +1075,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1125,9 +1089,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1264,13 +1225,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-			"integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+			"version": "20.19.42",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+			"integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.18.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -3465,9 +3426,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -921,6 +921,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -935,6 +938,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -949,6 +955,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -963,6 +972,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -977,6 +989,9 @@
 				"loong64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -991,6 +1006,9 @@
 				"loong64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1005,6 +1023,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1019,6 +1040,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1033,6 +1057,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1047,6 +1074,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1061,6 +1091,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1075,6 +1108,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1089,6 +1125,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
 	},
 	"devDependencies": {
 		"@fast-check/vitest": "^0.2.4",
-		"@types/node": "^25.3.0",
+		"@types/node": "^20.19.42",
 		"@typescript-eslint/eslint-plugin": "^8.56.0",
 		"@typescript-eslint/parser": "^8.56.0",
 		"@vitest/coverage-v8": "^4.1.8",


### PR DESCRIPTION
## Summary

Resolves audit finding **M9** (`docs/audits/AUDIT_2026-06-10.md` §3, PR #522): `@types/node ^25` resolved typings for APIs that don't exist on the supported floor (`engines.node >=18.17` runtime, Node 20 development floor per CONTRIBUTING.md). Any new code calling a Node 22+/25-only API (`fs.glob`, newer `AbortSignal` additions, etc.) would typecheck cleanly and fail at runtime for floor consumers.

This pins `@types/node` to `^20` so the compiler enforces the floor. This is the conservative half of the M9 decision (the alternative — raising `engines` — is a breaking change); raising the floor later just means bumping this pin alongside `engines` deliberately.

## Changes

- `package.json`: `@types/node` `^25.x` → `^20.19.42` (+ lockfile)

## Validation

- [x] `npm run typecheck` passes **unchanged** — confirming no over-floor Node APIs are in use today (this was the risk M9 flagged; it had not yet materialized)
- [x] Sample suites (`fs-retry`, `config`): pass

## Related

- Issue #523 (Node 18.x runtime-smoke CI job) is the runtime backstop for the same risk; this PR is the compile-time half.

## Risk / Rollback

Dev-dependency-only; no runtime or published-artifact change. Revert the commit to restore `^25` types.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

pins `@types/node` from `^25.3.0` to `^20.19.42` so the typescript compiler enforces the node 20 development floor rather than allowing node 22+/25-only apis to typecheck cleanly and silently fail on older runtimes. dev-dependency-only change; no runtime or published-artifact effect.

- `package.json`: `@types/node` range narrowed to `^20.19.42`; `engines.node` remains `>=18.0.0` (raising the floor is deferred as a deliberate breaking-change decision per the audit finding).
- `package-lock.json`: resolves `@types/node@20.19.42` and transitively downgrades `undici-types` from `7.18.2` → `6.21.0` to match; all integrity hashes are structurally valid sha512 values.

<h3>Confidence Score: 5/5</h3>

dev-dependency-only pin with no runtime or published-artifact change; safe to merge

the change narrows @types/node to ^20.19.42, adds no new code paths, and the pr description confirms typecheck passes against the existing codebase. the only lockfile side-effect (undici-types downgrade, libc field removal) is cosmetic or already tracked in a previous thread.

no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| package.json | pins `@types/node` from `^25.3.0` to `^20.19.42`; no runtime or published artifact change, only tightens compile-time enforcement to match the Node 20 dev floor |
| package-lock.json | lockfile updated to resolve `@types/node@20.19.42` and `undici-types@6.21.0`; all integrity hashes are valid sha512 values; `libc` field removal from optional native entries already flagged in a previous thread |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[developer writes code using Node API] --> B{API exists in\ntypes-node-20?}
    B -- yes --> C[typechecks clean\nworks on Node 20+ runtime]
    B -- no --> D[compiler error\ncaught at build time]
    D --> E[dev updates to compatible API]
    E --> A

    subgraph before["before this PR - types-node-25"]
        F[Node 25-only APIs typecheck silently]
        F --> G[fails at runtime for\nengines.node ge 18.0.0 consumers]
    end

    subgraph after["after this PR - types-node-20"]
        H[compile-time guard aligned\nwith CONTRIBUTING.md Node 20 floor]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `package.json`, line 154-156 ([link](https://github.com/ndycode/codex-multi-auth/blob/b8f1d3165efb4c0c374d121af9d34e13783cfd64/package.json#L154-L156)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **residual gap between `engines.node >=18.0.0` and `@types/node@^20`**

   `@types/node@20` includes APIs added in Node 20 (e.g. `fs.glob`, `stream.compose` additions) that don't exist on Node 18.x. any code calling those APIs will typecheck cleanly and fail at runtime for consumers running Node 18. the PR description acknowledges this as the deliberate conservative split (raising `engines` is a breaking change), so this is just a tracker note — but `engines` still reads `>=18.0.0`, which overpromises compatibility relative to what the types enforce. no vitest coverage exists to smoke-test the package against a Node 18 runtime outside of the CI job referenced in #523.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: package.json
   Line: 154-156

   Comment:
   **residual gap between `engines.node >=18.0.0` and `@types/node@^20`**

   `@types/node@20` includes APIs added in Node 20 (e.g. `fs.glob`, `stream.compose` additions) that don't exist on Node 18.x. any code calling those APIs will typecheck cleanly and fail at runtime for consumers running Node 18. the PR description acknowledges this as the deliberate conservative split (raising `engines` is a breaking change), so this is just a tracker note — but `engines` still reads `>=18.0.0`, which overpromises compatibility relative to what the types enforce. no vitest coverage exists to smoke-test the package against a Node 18 runtime outside of the CI job referenced in #523.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-13-types-node-pin%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-13-types-node-pin%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20package.json%0ALine%3A%20154-156%0A%0AComment%3A%0A**residual%20gap%20between%20%60engines.node%20%3E%3D18.0.0%60%20and%20%60%40types%2Fnode%40%5E20%60**%0A%0A%60%40types%2Fnode%4020%60%20includes%20APIs%20added%20in%20Node%2020%20%28e.g.%20%60fs.glob%60%2C%20%60stream.compose%60%20additions%29%20that%20don't%20exist%20on%20Node%2018.x.%20any%20code%20calling%20those%20APIs%20will%20typecheck%20cleanly%20and%20fail%20at%20runtime%20for%20consumers%20running%20Node%2018.%20the%20PR%20description%20acknowledges%20this%20as%20the%20deliberate%20conservative%20split%20%28raising%20%60engines%60%20is%20a%20breaking%20change%29%2C%20so%20this%20is%20just%20a%20tracker%20note%20%E2%80%94%20but%20%60engines%60%20still%20reads%20%60%3E%3D18.0.0%60%2C%20which%20overpromises%20compatibility%20relative%20to%20what%20the%20types%20enforce.%20no%20vitest%20coverage%20exists%20to%20smoke-test%20the%20package%20against%20a%20Node%2018%20runtime%20outside%20of%20the%20CI%20job%20referenced%20in%20%23523.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth&pr=528&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore(deps): restore libc fields the loc..."](https://github.com/ndycode/codex-multi-auth/commit/8cf973e9f4b134bc5fb42b1f592ddfea34e7e7a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36666287)</sub>

<!-- /greptile_comment -->