### PR TITLE
refactor(storage): separate public types from migration internals

### DIFF
--- a/lib/codex-manager/account-pool-write.ts
+++ b/lib/codex-manager/account-pool-write.ts
@@ -1,5 +1,5 @@
 import type { Workspace } from "../accounts.js";
-import type { AccountMetadataV3 } from "../storage/migrations.js";
+import type { AccountMetadataV3 } from "../storage/public-types.js";
 
 /**
  * Outcome of folding a single login result into the saved account pool.

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -87,14 +87,15 @@ import {
 	getLegacyFlaggedAccountsPath as buildLegacyFlaggedAccountsPath,
 } from "./storage/file-paths.js";
 import {
-	type AccountMetadataV1,
-	type AccountMetadataV3,
 	type AccountStorageV1,
-	type AccountStorageV3,
-	type CooldownReason,
 	migrateV1ToV3,
-	type RateLimitStateV3,
 } from "./storage/migrations.js";
+import type {
+	AccountMetadataV3,
+	AccountStorageV3,
+	CooldownReason,
+	RateLimitStateV3,
+} from "./storage/public-types.js";
 import { exportNamedBackupEntry } from "./storage/named-backup-entry.js";
 import {
 	collectNamedBackups,
@@ -145,8 +146,6 @@ export type {
 	StorageHealthSummary,
 	CooldownReason,
 	RateLimitStateV3,
-	AccountMetadataV1,
-	AccountStorageV1,
 	AccountMetadataV3,
 	AccountStorageV3,
 	NamedBackupSummary,

--- a/lib/storage/migrations.ts
+++ b/lib/storage/migrations.ts
@@ -1,17 +1,19 @@
 /**
  * Storage migration utilities for account data format upgrades.
  * Extracted from storage.ts to reduce module size.
+ *
+ * Historical migration-era shapes (v1) live here and are intentionally not
+ * exported from the lib/storage.ts facade; current-version shapes live in
+ * ./public-types.ts.
  */
 
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import type { AccountIdSource } from "../types.js";
-import type { Workspace } from "../accounts.js";
-
-export type CooldownReason = "auth-failure" | "network-error" | "server-error" | "rate-limit";
-
-export interface RateLimitStateV3 {
-	[key: string]: number | undefined;
-}
+import type {
+	AccountStorageV3,
+	CooldownReason,
+	RateLimitStateV3,
+} from "./public-types.js";
 
 export interface AccountMetadataV1 {
 	accountId?: string;
@@ -42,56 +44,6 @@ export interface AccountStorageV1 {
 	version: 1;
 	accounts: AccountMetadataV1[];
 	activeIndex: number;
-}
-
-export interface AccountMetadataV3 {
-	accountId?: string;
-	accountIdSource?: AccountIdSource;
-	accountLabel?: string;
-	email?: string;
-	refreshToken: string;
-	/** Optional cached access token (Codex CLI parity). */
-	accessToken?: string;
-	/** Optional access token expiry timestamp (ms since epoch). */
-	expiresAt?: number;
-	enabled?: boolean;
-	addedAt: number;
-	lastUsed: number;
-	lastSwitchReason?:
-		| "rate-limit"
-		| "initial"
-		| "rotation"
-		| "best"
-		| "restore"
-		| "manual";
-	rateLimitResetTimes?: RateLimitStateV3;
-	coolingDownUntil?: number;
-	cooldownReason?: CooldownReason;
-	workspaces?: Workspace[];
-	currentWorkspaceIndex?: number;
-}
-
-export interface AccountStorageV3 {
-	version: 3;
-	accounts: AccountMetadataV3[];
-	activeIndex: number;
-	activeIndexByFamily?: Partial<Record<ModelFamily, number>>;
-	/**
-	 * Optional manual pin set by `codex-multi-auth switch <n>` (0-based).
-	 * When set and valid, the runtime rotation proxy MUST route exclusively to
-	 * this account regardless of session affinity or hybrid scoring. Cleared by
-	 * `best` and the dedicated `unpin` command. See issue #474.
-	 */
-	pinnedAccountIndex?: number;
-	/**
-	 * Monotonically increasing counter bumped by user-initiated storage events
-	 * (`switch`, `unpin`, `best`) so the long-running runtime proxy can detect
-	 * a manual change and invalidate sticky session affinity. The proxy reads
-	 * this from disk via the same mtime-cached path as `pinnedAccountIndex` and
-	 * never bumps it from its own debounced writes. Treat `undefined` as
-	 * logically zero. See issue #474.
-	 */
-	affinityGeneration?: number;
 }
 
 function nowMs(): number {

--- a/lib/storage/public-types.ts
+++ b/lib/storage/public-types.ts
@@ -1,0 +1,65 @@
+/**
+ * Current-version account storage shapes shared with external consumers via
+ * the lib/storage.ts facade. Historical migration-era shapes (v1) live in
+ * ./migrations.ts and are intentionally not exported from the facade.
+ */
+
+import type { Workspace } from "../accounts.js";
+import type { ModelFamily } from "../prompts/codex.js";
+import type { AccountIdSource } from "../types.js";
+
+export type CooldownReason = "auth-failure" | "network-error" | "server-error" | "rate-limit";
+
+export interface RateLimitStateV3 {
+	[key: string]: number | undefined;
+}
+
+export interface AccountMetadataV3 {
+	accountId?: string;
+	accountIdSource?: AccountIdSource;
+	accountLabel?: string;
+	email?: string;
+	refreshToken: string;
+	/** Optional cached access token (Codex CLI parity). */
+	accessToken?: string;
+	/** Optional access token expiry timestamp (ms since epoch). */
+	expiresAt?: number;
+	enabled?: boolean;
+	addedAt: number;
+	lastUsed: number;
+	lastSwitchReason?:
+		| "rate-limit"
+		| "initial"
+		| "rotation"
+		| "best"
+		| "restore"
+		| "manual";
+	rateLimitResetTimes?: RateLimitStateV3;
+	coolingDownUntil?: number;
+	cooldownReason?: CooldownReason;
+	workspaces?: Workspace[];
+	currentWorkspaceIndex?: number;
+}
+
+export interface AccountStorageV3 {
+	version: 3;
+	accounts: AccountMetadataV3[];
+	activeIndex: number;
+	activeIndexByFamily?: Partial<Record<ModelFamily, number>>;
+	/**
+	 * Optional manual pin set by `codex-multi-auth switch <n>` (0-based).
+	 * When set and valid, the runtime rotation proxy MUST route exclusively to
+	 * this account regardless of session affinity or hybrid scoring. Cleared by
+	 * `best` and the dedicated `unpin` command. See issue #474.
+	 */
+	pinnedAccountIndex?: number;
+	/**
+	 * Monotonically increasing counter bumped by user-initiated storage events
+	 * (`switch`, `unpin`, `best`) so the long-running runtime proxy can detect
+	 * a manual change and invalidate sticky session affinity. The proxy reads
+	 * this from disk via the same mtime-cached path as `pinnedAccountIndex` and
+	 * never bumps it from its own debounced writes. Treat `undefined` as
+	 * logically zero. See issue #474.
+	 */
+	affinityGeneration?: number;
+}

--- a/test/codex-manager-account-pool-write.test.ts
+++ b/test/codex-manager-account-pool-write.test.ts
@@ -8,7 +8,7 @@ import {
 	type ResolvedAccountWrite,
 	resolveCurrentWorkspaceIndex,
 } from "../lib/codex-manager/account-pool-write.js";
-import type { AccountMetadataV3 } from "../lib/storage/migrations.js";
+import type { AccountMetadataV3 } from "../lib/storage/public-types.js";
 
 // Regression coverage for issue #512: the CLI `login` path persists through
 // persistAccountPool() in codex-manager.ts, which delegates the workspace


### PR DESCRIPTION
## Summary

Separates the storage facade's public types from migration-era internals — audit roadmap §4.1.4 (`docs/audits/AUDIT_2026-06-10.md`, PR #522). Zero runtime change; types and exports only.

## Changes

- **New `lib/storage/public-types.ts`**: the current-version shapes (`AccountStorageV3`, `AccountMetadataV3`, `RateLimitStateV3`, `CooldownReason`) move here verbatim from `migrations.ts`; the facade re-exports them so the `./storage` surface for these names is unchanged (and `lib/index.ts` is untouched).
- **`lib/storage/migrations.ts`** shrinks to what it should be: `AccountMetadataV1`, `AccountStorageV1`, and `migrateV1ToV3` only.
- **Facade exports dropped**: `AccountMetadataV1` / `AccountStorageV1` are no longer exported from `lib/storage.ts` — verified zero importers outside the migration module itself, and `test/public-api-contract.test.ts` pins no type names, so nothing breaks.
- Importers updated: `lib/codex-manager/account-pool-write.ts` (+ its test) now import `AccountMetadataV3` from `public-types.js`.

## Deviations from the audit's sketch (premises were stale)

- `RateLimitStateV3` stays public: it's structurally part of the **current** V3 shape (`AccountMetadataV3.rateLimitResetTimes`) and consumed via the facade by `lib/accounts.ts` — relocated, not removed.
- `lib/health.ts` no longer imports any migration type, so only one production importer needed updating.

This is also the groundwork for breaking the `storage.ts ↔ storage/*` import cycles (madge reports 23 on main), which blocks the roadmap's §4.1.6 no-cycle lint rule.

## Validation

- [x] `npm run typecheck`; eslint on all touched files at `--max-warnings=0`
- [x] 10 storage-adjacent suites (public-api-contract, file-paths, parser, scope, health, flagged-io, account-pool-write, project-migration, …): 62/62
- [x] `test/storage.test.ts` failure list identical before/after (known environment-only EACCES set)
- [x] Independently re-verified: typecheck + public-api-contract/account-pool-write, 20/20

## Risk / Rollback

Types-only; revert the single commit. Conflict note: touches `lib/storage.ts` exports, distinct region from #526's retry edits.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

types-only refactor extracting current-version v3 storage shapes into a new `lib/storage/public-types.ts`, leaving `migrations.ts` with only v1 types and `migrateV1ToV3`. zero runtime change; the `lib/storage.ts` facade surface for `AccountMetadataV3`, `AccountStorageV3`, `CooldownReason`, and `RateLimitStateV3` is unchanged, and `AccountMetadataV1`/`AccountStorageV1` are correctly hidden.

- **`lib/storage/public-types.ts`** (new): holds all current v3 shapes; `migrations.ts` and the facade both import from here, establishing a clean dependency direction.
- **facade export list trimmed**: v1 types dropped from `lib/storage.ts` re-exports after confirming zero external importers.
- **importers updated**: `lib/codex-manager/account-pool-write.ts` and its test now point at `public-types.js`; the test bypasses the facade and imports the internal path directly, which is a minor surface inconsistency noted in the inline comment.

<h3>Confidence Score: 4/5</h3>

safe to merge — zero runtime change, correct dependency direction, facade surface preserved

the refactor is clean and mechanically correct. the only thing worth a second look is that the test bypasses the facade to import directly from the internal module, which leaves a loose end as the roadmap continues restructuring the storage sub-modules

test/codex-manager-account-pool-write.test.ts — direct internal path import rather than facade

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage/public-types.ts | new file containing current-version v3 shapes verbatim from migrations.ts; types-only, no runtime change, correct imports |
| lib/storage/migrations.ts | trimmed to v1 shapes and migrateV1ToV3; imports v3 types from ./public-types.js; dependency direction is clean |
| lib/storage.ts | facade imports v3 types from public-types.js and drops v1 re-exports; AccountStorageV1 retained internally for AnyAccountStorage union |
| lib/codex-manager/account-pool-write.ts | one-line import path update from migrations.js to public-types.js; acceptable for internal lib module |
| test/codex-manager-account-pool-write.test.ts | import updated but test/ is an external consumer that should use the lib/storage.ts facade rather than the internal path |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    facade["lib/storage.ts (facade)"]
    pt["lib/storage/public-types.ts\nAccountMetadataV3\nAccountStorageV3\nCooldownReason\nRateLimitStateV3"]
    mig["lib/storage/migrations.ts\nAccountMetadataV1\nAccountStorageV1\nmigrateV1ToV3"]
    apw["lib/codex-manager/account-pool-write.ts"]
    test["test/codex-manager-account-pool-write.test.ts"]
    ext["external consumers\n(lib/accounts.ts, etc.)"]

    facade -->|"re-exports v3 types"| pt
    facade -->|"imports AccountStorageV1\n+ migrateV1ToV3"| mig
    mig -->|"imports v3 types"| pt
    apw -->|"imports AccountMetadataV3"| pt
    test -->|"imports AccountMetadataV3\n(should use facade)"| pt
    ext -->|"imports via facade"| facade
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-10-storage-type-hygiene%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-10-storage-type-hygiene%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fcodex-manager-account-pool-write.test.ts%3A11%0Athe%20test%20imports%20%60AccountMetadataV3%60%20directly%20from%20the%20internal%20%60public-types%60%20module%20rather%20than%20from%20the%20%60lib%2Fstorage.ts%60%20facade%20that%20already%20re-exports%20it.%20%60lib%2FAGENTS.md%60%20says%20public%20exports%20should%20flow%20through%20%60lib%2Findex.ts%60%20or%20documented%20subpaths%3B%20%60test%2F%60%20files%20are%20external%20consumers.%20if%20%60public-types.ts%60%20moves%20again%20as%20part%20of%20the%20%C2%A74.1.6%20no-cycle%20work%2C%20this%20direct%20path%20will%20break%20without%20the%20facade%20protecting%20it.%0A%0A%60%60%60suggestion%0Aimport%20type%20%7B%20AccountMetadataV3%20%7D%20from%20%22..%2Flib%2Fstorage.js%22%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=530&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/codex-manager-account-pool-write.test.ts:11
the test imports `AccountMetadataV3` directly from the internal `public-types` module rather than from the `lib/storage.ts` facade that already re-exports it. `lib/AGENTS.md` says public exports should flow through `lib/index.ts` or documented subpaths; `test/` files are external consumers. if `public-types.ts` moves again as part of the §4.1.6 no-cycle work, this direct path will break without the facade protecting it.

```suggestion
import type { AccountMetadataV3 } from "../lib/storage.js";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(storage): separate public types..."](https://github.com/ndycode/codex-multi-auth/commit/00baf9d624880e4ffe94df4ea031b0bb89420967) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36666843)</sub>

**Context used:**

- Context used - lib/AGENTS.md ([source](https://app.greptile.com/zeian/github/ndycode/codex-multi-auth/-/custom-context?memory=ffbed5b7-f299-4c32-b3f9-f7c095ca8632))
- Context used - test/AGENTS.md ([source](https://app.greptile.com/zeian/github/ndycode/codex-multi-auth/-/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))

<!-- /greptile_comment -->