### PR TITLE
refactor(runtime): carve rotation-proxy seams (phase 1)

### DIFF
--- a/lib/request/rate-limit-decision.ts
+++ b/lib/request/rate-limit-decision.ts
@@ -1,0 +1,211 @@
+import { HTTP_STATUS } from "../constants.js";
+import type { ExhaustionReason } from "../runtime/rotation-server-types.js";
+import type { TokenResult } from "../types.js";
+import { isRecord } from "../utils.js";
+
+// Phrases observed in upstream 401 response bodies when OpenAI/Microsoft has
+// explicitly revoked an OAuth token (as opposed to a generic expired-token 401
+// that can be retried after a refresh). Matching is case-insensitive substring.
+// If anti-abuse detection triggers different wording in production, add the new
+// phrase here and record the source provider and date. See issue #495.
+const TOKEN_INVALIDATION_PHRASES = [
+	"invalidated oauth token",
+	"authentication token has been invalidated",
+	"oauth token has been invalidated",
+	"token has been invalidated",
+] as const;
+
+export function isTokenInvalidationError(bodyText: string): boolean {
+	const lower = bodyText.toLowerCase();
+	return TOKEN_INVALIDATION_PHRASES.some((phrase) => lower.includes(phrase));
+}
+
+export function isTokenRefreshRetryable(result: Extract<TokenResult, { type: "failed" }>): boolean {
+	if (result.reason === "network_error" || result.reason === "unknown") return true;
+	if (result.reason === "invalid_response") return true;
+	if (result.reason === "http_error") {
+		return !(
+			result.statusCode === HTTP_STATUS.BAD_REQUEST ||
+			result.statusCode === HTTP_STATUS.UNAUTHORIZED ||
+			result.statusCode === HTTP_STATUS.FORBIDDEN
+		);
+	}
+	return false;
+}
+
+export function parseRetryAfterHeaderMs(headers: Headers, now: number): number | null {
+	const retryAfterMs = headers.get("retry-after-ms");
+	if (retryAfterMs) {
+		const parsed = Number.parseInt(retryAfterMs, 10);
+		if (Number.isFinite(parsed) && parsed > 0) return parsed;
+	}
+	const retryAfter = headers.get("retry-after");
+	if (!retryAfter) return null;
+	const asSeconds = Number.parseInt(retryAfter, 10);
+	if (Number.isFinite(asSeconds) && asSeconds > 0) return asSeconds * 1000;
+	const asDate = Date.parse(retryAfter);
+	if (Number.isFinite(asDate) && asDate > now) return asDate - now;
+	return null;
+}
+
+export function parseRetryAfterBodyMs(bodyText: string, now: number): number | null {
+	if (!bodyText.trim()) return null;
+	try {
+		const parsed = JSON.parse(bodyText) as unknown;
+		if (!isRecord(parsed) || !isRecord(parsed.error)) return null;
+		const retryAfterMs = Number(parsed.error.retry_after_ms);
+		if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) return retryAfterMs;
+		const retryAfterSeconds = Number(parsed.error.retry_after);
+		if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+			return retryAfterSeconds * 1000;
+		}
+		const resetAtRaw = Number(parsed.error.resets_at ?? parsed.error.reset_at);
+		if (Number.isFinite(resetAtRaw) && resetAtRaw > 0) {
+			const resetAtMs = resetAtRaw < 10_000_000_000 ? resetAtRaw * 1000 : resetAtRaw;
+			if (resetAtMs > now) return resetAtMs - now;
+		}
+	} catch {
+		return null;
+	}
+	return null;
+}
+
+const TOKEN_INVALIDATED_CODE = "token_invalidated";
+const TOKEN_INVALIDATED_FALLBACK_MESSAGE =
+	"OAuth token has been invalidated. Please re-login.";
+
+// Both invalidation exit paths (refresh-failure and upstream-401) must hand the
+// client the same machine-readable shape — { error: { message, code:
+// "token_invalidated" } } — so a consumer keying off error.code behaves
+// identically regardless of which vector fired. The upstream forwards a raw body
+// with no guaranteed code, so we wrap it here while preserving its human-readable
+// message when one is present.
+export function buildTokenInvalidationBody(upstreamBodyText: string): string {
+	let message = TOKEN_INVALIDATED_FALLBACK_MESSAGE;
+	const trimmed = upstreamBodyText.trim();
+	if (trimmed) {
+		try {
+			const parsed = JSON.parse(trimmed) as unknown;
+			if (isRecord(parsed)) {
+				const direct = parsed.message;
+				if (typeof direct === "string" && direct.trim()) {
+					message = direct.trim();
+				} else if (isRecord(parsed.error)) {
+					const nested = parsed.error.message;
+					if (typeof nested === "string" && nested.trim()) {
+						message = nested.trim();
+					}
+				}
+			}
+		} catch {
+			// Non-JSON upstream body (e.g. HTML error page): keep the stable fallback
+			// message rather than echoing markup back to the client.
+		}
+	}
+	return JSON.stringify({ error: { message, code: TOKEN_INVALIDATED_CODE } });
+}
+
+export function extractErrorCodeFromBody(bodyText: string): string | null {
+	if (!bodyText.trim()) return null;
+	try {
+		const parsed = JSON.parse(bodyText) as unknown;
+		if (!isRecord(parsed)) return null;
+		const directCode = parsed.code;
+		if (typeof directCode === "string" && directCode.trim()) {
+			return directCode.trim();
+		}
+		const maybeError = parsed.error;
+		if (!isRecord(maybeError)) return null;
+		const nestedCode = maybeError.code;
+		return typeof nestedCode === "string" && nestedCode.trim()
+			? nestedCode.trim()
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function getQuotaWindowWaitMs(headers: Headers, prefix: string, now: number): number {
+	const resetAfterSeconds = Number.parseInt(
+		headers.get(`${prefix}-reset-after-seconds`) ?? "",
+		10,
+	);
+	if (Number.isFinite(resetAfterSeconds) && resetAfterSeconds > 0) {
+		return resetAfterSeconds * 1000;
+	}
+	const resetAtRaw = headers.get(`${prefix}-reset-at`);
+	if (!resetAtRaw) return 0;
+	const trimmed = resetAtRaw.trim();
+	let resetAtMs = 0;
+	if (/^\d+$/.test(trimmed)) {
+		const parsed = Number.parseInt(trimmed, 10);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			resetAtMs = parsed < 10_000_000_000 ? parsed * 1000 : parsed;
+		}
+	} else {
+		const parsedDate = Date.parse(trimmed);
+		if (Number.isFinite(parsedDate)) resetAtMs = parsedDate;
+	}
+	return resetAtMs > now ? resetAtMs - now : 0;
+}
+
+export function getQuotaNearExhaustionWaitMs(
+	headers: Headers,
+	remainingThreshold: number,
+	now: number,
+): number {
+	const usedThreshold = 100 - Math.max(0, Math.min(100, remainingThreshold));
+	const candidates: number[] = [];
+	for (const prefix of ["x-codex-primary", "x-codex-secondary"]) {
+		const used = Number(headers.get(`${prefix}-used-percent`) ?? "");
+		if (!Number.isFinite(used) || used < usedThreshold) continue;
+		const waitMs = getQuotaWindowWaitMs(headers, prefix, now);
+		if (waitMs > 0) candidates.push(waitMs);
+	}
+	return candidates.length > 0 ? Math.max(...candidates) : 0;
+}
+
+export function normalizeExhaustionStatus(reason: ExhaustionReason): number {
+	return reason === "rate-limit" ? HTTP_STATUS.TOO_MANY_REQUESTS : 503;
+}
+
+/**
+ * Build the JSON `error` body for a pinned-account 503 response. Extracted so
+ * the null-reason desync path (`reason: null`, no parenthetical in `message`)
+ * can be unit-tested without standing up a full proxy. The shape mirrors
+ * `writePoolExhausted` so consumers can handle both 503 codes uniformly. See
+ * issue #486.
+ */
+export interface PinnedUnavailableErrorBody {
+	message: string;
+	code: "codex_pinned_account_unavailable";
+	pinnedAccountIndex: number | null;
+	reason: string | null;
+	account_skip_reasons: Record<string, string>;
+}
+
+export function buildPinnedUnavailableErrorBody(
+	pinnedIndex: number | null | undefined,
+	accountSkipReasons: ReadonlyMap<number, string>,
+): PinnedUnavailableErrorBody {
+	const normalizedPinnedIndex =
+		typeof pinnedIndex === "number" ? pinnedIndex : null;
+	const skipReason =
+		normalizedPinnedIndex !== null
+			? accountSkipReasons.get(normalizedPinnedIndex) ?? null
+			: null;
+	const reasonSuffix = skipReason ? ` (${skipReason})` : "";
+	const displayIndex = (normalizedPinnedIndex ?? 0) + 1;
+	return {
+		message: `Pinned account ${displayIndex} is currently unavailable${reasonSuffix}; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
+		code: "codex_pinned_account_unavailable",
+		pinnedAccountIndex: normalizedPinnedIndex,
+		reason: skipReason,
+		account_skip_reasons: Object.fromEntries(
+			[...accountSkipReasons.entries()].map(([index, reason]) => [
+				String(index),
+				reason,
+			]),
+		),
+	};
+}

--- a/lib/request/stream-failover-runtime.ts
+++ b/lib/request/stream-failover-runtime.ts
@@ -1,0 +1,170 @@
+import type { ServerResponse } from "node:http";
+import type { RuntimeRotationProxyStatus } from "../runtime/rotation-server-types.js";
+
+export const HOP_BY_HOP_HEADERS = new Set([
+	"connection",
+	"content-length",
+	"expect",
+	"keep-alive",
+	"proxy-authenticate",
+	"proxy-authorization",
+	"te",
+	"trailer",
+	"transfer-encoding",
+	"upgrade",
+]);
+const PRIVATE_CLIENT_RESPONSE_HEADERS = new Set([
+	"x-codex-multi-auth-account-index",
+	"x-codex-multi-auth-account-label",
+	"x-codex-multi-auth-account-email",
+	"x-codex-multi-auth-account-id",
+]);
+const DECODED_UPSTREAM_RESPONSE_HEADERS = new Set([
+	// Node fetch returns decoded bytes while preserving the upstream encoding header.
+	"content-encoding",
+]);
+
+export function responseHeadersForClient(upstreamHeaders: Headers): Record<string, string> {
+	const headers: Record<string, string> = {};
+	for (const [key, value] of upstreamHeaders.entries()) {
+		const normalizedKey = key.toLowerCase();
+		if (HOP_BY_HOP_HEADERS.has(normalizedKey)) continue;
+		if (PRIVATE_CLIENT_RESPONSE_HEADERS.has(normalizedKey)) continue;
+		if (DECODED_UPSTREAM_RESPONSE_HEADERS.has(normalizedKey)) continue;
+		headers[key] = value;
+	}
+	return headers;
+}
+
+export async function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	onTimeout: () => void,
+	message: string,
+): Promise<T> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<T>((_resolve, reject) => {
+				timeout = setTimeout(() => {
+					onTimeout();
+					reject(new Error(message));
+				}, Math.max(1, timeoutMs));
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
+export async function readErrorBody(
+	response: Response,
+	timeoutMs: number,
+	maxBytes = 1024 * 1024,
+): Promise<string> {
+	// The outbound fetch's abort timer is cleared once headers arrive, so a
+	// stalled error body would otherwise hang this handler forever (the success
+	// path is per-chunk stall-bounded; the error path was not). Read the body via
+	// a reader, bound it by an idle timeout AND a size cap, and cancel the stream
+	// on timeout/overflow so the socket is released.
+	const body = response.body;
+	if (!body || typeof body.getReader !== "function") {
+		// Fallback for impls without a streamable body: race text() against a timer.
+		try {
+			return await withTimeout(
+				response.text(),
+				timeoutMs,
+				() => undefined,
+				"error body stalled",
+			);
+		} catch {
+			return "";
+		}
+	}
+	const reader = body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		for (;;) {
+			let idleTimer: ReturnType<typeof setTimeout> | undefined;
+			const idle = new Promise<never>((_resolve, reject) => {
+				idleTimer = setTimeout(
+					() => reject(new Error("error body stalled")),
+					Math.max(1, timeoutMs),
+				);
+			});
+			let result: Awaited<ReturnType<typeof reader.read>>;
+			try {
+				result = await Promise.race([reader.read(), idle]);
+			} finally {
+				if (idleTimer) clearTimeout(idleTimer);
+			}
+			if (result.done) break;
+			if (result.value) {
+				total += result.value.byteLength;
+				if (total > maxBytes) break; // cap: enough for diagnostics, no OOM
+				chunks.push(result.value);
+			}
+		}
+	} catch {
+		// stalled or errored — fall through with whatever we have
+	} finally {
+		await reader.cancel().catch(() => undefined);
+	}
+	try {
+		return Buffer.concat(chunks).toString("utf8");
+	} catch {
+		return "";
+	}
+}
+
+export async function forwardStreamingResponse(
+	upstream: Response,
+	res: ServerResponse,
+	status: RuntimeRotationProxyStatus,
+	onStreamError: () => void,
+	streamStallTimeoutMs: number,
+): Promise<boolean> {
+	status.streamsStarted += 1;
+	res.writeHead(
+		upstream.status,
+		responseHeadersForClient(upstream.headers),
+	);
+	if (!upstream.body) {
+		res.end();
+		return true;
+	}
+
+	const reader = upstream.body.getReader();
+	res.on("close", () => {
+		if (!res.writableEnded) {
+			void reader.cancel().catch(() => undefined);
+		}
+	});
+	try {
+		while (true) {
+			const { done, value } = await withTimeout(
+				reader.read(),
+				streamStallTimeoutMs,
+				() => {
+					void reader.cancel().catch(() => undefined);
+				},
+				`upstream stream stalled after ${streamStallTimeoutMs}ms`,
+			);
+			if (done) break;
+			if (value && value.byteLength > 0) {
+				res.write(Buffer.from(value));
+			}
+		}
+		res.end();
+		return true;
+	} catch (error) {
+		status.lastError = error instanceof Error ? error.message : String(error);
+		onStreamError();
+		if (!res.destroyed) {
+			res.destroy(error instanceof Error ? error : undefined);
+		}
+		return false;
+	}
+}

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -51,76 +51,51 @@ import {
 } from "./policy/runtime-policy.js";
 import { isWorkspaceDisabledError } from "./request/fetch-helpers.js";
 import { createLogger, maskString, runWithCorrelationId } from "./logger.js";
+import {
+	buildPinnedUnavailableErrorBody,
+	buildTokenInvalidationBody,
+	extractErrorCodeFromBody,
+	getQuotaNearExhaustionWaitMs,
+	isTokenInvalidationError,
+	isTokenRefreshRetryable,
+	normalizeExhaustionStatus,
+	parseRetryAfterBodyMs,
+	parseRetryAfterHeaderMs,
+} from "./request/rate-limit-decision.js";
+import {
+	forwardStreamingResponse,
+	HOP_BY_HOP_HEADERS,
+	readErrorBody,
+	responseHeadersForClient,
+	withTimeout,
+} from "./request/stream-failover-runtime.js";
+import type {
+	ExhaustionReason,
+	RequestContext,
+	RuntimeProxyHttpError,
+	RuntimeRotationAccountIdentity,
+	RuntimeRotationProxyOptions,
+	RuntimeRotationProxyServer,
+	RuntimeRotationProxyStatus,
+} from "./runtime/rotation-server-types.js";
 import { SessionAffinityStore } from "./session-affinity.js";
-import type { OAuthAuthDetails, RequestBody, TokenResult } from "./types.js";
+import type { OAuthAuthDetails, RequestBody } from "./types.js";
 import { isRecord } from "./utils.js";
 
-export interface RuntimeRotationProxyServer {
-	host: string;
-	port: number;
-	baseUrl: string;
-	close: () => Promise<void>;
-	getStatus: () => RuntimeRotationProxyStatus;
-}
-
-export interface RuntimeRotationProxyStatus {
-	startedAt: number;
-	totalRequests: number;
-	upstreamRequests: number;
-	retries: number;
-	rotations: number;
-	streamsStarted: number;
-	lastError: string | null;
-	lastAccountIndex: number | null;
-	lastAccountLabel: string | null;
-	lastAccountId: string | null;
-	lastAccountUpdatedAt: number | null;
-}
-
-export interface RuntimeRotationProxyOptions {
-	host?: string;
-	port?: number;
-	upstreamBaseUrl?: string;
-	clientApiKey: string;
-	accountManager?: AccountManager;
-	fetchImpl?: typeof fetch;
-	now?: () => number;
-	quotaRemainingPercentThreshold?: number;
-	maxRequestBodyBytes?: number;
-	fetchTimeoutMs?: number;
-	streamStallTimeoutMs?: number;
-}
-
-interface RequestContext {
-	body: Buffer;
-	headers: Headers;
-	method: "GET" | "POST";
-	upstreamPath: string;
-	model: string | null;
-	family: ModelFamily;
-	stream: boolean;
-	sessionKey: string | null;
-}
-
-type ExhaustionReason =
-	| "rate-limit"
-	| "server-error"
-	| "network-error"
-	| "auth-failure"
-	| "budget"
-	| "deactivated"
-	| "no-account";
-type RuntimeProxyHttpError = Error & {
-	statusCode: number;
-	code: string;
-};
-
-interface RuntimeRotationAccountIdentity {
-	index: number;
-	label: string;
-	accountId: string | null;
-	updatedAt: number;
-}
+// Re-exports: these symbols were defined in this module before the §4.1.3
+// phase-1 carve and are part of its public surface (lib/index.ts star-exports
+// this file; tests and scripts import them from here). Keep every existing
+// import path working.
+export type {
+	RuntimeRotationProxyOptions,
+	RuntimeRotationProxyServer,
+	RuntimeRotationProxyStatus,
+} from "./runtime/rotation-server-types.js";
+export {
+	buildPinnedUnavailableErrorBody,
+	buildTokenInvalidationBody,
+} from "./request/rate-limit-decision.js";
+export type { PinnedUnavailableErrorBody } from "./request/rate-limit-decision.js";
 
 const DEFAULT_HOST = "127.0.0.1";
 
@@ -172,46 +147,8 @@ const DEFAULT_AUTH_FAILURE_COOLDOWN_MS = 30_000;
 
 const DEFAULT_MAX_RUNTIME_ACCOUNT_ATTEMPTS = 4;
 
-// Phrases observed in upstream 401 response bodies when OpenAI/Microsoft has
-// explicitly revoked an OAuth token (as opposed to a generic expired-token 401
-// that can be retried after a refresh). Matching is case-insensitive substring.
-// If anti-abuse detection triggers different wording in production, add the new
-// phrase here and record the source provider and date. See issue #495.
-const TOKEN_INVALIDATION_PHRASES = [
-	"invalidated oauth token",
-	"authentication token has been invalidated",
-	"oauth token has been invalidated",
-	"token has been invalidated",
-] as const;
-
-function isTokenInvalidationError(bodyText: string): boolean {
-	const lower = bodyText.toLowerCase();
-	return TOKEN_INVALIDATION_PHRASES.some((phrase) => lower.includes(phrase));
-}
 const MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024;
 const MAX_THREAD_GOAL_FALLBACKS = 512;
-const HOP_BY_HOP_HEADERS = new Set([
-	"connection",
-	"content-length",
-	"expect",
-	"keep-alive",
-	"proxy-authenticate",
-	"proxy-authorization",
-	"te",
-	"trailer",
-	"transfer-encoding",
-	"upgrade",
-]);
-const PRIVATE_CLIENT_RESPONSE_HEADERS = new Set([
-	"x-codex-multi-auth-account-index",
-	"x-codex-multi-auth-account-label",
-	"x-codex-multi-auth-account-email",
-	"x-codex-multi-auth-account-id",
-]);
-const DECODED_UPSTREAM_RESPONSE_HEADERS = new Set([
-	// Node fetch returns decoded bytes while preserving the upstream encoding header.
-	"content-encoding",
-]);
 const ALLOWED_RESPONSES_PATHS = new Set([
 	URL_PATHS.RESPONSES,
 	URL_PATHS.CODEX_RESPONSES,
@@ -582,18 +519,6 @@ async function persistRuntimeActiveAccount(
 	}
 }
 
-function responseHeadersForClient(upstreamHeaders: Headers): Record<string, string> {
-	const headers: Record<string, string> = {};
-	for (const [key, value] of upstreamHeaders.entries()) {
-		const normalizedKey = key.toLowerCase();
-		if (HOP_BY_HOP_HEADERS.has(normalizedKey)) continue;
-		if (PRIVATE_CLIENT_RESPONSE_HEADERS.has(normalizedKey)) continue;
-		if (DECODED_UPSTREAM_RESPONSE_HEADERS.has(normalizedKey)) continue;
-		headers[key] = value;
-	}
-	return headers;
-}
-
 function createRuntimeProxyHttpError(
 	message: string,
 	statusCode: number,
@@ -825,19 +750,6 @@ function hasUsableAccessToken(
 	);
 }
 
-function isTokenRefreshRetryable(result: Extract<TokenResult, { type: "failed" }>): boolean {
-	if (result.reason === "network_error" || result.reason === "unknown") return true;
-	if (result.reason === "invalid_response") return true;
-	if (result.reason === "http_error") {
-		return !(
-			result.statusCode === HTTP_STATUS.BAD_REQUEST ||
-			result.statusCode === HTTP_STATUS.UNAUTHORIZED ||
-			result.statusCode === HTTP_STATUS.FORBIDDEN
-		);
-	}
-	return false;
-}
-
 const runtimeRefreshCommitQueues = new WeakMap<
 	AccountManager,
 	Map<string, Promise<ManagedAccount | null>>
@@ -937,199 +849,6 @@ function resolveAccountId(account: ManagedAccount, accessToken: string): string 
 	const stored = account.accountId?.trim();
 	if (stored) return stored;
 	return extractAccountId(accessToken)?.trim() || null;
-}
-
-function parseRetryAfterHeaderMs(headers: Headers, now: number): number | null {
-	const retryAfterMs = headers.get("retry-after-ms");
-	if (retryAfterMs) {
-		const parsed = Number.parseInt(retryAfterMs, 10);
-		if (Number.isFinite(parsed) && parsed > 0) return parsed;
-	}
-	const retryAfter = headers.get("retry-after");
-	if (!retryAfter) return null;
-	const asSeconds = Number.parseInt(retryAfter, 10);
-	if (Number.isFinite(asSeconds) && asSeconds > 0) return asSeconds * 1000;
-	const asDate = Date.parse(retryAfter);
-	if (Number.isFinite(asDate) && asDate > now) return asDate - now;
-	return null;
-}
-
-function parseRetryAfterBodyMs(bodyText: string, now: number): number | null {
-	if (!bodyText.trim()) return null;
-	try {
-		const parsed = JSON.parse(bodyText) as unknown;
-		if (!isRecord(parsed) || !isRecord(parsed.error)) return null;
-		const retryAfterMs = Number(parsed.error.retry_after_ms);
-		if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) return retryAfterMs;
-		const retryAfterSeconds = Number(parsed.error.retry_after);
-		if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
-			return retryAfterSeconds * 1000;
-		}
-		const resetAtRaw = Number(parsed.error.resets_at ?? parsed.error.reset_at);
-		if (Number.isFinite(resetAtRaw) && resetAtRaw > 0) {
-			const resetAtMs = resetAtRaw < 10_000_000_000 ? resetAtRaw * 1000 : resetAtRaw;
-			if (resetAtMs > now) return resetAtMs - now;
-		}
-	} catch {
-		return null;
-	}
-	return null;
-}
-
-async function readErrorBody(
-	response: Response,
-	timeoutMs: number,
-	maxBytes = 1024 * 1024,
-): Promise<string> {
-	// The outbound fetch's abort timer is cleared once headers arrive, so a
-	// stalled error body would otherwise hang this handler forever (the success
-	// path is per-chunk stall-bounded; the error path was not). Read the body via
-	// a reader, bound it by an idle timeout AND a size cap, and cancel the stream
-	// on timeout/overflow so the socket is released.
-	const body = response.body;
-	if (!body || typeof body.getReader !== "function") {
-		// Fallback for impls without a streamable body: race text() against a timer.
-		try {
-			return await withTimeout(
-				response.text(),
-				timeoutMs,
-				() => undefined,
-				"error body stalled",
-			);
-		} catch {
-			return "";
-		}
-	}
-	const reader = body.getReader();
-	const chunks: Uint8Array[] = [];
-	let total = 0;
-	try {
-		for (;;) {
-			let idleTimer: ReturnType<typeof setTimeout> | undefined;
-			const idle = new Promise<never>((_resolve, reject) => {
-				idleTimer = setTimeout(
-					() => reject(new Error("error body stalled")),
-					Math.max(1, timeoutMs),
-				);
-			});
-			let result: Awaited<ReturnType<typeof reader.read>>;
-			try {
-				result = await Promise.race([reader.read(), idle]);
-			} finally {
-				if (idleTimer) clearTimeout(idleTimer);
-			}
-			if (result.done) break;
-			if (result.value) {
-				total += result.value.byteLength;
-				if (total > maxBytes) break; // cap: enough for diagnostics, no OOM
-				chunks.push(result.value);
-			}
-		}
-	} catch {
-		// stalled or errored — fall through with whatever we have
-	} finally {
-		await reader.cancel().catch(() => undefined);
-	}
-	try {
-		return Buffer.concat(chunks).toString("utf8");
-	} catch {
-		return "";
-	}
-}
-
-const TOKEN_INVALIDATED_CODE = "token_invalidated";
-const TOKEN_INVALIDATED_FALLBACK_MESSAGE =
-	"OAuth token has been invalidated. Please re-login.";
-
-// Both invalidation exit paths (refresh-failure and upstream-401) must hand the
-// client the same machine-readable shape — { error: { message, code:
-// "token_invalidated" } } — so a consumer keying off error.code behaves
-// identically regardless of which vector fired. The upstream forwards a raw body
-// with no guaranteed code, so we wrap it here while preserving its human-readable
-// message when one is present.
-export function buildTokenInvalidationBody(upstreamBodyText: string): string {
-	let message = TOKEN_INVALIDATED_FALLBACK_MESSAGE;
-	const trimmed = upstreamBodyText.trim();
-	if (trimmed) {
-		try {
-			const parsed = JSON.parse(trimmed) as unknown;
-			if (isRecord(parsed)) {
-				const direct = parsed.message;
-				if (typeof direct === "string" && direct.trim()) {
-					message = direct.trim();
-				} else if (isRecord(parsed.error)) {
-					const nested = parsed.error.message;
-					if (typeof nested === "string" && nested.trim()) {
-						message = nested.trim();
-					}
-				}
-			}
-		} catch {
-			// Non-JSON upstream body (e.g. HTML error page): keep the stable fallback
-			// message rather than echoing markup back to the client.
-		}
-	}
-	return JSON.stringify({ error: { message, code: TOKEN_INVALIDATED_CODE } });
-}
-
-function extractErrorCodeFromBody(bodyText: string): string | null {
-	if (!bodyText.trim()) return null;
-	try {
-		const parsed = JSON.parse(bodyText) as unknown;
-		if (!isRecord(parsed)) return null;
-		const directCode = parsed.code;
-		if (typeof directCode === "string" && directCode.trim()) {
-			return directCode.trim();
-		}
-		const maybeError = parsed.error;
-		if (!isRecord(maybeError)) return null;
-		const nestedCode = maybeError.code;
-		return typeof nestedCode === "string" && nestedCode.trim()
-			? nestedCode.trim()
-			: null;
-	} catch {
-		return null;
-	}
-}
-
-function getQuotaWindowWaitMs(headers: Headers, prefix: string, now: number): number {
-	const resetAfterSeconds = Number.parseInt(
-		headers.get(`${prefix}-reset-after-seconds`) ?? "",
-		10,
-	);
-	if (Number.isFinite(resetAfterSeconds) && resetAfterSeconds > 0) {
-		return resetAfterSeconds * 1000;
-	}
-	const resetAtRaw = headers.get(`${prefix}-reset-at`);
-	if (!resetAtRaw) return 0;
-	const trimmed = resetAtRaw.trim();
-	let resetAtMs = 0;
-	if (/^\d+$/.test(trimmed)) {
-		const parsed = Number.parseInt(trimmed, 10);
-		if (Number.isFinite(parsed) && parsed > 0) {
-			resetAtMs = parsed < 10_000_000_000 ? parsed * 1000 : parsed;
-		}
-	} else {
-		const parsedDate = Date.parse(trimmed);
-		if (Number.isFinite(parsedDate)) resetAtMs = parsedDate;
-	}
-	return resetAtMs > now ? resetAtMs - now : 0;
-}
-
-function getQuotaNearExhaustionWaitMs(
-	headers: Headers,
-	remainingThreshold: number,
-	now: number,
-): number {
-	const usedThreshold = 100 - Math.max(0, Math.min(100, remainingThreshold));
-	const candidates: number[] = [];
-	for (const prefix of ["x-codex-primary", "x-codex-secondary"]) {
-		const used = Number(headers.get(`${prefix}-used-percent`) ?? "");
-		if (!Number.isFinite(used) || used < usedThreshold) continue;
-		const waitMs = getQuotaWindowWaitMs(headers, prefix, now);
-		if (waitMs > 0) candidates.push(waitMs);
-	}
-	return candidates.length > 0 ? Math.max(...candidates) : 0;
 }
 
 /**
@@ -1409,10 +1128,6 @@ function writeUnauthorized(res: ServerResponse): void {
 	});
 }
 
-function normalizeExhaustionStatus(reason: ExhaustionReason): number {
-	return reason === "rate-limit" ? HTTP_STATUS.TOO_MANY_REQUESTS : 503;
-}
-
 function writePoolExhausted(params: {
 	res: ServerResponse;
 	accountManager: AccountManager;
@@ -1445,119 +1160,6 @@ function writePoolExhausted(params: {
 			hint,
 		},
 	});
-}
-
-/**
- * Build the JSON `error` body for a pinned-account 503 response. Extracted so
- * the null-reason desync path (`reason: null`, no parenthetical in `message`)
- * can be unit-tested without standing up a full proxy. The shape mirrors
- * `writePoolExhausted` so consumers can handle both 503 codes uniformly. See
- * issue #486.
- */
-export interface PinnedUnavailableErrorBody {
-	message: string;
-	code: "codex_pinned_account_unavailable";
-	pinnedAccountIndex: number | null;
-	reason: string | null;
-	account_skip_reasons: Record<string, string>;
-}
-
-export function buildPinnedUnavailableErrorBody(
-	pinnedIndex: number | null | undefined,
-	accountSkipReasons: ReadonlyMap<number, string>,
-): PinnedUnavailableErrorBody {
-	const normalizedPinnedIndex =
-		typeof pinnedIndex === "number" ? pinnedIndex : null;
-	const skipReason =
-		normalizedPinnedIndex !== null
-			? accountSkipReasons.get(normalizedPinnedIndex) ?? null
-			: null;
-	const reasonSuffix = skipReason ? ` (${skipReason})` : "";
-	const displayIndex = (normalizedPinnedIndex ?? 0) + 1;
-	return {
-		message: `Pinned account ${displayIndex} is currently unavailable${reasonSuffix}; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
-		code: "codex_pinned_account_unavailable",
-		pinnedAccountIndex: normalizedPinnedIndex,
-		reason: skipReason,
-		account_skip_reasons: Object.fromEntries(
-			[...accountSkipReasons.entries()].map(([index, reason]) => [
-				String(index),
-				reason,
-			]),
-		),
-	};
-}
-
-async function withTimeout<T>(
-	promise: Promise<T>,
-	timeoutMs: number,
-	onTimeout: () => void,
-	message: string,
-): Promise<T> {
-	let timeout: ReturnType<typeof setTimeout> | undefined;
-	try {
-		return await Promise.race([
-			promise,
-			new Promise<T>((_resolve, reject) => {
-				timeout = setTimeout(() => {
-					onTimeout();
-					reject(new Error(message));
-				}, Math.max(1, timeoutMs));
-			}),
-		]);
-	} finally {
-		if (timeout) clearTimeout(timeout);
-	}
-}
-
-async function forwardStreamingResponse(
-	upstream: Response,
-	res: ServerResponse,
-	status: RuntimeRotationProxyStatus,
-	onStreamError: () => void,
-	streamStallTimeoutMs: number,
-): Promise<boolean> {
-	status.streamsStarted += 1;
-	res.writeHead(
-		upstream.status,
-		responseHeadersForClient(upstream.headers),
-	);
-	if (!upstream.body) {
-		res.end();
-		return true;
-	}
-
-	const reader = upstream.body.getReader();
-	res.on("close", () => {
-		if (!res.writableEnded) {
-			void reader.cancel().catch(() => undefined);
-		}
-	});
-	try {
-		while (true) {
-			const { done, value } = await withTimeout(
-				reader.read(),
-				streamStallTimeoutMs,
-				() => {
-					void reader.cancel().catch(() => undefined);
-				},
-				`upstream stream stalled after ${streamStallTimeoutMs}ms`,
-			);
-			if (done) break;
-			if (value && value.byteLength > 0) {
-				res.write(Buffer.from(value));
-			}
-		}
-		res.end();
-		return true;
-	} catch (error) {
-		status.lastError = error instanceof Error ? error.message : String(error);
-		onStreamError();
-		if (!res.destroyed) {
-			res.destroy(error instanceof Error ? error : undefined);
-		}
-		return false;
-	}
 }
 
 export async function startRuntimeRotationProxy(

--- a/lib/runtime/rotation-server-types.ts
+++ b/lib/runtime/rotation-server-types.ts
@@ -1,0 +1,69 @@
+import type { AccountManager } from "../accounts.js";
+import type { ModelFamily } from "../prompts/codex.js";
+
+export interface RuntimeRotationProxyServer {
+	host: string;
+	port: number;
+	baseUrl: string;
+	close: () => Promise<void>;
+	getStatus: () => RuntimeRotationProxyStatus;
+}
+
+export interface RuntimeRotationProxyStatus {
+	startedAt: number;
+	totalRequests: number;
+	upstreamRequests: number;
+	retries: number;
+	rotations: number;
+	streamsStarted: number;
+	lastError: string | null;
+	lastAccountIndex: number | null;
+	lastAccountLabel: string | null;
+	lastAccountId: string | null;
+	lastAccountUpdatedAt: number | null;
+}
+
+export interface RuntimeRotationProxyOptions {
+	host?: string;
+	port?: number;
+	upstreamBaseUrl?: string;
+	clientApiKey: string;
+	accountManager?: AccountManager;
+	fetchImpl?: typeof fetch;
+	now?: () => number;
+	quotaRemainingPercentThreshold?: number;
+	maxRequestBodyBytes?: number;
+	fetchTimeoutMs?: number;
+	streamStallTimeoutMs?: number;
+}
+
+export interface RequestContext {
+	body: Buffer;
+	headers: Headers;
+	method: "GET" | "POST";
+	upstreamPath: string;
+	model: string | null;
+	family: ModelFamily;
+	stream: boolean;
+	sessionKey: string | null;
+}
+
+export type ExhaustionReason =
+	| "rate-limit"
+	| "server-error"
+	| "network-error"
+	| "auth-failure"
+	| "budget"
+	| "deactivated"
+	| "no-account";
+export type RuntimeProxyHttpError = Error & {
+	statusCode: number;
+	code: string;
+};
+
+export interface RuntimeRotationAccountIdentity {
+	index: number;
+	label: string;
+	accountId: string | null;
+	updatedAt: number;
+}

--- a/test/rate-limit-decision.test.ts
+++ b/test/rate-limit-decision.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildPinnedUnavailableErrorBody,
+	buildTokenInvalidationBody,
+	extractErrorCodeFromBody,
+	getQuotaNearExhaustionWaitMs,
+	isTokenInvalidationError,
+	isTokenRefreshRetryable,
+	normalizeExhaustionStatus,
+	parseRetryAfterBodyMs,
+	parseRetryAfterHeaderMs,
+} from "../lib/request/rate-limit-decision.js";
+
+describe("isTokenInvalidationError", () => {
+	it("matches known invalidation phrases case-insensitively", () => {
+		expect(
+			isTokenInvalidationError('{"message":"Invalidated OAuth Token"}'),
+		).toBe(true);
+		expect(
+			isTokenInvalidationError("the authentication TOKEN has been INVALIDATED"),
+		).toBe(true);
+	});
+
+	it("does not match generic 401 bodies", () => {
+		expect(isTokenInvalidationError('{"message":"token expired"}')).toBe(false);
+		expect(isTokenInvalidationError("")).toBe(false);
+	});
+});
+
+describe("isTokenRefreshRetryable", () => {
+	it("treats transient reasons as retryable", () => {
+		expect(isTokenRefreshRetryable({ type: "failed", reason: "network_error" })).toBe(true);
+		expect(isTokenRefreshRetryable({ type: "failed", reason: "unknown" })).toBe(true);
+		expect(isTokenRefreshRetryable({ type: "failed", reason: "invalid_response" })).toBe(true);
+	});
+
+	it("treats credential-level http errors as terminal and server errors as retryable", () => {
+		for (const statusCode of [400, 401, 403]) {
+			expect(
+				isTokenRefreshRetryable({ type: "failed", reason: "http_error", statusCode }),
+			).toBe(false);
+		}
+		expect(
+			isTokenRefreshRetryable({ type: "failed", reason: "http_error", statusCode: 500 }),
+		).toBe(true);
+		expect(
+			isTokenRefreshRetryable({ type: "failed", reason: "http_error", statusCode: 429 }),
+		).toBe(true);
+	});
+
+	it("treats missing_refresh, timeout, and absent reasons as non-retryable", () => {
+		expect(isTokenRefreshRetryable({ type: "failed", reason: "missing_refresh" })).toBe(false);
+		expect(isTokenRefreshRetryable({ type: "failed", reason: "timeout" })).toBe(false);
+		expect(isTokenRefreshRetryable({ type: "failed" })).toBe(false);
+	});
+});
+
+describe("parseRetryAfterHeaderMs", () => {
+	// Realistic epoch: Date.parse falls back on bare digit strings (e.g. "0"
+	// parses as the year 2000), which must land in the past to read as invalid.
+	const now = 1_700_000_000_000;
+
+	it("prefers retry-after-ms over retry-after", () => {
+		const headers = new Headers({ "retry-after-ms": "1500", "retry-after": "60" });
+		expect(parseRetryAfterHeaderMs(headers, now)).toBe(1500);
+	});
+
+	it("converts retry-after seconds to milliseconds", () => {
+		expect(parseRetryAfterHeaderMs(new Headers({ "retry-after": "30" }), now)).toBe(30_000);
+	});
+
+	it("supports HTTP-date retry-after values in the future", () => {
+		const future = new Date(now + 90_000).toUTCString();
+		const waitMs = parseRetryAfterHeaderMs(new Headers({ "retry-after": future }), now);
+		// toUTCString drops sub-second precision, so allow up to 1s of rounding.
+		expect(waitMs).toBeGreaterThan(88_000);
+		expect(waitMs).toBeLessThanOrEqual(90_000);
+	});
+
+	it("returns null for absent, non-positive, or unparseable values", () => {
+		expect(parseRetryAfterHeaderMs(new Headers(), now)).toBeNull();
+		expect(parseRetryAfterHeaderMs(new Headers({ "retry-after": "0" }), now)).toBeNull();
+		expect(parseRetryAfterHeaderMs(new Headers({ "retry-after": "-5" }), now)).toBeNull();
+		expect(parseRetryAfterHeaderMs(new Headers({ "retry-after": "soon" }), now)).toBeNull();
+		expect(
+			parseRetryAfterHeaderMs(
+				new Headers({ "retry-after": new Date(now - 1_000).toUTCString() }),
+				now,
+			),
+		).toBeNull();
+	});
+});
+
+describe("parseRetryAfterBodyMs", () => {
+	const now = 5_000_000_000_000; // epoch ms scale so resets_at heuristics are exercised
+
+	it("reads error.retry_after_ms first, then error.retry_after seconds", () => {
+		expect(
+			parseRetryAfterBodyMs(JSON.stringify({ error: { retry_after_ms: 2500 } }), now),
+		).toBe(2500);
+		expect(
+			parseRetryAfterBodyMs(JSON.stringify({ error: { retry_after: 12 } }), now),
+		).toBe(12_000);
+	});
+
+	it("derives waits from resets_at in epoch seconds or milliseconds", () => {
+		const resetsAtSeconds = Math.floor(now / 1000) + 60;
+		expect(
+			parseRetryAfterBodyMs(JSON.stringify({ error: { resets_at: resetsAtSeconds } }), now),
+		).toBe(resetsAtSeconds * 1000 - now);
+		expect(
+			parseRetryAfterBodyMs(JSON.stringify({ error: { reset_at: now + 45_000 } }), now),
+		).toBe(45_000);
+	});
+
+	it("returns null for empty, non-JSON, non-record, and array payloads", () => {
+		expect(parseRetryAfterBodyMs("", now)).toBeNull();
+		expect(parseRetryAfterBodyMs("   ", now)).toBeNull();
+		expect(parseRetryAfterBodyMs("{not json", now)).toBeNull();
+		expect(parseRetryAfterBodyMs("[1,2]", now)).toBeNull();
+		expect(parseRetryAfterBodyMs(JSON.stringify({ error: [] }), now)).toBeNull();
+		expect(parseRetryAfterBodyMs(JSON.stringify({ error: { resets_at: now - 1 } }), now)).toBeNull();
+	});
+});
+
+describe("buildTokenInvalidationBody", () => {
+	const parse = (body: string) =>
+		JSON.parse(body) as { error: { message: string; code: string } };
+
+	it("preserves a top-level upstream message inside the stable envelope", () => {
+		const body = parse(
+			buildTokenInvalidationBody(JSON.stringify({ message: " token revoked " })),
+		);
+		expect(body.error).toEqual({ message: "token revoked", code: "token_invalidated" });
+	});
+
+	it("falls back to the nested error.message", () => {
+		const body = parse(
+			buildTokenInvalidationBody(
+				JSON.stringify({ error: { message: "oauth token has been invalidated" } }),
+			),
+		);
+		expect(body.error.message).toBe("oauth token has been invalidated");
+	});
+
+	it("uses the stable fallback for non-JSON, empty, and message-less bodies", () => {
+		for (const upstream of ["", "<html>nope</html>", JSON.stringify({ message: "  " })]) {
+			const body = parse(buildTokenInvalidationBody(upstream));
+			expect(body.error).toEqual({
+				message: "OAuth token has been invalidated. Please re-login.",
+				code: "token_invalidated",
+			});
+		}
+	});
+});
+
+describe("extractErrorCodeFromBody", () => {
+	it("reads a top-level code before the nested error.code", () => {
+		expect(
+			extractErrorCodeFromBody(
+				JSON.stringify({ code: " direct ", error: { code: "nested" } }),
+			),
+		).toBe("direct");
+		expect(
+			extractErrorCodeFromBody(JSON.stringify({ error: { code: "nested" } })),
+		).toBe("nested");
+	});
+
+	it("returns null for empty, malformed, non-record, and whitespace codes", () => {
+		expect(extractErrorCodeFromBody("")).toBeNull();
+		expect(extractErrorCodeFromBody("{oops")).toBeNull();
+		expect(extractErrorCodeFromBody("[]")).toBeNull();
+		expect(extractErrorCodeFromBody(JSON.stringify({ code: "  " }))).toBeNull();
+		expect(extractErrorCodeFromBody(JSON.stringify({ error: { code: 42 } }))).toBeNull();
+	});
+});
+
+describe("getQuotaNearExhaustionWaitMs", () => {
+	const now = 1_700_000_000_000;
+
+	it("waits on a window at or above the used threshold via reset-after-seconds", () => {
+		const headers = new Headers({
+			"x-codex-primary-used-percent": "97",
+			"x-codex-primary-reset-after-seconds": "120",
+		});
+		expect(getQuotaNearExhaustionWaitMs(headers, 5, now)).toBe(120_000);
+	});
+
+	it("ignores windows below the threshold", () => {
+		const headers = new Headers({
+			"x-codex-primary-used-percent": "80",
+			"x-codex-primary-reset-after-seconds": "120",
+		});
+		expect(getQuotaNearExhaustionWaitMs(headers, 5, now)).toBe(0);
+	});
+
+	it("takes the max wait across primary and secondary windows", () => {
+		const headers = new Headers({
+			"x-codex-primary-used-percent": "100",
+			"x-codex-primary-reset-after-seconds": "60",
+			"x-codex-secondary-used-percent": "100",
+			"x-codex-secondary-reset-after-seconds": "300",
+		});
+		expect(getQuotaNearExhaustionWaitMs(headers, 5, now)).toBe(300_000);
+	});
+
+	it("supports reset-at in epoch seconds, epoch milliseconds, and date strings", () => {
+		const epochSeconds = Math.floor(now / 1000) + 60;
+		expect(
+			getQuotaNearExhaustionWaitMs(
+				new Headers({
+					"x-codex-primary-used-percent": "100",
+					"x-codex-primary-reset-at": String(epochSeconds),
+				}),
+				5,
+				now,
+			),
+		).toBe(epochSeconds * 1000 - now);
+		expect(
+			getQuotaNearExhaustionWaitMs(
+				new Headers({
+					"x-codex-primary-used-percent": "100",
+					"x-codex-primary-reset-at": String(now + 30_000),
+				}),
+				5,
+				now,
+			),
+		).toBe(30_000);
+		const dateWait = getQuotaNearExhaustionWaitMs(
+			new Headers({
+				"x-codex-primary-used-percent": "100",
+				"x-codex-primary-reset-at": new Date(now + 90_000).toUTCString(),
+			}),
+			5,
+			now,
+		);
+		expect(dateWait).toBeGreaterThan(88_000);
+		expect(dateWait).toBeLessThanOrEqual(90_000);
+	});
+
+	it("returns 0 when no usable reset signal exists", () => {
+		expect(getQuotaNearExhaustionWaitMs(new Headers(), 5, now)).toBe(0);
+		expect(
+			getQuotaNearExhaustionWaitMs(
+				new Headers({ "x-codex-primary-used-percent": "100" }),
+				5,
+				now,
+			),
+		).toBe(0);
+	});
+});
+
+describe("normalizeExhaustionStatus", () => {
+	it("maps rate-limit to 429 and everything else to 503", () => {
+		expect(normalizeExhaustionStatus("rate-limit")).toBe(429);
+		expect(normalizeExhaustionStatus("server-error")).toBe(503);
+		expect(normalizeExhaustionStatus("auth-failure")).toBe(503);
+	});
+});
+
+describe("buildPinnedUnavailableErrorBody", () => {
+	it("includes the 1-based pinned index and its skip reason", () => {
+		const body = buildPinnedUnavailableErrorBody(
+			1,
+			new Map([
+				[0, "rate-limited"],
+				[1, "disabled"],
+			]),
+		);
+		expect(body.code).toBe("codex_pinned_account_unavailable");
+		expect(body.pinnedAccountIndex).toBe(1);
+		expect(body.reason).toBe("disabled");
+		expect(body.message).toContain("Pinned account 2");
+		expect(body.message).toContain("(disabled)");
+		expect(body.account_skip_reasons).toEqual({ "0": "rate-limited", "1": "disabled" });
+	});
+
+	it("omits the parenthetical and reason on the null-index desync path", () => {
+		const body = buildPinnedUnavailableErrorBody(null, new Map());
+		expect(body.pinnedAccountIndex).toBeNull();
+		expect(body.reason).toBeNull();
+		expect(body.message).toContain("Pinned account 1 is currently unavailable;");
+		expect(body.message).not.toContain("(");
+		expect(body.account_skip_reasons).toEqual({});
+	});
+});

--- a/test/stream-failover-runtime.test.ts
+++ b/test/stream-failover-runtime.test.ts
@@ -1,0 +1,281 @@
+import { EventEmitter } from "node:events";
+import type { ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeRotationProxyStatus } from "../lib/runtime/rotation-server-types.js";
+import {
+	forwardStreamingResponse,
+	HOP_BY_HOP_HEADERS,
+	readErrorBody,
+	responseHeadersForClient,
+	withTimeout,
+} from "../lib/request/stream-failover-runtime.js";
+
+function createStatus(): RuntimeRotationProxyStatus {
+	return {
+		startedAt: 0,
+		totalRequests: 0,
+		upstreamRequests: 0,
+		retries: 0,
+		rotations: 0,
+		streamsStarted: 0,
+		lastError: null,
+		lastAccountIndex: null,
+		lastAccountLabel: null,
+		lastAccountId: null,
+		lastAccountUpdatedAt: null,
+	};
+}
+
+class FakeServerResponse extends EventEmitter {
+	statusCode: number | null = null;
+	headers: Record<string, string> = {};
+	chunks: Buffer[] = [];
+	ended = false;
+	destroyed = false;
+	destroyError: Error | undefined;
+
+	get writableEnded(): boolean {
+		return this.ended;
+	}
+
+	writeHead(status: number, headers: Record<string, string>): this {
+		this.statusCode = status;
+		this.headers = headers;
+		return this;
+	}
+
+	write(chunk: Buffer): boolean {
+		this.chunks.push(chunk);
+		return true;
+	}
+
+	end(): this {
+		this.ended = true;
+		return this;
+	}
+
+	destroy(error?: Error): this {
+		this.destroyed = true;
+		this.destroyError = error;
+		return this;
+	}
+
+	asServerResponse(): ServerResponse {
+		return this as unknown as ServerResponse;
+	}
+}
+
+function streamOf(...chunks: (Uint8Array | (() => Promise<Uint8Array>))[]): ReadableStream<Uint8Array> {
+	const queue = [...chunks];
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			const next = queue.shift();
+			if (next === undefined) {
+				controller.close();
+				return;
+			}
+			controller.enqueue(typeof next === "function" ? await next() : next);
+		},
+	});
+}
+
+describe("responseHeadersForClient", () => {
+	it("drops hop-by-hop, private rotation, and content-encoding headers", () => {
+		const upstream = new Headers({
+			"content-type": "application/json",
+			"x-request-id": "req_1",
+			connection: "keep-alive",
+			"transfer-encoding": "chunked",
+			"content-encoding": "gzip",
+			"x-codex-multi-auth-account-email": "user@example.com",
+			"x-codex-multi-auth-account-id": "acc_1",
+		});
+		expect(responseHeadersForClient(upstream)).toEqual({
+			"content-type": "application/json",
+			"x-request-id": "req_1",
+		});
+	});
+
+	it("covers every hop-by-hop header in the exported set", () => {
+		const upstream = new Headers();
+		for (const name of HOP_BY_HOP_HEADERS) {
+			// `expect` and `content-length` are restricted by Headers in some impls;
+			// set defensively via append on a plain record instead.
+			try {
+				upstream.set(name, "1");
+			} catch {
+				// Skip names the Headers impl refuses; the lowercase-set membership
+				// check in responseHeadersForClient is the same code path regardless.
+			}
+		}
+		expect(responseHeadersForClient(upstream)).toEqual({});
+	});
+});
+
+describe("withTimeout", () => {
+	it("resolves with the underlying promise before the deadline", async () => {
+		await expect(
+			withTimeout(Promise.resolve("ok"), 1_000, () => undefined, "stalled"),
+		).resolves.toBe("ok");
+	});
+
+	it("rejects with the supplied message and fires onTimeout when the promise stalls", async () => {
+		vi.useFakeTimers();
+		try {
+			const onTimeout = vi.fn();
+			const pending = withTimeout(
+				new Promise<never>(() => undefined),
+				500,
+				onTimeout,
+				"upstream stalled",
+			);
+			const assertion = expect(pending).rejects.toThrow("upstream stalled");
+			await vi.advanceTimersByTimeAsync(500);
+			await assertion;
+			expect(onTimeout).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("enforces a minimum 1ms timer for non-positive timeouts", async () => {
+		vi.useFakeTimers();
+		try {
+			const pending = withTimeout(
+				new Promise<never>(() => undefined),
+				0,
+				() => undefined,
+				"stalled",
+			);
+			const assertion = expect(pending).rejects.toThrow("stalled");
+			await vi.advanceTimersByTimeAsync(1);
+			await assertion;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+describe("readErrorBody", () => {
+	it("reads a streamed body to completion", async () => {
+		const response = new Response(streamOf(
+			new TextEncoder().encode('{"error":'),
+			new TextEncoder().encode('"nope"}'),
+		));
+		await expect(readErrorBody(response, 1_000)).resolves.toBe('{"error":"nope"}');
+	});
+
+	it("caps the body at maxBytes and returns the bytes read so far", async () => {
+		const big = new Uint8Array(64).fill(120); // 'x'
+		const response = new Response(streamOf(big, big, big));
+		// Cap below the second chunk's cumulative size: the overflowing chunk is
+		// dropped, so only the first 64 bytes survive.
+		await expect(readErrorBody(response, 1_000, 100)).resolves.toBe("x".repeat(64));
+	});
+
+	it("returns the partial body when a later chunk stalls past the idle timeout", async () => {
+		const response = new Response(streamOf(
+			new TextEncoder().encode("partial"),
+			() => new Promise<Uint8Array>(() => undefined), // never resolves
+		));
+		await expect(readErrorBody(response, 25)).resolves.toBe("partial");
+	});
+
+	it("falls back to text() when the response has no streamable body", async () => {
+		await expect(readErrorBody(new Response(null), 50)).resolves.toBe("");
+	});
+});
+
+describe("forwardStreamingResponse", () => {
+	it("forwards status, filtered headers, and chunks, then ends the response", async () => {
+		const res = new FakeServerResponse();
+		const status = createStatus();
+		const upstream = new Response(streamOf(
+			new TextEncoder().encode("data: a\n\n"),
+			new TextEncoder().encode("data: b\n\n"),
+		), {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				connection: "keep-alive",
+				"x-codex-multi-auth-account-id": "acc_1",
+			},
+		});
+
+		const onStreamError = vi.fn();
+		await expect(
+			forwardStreamingResponse(upstream, res.asServerResponse(), status, onStreamError, 1_000),
+		).resolves.toBe(true);
+
+		expect(status.streamsStarted).toBe(1);
+		expect(res.statusCode).toBe(200);
+		expect(res.headers).toEqual({ "content-type": "text/event-stream" });
+		expect(Buffer.concat(res.chunks).toString("utf8")).toBe("data: a\n\ndata: b\n\n");
+		expect(res.ended).toBe(true);
+		expect(onStreamError).not.toHaveBeenCalled();
+	});
+
+	it("ends immediately when the upstream has no body", async () => {
+		const res = new FakeServerResponse();
+		const status = createStatus();
+		await expect(
+			forwardStreamingResponse(
+				new Response(null, { status: 204 }),
+				res.asServerResponse(),
+				status,
+				() => undefined,
+				1_000,
+			),
+		).resolves.toBe(true);
+		expect(res.statusCode).toBe(204);
+		expect(res.ended).toBe(true);
+		expect(res.chunks).toEqual([]);
+	});
+
+	it("currently ends a stalled stream cleanly instead of failing it", async () => {
+		// Pins a BUG (not the intended design): on a stall, withTimeout's
+		// onTimeout cancels the reader, which settles the pending read() with
+		// {done: true} BEFORE the rejection lands, so Promise.race resolves.
+		// The stall is reported as a clean end: truncated body, res.end(), no
+		// lastError, and onStreamError (the failover hook) never fires. The
+		// stall branch of the catch block is unreachable today. Fixed in the
+		// stacked follow-up PR, which flips these expectations.
+		const res = new FakeServerResponse();
+		const status = createStatus();
+		const upstream = new Response(streamOf(
+			new TextEncoder().encode("data: a\n\n"),
+			() => new Promise<Uint8Array>(() => undefined), // stalls forever
+		), { status: 200 });
+
+		const onStreamError = vi.fn();
+		await expect(
+			forwardStreamingResponse(upstream, res.asServerResponse(), status, onStreamError, 25),
+		).resolves.toBe(true);
+
+		expect(onStreamError).not.toHaveBeenCalled();
+		expect(status.lastError).toBeNull();
+		expect(res.destroyed).toBe(false);
+		expect(Buffer.concat(res.chunks).toString("utf8")).toBe("data: a\n\n");
+		expect(res.ended).toBe(true);
+	});
+
+	it("fails the stream when the upstream read rejects mid-stream", async () => {
+		const res = new FakeServerResponse();
+		const status = createStatus();
+		const upstream = new Response(streamOf(
+			new TextEncoder().encode("data: a\n\n"),
+			() => Promise.reject(new Error("socket reset")),
+		), { status: 200 });
+
+		const onStreamError = vi.fn();
+		await expect(
+			forwardStreamingResponse(upstream, res.asServerResponse(), status, onStreamError, 1_000),
+		).resolves.toBe(false);
+
+		expect(onStreamError).toHaveBeenCalledTimes(1);
+		expect(status.lastError).toBe("socket reset");
+		expect(res.destroyed).toBe(true);
+		expect(res.destroyError).toBeInstanceOf(Error);
+		expect(res.ended).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Phase 1 of carving `lib/runtime-rotation-proxy.ts` along its natural seams — audit roadmap §4.1.3 (`docs/audits/AUDIT_2026-06-10.md`, PR #522). All code moved verbatim; every previously-exported symbol re-exported, so the 3 importing call sites (`lib/index.ts`, `scripts/codex.js`, `scripts/codex-app-router.js`) and all 8 test files are untouched. **Zero behavior change**; the proxy shrinks 2,498 → 2,099 lines.

## Changes

| New module | Lines | Contents |
| --- | --- | --- |
| `lib/runtime/rotation-server-types.ts` | 69 | `RuntimeRotationProxyServer/Status/Options`, plus previously-private `RequestContext`, `ExhaustionReason`, `RuntimeProxyHttpError`, account-identity type — type-only imports, no cycle risk |
| `lib/request/stream-failover-runtime.ts` | 170 | `forwardStreamingResponse`, `readErrorBody`, `withTimeout`, client-response header filtering (`HOP_BY_HOP_HEADERS` + private/decoded-header sets) — all inputs explicit, no closure state |
| `lib/request/rate-limit-decision.ts` | 211 | The pure rate-limit/auth decision tree: retry-after parsing (header + body), quota-near-exhaustion waits, token-invalidation detection and bodies, refresh retryability, exhaustion-status normalization, pinned-unavailable error body |

**Deliberately deferred to phase 2** (entangled with closure/module state; extracting now would change call semantics): the rotation loop and `startRuntimeRotationProxy` closure (status, affinity store, stale-reload dedupe), `chooseAccount`/linear-scan fallback (mutate AccountManager cursors), `ensureFreshAccessToken` + refresh-dedupe WeakMap, and the storage-meta cache helpers.

No logging was touched (token/email-redaction rules unaffected); new modules contain zero references back to the proxy (no cycles).

## Validation

- [x] `npm run typecheck`; eslint on all 4 files `--max-warnings=0`
- [x] Proxy suites (runtime-rotation-proxy, safe-equal, issue-474 ×4): 152/154 — the 2 failures are the IPv6 `::1` bind tests, reproduced **identically** on a clean origin/main tree (environment-only)
- [x] codex-app-router + codex-bin-wrapper: 101 pass, 3 known Windows-path environment failures, identical on main
- [x] Independently re-verified: typecheck + safe-equal suite

## Risk / Rollback

Mechanical move with re-exports; revert the single commit. Phase 2 (closure-state extraction) is a separate, riskier PR by design.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

phase 1 of the `runtime-rotation-proxy.ts` carve — mechanical extraction of ~400 lines into three focused modules (`rotation-server-types.ts`, `stream-failover-runtime.ts`, `rate-limit-decision.ts`) with verbatim code moves and full re-exports at the original import path. all 3 call sites and 8 proxy test files are untouched.

- `lib/runtime/rotation-server-types.ts`: type-only extraction (server interfaces + previously-private types); no runtime code, no cycles
- `lib/request/rate-limit-decision.ts` + `lib/request/stream-failover-runtime.ts`: pure-function extraction with explicit inputs; account email/token headers remain correctly stripped from client responses via `PRIVATE_CLIENT_RESPONSE_HEADERS`
- `test/stream-failover-runtime.test.ts` pins a known pre-existing bug where a stalled upstream stream resolves as a clean end rather than triggering the `onStreamError` failover hook (documented for a follow-up PR)

<h3>Confidence Score: 5/5</h3>

safe to merge — purely mechanical moves, all previously-exported symbols re-exported, no behavior change

every function and type moved verbatim; the re-export block in runtime-rotation-proxy.ts covers the complete prior public surface; token-safety header filtering is unchanged and verified by the new test suite; the only noteworthy item is two stall tests using real 25 ms timers rather than fake timers, which is a test-convention nit and not a correctness issue

test/stream-failover-runtime.test.ts — stall tests for readErrorBody and forwardStreamingResponse rely on real wall-clock timeouts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/rate-limit-decision.ts | new module: verbatim extraction of rate-limit / auth-decision helpers from runtime-rotation-proxy.ts; all functions exported cleanly with no closure state or cycle risk |
| lib/request/stream-failover-runtime.ts | new module: extracted forwardStreamingResponse, readErrorBody, withTimeout, and header-filtering helpers; all inputs explicit and account email/token headers correctly stripped from client responses |
| lib/runtime/rotation-server-types.ts | new module: type-only extraction of server interfaces and previously-private types (RequestContext, ExhaustionReason, RuntimeProxyHttpError, RuntimeRotationAccountIdentity); no cycles, no runtime code |
| lib/runtime-rotation-proxy.ts | proxy shrinks ~400 lines; all previously-exported symbols re-exported via explicit re-export block; TokenResult removed from local import after moving to rate-limit-decision.ts |
| test/rate-limit-decision.test.ts | new suite: good coverage of all extracted functions including edge cases (resets_at epoch heuristics, null-index pinned-body path, date-string retry-after); uses fake timers where applicable |
| test/stream-failover-runtime.test.ts | new suite: good FakeServerResponse harness; stall tests for readErrorBody and forwardStreamingResponse use real 25 ms timers rather than vi.useFakeTimers(), contrary to project convention; withTimeout stall test correctly uses fake timers |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["lib/runtime-rotation-proxy.ts\n(main proxy — rotation loop, startRuntimeRotationProxy)"]
    B["lib/runtime/rotation-server-types.ts\n(types: Server, Status, Options,\nRequestContext, ExhaustionReason, ...)"]
    C["lib/request/rate-limit-decision.ts\n(parseRetryAfter*, isTokenInvalidation*,\nbuildTokenInvalidation*, getQuotaWait*, ...)"]
    D["lib/request/stream-failover-runtime.ts\n(forwardStreamingResponse, readErrorBody,\nwithTimeout, responseHeadersForClient)"]
    E["lib/index.ts\n(barrel — star-exports proxy)"]
    F["scripts/codex.js\nscripts/codex-app-router.js"]

    A -->|"import type"| B
    A -->|"import"| C
    A -->|"import"| D
    A -->|"re-export type (Server/Status/Options)"| B
    A -->|"re-export (buildPinnedUnavailable*, buildTokenInvalidation*)"| C
    E -->|"star re-export"| A
    F -->|"import"| E

    C -->|"import type ExhaustionReason"| B
    D -->|"import type RuntimeRotationProxyStatus"| B
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-15-rotation-proxy-carve%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-15-rotation-proxy-carve%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fstream-failover-runtime.test.ts%3A1482-1488%0A**real%20timers%20in%20stall%20tests**%0A%0Atwo%20stall%20scenarios%20%E2%80%94%20the%20%60readErrorBody%60%20stall%20%28line%201482%2C%2025%20ms%20timeout%29%20and%20the%20%60forwardStreamingResponse%60%20stall%20%28line%201541%2C%2025%20ms%20timeout%29%20%E2%80%94%20rely%20on%20real%20%60setTimeout%60%20expiry.%20the%20project%20convention%20documented%20in%20%60test%2FAGENTS.md%60%20says%20stream-failover%20tests%20must%20use%20%60vi.useFakeTimers%28%29%60%20for%20deterministic%20assertions.%20the%20%60withTimeout%60%20stall%20test%20%28line%201428%29%20in%20this%20same%20file%20correctly%20does%20use%20fake%20timers.%20under%20load%2C%20a%2025%20ms%20wall-clock%20deadline%20is%20tight%20enough%20to%20produce%20intermittent%20flakes%20in%20ci.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=532&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/stream-failover-runtime.test.ts:1482-1488
**real timers in stall tests**

two stall scenarios — the `readErrorBody` stall (line 1482, 25 ms timeout) and the `forwardStreamingResponse` stall (line 1541, 25 ms timeout) — rely on real `setTimeout` expiry. the project convention documented in `test/AGENTS.md` says stream-failover tests must use `vi.useFakeTimers()` for deterministic assertions. the `withTimeout` stall test (line 1428) in this same file correctly does use fake timers. under load, a 25 ms wall-clock deadline is tight enough to produce intermittent flakes in ci.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: add unit suites for the extracted ..."](https://github.com/ndycode/codex-multi-auth/commit/4d5dd513c2e4af6e63534532d2e0d1a7350c853c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36667818)</sub>

**Context used:**

- Context used - test/AGENTS.md ([source](https://app.greptile.com/zeian/github/ndycode/codex-multi-auth/-/custom-context?memory=6e2636a9-e514-4bab-b249-4b4a84aa4ae3))
- Context used - lib/AGENTS.md ([source](https://app.greptile.com/zeian/github/ndycode/codex-multi-auth/-/custom-context?memory=ffbed5b7-f299-4c32-b3f9-f7c095ca8632))

<!-- /greptile_comment -->