### PR TITLE
refactor(codex-manager): dispatch through a command registry (phase 2)

### DIFF
--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -107,6 +107,23 @@ import {
 	printUsage,
 } from "./codex-manager/help.js";
 import {
+	availabilityTone,
+	formatAccountQuotaSummary,
+	formatBackupSavedAt,
+	formatCompactQuotaSnapshot,
+	formatModelInspection,
+	formatQuotaSnapshotForDashboard,
+	formatRateLimitEntry,
+	formatResultSummary,
+	inspectRequestedModel,
+	normalizeFailureDetail,
+	riskTone,
+	stringifyLogArgs,
+	styleAccountDetailText,
+	stylePromptText,
+	styleQuotaSummary,
+} from "./codex-manager/formatters/index.js";
+import {
 	applyUiThemeFromDashboardSettings,
 	configureUnifiedSettings,
 	resolveMenuLayoutMode,
@@ -131,20 +148,13 @@ import {
 } from "./dashboard-settings.js";
 import {
 	evaluateForecastAccounts,
-	type ForecastAccountResult,
 	recommendForecastAccount,
 	summarizeForecast,
 } from "./forecast.js";
 import { createLogger } from "./logger.js";
 import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
+import { DEFAULT_MODEL } from "./request/helpers/model-map.js";
 import {
-	DEFAULT_MODEL,
-	getModelCapabilities,
-	getModelProfile,
-	resolveNormalizedModel,
-} from "./request/helpers/model-map.js";
-import {
-	formatRateLimitEntry as formatAccountRateLimitEntry,
 	getRateLimitResetTimeForFamily,
 	resolveActiveIndex,
 } from "./runtime/account-status.js";
@@ -203,7 +213,6 @@ import type { AccountIdSource, TokenResult } from "./types.js";
 import { ANSI } from "./ui/ansi.js";
 import { confirm } from "./ui/confirm.js";
 import { UI_COPY } from "./ui/copy.js";
-import { paintUiText, quotaToneFromLeftPercent } from "./ui/format.js";
 import { getUiRuntimeOptions } from "./ui/runtime.js";
 import { type MenuItem, select } from "./ui/select.js";
 
@@ -214,150 +223,12 @@ type TokenSuccessWithAccount = TokenSuccess & {
 	accountLabel?: string;
 	workspaces?: Workspace[];
 };
-type PromptTone = "accent" | "success" | "warning" | "danger" | "muted";
+// Formatter implementations moved to lib/codex-manager/formatters/ (audit
+// roadmap §4.1.1 phase 1). Re-exported here so existing consumers importing
+// from lib/codex-manager.js keep working unchanged.
+export { formatBackupSavedAt, styleAccountDetailText };
+
 const log = createLogger("codex-manager");
-
-interface ModelInspection {
-	requested: string;
-	normalized: string;
-	remapped: boolean;
-	promptFamily: ModelFamily;
-	capabilities: ReturnType<typeof getModelCapabilities>;
-}
-
-function stylePromptText(text: string, tone: PromptTone): string {
-	if (!output.isTTY) return text;
-	const ui = getUiRuntimeOptions();
-	if (ui.v2Enabled) {
-		if (tone === "muted") {
-			return `${ui.theme.colors.dim}${paintUiText(ui, text, "muted")}${ui.theme.colors.reset}`;
-		}
-		const mapped = tone === "accent" ? "primary" : tone;
-		return paintUiText(ui, text, mapped);
-	}
-	const legacyCode =
-		tone === "accent"
-			? ANSI.green
-			: tone === "success"
-				? ANSI.green
-				: tone === "warning"
-					? ANSI.yellow
-					: tone === "danger"
-						? ANSI.red
-						: ANSI.dim;
-	return `${legacyCode}${text}${ANSI.reset}`;
-}
-
-function inspectRequestedModel(requestedModel: string): ModelInspection {
-	const normalized = resolveNormalizedModel(requestedModel);
-	const profile = getModelProfile(normalized);
-	return {
-		requested: requestedModel,
-		normalized,
-		remapped: requestedModel !== normalized,
-		promptFamily: profile.promptFamily,
-		capabilities: getModelCapabilities(normalized),
-	};
-}
-
-function formatModelInspection(model: ModelInspection): string {
-	const route = model.remapped
-		? `${model.requested} -> ${model.normalized}`
-		: model.normalized;
-	return [
-		route,
-		`prompt family ${model.promptFamily}`,
-		`tool search ${model.capabilities.toolSearch ? "yes" : "no"}`,
-		`computer use ${model.capabilities.computerUse ? "yes" : "no"}`,
-	].join(" | ");
-}
-
-function collapseWhitespace(value: string): string {
-	return value.replace(/\s+/g, " ").trim();
-}
-
-function formatReasonLabel(reason: string | undefined): string | undefined {
-	if (!reason) return undefined;
-	const normalized = collapseWhitespace(reason.replace(/_/g, " "));
-	return normalized.length > 0 ? normalized : undefined;
-}
-
-function extractErrorMessageFromPayload(payload: unknown): string | undefined {
-	if (!payload || typeof payload !== "object") return undefined;
-	const record = payload as Record<string, unknown>;
-
-	const directMessage =
-		typeof record.message === "string"
-			? collapseWhitespace(record.message)
-			: "";
-	const directCode =
-		typeof record.code === "string" ? collapseWhitespace(record.code) : "";
-	if (directMessage) {
-		if (
-			directCode &&
-			!directMessage.toLowerCase().includes(directCode.toLowerCase())
-		) {
-			return `${directMessage} [${directCode}]`;
-		}
-		return directMessage;
-	}
-
-	const nested = record.error;
-	if (nested && typeof nested === "object") {
-		return extractErrorMessageFromPayload(nested);
-	}
-	return undefined;
-}
-
-function parseStructuredErrorMessage(raw: string): string | undefined {
-	const trimmed = raw.trim();
-	if (!trimmed) return undefined;
-	const candidates = new Set<string>([trimmed]);
-	const firstBrace = trimmed.indexOf("{");
-	const lastBrace = trimmed.lastIndexOf("}");
-	if (firstBrace >= 0 && lastBrace > firstBrace) {
-		candidates.add(trimmed.slice(firstBrace, lastBrace + 1));
-	}
-
-	for (const candidate of candidates) {
-		try {
-			const parsed = JSON.parse(candidate) as unknown;
-			const message = extractErrorMessageFromPayload(parsed);
-			if (message) return message;
-		} catch {
-			// ignore non-JSON candidates
-		}
-	}
-	return undefined;
-}
-
-function normalizeFailureDetail(
-	message: string | undefined,
-	reason: string | undefined,
-): string {
-	const reasonLabel = formatReasonLabel(reason);
-	const raw = message?.trim() || reasonLabel || "refresh failed";
-	const structured = parseStructuredErrorMessage(raw);
-	const normalized = collapseWhitespace(structured ?? raw);
-	const bounded =
-		normalized.length > 260 ? `${normalized.slice(0, 257)}...` : normalized;
-	return bounded.length > 0 ? bounded : "refresh failed";
-}
-
-function joinStyledSegments(parts: string[]): string {
-	if (parts.length === 0) return "";
-	const separator = stylePromptText(" | ", "muted");
-	return parts.join(separator);
-}
-
-function formatResultSummary(
-	segments: ReadonlyArray<{ text: string; tone: PromptTone }>,
-): string {
-	const rendered = segments.map((segment) =>
-		stylePromptText(segment.text, segment.tone),
-	);
-	return `${stylePromptText("Result:", "accent")} ${joinStyledSegments(rendered)}`;
-}
 
 function createRepairCommandDeps(): RepairCommandDeps {
 	return {
@@ -383,113 +254,6 @@ function isOAuthCancellation(
 ): boolean {
 	const message = (result.message ?? result.reason ?? "").trim().toLowerCase();
 	return message.includes("cancelled") || message.includes("canceled");
-}
-
-function styleQuotaSummary(summary: string): string {
-	const normalized = collapseWhitespace(summary);
-	if (!normalized) return stylePromptText(summary, "muted");
-	const segments = normalized
-		.split("|")
-		.map((segment) => segment.trim())
-		.filter(Boolean);
-	if (segments.length === 0) return stylePromptText(normalized, "muted");
-
-	const rendered = segments.map((segment) => {
-		if (/rate-limited/i.test(segment)) {
-			return stylePromptText(segment, "danger");
-		}
-		const match = segment.match(/^([0-9a-zA-Z]+)\s+(\d{1,3})%$/);
-		if (!match) {
-			return stylePromptText(segment, "muted");
-		}
-		const windowLabel = match[1] ?? "";
-		const leftPercent = Math.max(
-			0,
-			Math.min(100, Number.parseInt(match[2] ?? "", 10)),
-		);
-		if (!Number.isFinite(leftPercent)) {
-			return stylePromptText(segment, "muted");
-		}
-		const tone = quotaToneFromLeftPercent(leftPercent);
-		return `${stylePromptText(windowLabel, "muted")} ${stylePromptText(`${leftPercent}%`, tone)}`;
-	});
-
-	return joinStyledSegments(rendered);
-}
-
-// Exported for unit tests: tone precedence (danger before warning) is
-// security/UX-relevant — a failure whose text contains "unavailable" must
-// render red, not be downgraded to yellow. See test/codex-manager-detail-tone.test.ts.
-export function styleAccountDetailText(
-	detail: string,
-	fallbackTone: PromptTone = "muted",
-): string {
-	const compact = collapseWhitespace(detail);
-	if (!compact) return stylePromptText("", fallbackTone);
-
-	const quotaMatch = compact.match(/^(.*?)\(([^()]*\d{1,3}%[^()]*)\)(.*)$/);
-	if (quotaMatch) {
-		const prefix = (quotaMatch[1] ?? "").trim();
-		const quota = (quotaMatch[2] ?? "").trim();
-		const suffix = (quotaMatch[3] ?? "").trim();
-
-		// danger wins across the WHOLE detail: a failure keyword anywhere — even
-		// trapped inside the (…%) quota segment, e.g.
-		// "signed in and working (live check failed: … 0%)" — must keep the prefix
-		// red, never let a "working"/"ok" prefix render green over a real failure.
-		const detailHasFailure = /failed|error|rate-limited/i.test(compact);
-		const prefixTone: PromptTone = detailHasFailure
-			? "danger"
-			: /\b(ok|working|succeeded|valid)\b/i.test(prefix)
-				? "success"
-				: fallbackTone;
-		const suffixTone: PromptTone =
-			// danger wins first: a real failure whose text happens to contain
-			// "unavailable"/"not available" (e.g. a 5xx "service not available")
-			// must render red, not be downgraded to a yellow warning.
-			/failed|error/i.test(suffix)
-				? "danger"
-				: /re-login|stale|warning|retry|fallback|unavailable|not available/i.test(suffix)
-					? "warning"
-					: "muted";
-
-		const chunks: string[] = [];
-		if (prefix) chunks.push(stylePromptText(prefix, prefixTone));
-		chunks.push(`(${styleQuotaSummary(quota)})`);
-		if (suffix) chunks.push(stylePromptText(suffix, suffixTone));
-		return chunks.join(" ");
-	}
-
-	if (/rate-limited/i.test(compact)) return stylePromptText(compact, "danger");
-	if (/failed|error/i.test(compact)) return stylePromptText(compact, "danger");
-	if (/re-login|stale|warning|fallback|unavailable|not available/i.test(compact))
-		return stylePromptText(compact, "warning");
-	if (/\b(ok|working|succeeded|valid)\b/i.test(compact))
-		return stylePromptText(compact, "success");
-	return stylePromptText(compact, fallbackTone);
-}
-
-function riskTone(
-	level: ForecastAccountResult["riskLevel"],
-): "success" | "warning" | "danger" {
-	if (level === "low") return "success";
-	if (level === "medium") return "warning";
-	return "danger";
-}
-
-function availabilityTone(
-	availability: ForecastAccountResult["availability"],
-): "success" | "warning" | "danger" {
-	if (availability === "ready") return "success";
-	if (availability === "delayed") return "warning";
-	return "danger";
-}
-function formatQuotaSnapshotForDashboard(
-	snapshot: Awaited<ReturnType<typeof fetchCodexQuotaSnapshot>>,
-	settings: DashboardDisplaySettings,
-): string {
-	if (!settings.showQuotaDetails) return "live session OK";
-	return `live session OK (${formatCompactQuotaSnapshot(snapshot)})`;
 }
 
 function isAbortError(error: unknown): boolean {
@@ -546,111 +310,6 @@ const IMPLEMENTED_FEATURES: ImplementedFeature[] = [
 	{ id: 40, name: "OAuth browser-first flow with manual callback fallback" },
 	{ id: 41, name: "Auto-switch to best account command" },
 ];
-
-function formatRateLimitEntry(
-	account: { rateLimitResetTimes?: Record<string, number | undefined> },
-	now: number,
-	family: ModelFamily = "codex",
-): string | null {
-	return formatAccountRateLimitEntry(account, now, formatWaitTime, family);
-}
-
-function quotaCacheEntryToSnapshot(entry: QuotaCacheEntry): CodexQuotaSnapshot {
-	return {
-		status: entry.status,
-		planType: entry.planType,
-		model: entry.model,
-		primary: {
-			usedPercent: entry.primary.usedPercent,
-			windowMinutes: entry.primary.windowMinutes,
-			resetAtMs: entry.primary.resetAtMs,
-		},
-		secondary: {
-			usedPercent: entry.secondary.usedPercent,
-			windowMinutes: entry.secondary.windowMinutes,
-			resetAtMs: entry.secondary.resetAtMs,
-		},
-	};
-}
-
-function formatCompactQuotaWindowLabel(
-	windowMinutes: number | undefined,
-): string {
-	if (!windowMinutes || !Number.isFinite(windowMinutes) || windowMinutes <= 0) {
-		return "quota";
-	}
-	if (windowMinutes % 1440 === 0) return `${windowMinutes / 1440}d`;
-	if (windowMinutes % 60 === 0) return `${windowMinutes / 60}h`;
-	return `${windowMinutes}m`;
-}
-
-function formatCompactQuotaPart(
-	windowMinutes: number | undefined,
-	usedPercent: number | undefined,
-): string | null {
-	const label = formatCompactQuotaWindowLabel(windowMinutes);
-	if (typeof usedPercent !== "number" || !Number.isFinite(usedPercent)) {
-		return null;
-	}
-	const left = quotaLeftPercentFromUsed(usedPercent);
-	return `${label} ${left}%`;
-}
-
-function formatCompactQuotaSnapshot(
-	snapshot: CodexQuotaSnapshot,
-	now = Date.now(),
-): string {
-	const parts = [
-		formatCompactQuotaPart(
-			snapshot.primary.windowMinutes,
-			snapshot.primary.usedPercent,
-		),
-		formatCompactQuotaPart(
-			snapshot.secondary.windowMinutes,
-			snapshot.secondary.usedPercent,
-		),
-	].filter(
-		(value): value is string => typeof value === "string" && value.length > 0,
-	);
-	if (snapshot.status === 429) {
-		parts.push("rate-limited");
-	}
-	if (isQuotaCacheEntryExhausted(snapshot, now)) {
-		parts.push("quota-exhausted");
-	}
-	if (parts.length > 0) {
-		return parts.join(" | ");
-	}
-	return formatQuotaSnapshotLine(snapshot);
-}
-
-function formatAccountQuotaSummary(
-	entry: QuotaCacheEntry,
-	now = Date.now(),
-): string {
-	const parts = [
-		formatCompactQuotaPart(
-			entry.primary.windowMinutes,
-			entry.primary.usedPercent,
-		),
-		formatCompactQuotaPart(
-			entry.secondary.windowMinutes,
-			entry.secondary.usedPercent,
-		),
-	].filter(
-		(value): value is string => typeof value === "string" && value.length > 0,
-	);
-	if (entry.status === 429) {
-		parts.push("rate-limited");
-	}
-	if (isQuotaCacheEntryExhausted(entry, now)) {
-		parts.push("quota-exhausted");
-	}
-	if (parts.length > 0) {
-		return parts.join(" | ");
-	}
-	return formatQuotaSnapshotLine(quotaCacheEntryToSnapshot(entry));
-}
 
 function getQuotaCacheEntryForAccount(
 	cache: QuotaCacheData,
@@ -1514,16 +1173,6 @@ type SignInFlowOptions = {
 	timeoutMs?: number;
 };
 
-export function formatBackupSavedAt(mtimeMs: number): string {
-	return new Date(mtimeMs).toLocaleString(undefined, {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-		hour: "numeric",
-		minute: "2-digit",
-	});
-}
-
 async function promptOAuthSignInMode(
 	backupOption: NamedBackupSummary | null,
 	backupDiscoveryWarning: string | null = null,
@@ -1808,19 +1457,6 @@ async function waitForMenuReturn(
 		rl.close();
 		clearInlineStatus();
 	}
-}
-
-function stringifyLogArgs(args: unknown[]): string {
-	return args
-		.map((value) => {
-			if (typeof value === "string") return value;
-			try {
-				return JSON.stringify(value);
-			} catch {
-				return String(value);
-			}
-		})
-		.join(" ");
 }
 
 async function runActionPanel(

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -3204,6 +3204,246 @@ function buildSelectAccountTraced(): (
 	};
 }
 
+/**
+ * Uniform handler signature for the `auth` subcommand registry: every entry
+ * receives the already-parsed argument tail (everything after the subcommand)
+ * and resolves to the process exit code. Dependencies are closure-captured
+ * from this module exactly as the previous if/else dispatch chain did.
+ */
+type CliCommandHandler = (rest: string[]) => number | Promise<number>;
+
+/**
+ * Shared handler for `list` and `status` (aliases of the same view).
+ */
+const runListOrStatusCommand: CliCommandHandler = (rest) =>
+	runStatusCommand({
+		setStoragePath,
+		getStoragePath,
+		loadAccounts,
+		inspectStorageHealth,
+		resolveActiveIndex,
+		formatRateLimitEntry,
+		loadRuntimeObservabilitySnapshot: loadPersistedRuntimeObservabilitySnapshot,
+		loadAppBindStatus: async () =>
+			getAppBindStatus()
+				.then((status) => (status.running ? status.router : null))
+				.catch(() => null),
+		loadAppHelperStatus: readAppRuntimeHelperAccountSignal,
+		loadQuotaCache,
+		json: rest.includes("--json") || rest.includes("-j"),
+	});
+
+/**
+ * Command registry for the `auth` dispatcher (audit roadmap §4.1.1 phase 2).
+ *
+ * Replaces the former `if (command === …)` chain in runCodexMultiAuthCli with
+ * a lookup map. Aliases (`status` → `list` view) point at the same handler.
+ * Per-invocation dependency factories (createRepairCommandDeps,
+ * buildSelectAccountTraced) are still invoked inside each handler so they are
+ * constructed at dispatch time, not at module load — identical to the old
+ * chain. Keys are exact-match and unique, so lookup order cannot change
+ * semantics relative to the sequential chain it replaces.
+ */
+const CLI_COMMAND_HANDLERS: ReadonlyMap<string, CliCommandHandler> = new Map<
+	string,
+	CliCommandHandler
+>([
+	["login", (rest) => runAuthLogin(rest)],
+	["list", runListOrStatusCommand],
+	["status", runListOrStatusCommand],
+	[
+		"switch",
+		(rest) =>
+			runSwitchCommand(rest, {
+				setStoragePath,
+				loadAccounts,
+				persistAndSyncSelectedAccount,
+			}),
+	],
+	[
+		"unpin",
+		() =>
+			runUnpinCommand({
+				setStoragePath,
+				loadAccounts,
+				saveAccounts,
+				getStoragePath,
+			}),
+	],
+	[
+		"workspace",
+		(rest) =>
+			runWorkspaceCommand(rest, {
+				setStoragePath,
+				loadAccounts,
+				saveAccounts,
+			}),
+	],
+	["check", () => runCheckCommand({ runHealthCheck })],
+	[
+		"features",
+		() => runFeaturesCommand({ implementedFeatures: IMPLEMENTED_FEATURES }),
+	],
+	[
+		"verify-flagged",
+		(rest) => runRepairVerifyFlagged(rest, createRepairCommandDeps()),
+	],
+	["forecast", (rest) => runForecast(rest)],
+	["best", (rest) => runBest(rest)],
+	[
+		"account",
+		(rest) =>
+			runAccountCommand(rest, {
+				setStoragePath,
+				loadAccounts,
+			}),
+	],
+	["budget", (rest) => runBudgetCommand(rest)],
+	["bridge", (rest) => runBridgeCommand(rest)],
+	["integrations", (rest) => runIntegrationsCommand(rest)],
+	[
+		"models",
+		(rest) =>
+			runModelsCommand(rest, {
+				setStoragePath,
+				loadAccounts,
+				loadQuotaCache,
+			}),
+	],
+	[
+		"monitor",
+		(rest) =>
+			runMonitorCommand(rest, {
+				setStoragePath,
+				loadAccounts,
+			}),
+	],
+	[
+		"report",
+		(rest) =>
+			runReportCommand(rest, {
+				setStoragePath,
+				getStoragePath,
+				loadAccounts,
+				inspectStorageHealth,
+				saveAccounts,
+				resolveActiveIndex,
+				hasUsableAccessToken,
+				queuedRefresh,
+				fetchCodexQuotaSnapshot,
+				formatRateLimitEntry,
+				normalizeFailureDetail,
+				loadRuntimeObservabilitySnapshot:
+					loadPersistedRuntimeObservabilitySnapshot,
+				loadQuotaCache,
+			}),
+	],
+	["usage", (rest) => runUsageCommand(rest)],
+	[
+		"rotation",
+		(rest) =>
+			runRotationCommand(rest, {
+				loadPluginConfig,
+				savePluginConfig,
+				getCodexRuntimeRotationProxy,
+				setStoragePath,
+				getStoragePath,
+				loadAccounts,
+				saveAccounts,
+				resolveActiveIndex,
+				bindCodexApp: bindCodexAppRuntimeRotation,
+				unbindCodexApp: unbindCodexAppRuntimeRotation,
+				getCodexAppBindStatus: getAppBindStatus,
+				loadRuntimeObservabilitySnapshot:
+					loadPersistedRuntimeObservabilitySnapshot,
+				loadQuotaCache,
+			}),
+	],
+	[
+		"why-selected",
+		(rest) =>
+			runWhySelectedCommand(rest, {
+				parseWhySelectedArgs,
+				printWhySelectedUsage,
+				setStoragePath,
+				loadAccounts,
+				resolveActiveIndex,
+				selectAccountTraced: buildSelectAccountTraced(),
+				loadRuntimeObservabilitySnapshot: async () => {
+					const snapshot = await loadPersistedRuntimeObservabilitySnapshot();
+					if (!snapshot) return null;
+					const generatedAt =
+						typeof (snapshot as { generatedAt?: unknown }).generatedAt ===
+							"number" ||
+						typeof (snapshot as { generatedAt?: unknown }).generatedAt ===
+							"string"
+							? (snapshot as { generatedAt?: number | string }).generatedAt
+							: undefined;
+					return { generatedAt };
+				},
+				sanitizeEmail,
+			}),
+	],
+	[
+		"verify",
+		(rest) =>
+			runVerifyCommand(rest, {
+				parseVerifyArgs,
+				printVerifyUsage,
+				runVerifyFlagged: async (flaggedArgs: string[]) =>
+					runRepairVerifyFlagged(flaggedArgs, createRepairCommandDeps()),
+				setStoragePath,
+				verifyPathsDeps: {
+					getCwd: () => process.cwd(),
+					findProjectRoot,
+					resolveProjectStorageIdentityRoot,
+					getProjectStorageKey,
+					getProjectConfigDir,
+					getProjectGlobalConfigDir,
+					resolvePath: resolveStoragePath,
+				},
+			}),
+	],
+	["fix", (rest) => runRepairFix(rest, createRepairCommandDeps())],
+	["doctor", (rest) => runRepairDoctor(rest, createRepairCommandDeps())],
+	["uninstall", (rest) => runUninstallCommand(rest, { clearAccounts })],
+	[
+		"config",
+		(rest) => {
+			const [subcommand, ...configArgs] = rest;
+			if (subcommand === "explain") {
+				return runConfigExplainCommand(configArgs, {
+					getReport: getPluginConfigExplainReport,
+				});
+			}
+			if (subcommand === "template") {
+				return runInitConfigCommand(configArgs);
+			}
+			console.error(`Unknown config command: ${subcommand ?? "(missing)"}`);
+			return 1;
+		},
+	],
+	["init-config", (rest) => runInitConfigCommand(rest)],
+	[
+		"debug",
+		(rest) => {
+			const [subcommand, ...debugArgs] = rest;
+			if (subcommand === "bundle") {
+				return runDebugBundleCommand(debugArgs, {
+					getConfigReport: getPluginConfigExplainReport,
+					getStoragePath,
+					loadAccounts,
+					loadFlaggedAccounts,
+					loadCodexCliState,
+					getLastAccountsSaveTimestamp,
+				});
+			}
+			console.error(`Unknown debug command: ${subcommand ?? "(missing)"}`);
+			return 1;
+		},
+	],
+]);
+
 export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 	const startupDisplaySettings = await loadDashboardDisplaySettings();
 	applyUiThemeFromDashboardSettings(startupDisplaySettings);
@@ -3232,212 +3472,10 @@ export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
 		printUsage();
 		return 0;
 	}
-	if (command === "login") {
-		return runAuthLogin(rest);
-	}
-	if (command === "list" || command === "status") {
-		return runStatusCommand({
-			setStoragePath,
-			getStoragePath,
-			loadAccounts,
-			inspectStorageHealth,
-			resolveActiveIndex,
-			formatRateLimitEntry,
-			loadRuntimeObservabilitySnapshot:
-				loadPersistedRuntimeObservabilitySnapshot,
-			loadAppBindStatus: async () =>
-				getAppBindStatus()
-					.then((status) => (status.running ? status.router : null))
-					.catch(() => null),
-			loadAppHelperStatus: readAppRuntimeHelperAccountSignal,
-			loadQuotaCache,
-			json: rest.includes("--json") || rest.includes("-j"),
-		});
-	}
-	if (command === "switch") {
-		return runSwitchCommand(rest, {
-			setStoragePath,
-			loadAccounts,
-			persistAndSyncSelectedAccount,
-		});
-	}
-	if (command === "unpin") {
-		return runUnpinCommand({
-			setStoragePath,
-			loadAccounts,
-			saveAccounts,
-			getStoragePath,
-		});
-	}
-	if (command === "workspace") {
-		return runWorkspaceCommand(rest, {
-			setStoragePath,
-			loadAccounts,
-			saveAccounts,
-		});
-	}
-	if (command === "check") {
-		return runCheckCommand({ runHealthCheck });
-	}
-	if (command === "features") {
-		return runFeaturesCommand({ implementedFeatures: IMPLEMENTED_FEATURES });
-	}
-	if (command === "verify-flagged") {
-		return runRepairVerifyFlagged(rest, createRepairCommandDeps());
-	}
-	if (command === "forecast") {
-		return runForecast(rest);
-	}
-	if (command === "best") {
-		return runBest(rest);
-	}
-	if (command === "account") {
-		return runAccountCommand(rest, {
-			setStoragePath,
-			loadAccounts,
-		});
-	}
-	if (command === "budget") {
-		return runBudgetCommand(rest);
-	}
-	if (command === "bridge") {
-		return runBridgeCommand(rest);
-	}
-	if (command === "integrations") {
-		return runIntegrationsCommand(rest);
-	}
-	if (command === "models") {
-		return runModelsCommand(rest, {
-			setStoragePath,
-			loadAccounts,
-			loadQuotaCache,
-		});
-	}
-	if (command === "monitor") {
-		return runMonitorCommand(rest, {
-			setStoragePath,
-			loadAccounts,
-		});
-	}
-	if (command === "report") {
-		return runReportCommand(rest, {
-			setStoragePath,
-			getStoragePath,
-			loadAccounts,
-			inspectStorageHealth,
-			saveAccounts,
-			resolveActiveIndex,
-			hasUsableAccessToken,
-			queuedRefresh,
-			fetchCodexQuotaSnapshot,
-			formatRateLimitEntry,
-			normalizeFailureDetail,
-			loadRuntimeObservabilitySnapshot:
-				loadPersistedRuntimeObservabilitySnapshot,
-			loadQuotaCache,
-		});
-	}
-	if (command === "usage") {
-		return runUsageCommand(rest);
-	}
-	if (command === "rotation") {
-		return runRotationCommand(rest, {
-			loadPluginConfig,
-			savePluginConfig,
-			getCodexRuntimeRotationProxy,
-			setStoragePath,
-			getStoragePath,
-			loadAccounts,
-			saveAccounts,
-			resolveActiveIndex,
-			bindCodexApp: bindCodexAppRuntimeRotation,
-			unbindCodexApp: unbindCodexAppRuntimeRotation,
-			getCodexAppBindStatus: getAppBindStatus,
-			loadRuntimeObservabilitySnapshot:
-				loadPersistedRuntimeObservabilitySnapshot,
-			loadQuotaCache,
-		});
-	}
-	if (command === "why-selected") {
-		return runWhySelectedCommand(rest, {
-			parseWhySelectedArgs,
-			printWhySelectedUsage,
-			setStoragePath,
-			loadAccounts,
-			resolveActiveIndex,
-			selectAccountTraced: buildSelectAccountTraced(),
-			loadRuntimeObservabilitySnapshot: async () => {
-				const snapshot = await loadPersistedRuntimeObservabilitySnapshot();
-				if (!snapshot) return null;
-				const generatedAt =
-					typeof (snapshot as { generatedAt?: unknown }).generatedAt ===
-						"number" ||
-					typeof (snapshot as { generatedAt?: unknown }).generatedAt ===
-						"string"
-						? (snapshot as { generatedAt?: number | string }).generatedAt
-						: undefined;
-				return { generatedAt };
-			},
-			sanitizeEmail,
-		});
-	}
-	if (command === "verify") {
-		return runVerifyCommand(rest, {
-			parseVerifyArgs,
-			printVerifyUsage,
-			runVerifyFlagged: async (flaggedArgs: string[]) =>
-				runRepairVerifyFlagged(flaggedArgs, createRepairCommandDeps()),
-			setStoragePath,
-			verifyPathsDeps: {
-				getCwd: () => process.cwd(),
-				findProjectRoot,
-				resolveProjectStorageIdentityRoot,
-				getProjectStorageKey,
-				getProjectConfigDir,
-				getProjectGlobalConfigDir,
-				resolvePath: resolveStoragePath,
-			},
-		});
-	}
-	if (command === "fix") {
-		return runRepairFix(rest, createRepairCommandDeps());
-	}
-	if (command === "doctor") {
-		return runRepairDoctor(rest, createRepairCommandDeps());
-	}
-	if (command === "uninstall") {
-		return runUninstallCommand(rest, { clearAccounts });
-	}
-	if (command === "config") {
-		const [subcommand, ...configArgs] = rest;
-		if (subcommand === "explain") {
-			return runConfigExplainCommand(configArgs, {
-				getReport: getPluginConfigExplainReport,
-			});
-		}
-		if (subcommand === "template") {
-			return runInitConfigCommand(configArgs);
-		}
-		console.error(`Unknown config command: ${subcommand ?? "(missing)"}`);
-		return 1;
-	}
-	if (command === "init-config") {
-		return runInitConfigCommand(rest);
-	}
-	if (command === "debug") {
-		const [subcommand, ...debugArgs] = rest;
-		if (subcommand === "bundle") {
-			return runDebugBundleCommand(debugArgs, {
-				getConfigReport: getPluginConfigExplainReport,
-				getStoragePath,
-				loadAccounts,
-				loadFlaggedAccounts,
-				loadCodexCliState,
-				getLastAccountsSaveTimestamp,
-			});
-		}
-		console.error(`Unknown debug command: ${subcommand ?? "(missing)"}`);
-		return 1;
+
+	const handler = CLI_COMMAND_HANDLERS.get(command);
+	if (handler) {
+		return handler(rest);
 	}
 
 	console.error(`Unknown command: ${command}`);

--- a/lib/codex-manager/formatters/account-formatters.ts
+++ b/lib/codex-manager/formatters/account-formatters.ts
@@ -1,0 +1,96 @@
+import { formatWaitTime } from "../../accounts.js";
+import type { ForecastAccountResult } from "../../forecast.js";
+import type { ModelFamily } from "../../prompts/codex.js";
+import { formatRateLimitEntry as formatAccountRateLimitEntry } from "../../runtime/account-status.js";
+import { styleQuotaSummary } from "./quota-formatters.js";
+import {
+	collapseWhitespace,
+	type PromptTone,
+	stylePromptText,
+} from "./text-style.js";
+
+// Exported for unit tests: tone precedence (danger before warning) is
+// security/UX-relevant — a failure whose text contains "unavailable" must
+// render red, not be downgraded to yellow. See test/codex-manager-detail-tone.test.ts.
+export function styleAccountDetailText(
+	detail: string,
+	fallbackTone: PromptTone = "muted",
+): string {
+	const compact = collapseWhitespace(detail);
+	if (!compact) return stylePromptText("", fallbackTone);
+
+	const quotaMatch = compact.match(/^(.*?)\(([^()]*\d{1,3}%[^()]*)\)(.*)$/);
+	if (quotaMatch) {
+		const prefix = (quotaMatch[1] ?? "").trim();
+		const quota = (quotaMatch[2] ?? "").trim();
+		const suffix = (quotaMatch[3] ?? "").trim();
+
+		// danger wins across the WHOLE detail: a failure keyword anywhere — even
+		// trapped inside the (…%) quota segment, e.g.
+		// "signed in and working (live check failed: … 0%)" — must keep the prefix
+		// red, never let a "working"/"ok" prefix render green over a real failure.
+		const detailHasFailure = /failed|error|rate-limited/i.test(compact);
+		const prefixTone: PromptTone = detailHasFailure
+			? "danger"
+			: /\b(ok|working|succeeded|valid)\b/i.test(prefix)
+				? "success"
+				: fallbackTone;
+		const suffixTone: PromptTone =
+			// danger wins first: a real failure whose text happens to contain
+			// "unavailable"/"not available" (e.g. a 5xx "service not available")
+			// must render red, not be downgraded to a yellow warning.
+			/failed|error/i.test(suffix)
+				? "danger"
+				: /re-login|stale|warning|retry|fallback|unavailable|not available/i.test(suffix)
+					? "warning"
+					: "muted";
+
+		const chunks: string[] = [];
+		if (prefix) chunks.push(stylePromptText(prefix, prefixTone));
+		chunks.push(`(${styleQuotaSummary(quota)})`);
+		if (suffix) chunks.push(stylePromptText(suffix, suffixTone));
+		return chunks.join(" ");
+	}
+
+	if (/rate-limited/i.test(compact)) return stylePromptText(compact, "danger");
+	if (/failed|error/i.test(compact)) return stylePromptText(compact, "danger");
+	if (/re-login|stale|warning|fallback|unavailable|not available/i.test(compact))
+		return stylePromptText(compact, "warning");
+	if (/\b(ok|working|succeeded|valid)\b/i.test(compact))
+		return stylePromptText(compact, "success");
+	return stylePromptText(compact, fallbackTone);
+}
+
+export function riskTone(
+	level: ForecastAccountResult["riskLevel"],
+): "success" | "warning" | "danger" {
+	if (level === "low") return "success";
+	if (level === "medium") return "warning";
+	return "danger";
+}
+
+export function availabilityTone(
+	availability: ForecastAccountResult["availability"],
+): "success" | "warning" | "danger" {
+	if (availability === "ready") return "success";
+	if (availability === "delayed") return "warning";
+	return "danger";
+}
+
+export function formatRateLimitEntry(
+	account: { rateLimitResetTimes?: Record<string, number | undefined> },
+	now: number,
+	family: ModelFamily = "codex",
+): string | null {
+	return formatAccountRateLimitEntry(account, now, formatWaitTime, family);
+}
+
+export function formatBackupSavedAt(mtimeMs: number): string {
+	return new Date(mtimeMs).toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}

--- a/lib/codex-manager/formatters/index.ts
+++ b/lib/codex-manager/formatters/index.ts
@@ -1,0 +1,4 @@
+export * from "./account-formatters.js";
+export * from "./model-formatters.js";
+export * from "./quota-formatters.js";
+export * from "./text-style.js";

--- a/lib/codex-manager/formatters/model-formatters.ts
+++ b/lib/codex-manager/formatters/model-formatters.ts
@@ -1,0 +1,38 @@
+import type { ModelFamily } from "../../prompts/codex.js";
+import {
+	getModelCapabilities,
+	getModelProfile,
+	resolveNormalizedModel,
+} from "../../request/helpers/model-map.js";
+
+export interface ModelInspection {
+	requested: string;
+	normalized: string;
+	remapped: boolean;
+	promptFamily: ModelFamily;
+	capabilities: ReturnType<typeof getModelCapabilities>;
+}
+
+export function inspectRequestedModel(requestedModel: string): ModelInspection {
+	const normalized = resolveNormalizedModel(requestedModel);
+	const profile = getModelProfile(normalized);
+	return {
+		requested: requestedModel,
+		normalized,
+		remapped: requestedModel !== normalized,
+		promptFamily: profile.promptFamily,
+		capabilities: getModelCapabilities(normalized),
+	};
+}
+
+export function formatModelInspection(model: ModelInspection): string {
+	const route = model.remapped
+		? `${model.requested} -> ${model.normalized}`
+		: model.normalized;
+	return [
+		route,
+		`prompt family ${model.promptFamily}`,
+		`tool search ${model.capabilities.toolSearch ? "yes" : "no"}`,
+		`computer use ${model.capabilities.computerUse ? "yes" : "no"}`,
+	].join(" | ");
+}

--- a/lib/codex-manager/formatters/quota-formatters.ts
+++ b/lib/codex-manager/formatters/quota-formatters.ts
@@ -1,0 +1,156 @@
+import type { DashboardDisplaySettings } from "../../dashboard-settings.js";
+import type { QuotaCacheEntry } from "../../quota-cache.js";
+import {
+	type CodexQuotaSnapshot,
+	fetchCodexQuotaSnapshot,
+	formatQuotaSnapshotLine,
+} from "../../quota-probe.js";
+import {
+	isQuotaCacheEntryExhausted,
+	quotaLeftPercentFromUsed,
+} from "../../quota-readiness.js";
+import { quotaToneFromLeftPercent } from "../../ui/format.js";
+import {
+	collapseWhitespace,
+	joinStyledSegments,
+	stylePromptText,
+} from "./text-style.js";
+
+export function styleQuotaSummary(summary: string): string {
+	const normalized = collapseWhitespace(summary);
+	if (!normalized) return stylePromptText(summary, "muted");
+	const segments = normalized
+		.split("|")
+		.map((segment) => segment.trim())
+		.filter(Boolean);
+	if (segments.length === 0) return stylePromptText(normalized, "muted");
+
+	const rendered = segments.map((segment) => {
+		if (/rate-limited/i.test(segment)) {
+			return stylePromptText(segment, "danger");
+		}
+		const match = segment.match(/^([0-9a-zA-Z]+)\s+(\d{1,3})%$/);
+		if (!match) {
+			return stylePromptText(segment, "muted");
+		}
+		const windowLabel = match[1] ?? "";
+		const leftPercent = Math.max(
+			0,
+			Math.min(100, Number.parseInt(match[2] ?? "", 10)),
+		);
+		if (!Number.isFinite(leftPercent)) {
+			return stylePromptText(segment, "muted");
+		}
+		const tone = quotaToneFromLeftPercent(leftPercent);
+		return `${stylePromptText(windowLabel, "muted")} ${stylePromptText(`${leftPercent}%`, tone)}`;
+	});
+
+	return joinStyledSegments(rendered);
+}
+
+export function formatQuotaSnapshotForDashboard(
+	snapshot: Awaited<ReturnType<typeof fetchCodexQuotaSnapshot>>,
+	settings: DashboardDisplaySettings,
+): string {
+	if (!settings.showQuotaDetails) return "live session OK";
+	return `live session OK (${formatCompactQuotaSnapshot(snapshot)})`;
+}
+
+export function quotaCacheEntryToSnapshot(
+	entry: QuotaCacheEntry,
+): CodexQuotaSnapshot {
+	return {
+		status: entry.status,
+		planType: entry.planType,
+		model: entry.model,
+		primary: {
+			usedPercent: entry.primary.usedPercent,
+			windowMinutes: entry.primary.windowMinutes,
+			resetAtMs: entry.primary.resetAtMs,
+		},
+		secondary: {
+			usedPercent: entry.secondary.usedPercent,
+			windowMinutes: entry.secondary.windowMinutes,
+			resetAtMs: entry.secondary.resetAtMs,
+		},
+	};
+}
+
+export function formatCompactQuotaWindowLabel(
+	windowMinutes: number | undefined,
+): string {
+	if (!windowMinutes || !Number.isFinite(windowMinutes) || windowMinutes <= 0) {
+		return "quota";
+	}
+	if (windowMinutes % 1440 === 0) return `${windowMinutes / 1440}d`;
+	if (windowMinutes % 60 === 0) return `${windowMinutes / 60}h`;
+	return `${windowMinutes}m`;
+}
+
+export function formatCompactQuotaPart(
+	windowMinutes: number | undefined,
+	usedPercent: number | undefined,
+): string | null {
+	const label = formatCompactQuotaWindowLabel(windowMinutes);
+	if (typeof usedPercent !== "number" || !Number.isFinite(usedPercent)) {
+		return null;
+	}
+	const left = quotaLeftPercentFromUsed(usedPercent);
+	return `${label} ${left}%`;
+}
+
+export function formatCompactQuotaSnapshot(
+	snapshot: CodexQuotaSnapshot,
+	now = Date.now(),
+): string {
+	const parts = [
+		formatCompactQuotaPart(
+			snapshot.primary.windowMinutes,
+			snapshot.primary.usedPercent,
+		),
+		formatCompactQuotaPart(
+			snapshot.secondary.windowMinutes,
+			snapshot.secondary.usedPercent,
+		),
+	].filter(
+		(value): value is string => typeof value === "string" && value.length > 0,
+	);
+	if (snapshot.status === 429) {
+		parts.push("rate-limited");
+	}
+	if (isQuotaCacheEntryExhausted(snapshot, now)) {
+		parts.push("quota-exhausted");
+	}
+	if (parts.length > 0) {
+		return parts.join(" | ");
+	}
+	return formatQuotaSnapshotLine(snapshot);
+}
+
+export function formatAccountQuotaSummary(
+	entry: QuotaCacheEntry,
+	now = Date.now(),
+): string {
+	const parts = [
+		formatCompactQuotaPart(
+			entry.primary.windowMinutes,
+			entry.primary.usedPercent,
+		),
+		formatCompactQuotaPart(
+			entry.secondary.windowMinutes,
+			entry.secondary.usedPercent,
+		),
+	].filter(
+		(value): value is string => typeof value === "string" && value.length > 0,
+	);
+	if (entry.status === 429) {
+		parts.push("rate-limited");
+	}
+	if (isQuotaCacheEntryExhausted(entry, now)) {
+		parts.push("quota-exhausted");
+	}
+	if (parts.length > 0) {
+		return parts.join(" | ");
+	}
+	return formatQuotaSnapshotLine(quotaCacheEntryToSnapshot(entry));
+}

--- a/lib/codex-manager/formatters/text-style.ts
+++ b/lib/codex-manager/formatters/text-style.ts
@@ -1,0 +1,133 @@
+import { stdout as output } from "node:process";
+import { ANSI } from "../../ui/ansi.js";
+import { paintUiText } from "../../ui/format.js";
+import { getUiRuntimeOptions } from "../../ui/runtime.js";
+
+export type PromptTone = "accent" | "success" | "warning" | "danger" | "muted";
+
+export function stylePromptText(text: string, tone: PromptTone): string {
+	if (!output.isTTY) return text;
+	const ui = getUiRuntimeOptions();
+	if (ui.v2Enabled) {
+		if (tone === "muted") {
+			return `${ui.theme.colors.dim}${paintUiText(ui, text, "muted")}${ui.theme.colors.reset}`;
+		}
+		const mapped = tone === "accent" ? "primary" : tone;
+		return paintUiText(ui, text, mapped);
+	}
+	const legacyCode =
+		tone === "accent"
+			? ANSI.green
+			: tone === "success"
+				? ANSI.green
+				: tone === "warning"
+					? ANSI.yellow
+					: tone === "danger"
+						? ANSI.red
+						: ANSI.dim;
+	return `${legacyCode}${text}${ANSI.reset}`;
+}
+
+export function collapseWhitespace(value: string): string {
+	return value.replace(/\s+/g, " ").trim();
+}
+
+export function formatReasonLabel(
+	reason: string | undefined,
+): string | undefined {
+	if (!reason) return undefined;
+	const normalized = collapseWhitespace(reason.replace(/_/g, " "));
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+export function extractErrorMessageFromPayload(
+	payload: unknown,
+): string | undefined {
+	if (!payload || typeof payload !== "object") return undefined;
+	const record = payload as Record<string, unknown>;
+
+	const directMessage =
+		typeof record.message === "string"
+			? collapseWhitespace(record.message)
+			: "";
+	const directCode =
+		typeof record.code === "string" ? collapseWhitespace(record.code) : "";
+	if (directMessage) {
+		if (
+			directCode &&
+			!directMessage.toLowerCase().includes(directCode.toLowerCase())
+		) {
+			return `${directMessage} [${directCode}]`;
+		}
+		return directMessage;
+	}
+
+	const nested = record.error;
+	if (nested && typeof nested === "object") {
+		return extractErrorMessageFromPayload(nested);
+	}
+	return undefined;
+}
+
+export function parseStructuredErrorMessage(raw: string): string | undefined {
+	const trimmed = raw.trim();
+	if (!trimmed) return undefined;
+	const candidates = new Set<string>([trimmed]);
+	const firstBrace = trimmed.indexOf("{");
+	const lastBrace = trimmed.lastIndexOf("}");
+	if (firstBrace >= 0 && lastBrace > firstBrace) {
+		candidates.add(trimmed.slice(firstBrace, lastBrace + 1));
+	}
+
+	for (const candidate of candidates) {
+		try {
+			const parsed = JSON.parse(candidate) as unknown;
+			const message = extractErrorMessageFromPayload(parsed);
+			if (message) return message;
+		} catch {
+			// ignore non-JSON candidates
+		}
+	}
+	return undefined;
+}
+
+export function normalizeFailureDetail(
+	message: string | undefined,
+	reason: string | undefined,
+): string {
+	const reasonLabel = formatReasonLabel(reason);
+	const raw = message?.trim() || reasonLabel || "refresh failed";
+	const structured = parseStructuredErrorMessage(raw);
+	const normalized = collapseWhitespace(structured ?? raw);
+	const bounded =
+		normalized.length > 260 ? `${normalized.slice(0, 257)}...` : normalized;
+	return bounded.length > 0 ? bounded : "refresh failed";
+}
+
+export function joinStyledSegments(parts: string[]): string {
+	if (parts.length === 0) return "";
+	const separator = stylePromptText(" | ", "muted");
+	return parts.join(separator);
+}
+
+export function formatResultSummary(
+	segments: ReadonlyArray<{ text: string; tone: PromptTone }>,
+): string {
+	const rendered = segments.map((segment) =>
+		stylePromptText(segment.text, segment.tone),
+	);
+	return `${stylePromptText("Result:", "accent")} ${joinStyledSegments(rendered)}`;
+}
+
+export function stringifyLogArgs(args: unknown[]): string {
+	return args
+		.map((value) => {
+			if (typeof value === "string") return value;
+			try {
+				return JSON.stringify(value);
+			} catch {
+				return String(value);
+			}
+		})
+		.join(" ");
+}

--- a/test/codex-manager-formatters.test.ts
+++ b/test/codex-manager-formatters.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+	collapseWhitespace,
+	extractErrorMessageFromPayload,
+	formatReasonLabel,
+	formatResultSummary,
+	joinStyledSegments,
+	normalizeFailureDetail,
+	parseStructuredErrorMessage,
+	stringifyLogArgs,
+} from "../lib/codex-manager/formatters/text-style.js";
+import {
+	quotaCacheEntryToSnapshot,
+	styleQuotaSummary,
+} from "../lib/codex-manager/formatters/quota-formatters.js";
+import type { QuotaCacheEntry } from "../lib/quota-cache.js";
+import {
+	formatModelInspection,
+	inspectRequestedModel,
+} from "../lib/codex-manager/formatters/model-formatters.js";
+
+// Unit contracts for the helpers that became public in the formatters/
+// extraction. The CLI suites cover them end-to-end; these pin the
+// per-function behavior so phase-3 decomposition regressions localize.
+// Note: vitest runs without a TTY, so stylePromptText is a passthrough and
+// the styled outputs below assert plain text deterministically.
+
+describe("text-style formatters", () => {
+	it("collapseWhitespace flattens runs and trims", () => {
+		expect(collapseWhitespace("  a\t\n b   c ")).toBe("a b c");
+		expect(collapseWhitespace("\n\t ")).toBe("");
+	});
+
+	it("formatReasonLabel humanizes snake_case reasons and drops empties", () => {
+		expect(formatReasonLabel("invalid_grant")).toBe("invalid grant");
+		expect(formatReasonLabel("  rate__limited  ")).toBe("rate limited");
+		expect(formatReasonLabel("")).toBeUndefined();
+		expect(formatReasonLabel(undefined)).toBeUndefined();
+		expect(formatReasonLabel("___")).toBeUndefined();
+	});
+
+	it("extractErrorMessageFromPayload reads direct, coded, and nested shapes", () => {
+		expect(
+			extractErrorMessageFromPayload({ message: "token  expired" }),
+		).toBe("token expired");
+		// code is appended only when the message does not already mention it
+		expect(
+			extractErrorMessageFromPayload({
+				message: "token expired",
+				code: "invalid_grant",
+			}),
+		).toBe("token expired [invalid_grant]");
+		expect(
+			extractErrorMessageFromPayload({
+				message: "Invalid_Grant: token expired",
+				code: "invalid_grant",
+			}),
+		).toBe("Invalid_Grant: token expired");
+		expect(
+			extractErrorMessageFromPayload({
+				error: { error: { message: "deeply nested" } },
+			}),
+		).toBe("deeply nested");
+		expect(extractErrorMessageFromPayload(null)).toBeUndefined();
+		expect(extractErrorMessageFromPayload("string")).toBeUndefined();
+		expect(extractErrorMessageFromPayload({ code: "only_code" })).toBeUndefined();
+	});
+
+	it("parseStructuredErrorMessage finds JSON embedded in prose", () => {
+		expect(
+			parseStructuredErrorMessage('{"error":{"message":"quota hit"}}'),
+		).toBe("quota hit");
+		expect(
+			parseStructuredErrorMessage(
+				'refresh failed: {"message":"server says no"} (status 400)',
+			),
+		).toBe("server says no");
+		expect(parseStructuredErrorMessage("plain text failure")).toBeUndefined();
+		expect(parseStructuredErrorMessage("   ")).toBeUndefined();
+	});
+
+	it("normalizeFailureDetail prefers message, falls back to reason, bounds length", () => {
+		expect(normalizeFailureDetail("boom", "invalid_grant")).toBe("boom");
+		expect(normalizeFailureDetail(undefined, "invalid_grant")).toBe(
+			"invalid grant",
+		);
+		expect(normalizeFailureDetail(undefined, undefined)).toBe(
+			"refresh failed",
+		);
+		expect(normalizeFailureDetail("  ", "")).toBe("refresh failed");
+		// structured payloads are unwrapped before display
+		expect(
+			normalizeFailureDetail('{"error":{"message":"unwrapped"}}', undefined),
+		).toBe("unwrapped");
+		const long = "x".repeat(300);
+		const bounded = normalizeFailureDetail(long, undefined);
+		expect(bounded).toHaveLength(260);
+		expect(bounded.endsWith("...")).toBe(true);
+	});
+
+	it("joinStyledSegments and formatResultSummary render plain in non-TTY", () => {
+		expect(joinStyledSegments([])).toBe("");
+		expect(joinStyledSegments(["a", "b"])).toBe("a | b");
+		expect(
+			formatResultSummary([
+				{ text: "saved", tone: "success" },
+				{ text: "synced", tone: "muted" },
+			]),
+		).toBe("Result: saved | synced");
+	});
+
+	it("stringifyLogArgs serializes mixed args and survives cycles", () => {
+		const cyclic: Record<string, unknown> = {};
+		cyclic.self = cyclic;
+		expect(stringifyLogArgs(["msg", { a: 1 }, cyclic])).toBe(
+			'msg {"a":1} [object Object]',
+		);
+	});
+});
+
+describe("quota formatters", () => {
+	it("styleQuotaSummary keeps rate-limited and percent segments, clamps to 100", () => {
+		expect(styleQuotaSummary("5h 80% | weekly 15%")).toBe(
+			"5h 80% | weekly 15%",
+		);
+		expect(styleQuotaSummary("rate-limited until 18:00")).toBe(
+			"rate-limited until 18:00",
+		);
+		// \d{1,3} admits values over 100; the formatter clamps them
+		expect(styleQuotaSummary("5h 150%")).toBe("5h 100%");
+		expect(styleQuotaSummary("   ")).toBe("   ");
+		expect(styleQuotaSummary("no percent here")).toBe("no percent here");
+	});
+
+	it("quotaCacheEntryToSnapshot maps exactly the snapshot fields", () => {
+		const entry = {
+			status: "ok",
+			planType: "plus",
+			model: "gpt-5.3-codex",
+			fetchedAt: 123,
+			primary: { usedPercent: 20, windowMinutes: 300, resetAtMs: 1000 },
+			secondary: { usedPercent: 5, windowMinutes: 10080, resetAtMs: 2000 },
+		} as unknown as QuotaCacheEntry;
+		expect(quotaCacheEntryToSnapshot(entry)).toEqual({
+			status: "ok",
+			planType: "plus",
+			model: "gpt-5.3-codex",
+			primary: { usedPercent: 20, windowMinutes: 300, resetAtMs: 1000 },
+			secondary: { usedPercent: 5, windowMinutes: 10080, resetAtMs: 2000 },
+		});
+	});
+});
+
+describe("model formatters", () => {
+	it("inspectRequestedModel reports remapping consistently", () => {
+		const inspection = inspectRequestedModel("gpt-5.3-codex");
+		expect(inspection.requested).toBe("gpt-5.3-codex");
+		expect(inspection.remapped).toBe(
+			inspection.requested !== inspection.normalized,
+		);
+		expect(typeof inspection.promptFamily).toBe("string");
+		expect(typeof inspection.capabilities.toolSearch).toBe("boolean");
+	});
+
+	it("formatModelInspection shows the route and capability flags", () => {
+		const plain = formatModelInspection({
+			requested: "m",
+			normalized: "m",
+			remapped: false,
+			promptFamily: inspectRequestedModel("gpt-5.3-codex").promptFamily,
+			capabilities: { toolSearch: true, computerUse: false },
+		});
+		expect(plain).toContain("m | prompt family ");
+		expect(plain).toContain("tool search yes");
+		expect(plain).toContain("computer use no");
+
+		const remapped = formatModelInspection({
+			requested: "alias",
+			normalized: "real",
+			remapped: true,
+			promptFamily: inspectRequestedModel("gpt-5.3-codex").promptFamily,
+			capabilities: { toolSearch: false, computerUse: true },
+		});
+		expect(remapped).toContain("alias -> real");
+	});
+});


### PR DESCRIPTION
## Summary

Phase 2 of the `codex-manager.ts` decomposition — audit roadmap §4.1.1 (`docs/audits/AUDIT_2026-06-10.md`, PR #522): the `if (command === …)` dispatch chains become a `CLI_COMMAND_HANDLERS: ReadonlyMap<string, CliCommandHandler>` registry. **Zero behavior change**; the extensive CLI suites are the safety net (811 passing).

> **Stacked on #525** (formatter extraction, phase 1) — merge that first; this PR then shows only the registry commit.

## Design

- `type CliCommandHandler = (rest: string[]) => number | Promise<number>` — `rest` is the parsed argument tail, the return is the exit code. No heavier context object was needed.
- The registry lives **in `codex-manager.ts`**, not a separate module: every handler closure-captures module-scope deps (`persistAndSyncSelectedAccount`, `runAuthLogin`, repair-deps factory, traced selection, storage fns); an adjacent file would have meant exporting ~30 internals from the entrypoint and inviting a cycle.
- **28 keys = 27 commands + 1 alias** (`status`/`list` share a handler), exactly matching `ACCOUNT_MANAGER_COMMANDS` (the routing test asserts alignment).

## Dispatch quirks preserved exactly

- `auth`-prefix compatibility rewrite; default subcommand `login`; `--help`/`-h` short-circuits ahead of registry lookup; non-`auth` root → usage + exit 1
- `--json`/`-j` detection inside the shared list/status handler; nested `config`/`debug` sub-dispatch with their exact unknown-subcommand stderr + exit 1
- Unknown command → stderr + usage + exit 1; repair deps still constructed per dispatch, not at module load
- No order-shadowing existed in the chains, so the map is semantically identical

## Validation

- [x] `npm run typecheck`; eslint `--max-warnings=0`
- [x] All 63 suites matching codex-manager/runCodexMultiAuthCli: **811 passed**, 6 skipped, 3 failed — the 3 are the known Windows-path environment cases, identical on the base branch
- [x] Independently re-verified: codex-manager-cli + codex-routing, 205/205

## Risk / Rollback

Dispatch-only refactor (+38 lines net, from registry doc comments); handler bodies untouched. Revert the single commit. Phase 3 (moving remaining handler bodies into `commands/`) follows the roadmap.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

phase 2 of the `codex-manager.ts` decomposition: the `if (command === …)` dispatch chain (~200 lines) is replaced by a `CLI_COMMAND_HANDLERS: ReadonlyMap<string, CliCommandHandler>` with 28 entries, and the formatter helpers extracted in phase 1 are moved into `lib/codex-manager/formatters/` with a new vitest suite covering the newly-public contracts.

- `CLI_COMMAND_HANDLERS` map mirrors all 27 commands + 1 alias exactly; per-dispatch factories (`createRepairCommandDeps`, `buildSelectAccountTraced`) remain lazy inside handler closures, preserving the original evaluation order.
- Four formatter modules (`text-style`, `quota-formatters`, `model-formatters`, `account-formatters`) and a barrel `index.ts` promote previously-private helpers to exported symbols; `codex-manager.ts` re-exports only the two symbols that had prior external consumers.
- `test/codex-manager-formatters.test.ts` adds unit contracts for the extracted helpers, including edge cases for cyclic log args, clamped quota percentages, and structured error payloads.

<h3>Confidence Score: 5/5</h3>

safe to merge — purely mechanical dispatch refactor with no handler body changes and 811 passing CLI tests as the safety net.

the dispatch change is a direct key-lookup substitution for a sequential if/else chain; all 28 entries are verified against ACCOUNT_MANAGER_COMMANDS by the routing test. per-dispatch factories remain lazy inside handler closures. the two style nits (type-only import, stale test reference in a comment) have no runtime impact.

no files require special attention; the two nits are in lib/codex-manager/formatters/quota-formatters.ts (import style) and lib/codex-manager/formatters/account-formatters.ts (comment pointer).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager.ts | replaces ~200-line if/else dispatch chain with CLI_COMMAND_HANDLERS ReadonlyMap; all 28 keys (27 commands + status alias) match the old chain exactly, per-dispatch factories remain lazy inside handler closures |
| lib/codex-manager/formatters/quota-formatters.ts | formatter helpers extracted from codex-manager.ts; fetchCodexQuotaSnapshot imported as a value but used only as a typeof type reference — should be type-only import |
| lib/codex-manager/formatters/account-formatters.ts | styleAccountDetailText, riskTone, availabilityTone, formatRateLimitEntry, formatBackupSavedAt extracted here; doc-comment references test/codex-manager-detail-tone.test.ts which does not exist |
| lib/codex-manager/formatters/text-style.ts | previously-private helpers extracted and exported; logic identical to the original codex-manager.ts implementations |
| lib/codex-manager/formatters/model-formatters.ts | inspectRequestedModel and formatModelInspection extracted; ModelInspection interface promoted to exported, no logic changes |
| lib/codex-manager/formatters/index.ts | barrel re-export of all four formatter modules; many previously-internal helpers are now part of the public surface |
| test/codex-manager-formatters.test.ts | new vitest suite covering text-style, quota, and model formatter helpers; good edge-case coverage; styleAccountDetailText tone-precedence logic is not yet covered here |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["runCodexMultiAuthCli(rawArgs)"] --> B{auth-prefix\ncompat rewrite}
    B --> C[normalize command]
    C --> D{"--help / -h?"}
    D -->|yes| E[printUsage → exit 0]
    D -->|no| F{"non-auth root?"}
    F -->|yes| G[usage + exit 1]
    F -->|no| H["CLI_COMMAND_HANDLERS.get(command)"]
    H -->|found| I["handler(rest) → exit code"]
    H -->|not found| J["stderr + usage + exit 1"]
    I --> K["lazy factories at dispatch time\n(createRepairCommandDeps, buildSelectAccountTraced)"]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-18-manager-registry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-18-manager-registry%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fcodex-manager%2Fformatters%2Fquota-formatters.ts%3A3-7%0A%60fetchCodexQuotaSnapshot%60%20value%20import%20used%20only%20as%20a%20type%0A%0A%60fetchCodexQuotaSnapshot%60%20is%20imported%20as%20a%20value%20but%20only%20ever%20appears%20in%20a%20%60typeof%60%20type%20annotation%20%28%60Awaited%3CReturnType%3Ctypeof%20fetchCodexQuotaSnapshot%3E%3E%60%29.%20this%20pulls%20the%20runtime%20value%20into%20the%20module%20graph%20unnecessarily%3B%20if%20the%20project%20ever%20enables%20%60verbatimModuleSyntax%60%20in%20tsconfig%20it%20will%20become%20a%20compile%20error.%20mark%20it%20%60type%60%20alongside%20%60CodexQuotaSnapshot%60.%0A%0A%60%60%60suggestion%0Aimport%20%7B%0A%09type%20CodexQuotaSnapshot%2C%0A%09type%20fetchCodexQuotaSnapshot%2C%0A%09formatQuotaSnapshotLine%2C%0A%7D%20from%20%22..%2F..%2Fquota-probe.js%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fcodex-manager%2Fformatters%2Faccount-formatters.ts%3A959-961%0AComment%20references%20a%20test%20file%20that%20does%20not%20exist%0A%0AThe%20doc-comment%20says%20%60%2F%2F%20See%20test%2Fcodex-manager-detail-tone.test.ts%60%20but%20that%20file%20is%20absent%20from%20both%20this%20PR%20and%20the%20repo.%20%60test%2Fcodex-manager-formatters.test.ts%60%20is%20the%20new%20suite%2C%20but%20it%20does%20not%20cover%20%60styleAccountDetailText%60%20at%20all.%20the%20reference%20will%20send%20future%20contributors%20on%20a%20dead-end%20search%3B%20either%20add%20the%20missing%20suite%20or%20update%20the%20pointer%20to%20the%20actual%20test%20file.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=535&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/codex-manager/formatters/quota-formatters.ts:3-7
`fetchCodexQuotaSnapshot` value import used only as a type

`fetchCodexQuotaSnapshot` is imported as a value but only ever appears in a `typeof` type annotation (`Awaited<ReturnType<typeof fetchCodexQuotaSnapshot>>`). this pulls the runtime value into the module graph unnecessarily; if the project ever enables `verbatimModuleSyntax` in tsconfig it will become a compile error. mark it `type` alongside `CodexQuotaSnapshot`.

```suggestion
import {
	type CodexQuotaSnapshot,
	type fetchCodexQuotaSnapshot,
	formatQuotaSnapshotLine,
} from "../../quota-probe.js";
```

### Issue 2 of 2
lib/codex-manager/formatters/account-formatters.ts:959-961
Comment references a test file that does not exist

The doc-comment says `// See test/codex-manager-detail-tone.test.ts` but that file is absent from both this PR and the repo. `test/codex-manager-formatters.test.ts` is the new suite, but it does not cover `styleAccountDetailText` at all. the reference will send future contributors on a dead-end search; either add the missing suite or update the pointer to the actual test file.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(codex-manager): unit-pin the extrac..."](https://github.com/ndycode/codex-multi-auth/commit/4a09bcf9f4c65b9e28a4517b87f7e7697581df1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36669759)</sub>

<!-- /greptile_comment -->