### PR TITLE
docs(security): record the undici exact-pin rationale

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,6 +82,10 @@ Security override rationale (`package.json` -> `overrides`):
 - `hono`: pinned to `4.12.21` to keep builds out of the vulnerable `<4.12.21` range reported in `GHSA-3hrh-pfw6-9m5x`, `GHSA-2gcr-mfcq-wcc3`, `GHSA-xrhx-7g5j-rcj5`, and `GHSA-f577-qrjj-4474` (Set-Cookie injection, `app.mount()` path-decoding, IPv6 IP-restriction bypass, and JWT scheme-acceptance advisories).
 - `rollup`: pinned to `^4.59.0` to keep the Vite and Vitest transitive graph above the vulnerable `<4.59.0` range surfaced by `npm audit`.
 
+Runtime dependency pin rationale (`package.json` -> `dependencies`):
+
+- `undici`: pinned exactly to `6.25.0`. It is the only runtime HTTP dependency (proxy `ProxyAgent` dispatch and the fetch fallback in the local bridge), it drives the published `engines.node >=18.17.0` floor, and its dispatcher behavior is part of the rotation proxy's tested surface — so version movement is taken deliberately via an explicit bump, never silently through a range. Moving to the undici `7.x` line is deferred until Node 18 support is dropped, since `7.x` raises the runtime floor to Node 20.
+
 Before release and after dependency changes:
 
 ```bash


### PR DESCRIPTION
## Summary

Documents the `undici` exact-pin rationale in SECURITY.md's Dependency and Release Hygiene section, in the same style as the existing `hono`/`rollup` entries — audit roadmap §4.5.5 (`docs/audits/AUDIT_2026-06-10.md`, PR #522).

## Changes

New "Runtime dependency pin rationale" entry explaining why `undici` is pinned exactly to `6.25.0`:
- only runtime HTTP dependency (`ProxyAgent` dispatch + local-bridge fetch fallback)
- it drives the published `engines.node >=18.17.0` floor
- dispatcher behavior is tested surface for the rotation proxy, so version movement should be a deliberate bump, never a silent range resolution
- undici `7.x` is explicitly deferred until Node 18 support is dropped (7.x raises the floor to Node 20)

## Validation

- [x] `npx vitest run test/documentation.test.ts` — 25/25 (doc-integrity suite)

## Risk / Rollback

Docs-only. Related: #518 (engines floor), #523 (runtime-smoke job), #528 (`@types/node` pin) — this completes the floor-management story.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

docs-only change adding a `undici` exact-pin rationale to `SECURITY.md`'s Dependency and Release Hygiene section, matching the existing `hono`/`rollup` style.

- adds a new \"Runtime dependency pin rationale\" subsection under `dependencies` (distinct from the existing \"Security override rationale\" under `overrides`), explaining that `undici` is pinned to `6.25.0` because it is the sole runtime http dependency, it drives the `engines.node >=18.17.0` floor, and its dispatcher behavior is part of the tested rotation proxy surface — with migration to `7.x` deferred until node 18 support is dropped.

<h3>Confidence Score: 5/5</h3>

docs-only edit with no runtime or security surface changes — safe to merge as-is

the change is a single paragraph added to SECURITY.md; factual claims match the repo's established node floor, the undici version in package.json, and the rotation proxy test surface described in AGENTS.md. no code, no config, no token or windows-path handling touched.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| SECURITY.md | adds "Runtime dependency pin rationale" subsection for undici 6.25.0 exact pin; content is accurate, style matches existing hono/rollup entries, no code touched |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[undici 6.25.0 exact pin] --> B{why exact pin?}
    B --> C[only runtime HTTP dep\nProxyAgent + fetch fallback]
    B --> D[drives engines.node >=18.17.0 floor]
    B --> E[dispatcher behavior = tested surface\nrotation proxy]
    E --> F[version bump must be deliberate\nnot silent range resolution]
    A --> G{upgrade to 7.x?}
    G -->|blocked| H[7.x raises floor to Node 20\ndeferred until Node 18 dropped]
```

<sub>Reviews (1): Last reviewed commit: ["docs(security): record the undici exact-..."](https://github.com/ndycode/codex-multi-auth/commit/b96714d430a4e13d869af5c01dc8f7f8546cf7e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36666451)</sub>

<!-- /greptile_comment -->