### PR TITLE
test(cli): extract shared mock factories for the manager suites

### DIFF
--- a/test/auth-menu-hotkeys.test.ts
+++ b/test/auth-menu-hotkeys.test.ts
@@ -1,16 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AccountInfo } from "../lib/ui/auth-menu.js";
+import { createUiPromptMocks } from "./helpers/cli-test-fixtures.js";
 
-const selectMock = vi.fn();
-const confirmMock = vi.fn(async () => true);
+const uiMocks = createUiPromptMocks();
+const { select: selectMock, confirm: confirmMock } = uiMocks;
 
-vi.mock("../lib/ui/select.js", () => ({
-	select: selectMock,
-}));
+vi.mock("../lib/ui/select.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).uiSelectModuleMock(uiMocks),
+);
 
-vi.mock("../lib/ui/confirm.js", () => ({
-	confirm: confirmMock,
-}));
+vi.mock("../lib/ui/confirm.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).uiConfirmModuleMock(uiMocks),
+);
 
 function createAccounts(): AccountInfo[] {
 	const baseTime = 1_700_000_000_000;

--- a/test/auth-menu-quota-bar.test.ts
+++ b/test/auth-menu-quota-bar.test.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import type { AccountInfo } from "../lib/ui/auth-menu.js";
+import { createUiPromptMocks } from "./helpers/cli-test-fixtures.js";
 import type { MenuItem } from "../lib/ui/select.js";
 import type { AuthMenuAction } from "../lib/ui/auth-menu.js";
 
@@ -13,16 +14,16 @@ import type { AuthMenuAction } from "../lib/ui/auth-menu.js";
 // which avoids guessing the terminal's capabilities. These tests pin each mode so a
 // regression that leaks block glyphs into ascii output is caught.
 
-const selectMock = vi.fn();
-const confirmMock = vi.fn(async () => true);
+const uiMocks = createUiPromptMocks();
+const { select: selectMock, confirm: confirmMock } = uiMocks;
 
-vi.mock("../lib/ui/select.js", () => ({
-	select: selectMock,
-}));
+vi.mock("../lib/ui/select.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).uiSelectModuleMock(uiMocks),
+);
 
-vi.mock("../lib/ui/confirm.js", () => ({
-	confirm: confirmMock,
-}));
+vi.mock("../lib/ui/confirm.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).uiConfirmModuleMock(uiMocks),
+);
 
 const UNICODE_FILL = "█"; // █
 const UNICODE_EMPTY = "▒"; // ▒

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -1,48 +1,46 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexUnavailableError } from "../lib/errors.js";
 import { DEFAULT_MODEL } from "../lib/request/helpers/model-map.js";
+import {
+	createAppBindMocks,
+	createCodexCliStateMocks,
+	createCodexCliWriterMocks,
+	createQuotaCacheMocks,
+	createQuotaProbeMocks,
+	createRefreshQueueMocks,
+	createRuntimeObservabilityMocks,
+	createStorageMocks,
+	createUiPromptMocks,
+	silenceConsole,
+} from "./helpers/cli-test-fixtures.js";
 // quota-probe is mocked below; reference the note as a literal to avoid a
 // top-level import racing the hoisted vi.mock factory.
 const CODEX_UNAVAILABLE_PROBE_NOTE_LITERAL = "Codex not available for this account";
 
-const loadAccountsMock = vi.fn();
-const loadFlaggedAccountsMock = vi.fn();
-const saveAccountsMock = vi.fn();
-const saveFlaggedAccountsMock = vi.fn();
-const setStoragePathMock = vi.fn();
-const getStoragePathMock = vi.fn(() => "/mock/openai-codex-accounts.json");
-const inspectStorageHealthMock = vi.fn();
-const getNamedBackupsMock = vi.fn();
-const restoreAccountsFromBackupMock = vi.fn();
-const queuedRefreshMock = vi.fn();
-const setCodexCliActiveSelectionMock = vi.fn();
-const loadCodexCliStateMock = vi.fn();
+// Shared mock groups (test/helpers/cli-test-fixtures.ts); the vi.mock
+// factories below resolve the helper lazily so hoisting stays safe.
+const storageMocks = createStorageMocks();
+const refreshQueueMocks = createRefreshQueueMocks();
+const quotaProbeMocks = createQuotaProbeMocks();
+const quotaCacheMocks = createQuotaCacheMocks();
+const runtimeObservabilityMocks = createRuntimeObservabilityMocks();
+const appBindMocks = createAppBindMocks();
+const codexCliStateMocks = createCodexCliStateMocks();
+const codexCliWriterMocks = createCodexCliWriterMocks();
+const uiMocks = createUiPromptMocks();
+
 const promptAddAnotherAccountMock = vi.fn();
 const promptLoginModeMock = vi.fn();
-const fetchCodexQuotaSnapshotMock = vi.fn();
 const loadDashboardDisplaySettingsMock = vi.fn();
 const saveDashboardDisplaySettingsMock = vi.fn();
-const loadQuotaCacheMock = vi.fn();
-const saveQuotaCacheMock = vi.fn();
 const loadPluginConfigMock = vi.fn();
 const savePluginConfigMock = vi.fn();
 const getPluginConfigExplainReportMock = vi.fn();
-const loadPersistedRuntimeObservabilitySnapshotMock = vi.fn();
-const bindCodexAppRuntimeRotationMock = vi.fn();
-const getAppBindStatusMock = vi.fn();
-const unbindCodexAppRuntimeRotationMock = vi.fn();
-const selectMock = vi.fn();
-const confirmMock = vi.fn(async () => true);
 const planOcChatgptSyncMock = vi.fn();
 const applyOcChatgptSyncMock = vi.fn();
 const runNamedBackupExportMock = vi.fn();
-const exportNamedBackupMock = vi.fn();
 const promptQuestionMock = vi.fn();
 const detectOcChatgptMultiAuthTargetMock = vi.fn();
-const normalizeAccountStorageMock = vi.fn((value) => value);
-const withAccountStorageTransactionMock = vi.fn();
-const withAccountAndFlaggedStorageTransactionMock = vi.fn();
-const withFlaggedStorageTransactionMock = vi.fn();
 const loggerDebugMock = vi.fn();
 const loggerInfoMock = vi.fn();
 const loggerWarnMock = vi.fn();
@@ -144,16 +142,17 @@ vi.mock("../lib/auth/server.js", () => ({
 	startLocalOAuthServer: vi.fn(),
 }));
 
-vi.mock("../lib/runtime/runtime-observability.js", () => ({
-	loadPersistedRuntimeObservabilitySnapshot:
-		loadPersistedRuntimeObservabilitySnapshotMock,
-}));
+vi.mock("../lib/runtime/runtime-observability.js", async () =>
+	(
+		await import("./helpers/cli-test-fixtures.js")
+	).runtimeObservabilityModuleMock(runtimeObservabilityMocks),
+);
 
-vi.mock("../lib/runtime/app-bind.js", () => ({
-	bindCodexAppRuntimeRotation: bindCodexAppRuntimeRotationMock,
-	getAppBindStatus: getAppBindStatusMock,
-	unbindCodexAppRuntimeRotation: unbindCodexAppRuntimeRotationMock,
-}));
+vi.mock("../lib/runtime/app-bind.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).appBindModuleMock(
+		appBindMocks,
+	),
+);
 
 vi.mock("../lib/cli.js", () => ({
 	promptAddAnotherAccount: promptAddAnotherAccountMock,
@@ -212,59 +211,49 @@ vi.mock("../lib/accounts.js", () => ({
 	),
 }));
 
-vi.mock("../lib/storage.js", async () => {
-	const actual = await vi.importActual("../lib/storage.js");
-	return {
-		...(actual as Record<string, unknown>),
+vi.mock("../lib/storage.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).storageModuleMock({
+		...storageMocks,
 		loadAccounts: async (...args: unknown[]) => {
-			const value = await loadAccountsMock(...args);
+			const value = await storageMocks.loadAccounts(...args);
 			if (value != null) {
 				updateLastAccountStorageSnapshot(value);
 			}
 			return value;
 		},
 		loadFlaggedAccounts: async (...args: unknown[]) => {
-			const value = await loadFlaggedAccountsMock(...args);
+			const value = await storageMocks.loadFlaggedAccounts(...args);
 			if (value != null) {
 				updateLastFlaggedStorageSnapshot(value);
 			}
 			return value;
 		},
-		saveAccounts: saveAccountsMock,
-		saveFlaggedAccounts: saveFlaggedAccountsMock,
-		withAccountAndFlaggedStorageTransaction:
-			withAccountAndFlaggedStorageTransactionMock,
-		withFlaggedStorageTransaction: withFlaggedStorageTransactionMock,
-		withAccountStorageTransaction: withAccountStorageTransactionMock,
-		setStoragePath: setStoragePathMock,
-		getStoragePath: getStoragePathMock,
-		inspectStorageHealth: inspectStorageHealthMock,
-		getNamedBackups: getNamedBackupsMock,
-		restoreAccountsFromBackup: restoreAccountsFromBackupMock,
-		exportNamedBackup: exportNamedBackupMock,
-		normalizeAccountStorage: normalizeAccountStorageMock,
-	};
-});
+	}),
+);
 
-vi.mock("../lib/refresh-queue.js", () => ({
-	queuedRefresh: queuedRefreshMock,
-}));
+vi.mock("../lib/refresh-queue.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).refreshQueueModuleMock(
+		refreshQueueMocks,
+	),
+);
 
-vi.mock("../lib/codex-cli/writer.js", () => ({
-	setCodexCliActiveSelection: setCodexCliActiveSelectionMock,
-}));
+vi.mock("../lib/codex-cli/writer.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).codexCliWriterModuleMock(
+		codexCliWriterMocks,
+	),
+);
 
-vi.mock("../lib/codex-cli/state.js", () => ({
-	getCodexCliAuthPath: vi.fn(() => "/mock/.codex/auth.json"),
-	getCodexCliConfigPath: vi.fn(() => "/mock/.codex/config.toml"),
-	loadCodexCliState: loadCodexCliStateMock,
-}));
+vi.mock("../lib/codex-cli/state.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).codexCliStateModuleMock(
+		codexCliStateMocks,
+	),
+);
 
-vi.mock("../lib/quota-probe.js", async (importOriginal) => ({
-	...(await importOriginal<typeof import("../lib/quota-probe.js")>()),
-	fetchCodexQuotaSnapshot: fetchCodexQuotaSnapshotMock,
-	formatQuotaSnapshotLine: vi.fn(() => "probe-ok"),
-}));
+vi.mock("../lib/quota-probe.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).quotaProbeModuleMock(
+		quotaProbeMocks,
+	),
+);
 
 vi.mock("../lib/dashboard-settings.js", () => ({
 	DEFAULT_DASHBOARD_DISPLAY_SETTINGS: {
@@ -294,18 +283,19 @@ vi.mock("../lib/config.js", async () => {
 	};
 });
 
-vi.mock("../lib/quota-cache.js", () => ({
-	loadQuotaCache: loadQuotaCacheMock,
-	saveQuotaCache: saveQuotaCacheMock,
-}));
+vi.mock("../lib/quota-cache.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).quotaCacheModuleMock(
+		quotaCacheMocks,
+	),
+);
 
-vi.mock("../lib/ui/select.js", () => ({
-	select: selectMock,
-}));
+vi.mock("../lib/ui/select.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).uiSelectModuleMock(uiMocks),
+);
 
-vi.mock("../lib/ui/confirm.js", () => ({
-	confirm: confirmMock,
-}));
+vi.mock("../lib/ui/confirm.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).uiConfirmModuleMock(uiMocks),
+);
 
 vi.mock("../lib/oc-chatgpt-orchestrator.js", () => ({
 	planOcChatgptSync: planOcChatgptSyncMock,
@@ -476,7 +466,7 @@ function getLastLoadedFlaggedSnapshot(): unknown {
 }
 
 async function getCurrentAccountSnapshot(): Promise<unknown> {
-	const current = await loadAccountsMock();
+	const current = await storageMocks.loadAccounts();
 	if (current != null) {
 		updateLastAccountStorageSnapshot(current);
 		return current;
@@ -487,7 +477,7 @@ async function getCurrentAccountSnapshot(): Promise<unknown> {
 }
 
 async function getCurrentFlaggedSnapshot(): Promise<unknown> {
-	const current = await loadFlaggedAccountsMock();
+	const current = await storageMocks.loadFlaggedAccounts();
 	if (current != null) {
 		updateLastFlaggedStorageSnapshot(current);
 		return current;
@@ -597,7 +587,7 @@ function createSettingsStorage(
 
 function setupInteractiveSettingsLogin(storage: SettingsTestStorage): void {
 	setInteractiveTTY(true);
-	loadAccountsMock.mockImplementation(async () => structuredClone(storage));
+	storageMocks.loadAccounts.mockImplementation(async () => structuredClone(storage));
 	promptLoginModeMock
 		.mockResolvedValueOnce({ mode: "settings" })
 		.mockResolvedValueOnce({ mode: "cancel" });
@@ -607,7 +597,7 @@ function queueSettingsSelectSequence(
 	steps: readonly SettingsSelectSequenceStep[],
 ): { remaining: () => number } {
 	const queue = [...steps];
-	selectMock.mockImplementation(async (_items, options) => {
+	uiMocks.select.mockImplementation(async (_items, options) => {
 		const next = queue.shift();
 		if (!next) return { type: "back" };
 		if (typeof next === "function") {
@@ -695,7 +685,7 @@ function createSettingsCancelSequence(
 }
 
 function readSettingsHubPanelContract(): string[] {
-	const items = (selectMock.mock.calls[0]?.[0] ?? []) as SettingsHubMenuItem[];
+	const items = (uiMocks.select.mock.calls[0]?.[0] ?? []) as SettingsHubMenuItem[];
 	return items
 		.filter(
 			(item) => !item.separator && !item.disabled && item.kind !== "heading",
@@ -708,53 +698,53 @@ describe("codex manager cli commands", () => {
 	beforeEach(async () => {
 		vi.resetModules();
 		vi.clearAllMocks();
-		loadAccountsMock.mockReset();
-		loadFlaggedAccountsMock.mockReset();
-		saveAccountsMock.mockReset();
-		saveFlaggedAccountsMock.mockReset();
-		getNamedBackupsMock.mockReset();
-		restoreAccountsFromBackupMock.mockReset();
-		withAccountAndFlaggedStorageTransactionMock.mockReset();
-		withAccountStorageTransactionMock.mockReset();
-		withFlaggedStorageTransactionMock.mockReset();
-		inspectStorageHealthMock.mockReset();
-		queuedRefreshMock.mockReset();
-		setCodexCliActiveSelectionMock.mockReset();
-		loadCodexCliStateMock.mockReset();
+		storageMocks.loadAccounts.mockReset();
+		storageMocks.loadFlaggedAccounts.mockReset();
+		storageMocks.saveAccounts.mockReset();
+		storageMocks.saveFlaggedAccounts.mockReset();
+		storageMocks.getNamedBackups.mockReset();
+		storageMocks.restoreAccountsFromBackup.mockReset();
+		storageMocks.withAccountAndFlaggedStorageTransaction.mockReset();
+		storageMocks.withAccountStorageTransaction.mockReset();
+		storageMocks.withFlaggedStorageTransaction.mockReset();
+		storageMocks.inspectStorageHealth.mockReset();
+		refreshQueueMocks.queuedRefresh.mockReset();
+		codexCliWriterMocks.setCodexCliActiveSelection.mockReset();
+		codexCliStateMocks.loadCodexCliState.mockReset();
 		promptAddAnotherAccountMock.mockReset();
 		promptLoginModeMock.mockReset();
 		promptQuestionMock.mockReset();
-		fetchCodexQuotaSnapshotMock.mockReset();
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockReset();
 		loadDashboardDisplaySettingsMock.mockReset();
 		saveDashboardDisplaySettingsMock.mockReset();
-		loadQuotaCacheMock.mockReset();
-		saveQuotaCacheMock.mockReset();
+		quotaCacheMocks.loadQuotaCache.mockReset();
+		quotaCacheMocks.saveQuotaCache.mockReset();
 		loadPluginConfigMock.mockReset();
 		savePluginConfigMock.mockReset();
-		selectMock.mockReset();
-		loadPersistedRuntimeObservabilitySnapshotMock.mockReset();
-		bindCodexAppRuntimeRotationMock.mockReset();
-		getAppBindStatusMock.mockReset();
-		unbindCodexAppRuntimeRotationMock.mockReset();
-		confirmMock.mockReset();
+		uiMocks.select.mockReset();
+		runtimeObservabilityMocks.loadPersistedRuntimeObservabilitySnapshot.mockReset();
+		appBindMocks.bindCodexAppRuntimeRotation.mockReset();
+		appBindMocks.getAppBindStatus.mockReset();
+		appBindMocks.unbindCodexAppRuntimeRotation.mockReset();
+		uiMocks.confirm.mockReset();
 		planOcChatgptSyncMock.mockReset();
 		applyOcChatgptSyncMock.mockReset();
 		runNamedBackupExportMock.mockReset();
-		exportNamedBackupMock.mockReset();
+		storageMocks.exportNamedBackup.mockReset();
 		detectOcChatgptMultiAuthTargetMock.mockReset();
-		normalizeAccountStorageMock.mockReset();
-		confirmMock.mockResolvedValue(true);
-		fetchCodexQuotaSnapshotMock.mockResolvedValue({
+		storageMocks.normalizeAccountStorage.mockReset();
+		uiMocks.confirm.mockResolvedValue(true);
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValue({
 			status: 200,
 			model: DEFAULT_MODEL,
 			primary: {},
 			secondary: {},
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {},
 		});
-		loadFlaggedAccountsMock.mockResolvedValue({
+		storageMocks.loadFlaggedAccounts.mockResolvedValue({
 			version: 1,
 			accounts: [],
 		});
@@ -768,8 +758,8 @@ describe("codex manager cli commands", () => {
 			version: 1,
 			accounts: [],
 		};
-		loadCodexCliStateMock.mockResolvedValue(null);
-		withAccountStorageTransactionMock.mockImplementation(async (handler) => {
+		codexCliStateMocks.loadCodexCliState.mockResolvedValue(null);
+		storageMocks.withAccountStorageTransaction.mockImplementation(async (handler) => {
 			const current = await getCurrentAccountSnapshot();
 			return handler(
 				current == null
@@ -781,12 +771,12 @@ describe("codex manager cli commands", () => {
 						}
 					: structuredClone(current),
 				async (storage: unknown) => {
-					await saveAccountsMock(storage);
+					await storageMocks.saveAccounts(storage);
 					updateLastAccountStorageSnapshot(storage);
 				},
 			);
 		});
-		withAccountAndFlaggedStorageTransactionMock.mockImplementation(
+		storageMocks.withAccountAndFlaggedStorageTransaction.mockImplementation(
 			async (handler) => {
 				const current = await getCurrentAccountSnapshot();
 				const flaggedCurrent = await getCurrentFlaggedSnapshot();
@@ -812,10 +802,10 @@ describe("codex manager cli commands", () => {
 						const previousSnapshot = structuredClone(snapshot);
 						const previousFlaggedSnapshot = structuredClone(flaggedSnapshot);
 						accountStorageState = structuredClone(storage);
-						await saveAccountsMock(storage);
+						await storageMocks.saveAccounts(storage);
 						try {
 							flaggedStorageState = structuredClone(flaggedStorage);
-							await saveFlaggedAccountsMock(flaggedStorage);
+							await storageMocks.saveFlaggedAccounts(flaggedStorage);
 							snapshot = structuredClone(storage);
 							flaggedSnapshot = structuredClone(flaggedStorage);
 							updateLastAccountStorageSnapshot(snapshot);
@@ -823,7 +813,7 @@ describe("codex manager cli commands", () => {
 						} catch (error) {
 							accountStorageState = structuredClone(previousSnapshot);
 							flaggedStorageState = structuredClone(previousFlaggedSnapshot);
-							await saveAccountsMock(previousSnapshot);
+							await storageMocks.saveAccounts(previousSnapshot);
 							updateLastAccountStorageSnapshot(previousSnapshot);
 							updateLastFlaggedStorageSnapshot(previousFlaggedSnapshot);
 							throw error;
@@ -833,7 +823,7 @@ describe("codex manager cli commands", () => {
 				);
 			},
 		);
-		withFlaggedStorageTransactionMock.mockImplementation(async (handler) => {
+		storageMocks.withFlaggedStorageTransaction.mockImplementation(async (handler) => {
 			const current = await getCurrentFlaggedSnapshot();
 			const snapshot =
 				current == null
@@ -846,7 +836,7 @@ describe("codex manager cli commands", () => {
 				const previousSnapshot = structuredClone(snapshot);
 				flaggedStorageState = structuredClone(storage);
 				try {
-					await saveFlaggedAccountsMock(storage);
+					await storageMocks.saveFlaggedAccounts(storage);
 					updateLastFlaggedStorageSnapshot(storage);
 				} catch (error) {
 					flaggedStorageState = structuredClone(previousSnapshot);
@@ -869,13 +859,13 @@ describe("codex manager cli commands", () => {
 		});
 		loadPluginConfigMock.mockReturnValue({});
 		savePluginConfigMock.mockResolvedValue(undefined);
-		loadPersistedRuntimeObservabilitySnapshotMock.mockResolvedValue(null);
-		bindCodexAppRuntimeRotationMock.mockResolvedValue({
+		runtimeObservabilityMocks.loadPersistedRuntimeObservabilitySnapshot.mockResolvedValue(null);
+		appBindMocks.bindCodexAppRuntimeRotation.mockResolvedValue({
 			message: "Codex app bind unavailable in tests",
 			status: { router: null },
 		});
-		getAppBindStatusMock.mockResolvedValue({ router: null });
-		unbindCodexAppRuntimeRotationMock.mockResolvedValue({
+		appBindMocks.getAppBindStatus.mockResolvedValue({ router: null });
+		appBindMocks.unbindCodexAppRuntimeRotation.mockResolvedValue({
 			message: "Codex app unbind unavailable in tests",
 			status: { router: null },
 		});
@@ -892,13 +882,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		selectMock.mockResolvedValue(undefined);
-		getNamedBackupsMock.mockResolvedValue([]);
+		uiMocks.select.mockResolvedValue(undefined);
+		storageMocks.getNamedBackups.mockResolvedValue([]);
 		restoreTTYDescriptors();
 		setOpenStdinState();
-		setStoragePathMock.mockReset();
-		getStoragePathMock.mockReturnValue("/mock/openai-codex-accounts.json");
-		inspectStorageHealthMock.mockResolvedValue({
+		storageMocks.setStoragePath.mockReset();
+		storageMocks.getStoragePath.mockReturnValue("/mock/openai-codex-accounts.json");
+		storageMocks.inspectStorageHealth.mockResolvedValue({
 			state: "empty",
 			path: "/mock/openai-codex-accounts.json",
 			resetMarkerPath: "/mock/openai-codex-accounts.json.intentional-reset",
@@ -907,7 +897,7 @@ describe("codex manager cli commands", () => {
 			hasWal: false,
 			details: "storage file is missing",
 		});
-		normalizeAccountStorageMock.mockImplementation((value) => value);
+		storageMocks.normalizeAccountStorage.mockImplementation((value) => value);
 
 		const authModule = await import("../lib/auth/auth.js");
 		vi.mocked(authModule.createAuthorizationFlow).mockReset();
@@ -1016,8 +1006,8 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("prints empty account status for auth list", async () => {
-		loadAccountsMock.mockResolvedValueOnce(null);
-		inspectStorageHealthMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce(null);
+		storageMocks.inspectStorageHealth.mockResolvedValueOnce({
 			state: "intentional-reset",
 			path: "/mock/openai-codex-accounts.json",
 			resetMarkerPath: "/mock/openai-codex-accounts.json.intentional-reset",
@@ -1026,7 +1016,7 @@ describe("codex manager cli commands", () => {
 			hasWal: false,
 			details: "intentional reset marker present",
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "list"]);
@@ -1039,13 +1029,13 @@ describe("codex manager cli commands", () => {
 			"Storage: /mock/openai-codex-accounts.json",
 		);
 		expect(logSpy).toHaveBeenCalledWith("Storage health: intentional-reset");
-		expect(setStoragePathMock).toHaveBeenCalledWith(null);
+		expect(storageMocks.setStoragePath).toHaveBeenCalledWith(null);
 	});
 
 	it("prints intentional-reset status with windows-style storage paths", async () => {
-		loadAccountsMock.mockResolvedValueOnce(null);
-		getStoragePathMock.mockReturnValueOnce("C:\\mock\\openai-codex-accounts.json");
-		inspectStorageHealthMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce(null);
+		storageMocks.getStoragePath.mockReturnValueOnce("C:\\mock\\openai-codex-accounts.json");
+		storageMocks.inspectStorageHealth.mockResolvedValueOnce({
 			state: "intentional-reset",
 			path: "C:\\mock\\openai-codex-accounts.json",
 			resetMarkerPath: "C:\\mock\\openai-codex-accounts.json.intentional-reset",
@@ -1054,7 +1044,7 @@ describe("codex manager cli commands", () => {
 			hasWal: false,
 			details: "intentional reset marker present",
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "list"]);
@@ -1080,7 +1070,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1117,7 +1107,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "config", "explain"]);
@@ -1130,7 +1120,7 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("errors for unknown config explain args", async () => {
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1148,7 +1138,7 @@ describe("codex manager cli commands", () => {
 		getPluginConfigExplainReportMock.mockImplementationOnce(() => {
 			throw new Error("busy");
 		});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "config", "explain"]);
@@ -1158,7 +1148,7 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("errors when auth config is missing a subcommand", async () => {
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "config"]);
@@ -1168,7 +1158,7 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("errors for unknown config subcommands", async () => {
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "config", "unknown"]);
@@ -1225,17 +1215,17 @@ describe("codex manager cli commands", () => {
 			preemptiveQuotaRemainingPercent7d: 5,
 			preemptiveQuotaMaxDeferralMs: 7200000,
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [{ refreshToken: "token-1", enabled: true }],
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 		});
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [{ refreshToken: "flagged-1" }],
 		});
-		loadCodexCliStateMock.mockResolvedValueOnce({
+		codexCliStateMocks.loadCodexCliState.mockResolvedValueOnce({
 			path: "/mock/.codex/state.json",
 			accounts: [{ email: "codex@example.com" }],
 			activeEmail: "codex@example.com",
@@ -1243,7 +1233,7 @@ describe("codex manager cli commands", () => {
 			syncVersion: 7,
 			sourceUpdatedAtMs: 1_710_000_000_000,
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1254,7 +1244,7 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(loadCodexCliStateMock).toHaveBeenCalledWith({
+		expect(codexCliStateMocks.loadCodexCliState).toHaveBeenCalledWith({
 			forceRefresh: true,
 		});
 		expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
@@ -1287,27 +1277,27 @@ describe("codex manager cli commands", () => {
 		[
 			"flagged accounts",
 			() =>
-				loadFlaggedAccountsMock.mockRejectedValueOnce(
+				storageMocks.loadFlaggedAccounts.mockRejectedValueOnce(
 					new Error("flagged storage unavailable"),
 				),
 		],
 		[
 			"codex cli state",
 			() =>
-				loadCodexCliStateMock.mockRejectedValueOnce(
+				codexCliStateMocks.loadCodexCliState.mockRejectedValueOnce(
 					new Error("codex cli state unavailable"),
 				),
 		],
 	])("returns an error when debug bundle loading fails for %s", async (_label, primeFailure) => {
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [{ refreshToken: "token-1", enabled: true }],
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 		});
 		primeFailure();
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1325,7 +1315,7 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("rejects unknown debug bundle args", async () => {
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1340,7 +1330,7 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("prints init-config template to stdout by default", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1356,7 +1346,7 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("prints report explain account rows in text mode", async () => {
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -1369,12 +1359,12 @@ describe("codex manager cli commands", () => {
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "invalid_grant",
 			message: "refresh expired",
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1390,7 +1380,7 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("keeps explain output out of json mode", async () => {
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -1403,7 +1393,7 @@ describe("codex manager cli commands", () => {
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1422,7 +1412,7 @@ describe("codex manager cli commands", () => {
 
 	it("prints populated account status for auth status", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1444,13 +1434,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "status"]);
 
 		expect(exitCode).toBe(0);
-		expect(setStoragePathMock).toHaveBeenCalledWith(null);
+		expect(storageMocks.setStoragePath).toHaveBeenCalledWith(null);
 		expect(logSpy).toHaveBeenCalledWith("Accounts (2)");
 		expect(logSpy).toHaveBeenCalledWith(
 			"Storage: /mock/openai-codex-accounts.json",
@@ -1467,7 +1457,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs forecast in json mode", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1488,14 +1478,14 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "forecast", "--json"]);
 		expect(exitCode).toBe(0);
 		expect(errorSpy).not.toHaveBeenCalled();
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
 
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			command: string;
@@ -1511,7 +1501,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs forecast in json explain mode", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1532,8 +1522,8 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1567,7 +1557,7 @@ describe("codex manager cli commands", () => {
 
 	it("prints explain details in text forecast mode", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1588,8 +1578,8 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1613,7 +1603,7 @@ describe("codex manager cli commands", () => {
 
 	it("prints explain details even when recommendation summaries are hidden", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1646,8 +1636,8 @@ describe("codex manager cli commands", () => {
 			menuSortQuickSwitchVisibleRow: true,
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -1669,7 +1659,7 @@ describe("codex manager cli commands", () => {
 
 	it("keeps forecast json explain output isolated across concurrent runs", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1694,7 +1684,7 @@ describe("codex manager cli commands", () => {
 		const logSpy = vi
 			.spyOn(console, "log")
 			.mockImplementation((value?: unknown) => outputs.push(String(value)));
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const [plainExitCode, explainExitCode] = await Promise.all([
@@ -1730,7 +1720,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		};
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1747,8 +1737,8 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
-		saveQuotaCacheMock.mockRejectedValueOnce(
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(originalQuotaCache);
+		quotaCacheMocks.saveQuotaCache.mockRejectedValueOnce(
 			makeErrnoError("save failed", "EBUSY"),
 		);
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
@@ -1767,8 +1757,8 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		});
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				acc_forecast: {
 					updatedAt: expect.any(Number),
@@ -1797,7 +1787,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		};
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1814,8 +1804,8 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(originalQuotaCache);
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5.3-codex",
 			primary: {
@@ -1829,7 +1819,7 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		saveQuotaCacheMock.mockRejectedValueOnce(
+		quotaCacheMocks.saveQuotaCache.mockRejectedValueOnce(
 			makeErrnoError("save failed", "EBUSY"),
 		);
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
@@ -1847,8 +1837,8 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		});
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				acc_forecast: {
 					updatedAt: expect.any(Number),
@@ -1877,7 +1867,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		};
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -1894,8 +1884,8 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(originalQuotaCache);
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5.3-codex",
 			primary: {
@@ -1909,7 +1899,7 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "forecast", "--live"]);
@@ -1919,8 +1909,8 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		});
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				acc_forecast: {
 					updatedAt: expect.any(Number),
@@ -1949,8 +1939,8 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("prints implemented 41-feature matrix", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "features"]);
@@ -1965,8 +1955,8 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("prints auth help when subcommand is --help", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "--help"]);
@@ -1976,40 +1966,40 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("prints best help without mutating storage", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--help"]);
 
 		expect(exitCode).toBe(0);
 		expect(errorSpy).not.toHaveBeenCalled();
-		expect(loadAccountsMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.loadAccounts).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(logSpy.mock.calls[0]?.[0]).toContain("codex-multi-auth best");
 	});
 
 	it("rejects malformed best args before switching accounts", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--model"]);
 
 		expect(exitCode).toBe(1);
 		expect(errorSpy).toHaveBeenCalledWith("Missing value for --model");
-		expect(loadAccountsMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.loadAccounts).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(logSpy.mock.calls[0]?.[0]).toContain("codex-multi-auth best");
 	});
 
 	it("rejects a flag-like value after best --model instead of consuming it", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		// "--model --live" must NOT swallow --live as the model value.
@@ -2022,30 +2012,30 @@ describe("codex manager cli commands", () => {
 
 		expect(exitCode).toBe(1);
 		expect(errorSpy).toHaveBeenCalledWith("Missing value for --model");
-		expect(loadAccountsMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(storageMocks.loadAccounts).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
 		expect(logSpy.mock.calls[0]?.[0]).toContain("codex-multi-auth best");
 	});
 
 	it("rejects unknown best args before switching accounts", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--bogus"]);
 
 		expect(exitCode).toBe(1);
 		expect(errorSpy).toHaveBeenCalledWith("Unknown option: --bogus");
-		expect(loadAccountsMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.loadAccounts).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(logSpy.mock.calls[0]?.[0]).toContain("codex-multi-auth best");
 	});
 
 	it("rejects --model without --live before loading accounts", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -2059,50 +2049,50 @@ describe("codex manager cli commands", () => {
 		expect(errorSpy).toHaveBeenCalledWith(
 			"--model requires --live for codex-multi-auth best",
 		);
-		expect(loadAccountsMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(fetchCodexQuotaSnapshotMock).not.toHaveBeenCalled();
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.loadAccounts).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(logSpy.mock.calls[0]?.[0]).toContain("codex-multi-auth best");
 	});
 
 	it("prints json error when no accounts are configured for best", async () => {
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 			accounts: [],
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--json"]);
 
 		expect(exitCode).toBe(1);
 		expect(errorSpy).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toEqual({
 			error: "No accounts configured.",
 		});
 	});
 
 	it("prints json error when storage is null for best", async () => {
-		loadAccountsMock.mockResolvedValueOnce(null);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		storageMocks.loadAccounts.mockResolvedValueOnce(null);
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--json"]);
 
 		expect(exitCode).toBe(1);
 		expect(errorSpy).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toEqual({
 			error: "No accounts configured.",
 		});
@@ -2110,7 +2100,7 @@ describe("codex manager cli commands", () => {
 
 	it("restores healthy flagged accounts into active storage", async () => {
 		const now = Date.now();
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [
 				{
@@ -2123,8 +2113,8 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadAccountsMock.mockResolvedValueOnce(null);
-		queuedRefreshMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce(null);
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
@@ -2138,9 +2128,9 @@ describe("codex manager cli commands", () => {
 			"--json",
 		]);
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveFlaggedAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveFlaggedAccountsMock).toHaveBeenCalledWith({
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveFlaggedAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveFlaggedAccounts).toHaveBeenCalledWith({
 			version: 1,
 			accounts: [],
 		});
@@ -2156,7 +2146,7 @@ describe("codex manager cli commands", () => {
 			lastUsed: now - 1_000,
 			flaggedAt: now - 5_000,
 		};
-		loadFlaggedAccountsMock
+		storageMocks.loadFlaggedAccounts
 			.mockResolvedValueOnce({
 				version: 1,
 				accounts: [originalFlagged],
@@ -2175,8 +2165,8 @@ describe("codex manager cli commands", () => {
 					},
 				],
 			});
-		loadAccountsMock.mockResolvedValueOnce(null);
-		queuedRefreshMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce(null);
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
@@ -2191,10 +2181,10 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountAndFlaggedStorageTransactionMock).toHaveBeenCalledTimes(
+		expect(storageMocks.withAccountAndFlaggedStorageTransaction).toHaveBeenCalledTimes(
 			1,
 		);
-		expect(saveFlaggedAccountsMock).toHaveBeenCalledWith({
+		expect(storageMocks.saveFlaggedAccounts).toHaveBeenCalledWith({
 			version: 1,
 			accounts: [
 				expect.objectContaining({
@@ -2207,7 +2197,7 @@ describe("codex manager cli commands", () => {
 
 	it("preserves distinct shared-accountId accounts when flagged recovery has no email", async () => {
 		const now = Date.now();
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [
 				{
@@ -2219,7 +2209,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 1,
 			activeIndexByFamily: { codex: 1 },
@@ -2240,7 +2230,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
@@ -2258,10 +2248,10 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountAndFlaggedStorageTransactionMock).toHaveBeenCalledTimes(
+		expect(storageMocks.withAccountAndFlaggedStorageTransaction).toHaveBeenCalledTimes(
 			1,
 		);
-		expect(saveAccountsMock).toHaveBeenCalledWith(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: expect.arrayContaining([
 					expect.objectContaining({ refreshToken: "refresh-alpha" }),
@@ -2274,7 +2264,7 @@ describe("codex manager cli commands", () => {
 
 	it("updates a unique shared-accountId account during flagged recovery when email is missing", async () => {
 		const now = Date.now();
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [
 				{
@@ -2286,7 +2276,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -2299,7 +2289,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
@@ -2317,10 +2307,10 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountAndFlaggedStorageTransactionMock).toHaveBeenCalledTimes(
+		expect(storageMocks.withAccountAndFlaggedStorageTransaction).toHaveBeenCalledTimes(
 			1,
 		);
-		const savedStorage = saveAccountsMock.mock.calls.at(-1)?.[0];
+		const savedStorage = storageMocks.saveAccounts.mock.calls.at(-1)?.[0];
 		expect(savedStorage).toEqual(
 			expect.objectContaining({
 				accounts: [
@@ -2337,7 +2327,7 @@ describe("codex manager cli commands", () => {
 
 	it("preserves org-selected workspace binding during flagged recovery refresh", async () => {
 		const now = Date.now();
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [
 				{
@@ -2351,7 +2341,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -2366,7 +2356,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
@@ -2386,7 +2376,7 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		const savedStorage = saveAccountsMock.mock.calls.at(-1)?.[0] as {
+		const savedStorage = storageMocks.saveAccounts.mock.calls.at(-1)?.[0] as {
 			accounts: Array<{
 				accountId?: string;
 				accountIdSource?: string;
@@ -2405,7 +2395,7 @@ describe("codex manager cli commands", () => {
 
 	it("does not clear an existing workspace binding when flagged recovery refresh has no account id", async () => {
 		const now = Date.now();
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [
 				{
@@ -2417,7 +2407,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -2433,7 +2423,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
@@ -2453,7 +2443,7 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		const savedStorage = saveAccountsMock.mock.calls.at(-1)?.[0] as {
+		const savedStorage = storageMocks.saveAccounts.mock.calls.at(-1)?.[0] as {
 			accounts: Array<{
 				accountId?: string;
 				accountIdSource?: string;
@@ -2474,7 +2464,7 @@ describe("codex manager cli commands", () => {
 
 	it("rolls back active storage when flagged persistence fails during recovery", async () => {
 		const now = Date.now();
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [
 				{
@@ -2487,7 +2477,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -2501,13 +2491,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
 			expires: now + 3_600_000,
 		});
-		saveFlaggedAccountsMock.mockRejectedValueOnce(
+		storageMocks.saveFlaggedAccounts.mockRejectedValueOnce(
 			new Error("flagged write failed"),
 		);
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
@@ -2515,11 +2505,11 @@ describe("codex manager cli commands", () => {
 		await expect(
 			runCodexMultiAuthCli(["auth", "verify-flagged", "--json"]),
 		).rejects.toThrow("flagged write failed");
-		expect(withAccountAndFlaggedStorageTransactionMock).toHaveBeenCalledTimes(
+		expect(storageMocks.withAccountAndFlaggedStorageTransaction).toHaveBeenCalledTimes(
 			1,
 		);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(2);
-		expect(saveAccountsMock.mock.calls[0]?.[0]).toEqual(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(2);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]).toEqual(
 			expect.objectContaining({
 				accounts: expect.arrayContaining([
 					expect.objectContaining({ refreshToken: "refresh-existing" }),
@@ -2527,7 +2517,7 @@ describe("codex manager cli commands", () => {
 				]),
 			}),
 		);
-		expect(saveAccountsMock.mock.calls[1]?.[0]).toEqual(
+		expect(storageMocks.saveAccounts.mock.calls[1]?.[0]).toEqual(
 			expect.objectContaining({
 				accounts: [
 					expect.objectContaining({ refreshToken: "refresh-existing" }),
@@ -2552,13 +2542,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [
 				{
@@ -2571,13 +2561,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
 			expires: now + 3_600_000,
 		});
-		saveFlaggedAccountsMock.mockRejectedValueOnce(
+		storageMocks.saveFlaggedAccounts.mockRejectedValueOnce(
 			new Error("flagged write failed"),
 		);
 
@@ -2592,8 +2582,8 @@ describe("codex manager cli commands", () => {
 				"--json",
 			]),
 		).rejects.toThrow("flagged write failed");
-		expect(withFlaggedStorageTransactionMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(storageMocks.withFlaggedStorageTransaction).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
 		expect(storageState).toEqual(originalStorage);
 	});
 
@@ -2607,7 +2597,7 @@ describe("codex manager cli commands", () => {
 			lastUsed: now - 5_000,
 			flaggedAt: now - 5_000,
 		};
-		loadFlaggedAccountsMock
+		storageMocks.loadFlaggedAccounts
 			.mockResolvedValueOnce({
 				version: 1,
 				accounts: [originalFlagged],
@@ -2626,7 +2616,7 @@ describe("codex manager cli commands", () => {
 					},
 				],
 			});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-restored",
 			refresh: "refresh-restored",
@@ -2642,9 +2632,9 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(withFlaggedStorageTransactionMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(saveFlaggedAccountsMock).toHaveBeenCalledWith(
+		expect(storageMocks.withFlaggedStorageTransaction).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(storageMocks.saveFlaggedAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: expect.arrayContaining([
 					expect.objectContaining({
@@ -2669,7 +2659,7 @@ describe("codex manager cli commands", () => {
 			lastUsed: now - 1_000,
 			flaggedAt: now - 5_000,
 		};
-		loadFlaggedAccountsMock
+		storageMocks.loadFlaggedAccounts
 			.mockResolvedValueOnce({
 				version: 1,
 				accounts: [flaggedAccount],
@@ -2678,13 +2668,13 @@ describe("codex manager cli commands", () => {
 				version: 1,
 				accounts: [flaggedAccount],
 			});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 			accounts: [],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "http_error",
 			statusCode: 401,
@@ -2698,17 +2688,17 @@ describe("codex manager cli commands", () => {
 			"--json",
 		]);
 		expect(exitCode).toBe(0);
-		expect(withAccountAndFlaggedStorageTransactionMock).toHaveBeenCalledTimes(
+		expect(storageMocks.withAccountAndFlaggedStorageTransaction).toHaveBeenCalledTimes(
 			1,
 		);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledWith(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: [],
 			}),
 		);
-		expect(saveFlaggedAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveFlaggedAccountsMock).toHaveBeenCalledWith(
+		expect(storageMocks.saveFlaggedAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveFlaggedAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: [
 					expect.objectContaining({
@@ -2722,7 +2712,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs fix dry-run without persisting changes", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -2735,13 +2725,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "missing_refresh",
 			message: "No refresh token in response or input",
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -2751,7 +2741,7 @@ describe("codex manager cli commands", () => {
 			"--json",
 		]);
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
 
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			command: string;
@@ -2787,7 +2777,7 @@ describe("codex manager cli commands", () => {
 			lastUsed: now - 1_000,
 			enabled: true,
 		};
-		loadAccountsMock
+		storageMocks.loadAccounts
 			.mockResolvedValueOnce({
 				version: 3,
 				activeIndex: 0,
@@ -2800,7 +2790,7 @@ describe("codex manager cli commands", () => {
 				activeIndexByFamily: { codex: 0 },
 				accounts: [originalAccount, concurrentAccount],
 			});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-alpha-refreshed",
 			refresh: "refresh-alpha-next",
@@ -2812,9 +2802,9 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "fix", "--json"]);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledWith(
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: expect.arrayContaining([
 					expect.objectContaining({
@@ -2833,7 +2823,7 @@ describe("codex manager cli commands", () => {
 
 	it("does not persist quota cache during auth fix --dry-run --live", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -2850,7 +2840,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {
@@ -2865,7 +2855,7 @@ describe("codex manager cli commands", () => {
 			},
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
 			"auth",
@@ -2876,8 +2866,8 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(saveQuotaCacheMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(quotaCacheMocks.saveQuotaCache).not.toHaveBeenCalled();
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			dryRun: boolean;
 			liveProbe: boolean;
@@ -2897,7 +2887,7 @@ describe("codex manager cli commands", () => {
 
 	it("persists rotated tokens during auth check and preserves org-selected workspace binding", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -2921,21 +2911,21 @@ describe("codex manager cli commands", () => {
 		extractAccountIdMock.mockImplementation((accessToken?: string) =>
 			accessToken === "access-a-next" ? "token-personal" : "workspace-alpha",
 		);
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-a-next",
 			refresh: "refresh-a-next",
 			expires: now + 3_600_000,
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "check"]);
 		expect(exitCode).toBe(0);
 		expect(logSpy).toHaveBeenCalled();
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		const savedStorage = saveAccountsMock.mock.calls.at(-1)?.[0] as {
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		const savedStorage = storageMocks.saveAccounts.mock.calls.at(-1)?.[0] as {
 			accounts: Array<{ accountId?: string; accountIdSource?: string }>;
 		};
 		expect(savedStorage.accounts[0]).toEqual(
@@ -2944,8 +2934,8 @@ describe("codex manager cli commands", () => {
 				accountIdSource: "org",
 			}),
 		);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "workspace-alpha",
 				accessToken: "access-a-next",
@@ -2957,7 +2947,7 @@ describe("codex manager cli commands", () => {
 
 	it("recomputes live quota fallback state during auth check after refresh changes a shared-workspace email", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -2984,7 +2974,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"owner@example.com": {
@@ -3004,7 +2994,7 @@ describe("codex manager cli commands", () => {
 				},
 			},
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-alpha-refreshed",
 			refresh: "refresh-alpha-next",
@@ -3026,7 +3016,7 @@ describe("codex manager cli commands", () => {
 			if (accessToken === "access-alpha-refreshed") return "owner@example.com";
 			return undefined;
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -3055,25 +3045,25 @@ describe("codex manager cli commands", () => {
 					resetAtMs: now + 4_000,
 				},
 			});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		try {
 			const exitCode = await runCodexMultiAuthCli(["auth", "check"]);
 
 			expect(exitCode).toBe(0);
-			expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-			expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
-			expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-			expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+			expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+			expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(2);
+			expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+			expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 				byAccountId: {},
 				byEmail: {},
 			});
-			expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-			expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts?.[0]?.email).toBe(
+			expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+			expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts?.[0]?.email).toBe(
 				"owner@example.com",
 			);
-			expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+			expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 			expect(
 				logSpy.mock.calls.some((call) =>
 					String(call[0]).includes("Result: 2 Codex available"),
@@ -3089,7 +3079,7 @@ describe("codex manager cli commands", () => {
 
 	it("prunes stale quota email cache entries during auth check after refresh changes a shared-workspace email", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -3116,7 +3106,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"alpha@example.com": {
@@ -3136,7 +3126,7 @@ describe("codex manager cli commands", () => {
 				},
 			},
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-alpha-refreshed",
 			refresh: "refresh-alpha-next",
@@ -3158,7 +3148,7 @@ describe("codex manager cli commands", () => {
 			if (accessToken === "access-alpha-refreshed") return "owner@example.com";
 			return undefined;
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -3193,8 +3183,8 @@ describe("codex manager cli commands", () => {
 			const exitCode = await runCodexMultiAuthCli(["auth", "check"]);
 
 			expect(exitCode).toBe(0);
-			expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-			expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+			expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+			expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 				byAccountId: {},
 				byEmail: {
 					"beta@example.com": {
@@ -3241,7 +3231,7 @@ describe("codex manager cli commands", () => {
 
 	it("treats fresh access tokens as healthy without forcing refresh", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -3258,18 +3248,18 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "check"]);
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(1);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledWith(
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(1);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledWith(
 			expect.objectContaining({ model: DEFAULT_MODEL }),
 		);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 		expect(
 			logSpy.mock.calls.some((call) =>
 				String(call[0]).includes("live session OK"),
@@ -3279,7 +3269,7 @@ describe("codex manager cli commands", () => {
 
 	it("does not label Codex-unavailable live checks as working now", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -3306,14 +3296,14 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-refreshed-unavailable-next",
 			refresh: "refresh-refreshed-unavailable-next",
 			expires: now + 60 * 60 * 1000,
 			idToken: "id-refreshed-unavailable-next",
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockRejectedValueOnce(
 				new CodexUnavailableError(
 					"The requested Codex model is not available for this account.",
@@ -3324,14 +3314,14 @@ describe("codex manager cli commands", () => {
 					"The requested Codex model is not available for this account.",
 				),
 			);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "check"]);
 
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(2);
 		const output = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
 		const unavailableRows = output
 			.split("\n")
@@ -3356,7 +3346,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		};
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -3373,11 +3363,11 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(originalQuotaCache);
 		// Use mockRejectedValue (unbounded) so saveAccountsWithRetry's EBUSY retries
 		// also fail; the test asserts the rejection path and that we never silently
 		// drop the error.
-		saveAccountsMock.mockRejectedValue(makeErrnoError("save failed", "EBUSY"));
+		storageMocks.saveAccounts.mockRejectedValue(makeErrnoError("save failed", "EBUSY"));
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		await expect(runCodexMultiAuthCli(["auth", "check"])).rejects.toMatchObject(
@@ -3388,13 +3378,13 @@ describe("codex manager cli commands", () => {
 		);
 		// saveAccountsWithRetry must have retried beyond a single attempt; if a
 		// regression replaces it with a raw saveAccounts call, this drops to 1.
-		expect(saveAccountsMock.mock.calls.length).toBeGreaterThan(1);
+		expect(storageMocks.saveAccounts.mock.calls.length).toBeGreaterThan(1);
 		expect(originalQuotaCache).toEqual({
 			byAccountId: {},
 			byEmail: {},
 		});
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				acc_live: {
 					updatedAt: expect.any(Number),
@@ -3419,7 +3409,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs fix apply mode and returns a switch recommendation", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -3439,7 +3429,7 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		queuedRefreshMock
+		refreshQueueMocks.queuedRefresh
 			.mockResolvedValueOnce({
 				type: "failed",
 				reason: "http_error",
@@ -3453,14 +3443,14 @@ describe("codex manager cli commands", () => {
 				expires: now + 3_600_000,
 			});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "fix", "--json"]);
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			changed: boolean;
@@ -3495,20 +3485,20 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-best-next",
 			refresh: "refresh-best-next",
 			expires: now + 3_600_000,
 			idToken: "id-best-next",
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {
@@ -3522,24 +3512,24 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--live"]);
 
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(queuedRefreshMock).toHaveBeenCalledWith("refresh-best");
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledWith("refresh-best");
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
 		expect(storageState.activeIndex).toBe(1);
 		expect(storageState.activeIndexByFamily.codex).toBe(1);
 		expect(storageState.accounts[1]?.accessToken).toBe("access-best-next");
 		expect(storageState.accounts[1]?.refreshToken).toBe("refresh-best-next");
 		// extractAccountId is globally mocked to return "acc_test" in this suite.
 		expect(storageState.accounts[1]?.accountId).toBe("acc_test");
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: storageState.accounts[1]?.accountId,
 				email: "best@example.com",
@@ -3556,7 +3546,7 @@ describe("codex manager cli commands", () => {
 
 	it("emits json payload when best live run switches accounts", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -3584,7 +3574,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -3613,9 +3603,9 @@ describe("codex manager cli commands", () => {
 					resetAtMs: now + 2_000,
 				},
 			});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -3626,7 +3616,7 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			message: string;
 			accountIndex: number;
@@ -3671,26 +3661,26 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best"]);
 
 		expect(exitCode).toBe(0);
-		expect(fetchCodexQuotaSnapshotMock).not.toHaveBeenCalled();
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
 		expect(storageState.activeIndex).toBe(1);
 		expect(storageState.activeIndexByFamily.codex).toBe(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "acc_next",
 				email: "next@example.com",
@@ -3737,26 +3727,26 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
 		// First save attempt rejects with EBUSY; second succeeds. Without the
 		// retry wrapper this collapses to a single attempt and the switch fails.
-		saveAccountsMock.mockRejectedValueOnce(makeErrnoError("busy", "EBUSY"));
-		saveAccountsMock.mockImplementationOnce(async (nextStorage) => {
+		storageMocks.saveAccounts.mockRejectedValueOnce(makeErrnoError("busy", "EBUSY"));
+		storageMocks.saveAccounts.mockImplementationOnce(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best"]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(2);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(2);
 		expect(storageState.activeIndex).toBe(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 		expect(logSpy).toHaveBeenCalledWith(
 			expect.stringContaining("Switched to best account 2"),
 		);
@@ -3797,10 +3787,10 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockRejectedValue(makeErrnoError("busy", "EBUSY"));
+		storageMocks.saveAccounts.mockRejectedValue(makeErrnoError("busy", "EBUSY"));
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
@@ -3810,13 +3800,13 @@ describe("codex manager cli commands", () => {
 			},
 		);
 		// Initial attempt + 3 retries = 4 calls before throwing.
-		expect(saveAccountsMock).toHaveBeenCalledTimes(4);
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(4);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 	});
 
 	it("parses --model=value for live best selection", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -3843,7 +3833,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 429,
 				model: "gpt-5-mini",
@@ -3864,7 +3854,7 @@ describe("codex manager cli commands", () => {
 					resetAtMs: now + 2_000,
 				},
 			});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -3875,21 +3865,21 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenNthCalledWith(
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(2);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenNthCalledWith(
 			1,
 			expect.objectContaining({ model: "gpt-5-mini" }),
 		);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenNthCalledWith(
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenNthCalledWith(
 			2,
 			expect.objectContaining({ model: "gpt-5-mini" }),
 		);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps the current account when it is already best and parses --model value", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -3906,7 +3896,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5.1",
 			primary: {
@@ -3920,7 +3910,7 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -3932,11 +3922,11 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledWith(
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledWith(
 			expect.objectContaining({ model: "gpt-5.1" }),
 		);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(
 			logSpy.mock.calls.some((call) =>
 				String(call[0]).includes("Already on best account 1"),
@@ -3961,20 +3951,20 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-best-next",
 			refresh: "refresh-best-next",
 			expires: now + 3_600_000,
 			idToken: "id-best-next",
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {
@@ -3988,18 +3978,18 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--live"]);
 
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
 		expect(storageState.accounts[0]?.accessToken).toBe("access-best-next");
 		expect(storageState.accounts[0]?.refreshToken).toBe("refresh-best-next");
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: storageState.accounts[0]?.accountId,
 				email: "best@example.com",
@@ -4033,20 +4023,20 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-best-next",
 			refresh: "refresh-best-next",
 			expires: now + 3_600_000,
 			idToken: "id-best-next",
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {
@@ -4060,9 +4050,9 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(false);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(false);
+		const logSpy = silenceConsole("log");
+		const warnSpy = silenceConsole("warn");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -4073,8 +4063,8 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: storageState.accounts[0]?.accountId,
 				email: "best@example.com",
@@ -4099,7 +4089,7 @@ describe("codex manager cli commands", () => {
 
 	it("reports 429 pressure when the current best account is delayed by live quota", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4116,7 +4106,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 429,
 			model: "gpt-5-codex",
 			primary: {
@@ -4130,7 +4120,7 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 120_000,
 			},
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -4141,8 +4131,8 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			message: string;
 			accountIndex: number;
@@ -4157,7 +4147,7 @@ describe("codex manager cli commands", () => {
 
 	it("prints live probe notes when best live probes fail", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4174,17 +4164,17 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		fetchCodexQuotaSnapshotMock.mockRejectedValueOnce(
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockRejectedValueOnce(
 			new Error("network timeout"),
 		);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--live"]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(
 			logSpy.mock.calls.some((call) =>
 				String(call[0]).includes("Already on best account 1"),
@@ -4204,7 +4194,7 @@ describe("codex manager cli commands", () => {
 
 	it("prints the friendly codex-unavailable note instead of raw probe detail", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4221,12 +4211,12 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		fetchCodexQuotaSnapshotMock.mockRejectedValueOnce(
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockRejectedValueOnce(
 			new CodexUnavailableError(
 				"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
 			),
 		);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "best", "--live"]);
@@ -4258,13 +4248,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValue({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValue({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {
@@ -4278,7 +4268,7 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValue(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValue(true);
 
 		const refreshDeferred = createDeferred<{
 			type: "success";
@@ -4297,14 +4287,14 @@ describe("codex manager cli commands", () => {
 					idToken: string;
 			  }>
 			| undefined;
-		queuedRefreshMock.mockImplementation(async () => {
+		refreshQueueMocks.queuedRefresh.mockImplementation(async () => {
 			if (!inFlight) {
 				inFlight = refreshNetworkMock();
 			}
 			return inFlight;
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const firstRun = runCodexMultiAuthCli(["auth", "best", "--live", "--json"]);
@@ -4330,13 +4320,13 @@ describe("codex manager cli commands", () => {
 
 		expect(firstExitCode).toBe(0);
 		expect(secondExitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(2);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(2);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(2);
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(2);
 		expect(refreshNetworkMock).toHaveBeenCalledTimes(1);
 		expect(storageState.accounts[0]?.accessToken).toBe("access-best-next");
 		expect(storageState.accounts[0]?.refreshToken).toBe("refresh-best-next");
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(2);
-		for (const call of setCodexCliActiveSelectionMock.mock.calls) {
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(2);
+		for (const call of codexCliWriterMocks.setCodexCliActiveSelection.mock.calls) {
 			expect(call[0]).toEqual(
 				expect.objectContaining({
 					accountId: "acc_test",
@@ -4363,7 +4353,7 @@ describe("codex manager cli commands", () => {
 
 	it("keeps local switch active when Codex auth sync fails", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4379,14 +4369,14 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(false);
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(false);
+		const warnSpy = silenceConsole("warn");
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "switch", "1"]);
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
 		expect(warnSpy).toHaveBeenCalledWith(
 			expect.stringContaining("Codex auth sync did not complete"),
 		);
@@ -4397,7 +4387,7 @@ describe("codex manager cli commands", () => {
 
 	it("refreshes token pair during switch without downgrading an org-selected workspace binding", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4419,22 +4409,22 @@ describe("codex manager cli commands", () => {
 		extractAccountIdMock.mockImplementation((accessToken?: string) =>
 			accessToken === "access-a-next" ? "token-personal" : "workspace-alpha",
 		);
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-a-next",
 			refresh: "refresh-a-next",
 			expires: now + 3_600_000,
 			idToken: "id-a-next",
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "switch", "1"]);
 
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		const savedStorage = saveAccountsMock.mock.calls.at(-1)?.[0] as {
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		const savedStorage = storageMocks.saveAccounts.mock.calls.at(-1)?.[0] as {
 			accounts: Array<{ accountId?: string; accountIdSource?: string }>;
 		};
 		expect(savedStorage.accounts[0]).toEqual(
@@ -4443,7 +4433,7 @@ describe("codex manager cli commands", () => {
 				accountIdSource: "org",
 			}),
 		);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "workspace-alpha",
 				accessToken: "access-a-next",
@@ -4457,7 +4447,7 @@ describe("codex manager cli commands", () => {
 
 	it("warns on switch validation refresh failure and keeps local active index", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4472,21 +4462,21 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "http_error",
 			statusCode: 401,
 			message: "refresh revoked",
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(false);
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(false);
+		const warnSpy = silenceConsole("warn");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "switch", "1"]);
 
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
 		expect(warnSpy).toHaveBeenCalledWith(
 			expect.stringContaining("Switch validation refresh failed"),
 		);
@@ -4497,7 +4487,7 @@ describe("codex manager cli commands", () => {
 
 	it("autoSyncActiveAccountToCodex syncs active account without refresh when access is valid", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4514,7 +4504,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
 		const { autoSyncActiveAccountToCodex } = await import(
 			"../lib/codex-manager.js"
@@ -4522,9 +4512,9 @@ describe("codex manager cli commands", () => {
 		const synced = await autoSyncActiveAccountToCodex();
 
 		expect(synced).toBe(true);
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "acc_a",
 				email: "a@example.com",
@@ -4536,7 +4526,7 @@ describe("codex manager cli commands", () => {
 
 	it("autoSyncActiveAccountToCodex refreshes missing access token while preserving org-selected workspace binding", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4558,14 +4548,14 @@ describe("codex manager cli commands", () => {
 		extractAccountIdMock.mockImplementation((accessToken?: string) =>
 			accessToken === "access-a-next" ? "token-personal" : "workspace-alpha",
 		);
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-a-next",
 			refresh: "refresh-a-next",
 			expires: now + 3_600_000,
 			idToken: "id-a-next",
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
 		const { autoSyncActiveAccountToCodex } = await import(
 			"../lib/codex-manager.js"
@@ -4573,9 +4563,9 @@ describe("codex manager cli commands", () => {
 		const synced = await autoSyncActiveAccountToCodex();
 
 		expect(synced).toBe(true);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		const savedStorage = saveAccountsMock.mock.calls.at(-1)?.[0] as {
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		const savedStorage = storageMocks.saveAccounts.mock.calls.at(-1)?.[0] as {
 			accounts: Array<{ accountId?: string; accountIdSource?: string }>;
 		};
 		expect(savedStorage.accounts[0]).toEqual(
@@ -4584,7 +4574,7 @@ describe("codex manager cli commands", () => {
 				accountIdSource: "org",
 			}),
 		);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "workspace-alpha",
 				accessToken: "access-a-next",
@@ -4598,7 +4588,7 @@ describe("codex manager cli commands", () => {
 
 	it("autoSyncActiveAccountToCodex preserves concurrent storage updates during refresh sync", async () => {
 		const now = Date.now();
-		loadAccountsMock
+		storageMocks.loadAccounts
 			.mockResolvedValueOnce({
 				version: 3,
 				activeIndex: 0,
@@ -4647,14 +4637,14 @@ describe("codex manager cli commands", () => {
 		extractAccountIdMock.mockImplementation((accessToken?: string) =>
 			accessToken === "access-a-next" ? "token-personal" : "workspace-alpha",
 		);
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-a-next",
 			refresh: "refresh-a-next",
 			expires: now + 3_600_000,
 			idToken: "id-a-next",
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
 		const { autoSyncActiveAccountToCodex } = await import(
 			"../lib/codex-manager.js"
@@ -4662,8 +4652,8 @@ describe("codex manager cli commands", () => {
 		const synced = await autoSyncActiveAccountToCodex();
 
 		expect(synced).toBe(true);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
-		const savedStorage = saveAccountsMock.mock.calls.at(-1)?.[0] as {
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
+		const savedStorage = storageMocks.saveAccounts.mock.calls.at(-1)?.[0] as {
 			accounts: Array<{ refreshToken?: string; accountId?: string }>;
 		};
 		expect(savedStorage.accounts).toHaveLength(2);
@@ -4684,7 +4674,7 @@ describe("codex manager cli commands", () => {
 
 	it("autoSyncActiveAccountToCodex skips stale Codex sync when refresh fails", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -4702,7 +4692,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "http_error",
 			statusCode: 401,
@@ -4715,9 +4705,9 @@ describe("codex manager cli commands", () => {
 		const synced = await autoSyncActiveAccountToCodex();
 
 		expect(synced).toBe(false);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 	});
 
 	it("keeps auth login menu open after switch until user cancels", async () => {
@@ -4749,18 +4739,18 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(storage);
-		setCodexCliActiveSelectionMock.mockResolvedValue(true);
+		storageMocks.loadAccounts.mockResolvedValue(storage);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValue(true);
 		promptLoginModeMock
 			.mockResolvedValueOnce({ mode: "manage", switchAccountIndex: 1 })
 			.mockResolvedValueOnce({ mode: "cancel" });
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 		expect(exitCode).toBe(0);
 		expect(promptLoginModeMock).toHaveBeenCalledTimes(2);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
 		expect(logSpy).toHaveBeenCalledWith(
 			expect.stringContaining("Switched to account 2"),
 		);
@@ -4800,10 +4790,10 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock
@@ -4852,18 +4842,18 @@ describe("codex manager cli commands", () => {
 			close: vi.fn(),
 		};
 		startLocalOAuthServerMock.mockResolvedValue(oauthServer);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 		const renderedLogs = logSpy.mock.calls.flat().map((entry) => String(entry));
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(storageState.accounts).toHaveLength(2);
 		expect(storageState.activeIndex).toBe(1);
 		expect(storageState.activeIndexByFamily.codex).toBe(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 		expect(renderedLogs).toContain("Next steps:");
 		expect(renderedLogs).toContain(
 			"  codex-multi-auth status  Check that the wrapper is active.",
@@ -4886,10 +4876,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -4922,7 +4912,7 @@ describe("codex manager cli commands", () => {
 		promptQuestionMock.mockResolvedValueOnce(
 			"http://127.0.0.1:1455/auth/callback?code=oauth-code&state=oauth-state",
 		);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "login", "--manual"]);
@@ -4957,10 +4947,10 @@ describe("codex manager cli commands", () => {
 				activeIndexByFamily: { codex: 0 },
 				accounts: [] as Array<Record<string, unknown>>,
 			};
-			loadAccountsMock.mockImplementation(async () =>
+			storageMocks.loadAccounts.mockImplementation(async () =>
 				structuredClone(storageState),
 			);
-			saveAccountsMock.mockImplementation(async (nextStorage) => {
+			storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 				storageState = structuredClone(nextStorage);
 			});
 			promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -5002,7 +4992,7 @@ describe("codex manager cli commands", () => {
 
 			const browserModule = await import("../lib/auth/browser.js");
 			const serverModule = await import("../lib/auth/server.js");
-			const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+			const logSpy = silenceConsole("log");
 
 			const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 			const exitCode = await runCodexMultiAuthCli([
@@ -5053,7 +5043,7 @@ describe("codex manager cli commands", () => {
 				"https://auth.openai.com/deviceauth/callback",
 			);
 			expect(storageState.accounts).toHaveLength(1);
-			expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+			expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 		},
 	);
 
@@ -5074,10 +5064,10 @@ describe("codex manager cli commands", () => {
 				},
 			] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptAddAnotherAccountMock.mockResolvedValue(false);
@@ -5114,7 +5104,7 @@ describe("codex manager cli commands", () => {
 			idToken: "id-token-device-2",
 			multiAccount: true,
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
@@ -5148,10 +5138,10 @@ describe("codex manager cli commands", () => {
 				},
 			] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptAddAnotherAccountMock.mockResolvedValue(false);
@@ -5183,7 +5173,7 @@ describe("codex manager cli commands", () => {
 		promptQuestionMock.mockResolvedValueOnce(
 			"http://127.0.0.1:1455/auth/callback?code=oauth-code&state=oauth-state",
 		);
-		vi.spyOn(console, "log").mockImplementation(() => {});
+		silenceConsole("log");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "login", "--manual"]);
@@ -5211,7 +5201,7 @@ describe("codex manager cli commands", () => {
 				},
 			] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
 
@@ -5225,8 +5215,8 @@ describe("codex manager cli commands", () => {
 				new Response("user cancelled the request", { status: 400 }),
 			);
 		vi.stubGlobal("fetch", fetchMock);
-		vi.spyOn(console, "log").mockImplementation(() => {});
-		vi.spyOn(console, "error").mockImplementation(() => {});
+		silenceConsole("log");
+		silenceConsole("error");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
@@ -5238,7 +5228,7 @@ describe("codex manager cli commands", () => {
 		expect(exitCode).toBe(0);
 		expect(promptLoginModeMock).not.toHaveBeenCalled();
 		expect(fetchMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
 	});
 
 	it("exits cleanly when --device-auth fills the account pool to MAX_ACCOUNTS", async () => {
@@ -5265,10 +5255,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: seedAccounts as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		// If the test reached this prompt it would mean the cap branch fell
@@ -5309,7 +5299,7 @@ describe("codex manager cli commands", () => {
 			idToken: "id-token-cap",
 			multiAccount: true,
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
@@ -5335,7 +5325,7 @@ describe("codex manager cli commands", () => {
 
 	it("returns a clear failure when --device-auth polling reaches server expiry", async () => {
 		setInteractiveTTY(false);
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -5356,8 +5346,8 @@ describe("codex manager cli commands", () => {
 			)
 			.mockResolvedValueOnce(new Response("", { status: 403 }));
 		vi.stubGlobal("fetch", fetchMock);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
@@ -5372,8 +5362,8 @@ describe("codex manager cli commands", () => {
 		expect(errorSpy).toHaveBeenCalledWith(
 			"Login failed: Device auth timed out after 1 second",
 		);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 	});
 
 	it("honors Retry-After during --device-auth polling before persisting login", async () => {
@@ -5387,10 +5377,10 @@ describe("codex manager cli commands", () => {
 				activeIndexByFamily: { codex: 0 },
 				accounts: [] as Array<Record<string, unknown>>,
 			};
-			loadAccountsMock.mockImplementation(async () =>
+			storageMocks.loadAccounts.mockImplementation(async () =>
 				structuredClone(storageState),
 			);
-			saveAccountsMock.mockImplementation(async (nextStorage) => {
+			storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 				storageState = structuredClone(nextStorage);
 			});
 			promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -5440,7 +5430,7 @@ describe("codex manager cli commands", () => {
 				idToken: "id-token-device",
 				multiAccount: true,
 			});
-			vi.spyOn(console, "log").mockImplementation(() => {});
+			silenceConsole("log");
 
 			const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 			const exitCodePromise = runCodexMultiAuthCli([
@@ -5462,7 +5452,7 @@ describe("codex manager cli commands", () => {
 				"https://auth.openai.com/deviceauth/callback",
 			);
 			expect(storageState.accounts).toHaveLength(1);
-			expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+			expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -5513,13 +5503,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			storageState == null ? null : structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/last-good.json",
 				fileName: "last-good.json",
@@ -5533,15 +5523,15 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now - 60_000,
 			},
 		]);
-		restoreAccountsFromBackupMock.mockResolvedValue(
+		storageMocks.restoreAccountsFromBackup.mockResolvedValue(
 			structuredClone(restoredStorage),
 		);
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
-		selectMock
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("latest");
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const localeSpy = vi
 			.spyOn(Date.prototype, "toLocaleString")
 			.mockReturnValue("Localized Saved Time");
@@ -5551,8 +5541,8 @@ describe("codex manager cli commands", () => {
 			const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 			expect(exitCode).toBe(0);
-			expect(getNamedBackupsMock).toHaveBeenCalled();
-			const signInItems = selectMock.mock.calls[0]?.[0] as Array<{
+			expect(storageMocks.getNamedBackups).toHaveBeenCalled();
+			const signInItems = uiMocks.select.mock.calls[0]?.[0] as Array<{
 				label: string;
 				kind?: string;
 				hint?: string;
@@ -5574,15 +5564,15 @@ describe("codex manager cli commands", () => {
 				hour: "numeric",
 				minute: "2-digit",
 			});
-			expect(restoreAccountsFromBackupMock).toHaveBeenCalledWith(
+			expect(storageMocks.restoreAccountsFromBackup).toHaveBeenCalledWith(
 				"/mock/backups/last-good.json",
 				{ persist: false },
 			);
-			expect(confirmMock).toHaveBeenCalledWith(
+			expect(uiMocks.confirm).toHaveBeenCalledWith(
 				"Load last-good.json (2 accounts)?",
 			);
-			expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-			expect(saveAccountsMock.mock.calls[0]?.[0]).toEqual(
+			expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+			expect(storageMocks.saveAccounts.mock.calls[0]?.[0]).toEqual(
 				expect.objectContaining({
 					activeIndex: 1,
 					activeIndexByFamily: { codex: 1 },
@@ -5594,7 +5584,7 @@ describe("codex manager cli commands", () => {
 					]),
 				}),
 			);
-			expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+			expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 				expect.objectContaining({
 					accountId: "acc_restored",
 					email: "restored@example.com",
@@ -5612,8 +5602,8 @@ describe("codex manager cli commands", () => {
 	it("returns to onboarding when restore mode is back", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);
-		loadAccountsMock.mockResolvedValue(null);
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.loadAccounts.mockResolvedValue(null);
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/latest.json",
 				fileName: "latest.json",
@@ -5621,7 +5611,7 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now,
 			},
 		]);
-		selectMock
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("back")
 			.mockResolvedValueOnce("cancel");
@@ -5630,17 +5620,17 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(restoreAccountsFromBackupMock).not.toHaveBeenCalled();
-		expect(confirmMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(storageMocks.restoreAccountsFromBackup).not.toHaveBeenCalled();
+		expect(uiMocks.confirm).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
 		expect(promptLoginModeMock).not.toHaveBeenCalled();
 	});
 
 	it("returns to the onboarding menu when the manual backup picker is backed out", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);
-		loadAccountsMock.mockResolvedValue(null);
-		getNamedBackupsMock
+		storageMocks.loadAccounts.mockResolvedValue(null);
+		storageMocks.getNamedBackups
 			.mockResolvedValueOnce([
 				{
 					path: "/mock/backups/latest.json",
@@ -5669,7 +5659,7 @@ describe("codex manager cli commands", () => {
 					mtimeMs: now - 60_000,
 				},
 			]);
-		selectMock
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("manual")
 			.mockResolvedValueOnce(null)
@@ -5679,19 +5669,19 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(restoreAccountsFromBackupMock).not.toHaveBeenCalled();
-		expect(confirmMock).not.toHaveBeenCalledWith(
+		expect(storageMocks.restoreAccountsFromBackup).not.toHaveBeenCalled();
+		expect(uiMocks.confirm).not.toHaveBeenCalledWith(
 			"Load manual-choice.json (1 account)?",
 		);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
 		expect(promptLoginModeMock).not.toHaveBeenCalled();
 	});
 
 	it("refreshes the manual backup picker list when onboarding restore is reopened", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);
-		loadAccountsMock.mockResolvedValue(null);
-		getNamedBackupsMock
+		storageMocks.loadAccounts.mockResolvedValue(null);
+		storageMocks.getNamedBackups
 			.mockResolvedValueOnce([
 				{
 					path: "/mock/backups/latest.json",
@@ -5722,7 +5712,7 @@ describe("codex manager cli commands", () => {
 					mtimeMs: now + 60_000,
 				},
 			]);
-		selectMock
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("manual")
 			.mockResolvedValueOnce(null)
@@ -5735,17 +5725,17 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now + 60_000,
 			})
 			.mockResolvedValueOnce("cancel");
-		confirmMock.mockResolvedValueOnce(false);
+		uiMocks.confirm.mockResolvedValueOnce(false);
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(getNamedBackupsMock).toHaveBeenCalledTimes(3);
-		const firstManualPickerItems = selectMock.mock.calls[2]?.[0] as Array<{
+		expect(storageMocks.getNamedBackups).toHaveBeenCalledTimes(3);
+		const firstManualPickerItems = uiMocks.select.mock.calls[2]?.[0] as Array<{
 			label: string;
 		}>;
-		const secondManualPickerItems = selectMock.mock.calls[5]?.[0] as Array<{
+		const secondManualPickerItems = uiMocks.select.mock.calls[5]?.[0] as Array<{
 			label: string;
 		}>;
 		expect(firstManualPickerItems.map((item) => item.label)).toEqual([
@@ -5757,8 +5747,8 @@ describe("codex manager cli commands", () => {
 			"replacement.json",
 			expect.any(String),
 		]);
-		expect(restoreAccountsFromBackupMock).not.toHaveBeenCalled();
-		expect(confirmMock).toHaveBeenCalledWith(
+		expect(storageMocks.restoreAccountsFromBackup).not.toHaveBeenCalled();
+		expect(uiMocks.confirm).toHaveBeenCalledWith(
 			"Load replacement.json (2 accounts)?",
 		);
 	});
@@ -5766,7 +5756,7 @@ describe("codex manager cli commands", () => {
 	it("does not offer backup restore on onboarding when accounts already exist", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);
-		loadAccountsMock
+		storageMocks.loadAccounts
 			.mockResolvedValueOnce({
 				version: 3,
 				activeIndex: 0,
@@ -5808,24 +5798,24 @@ describe("codex manager cli commands", () => {
 
 		expect(exitCode).toBe(0);
 		expect(promptLoginModeMock).toHaveBeenCalledTimes(1);
-		expect(getNamedBackupsMock).not.toHaveBeenCalled();
+		expect(storageMocks.getNamedBackups).not.toHaveBeenCalled();
 	});
 
 	it("warns and falls back to normal sign-in when backup discovery fails in an empty pool", async () => {
 		setInteractiveTTY(true);
-		loadAccountsMock.mockResolvedValue(null);
-		getNamedBackupsMock.mockRejectedValueOnce(
+		storageMocks.loadAccounts.mockResolvedValue(null);
+		storageMocks.getNamedBackups.mockRejectedValueOnce(
 			makeErrnoError("backups directory is locked", "EPERM"),
 		);
-		selectMock.mockResolvedValueOnce("cancel");
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		uiMocks.select.mockResolvedValueOnce("cancel");
+		const warnSpy = silenceConsole("warn");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(getNamedBackupsMock).toHaveBeenCalledTimes(1);
-		const signInItems = selectMock.mock.calls[0]?.[0] as Array<{
+		expect(storageMocks.getNamedBackups).toHaveBeenCalledTimes(1);
+		const signInItems = uiMocks.select.mock.calls[0]?.[0] as Array<{
 			label: string;
 			value?: string;
 		}>;
@@ -5834,7 +5824,7 @@ describe("codex manager cli commands", () => {
 		expect(signInItems.some((item) => item.value === "restore-backup")).toBe(
 			false,
 		);
-		const signInOptions = selectMock.mock.calls[0]?.[1] as {
+		const signInOptions = uiMocks.select.mock.calls[0]?.[1] as {
 			subtitle?: string;
 		};
 		expect(signInOptions.subtitle).toContain(
@@ -5884,13 +5874,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			storageState == null ? null : structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/warn.json",
 				fileName: "warn.json",
@@ -5898,26 +5888,26 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now,
 			},
 		]);
-		restoreAccountsFromBackupMock.mockResolvedValue(
+		storageMocks.restoreAccountsFromBackup.mockResolvedValue(
 			structuredClone(restoredStorage),
 		);
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(false);
-		selectMock
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(false);
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("latest");
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(restoreAccountsFromBackupMock).toHaveBeenCalledWith(
+		expect(storageMocks.restoreAccountsFromBackup).toHaveBeenCalledWith(
 			"/mock/backups/warn.json",
 			{ persist: false },
 		);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "acc_warn",
 				email: "warn@example.com",
@@ -5927,14 +5917,14 @@ describe("codex manager cli commands", () => {
 			expect.stringContaining("Codex auth sync did not complete"),
 		);
 		expect(promptLoginModeMock).toHaveBeenCalledTimes(1);
-		expect(selectMock).toHaveBeenCalledTimes(2);
+		expect(uiMocks.select).toHaveBeenCalledTimes(2);
 	});
 
 	it("keeps the session alive when interactive backup restore fails with EBUSY", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);
-		loadAccountsMock.mockResolvedValue(null);
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.loadAccounts.mockResolvedValue(null);
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "C:/mock/backups/locked.json",
 				fileName: "locked.json",
@@ -5944,24 +5934,24 @@ describe("codex manager cli commands", () => {
 		]);
 		const busyError = new Error("File is busy") as NodeJS.ErrnoException;
 		busyError.code = "EBUSY";
-		restoreAccountsFromBackupMock.mockRejectedValueOnce(busyError);
-		selectMock
+		storageMocks.restoreAccountsFromBackup.mockRejectedValueOnce(busyError);
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("latest")
 			.mockResolvedValueOnce("cancel");
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(restoreAccountsFromBackupMock).toHaveBeenCalledWith(
+		expect(storageMocks.restoreAccountsFromBackup).toHaveBeenCalledWith(
 			"C:/mock/backups/locked.json",
 			{ persist: false },
 		);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
 		expect(promptLoginModeMock).not.toHaveBeenCalled();
-		expect(selectMock).toHaveBeenCalledTimes(3);
+		expect(uiMocks.select).toHaveBeenCalledTimes(3);
 		expect(errorSpy).toHaveBeenCalledWith(
 			"Backup restore failed: File is busy",
 		);
@@ -5970,8 +5960,8 @@ describe("codex manager cli commands", () => {
 	it("prints the storage hint only once when restore fails with StorageError", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);
-		loadAccountsMock.mockResolvedValue(null);
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.loadAccounts.mockResolvedValue(null);
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/locked.json",
 				fileName: "locked.json",
@@ -5986,12 +5976,12 @@ describe("codex manager cli commands", () => {
 			"/mock/backups/locked.json",
 			"File is locked",
 		);
-		restoreAccountsFromBackupMock.mockRejectedValueOnce(busyError);
-		selectMock
+		storageMocks.restoreAccountsFromBackup.mockRejectedValueOnce(busyError);
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("latest")
 			.mockResolvedValueOnce("cancel");
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
@@ -6026,8 +6016,8 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(null);
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.loadAccounts.mockResolvedValue(null);
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/persisted.json",
 				fileName: "persisted.json",
@@ -6035,30 +6025,30 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now,
 			},
 		]);
-		restoreAccountsFromBackupMock.mockResolvedValue(
+		storageMocks.restoreAccountsFromBackup.mockResolvedValue(
 			structuredClone(restoredStorage),
 		);
-		saveAccountsMock.mockRejectedValueOnce(
+		storageMocks.saveAccounts.mockRejectedValueOnce(
 			new Error("save selected account failed"),
 		);
-		selectMock
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("latest")
 			.mockResolvedValueOnce("cancel");
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(restoreAccountsFromBackupMock).toHaveBeenCalledWith(
+		expect(storageMocks.restoreAccountsFromBackup).toHaveBeenCalledWith(
 			"/mock/backups/persisted.json",
 			{ persist: false },
 		);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(promptLoginModeMock).not.toHaveBeenCalled();
-		expect(selectMock).toHaveBeenCalledTimes(3);
+		expect(uiMocks.select).toHaveBeenCalledTimes(3);
 		expect(errorSpy).toHaveBeenCalledWith(
 			"Backup restore failed: save selected account failed",
 		);
@@ -6085,14 +6075,14 @@ describe("codex manager cli commands", () => {
 			],
 		};
 		let storageState: typeof restoredStorage | null = null;
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			storageState == null ? null : structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementationOnce(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementationOnce(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 			throw new Error("save selected account failed");
 		});
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/persisted-after-error.json",
 				fileName: "persisted-after-error.json",
@@ -6100,22 +6090,22 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now,
 			},
 		]);
-		restoreAccountsFromBackupMock.mockResolvedValue(
+		storageMocks.restoreAccountsFromBackup.mockResolvedValue(
 			structuredClone(restoredStorage),
 		);
-		selectMock
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("latest");
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
 		expect(promptLoginModeMock).toHaveBeenCalledTimes(1);
-		expect(selectMock).toHaveBeenCalledTimes(2);
+		expect(uiMocks.select).toHaveBeenCalledTimes(2);
 		expect(errorSpy).toHaveBeenCalledWith(
 			"Backup restore failed: save selected account failed",
 		);
@@ -6124,8 +6114,8 @@ describe("codex manager cli commands", () => {
 	it("does not restore the latest backup when confirmation is declined", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);
-		loadAccountsMock.mockResolvedValueOnce(null).mockResolvedValue(null);
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.loadAccounts.mockResolvedValueOnce(null).mockResolvedValue(null);
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/latest.json",
 				fileName: "latest.json",
@@ -6133,8 +6123,8 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now,
 			},
 		]);
-		confirmMock.mockResolvedValueOnce(false);
-		selectMock
+		uiMocks.confirm.mockResolvedValueOnce(false);
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("latest")
 			.mockResolvedValueOnce("cancel");
@@ -6143,17 +6133,17 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(confirmMock).toHaveBeenCalledWith("Load latest.json (2 accounts)?");
-		expect(restoreAccountsFromBackupMock).not.toHaveBeenCalled();
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(uiMocks.confirm).toHaveBeenCalledWith("Load latest.json (2 accounts)?");
+		expect(storageMocks.restoreAccountsFromBackup).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 	});
 
 	it("does not restore a manually chosen backup when confirmation is declined", async () => {
 		const now = Date.now();
 		setInteractiveTTY(true);
-		loadAccountsMock.mockResolvedValueOnce(null).mockResolvedValue(null);
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.loadAccounts.mockResolvedValueOnce(null).mockResolvedValue(null);
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/manual-choice.json",
 				fileName: "manual-choice.json",
@@ -6161,8 +6151,8 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now,
 			},
 		]);
-		confirmMock.mockResolvedValueOnce(false);
-		selectMock
+		uiMocks.confirm.mockResolvedValueOnce(false);
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("manual")
 			.mockResolvedValueOnce({
@@ -6177,11 +6167,11 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(confirmMock).toHaveBeenCalledWith(
+		expect(uiMocks.confirm).toHaveBeenCalledWith(
 			"Load manual-choice.json (1 account)?",
 		);
-		expect(restoreAccountsFromBackupMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.restoreAccountsFromBackup).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 	});
 
 	it("keeps manual refresh available from the existing-account menu", async () => {
@@ -6204,11 +6194,11 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(storage);
+		storageMocks.loadAccounts.mockResolvedValue(storage);
 		promptLoginModeMock
 			.mockResolvedValueOnce({ mode: "manage", refreshAccountIndex: 0 })
 			.mockResolvedValueOnce({ mode: "cancel" });
-		selectMock.mockResolvedValueOnce("manual");
+		uiMocks.select.mockResolvedValueOnce("manual");
 
 		const authModule = await import("../lib/auth/auth.js");
 		vi.mocked(authModule.createAuthorizationFlow).mockResolvedValueOnce({
@@ -6237,20 +6227,20 @@ describe("codex manager cli commands", () => {
 		promptQuestionMock.mockResolvedValueOnce(
 			"http://127.0.0.1:1455/auth/callback?code=oauth-code&state=oauth-state",
 		);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 		const renderedLogs = logSpy.mock.calls.flat().map((entry) => String(entry));
 
 		expect(exitCode).toBe(0);
-		expect(selectMock).toHaveBeenCalled();
+		expect(uiMocks.select).toHaveBeenCalled();
 		expect(openBrowserUrlMock).not.toHaveBeenCalled();
 		expect(
 			vi.mocked(serverModule.startLocalOAuthServer),
 		).not.toHaveBeenCalled();
 		expect(waitForCodeMock).not.toHaveBeenCalled();
-		const signInItems = selectMock.mock.calls[0]?.[0] as Array<{
+		const signInItems = uiMocks.select.mock.calls[0]?.[0] as Array<{
 			label: string;
 			value?: string;
 		}>;
@@ -6273,15 +6263,15 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
 		promptAddAnotherAccountMock.mockResolvedValue(false);
-		selectMock.mockResolvedValueOnce("browser");
+		uiMocks.select.mockResolvedValueOnce("browser");
 		promptQuestionMock.mockResolvedValueOnce(
 			"http://127.0.0.1:1455/auth/callback?code=oauth-code&state=oauth-state",
 		);
@@ -6330,10 +6320,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -6380,10 +6370,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -6405,7 +6395,7 @@ describe("codex manager cli commands", () => {
 		const openBrowserUrlMock = vi.mocked(browserModule.openBrowserUrl);
 		const serverModule = await import("../lib/auth/server.js");
 
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "login", "--manual"]);
 
@@ -6434,10 +6424,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -6460,7 +6450,7 @@ describe("codex manager cli commands", () => {
 		const openBrowserUrlMock = vi.mocked(browserModule.openBrowserUrl);
 		const serverModule = await import("../lib/auth/server.js");
 
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "login", "--manual"]);
 
@@ -6494,10 +6484,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -6538,10 +6528,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -6588,10 +6578,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -6645,13 +6635,13 @@ describe("codex manager cli commands", () => {
 			],
 		};
 		let storageState: typeof restoredStorage | null = null;
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			storageState == null ? null : structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/latest.json",
 				fileName: "latest.json",
@@ -6665,11 +6655,11 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now - 60_000,
 			},
 		]);
-		restoreAccountsFromBackupMock.mockResolvedValue(
+		storageMocks.restoreAccountsFromBackup.mockResolvedValue(
 			structuredClone(restoredStorage),
 		);
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
-		selectMock
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("manual")
 			.mockResolvedValueOnce({
@@ -6684,16 +6674,16 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(getNamedBackupsMock).toHaveBeenCalledTimes(1);
-		expect(restoreAccountsFromBackupMock).toHaveBeenCalledWith(
+		expect(storageMocks.getNamedBackups).toHaveBeenCalledTimes(1);
+		expect(storageMocks.restoreAccountsFromBackup).toHaveBeenCalledWith(
 			"/mock/backups/manual-choice.json",
 			{ persist: false },
 		);
-		expect(confirmMock).toHaveBeenCalledWith(
+		expect(uiMocks.confirm).toHaveBeenCalledWith(
 			"Load manual-choice.json (1 account)?",
 		);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "acc_manual",
 				email: "manual@example.com",
@@ -6733,13 +6723,13 @@ describe("codex manager cli commands", () => {
 			],
 		};
 		let storageState: typeof restoredStorage | null = null;
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			storageState == null ? null : structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/stale-index.json",
 				fileName: "stale-index.json",
@@ -6747,11 +6737,11 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now,
 			},
 		]);
-		restoreAccountsFromBackupMock.mockResolvedValue(
+		storageMocks.restoreAccountsFromBackup.mockResolvedValue(
 			structuredClone(restoredStorage),
 		);
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
-		selectMock
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
+		uiMocks.select
 			.mockResolvedValueOnce("restore-backup")
 			.mockResolvedValueOnce("latest");
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
@@ -6760,12 +6750,12 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
 		expect(storageState).toMatchObject({
 			activeIndex: 1,
 			activeIndexByFamily: { codex: 1 },
 		});
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "acc_selected",
 				email: "selected@example.com",
@@ -6791,13 +6781,13 @@ describe("codex manager cli commands", () => {
 			}>;
 		} | null = null;
 		setInteractiveTTY(true);
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			storageState == null ? null : structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		getNamedBackupsMock.mockResolvedValue([
+		storageMocks.getNamedBackups.mockResolvedValue([
 			{
 				path: "/mock/backups/latest.json",
 				fileName: "latest.json",
@@ -6805,7 +6795,7 @@ describe("codex manager cli commands", () => {
 				mtimeMs: now,
 			},
 		]);
-		selectMock.mockResolvedValueOnce("browser").mockResolvedValueOnce("cancel");
+		uiMocks.select.mockResolvedValueOnce("browser").mockResolvedValueOnce("cancel");
 		promptAddAnotherAccountMock.mockResolvedValueOnce(true);
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
 
@@ -6844,12 +6834,12 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(getNamedBackupsMock).toHaveBeenCalledTimes(1);
-		const firstSignInItems = selectMock.mock.calls[0]?.[0] as Array<{
+		expect(storageMocks.getNamedBackups).toHaveBeenCalledTimes(1);
+		const firstSignInItems = uiMocks.select.mock.calls[0]?.[0] as Array<{
 			label: string;
 			value?: string;
 		}>;
-		const secondSignInItems = selectMock.mock.calls[1]?.[0] as Array<{
+		const secondSignInItems = uiMocks.select.mock.calls[1]?.[0] as Array<{
 			label: string;
 			value?: string;
 		}>;
@@ -6882,10 +6872,10 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock
@@ -6961,7 +6951,7 @@ describe("codex manager cli commands", () => {
 		]);
 		expect(storageState.activeIndex).toBe(1);
 		expect(storageState.activeIndexByFamily.codex).toBe(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 	});
 
 	it("persists tracked workspaces when logging in with an explicit --org override (#512)", async () => {
@@ -6972,10 +6962,10 @@ describe("codex manager cli commands", () => {
 			activeIndexByFamily: { codex: 0 },
 			accounts: [] as Array<Record<string, unknown>>,
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		// First login starts with an empty pool, so the dashboard menu is
@@ -7073,10 +7063,10 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 		promptLoginModeMock
@@ -7115,7 +7105,7 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(storageState.accounts).toHaveLength(1);
 		expect(storageState.accounts[0]).toEqual(
 			expect.objectContaining({
@@ -7146,23 +7136,23 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(storage);
+		storageMocks.loadAccounts.mockResolvedValue(storage);
 		promptLoginModeMock
 			.mockResolvedValueOnce({ mode: "deep-check" })
 			.mockResolvedValueOnce({ mode: "cancel" });
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-a-next",
 			refresh: "refresh-a-next",
 			expires: now + 7_200_000,
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(3);
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(3);
 		expect(
 			logSpy.mock.calls.some((call) =>
 				String(call[0]).includes("full refresh test"),
@@ -7194,18 +7184,18 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(storage);
+		storageMocks.loadAccounts.mockResolvedValue(storage);
 		promptLoginModeMock
 			.mockResolvedValueOnce({ mode: "deep-check" })
 			.mockResolvedValueOnce({ mode: "cancel" });
 		// Refresh fails transiently (NOT a hard/revoked failure) so the session
 		// stays valid and the account is signed-in-only, not need-re-login.
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "error",
 			reason: "network",
 			message: "temporary network failure",
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
@@ -7238,7 +7228,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(storage);
+		storageMocks.loadAccounts.mockResolvedValue(storage);
 		promptLoginModeMock
 			.mockResolvedValueOnce({ mode: "check" })
 			.mockResolvedValueOnce({ mode: "cancel" });
@@ -7246,13 +7236,13 @@ describe("codex manager cli commands", () => {
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 		expect(exitCode).toBe(0);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(3);
-		expect(queuedRefreshMock).not.toHaveBeenCalled();
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(3);
+		expect(refreshQueueMocks.queuedRefresh).not.toHaveBeenCalled();
 	});
 
 	it("runs verify-flagged from the login menu", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -7269,7 +7259,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadFlaggedAccountsMock.mockResolvedValue({
+		storageMocks.loadFlaggedAccounts.mockResolvedValue({
 			version: 1,
 			accounts: [
 				{
@@ -7285,7 +7275,7 @@ describe("codex manager cli commands", () => {
 		promptLoginModeMock
 			.mockResolvedValueOnce({ mode: "verify-flagged" })
 			.mockResolvedValueOnce({ mode: "cancel" });
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "invalid_grant",
 			message: "token expired",
@@ -7294,16 +7284,16 @@ describe("codex manager cli commands", () => {
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(withAccountAndFlaggedStorageTransactionMock).toHaveBeenCalledTimes(
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountAndFlaggedStorageTransaction).toHaveBeenCalledTimes(
 			1,
 		);
-		expect(saveFlaggedAccountsMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveFlaggedAccounts).toHaveBeenCalledTimes(1);
 	});
 
 	it("auto-refreshes cached limits on menu open", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -7338,9 +7328,9 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				acc_a: {
 					updatedAt: expect.any(Number),
@@ -7365,7 +7355,7 @@ describe("codex manager cli commands", () => {
 
 	it("writes shared workspace quota cache entries by email without reusing bare accountId keys", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -7404,7 +7394,7 @@ describe("codex manager cli commands", () => {
 			menuSortPinCurrent: true,
 			menuSortQuickSwitchVisibleRow: true,
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -7439,9 +7429,9 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(2);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {},
 			byEmail: {
 				"alpha@example.com": {
@@ -7480,7 +7470,7 @@ describe("codex manager cli commands", () => {
 
 	it("writes multi-workspace quota cache entries by accountId when one email spans multiple workspaces", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -7519,7 +7509,7 @@ describe("codex manager cli commands", () => {
 			menuSortPinCurrent: true,
 			menuSortQuickSwitchVisibleRow: true,
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -7554,19 +7544,19 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenNthCalledWith(1, {
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(2);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenNthCalledWith(1, {
 			accountId: "workspace-alpha",
 			accessToken: "access-alpha",
 			model: DEFAULT_MODEL,
 		});
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenNthCalledWith(2, {
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenNthCalledWith(2, {
 			accountId: "workspace-beta",
 			accessToken: "access-beta",
 			model: DEFAULT_MODEL,
 		});
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				"workspace-alpha": {
 					updatedAt: expect.any(Number),
@@ -7605,7 +7595,7 @@ describe("codex manager cli commands", () => {
 
 	it("skips live probe when same-email workspaces still lack stored accountIds", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -7642,7 +7632,7 @@ describe("codex manager cli commands", () => {
 			menuSortPinCurrent: true,
 			menuSortQuickSwitchVisibleRow: true,
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"owner@example.com": {
@@ -7677,8 +7667,8 @@ describe("codex manager cli commands", () => {
 			const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 			expect(exitCode).toBe(0);
-			expect(fetchCodexQuotaSnapshotMock).not.toHaveBeenCalled();
-			expect(saveQuotaCacheMock).not.toHaveBeenCalled();
+			expect(quotaProbeMocks.fetchCodexQuotaSnapshot).not.toHaveBeenCalled();
+			expect(quotaCacheMocks.saveQuotaCache).not.toHaveBeenCalled();
 		} finally {
 			extractAccountIdMock.mockReset();
 			extractAccountIdMock.mockImplementation(() => "acc_test");
@@ -7687,7 +7677,7 @@ describe("codex manager cli commands", () => {
 
 	it("does not reuse email-scoped quota cache entries for mixed same-email accountId rows", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -7725,7 +7715,7 @@ describe("codex manager cli commands", () => {
 			menuSortPinCurrent: true,
 			menuSortQuickSwitchVisibleRow: true,
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"owner@example.com": {
@@ -7752,7 +7742,7 @@ describe("codex manager cli commands", () => {
 			if (accessToken === "access-beta") return "workspace-beta";
 			return "acc_test";
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -7789,9 +7779,9 @@ describe("codex manager cli commands", () => {
 			const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 			expect(exitCode).toBe(0);
-			expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(1);
-			expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-			expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+			expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(1);
+			expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+			expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 				byAccountId: {
 					"workspace-alpha": {
 						updatedAt: expect.any(Number),
@@ -7836,7 +7826,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(storage);
+		storageMocks.loadAccounts.mockResolvedValue(storage);
 		promptLoginModeMock
 			.mockResolvedValueOnce({ mode: "settings" })
 			.mockResolvedValueOnce({ mode: "cancel" });
@@ -7886,7 +7876,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(storage);
+		storageMocks.loadAccounts.mockResolvedValue(storage);
 		loadDashboardDisplaySettingsMock.mockResolvedValue({
 			showPerAccountRows: true,
 			showQuotaDetails: true,
@@ -7899,7 +7889,7 @@ describe("codex manager cli commands", () => {
 			menuSortPinCurrent: true,
 			menuSortQuickSwitchVisibleRow: true,
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"a@example.com": {
@@ -8009,7 +7999,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockResolvedValue(storage);
+		storageMocks.loadAccounts.mockResolvedValue(storage);
 		loadDashboardDisplaySettingsMock.mockResolvedValue({
 			showPerAccountRows: true,
 			showQuotaDetails: true,
@@ -8019,20 +8009,20 @@ describe("codex manager cli commands", () => {
 			menuAutoFetchLimits: false,
 			menuSortEnabled: false,
 		});
-		loadCodexCliStateMock.mockResolvedValue({
+		codexCliStateMocks.loadCodexCliState.mockResolvedValue({
 			path: "/mock/.codex/accounts.json",
 			accounts: [],
 			activeAccountId: "acc_a",
 			activeEmail: "a@example.com",
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValue(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValue(true);
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledWith(
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accountId: "acc_b",
 				email: "b@example.com",
@@ -8042,7 +8032,7 @@ describe("codex manager cli commands", () => {
 			}),
 		);
 		const syncCallOrder =
-			setCodexCliActiveSelectionMock.mock.invocationCallOrder[0];
+			codexCliWriterMocks.setCodexCliActiveSelection.mock.invocationCallOrder[0];
 		const renderCallOrder = promptLoginModeMock.mock.invocationCallOrder[0];
 		expect(syncCallOrder).toBeLessThan(renderCallOrder);
 		const firstCallAccounts = promptLoginModeMock.mock.calls[0]?.[0] as Array<{
@@ -8055,7 +8045,7 @@ describe("codex manager cli commands", () => {
 
 	it("marks runtime in-use account separately from stored selected account", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -8085,7 +8075,7 @@ describe("codex manager cli commands", () => {
 		loadDashboardDisplaySettingsMock.mockResolvedValue(
 			createReadyFirstMenuSettings({ menuSortEnabled: false }),
 		);
-		loadPersistedRuntimeObservabilitySnapshotMock.mockResolvedValue({
+		runtimeObservabilityMocks.loadPersistedRuntimeObservabilitySnapshot.mockResolvedValue({
 			version: 1,
 			updatedAt: now,
 			currentRequestId: null,
@@ -8132,7 +8122,7 @@ describe("codex manager cli commands", () => {
 
 	it("does not mark runtime in-use when helper and app-bind telemetry are unavailable", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -8162,8 +8152,8 @@ describe("codex manager cli commands", () => {
 		loadDashboardDisplaySettingsMock.mockResolvedValue(
 			createReadyFirstMenuSettings({ menuSortEnabled: false }),
 		);
-		loadPersistedRuntimeObservabilitySnapshotMock.mockResolvedValue(null);
-		getAppBindStatusMock.mockResolvedValue({ running: false, router: null });
+		runtimeObservabilityMocks.loadPersistedRuntimeObservabilitySnapshot.mockResolvedValue(null);
+		appBindMocks.getAppBindStatus.mockResolvedValue({ running: false, router: null });
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
@@ -8199,7 +8189,7 @@ describe("codex manager cli commands", () => {
 	it("ignores stale runtime snapshots after the account list changes", async () => {
 		const now = 2_000_000_000;
 		vi.spyOn(Date, "now").mockReturnValue(now);
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -8229,7 +8219,7 @@ describe("codex manager cli commands", () => {
 		loadDashboardDisplaySettingsMock.mockResolvedValue(
 			createReadyFirstMenuSettings({ menuSortEnabled: false }),
 		);
-		loadPersistedRuntimeObservabilitySnapshotMock.mockResolvedValue({
+		runtimeObservabilityMocks.loadPersistedRuntimeObservabilitySnapshot.mockResolvedValue({
 			version: 1,
 			updatedAt: now - 25 * 60 * 60 * 1000,
 			currentRequestId: null,
@@ -8278,7 +8268,7 @@ describe("codex manager cli commands", () => {
 
 	it("keeps ready accounts ahead of degraded limit rows in ready-first sorting", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 3,
 			activeIndexByFamily: { codex: 3 },
@@ -8340,7 +8330,7 @@ describe("codex manager cli commands", () => {
 		loadDashboardDisplaySettingsMock.mockResolvedValue(
 			createReadyFirstMenuSettings(),
 		);
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"cached-limit@example.com": {
@@ -8446,7 +8436,7 @@ describe("codex manager cli commands", () => {
 
 	it("keeps exhausted quota below balanced ready accounts in ready-first sorting", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -8476,7 +8466,7 @@ describe("codex manager cli commands", () => {
 		loadDashboardDisplaySettingsMock.mockResolvedValue(
 			createReadyFirstMenuSettings(),
 		);
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"weekly-empty@example.com": {
@@ -8540,7 +8530,7 @@ describe("codex manager cli commands", () => {
 
 	it("treats missing quota windows as the lowest ready-first floor", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -8570,7 +8560,7 @@ describe("codex manager cli commands", () => {
 		loadDashboardDisplaySettingsMock.mockResolvedValue(
 			createReadyFirstMenuSettings(),
 		);
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"partial-window@example.com": {
@@ -8628,7 +8618,7 @@ describe("codex manager cli commands", () => {
 
 	it("surfaces persisted account rate limits when quota cache is empty", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -8651,7 +8641,7 @@ describe("codex manager cli commands", () => {
 		loadDashboardDisplaySettingsMock.mockResolvedValue(
 			createReadyFirstMenuSettings({ menuAutoFetchLimits: false }),
 		);
-		loadQuotaCacheMock.mockResolvedValue({ byAccountId: {}, byEmail: {} });
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({ byAccountId: {}, byEmail: {} });
 		promptLoginModeMock.mockResolvedValueOnce({ mode: "cancel" });
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
@@ -8670,12 +8660,12 @@ describe("codex manager cli commands", () => {
 		expect(firstCallAccounts[0]?.quota5hResetAtMs).toBe(now + 60_000);
 		expect(firstCallAccounts[0]?.quotaSummary).toBe("rate-limited");
 		expect(firstCallAccounts[0]?.status).toBe("rate-limited");
-		expect(fetchCodexQuotaSnapshotMock).not.toHaveBeenCalled();
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).not.toHaveBeenCalled();
 	});
 
 	it("treats accounts with no quota windows as the lowest ready-first floor", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -8705,7 +8695,7 @@ describe("codex manager cli commands", () => {
 		loadDashboardDisplaySettingsMock.mockResolvedValue(
 			createReadyFirstMenuSettings(),
 		);
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"missing-window@example.com": {
@@ -8785,10 +8775,10 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 
@@ -8835,15 +8825,15 @@ describe("codex manager cli commands", () => {
 				},
 			},
 		};
-		loadQuotaCacheMock.mockImplementation(async () =>
+		quotaCacheMocks.loadQuotaCache.mockImplementation(async () =>
 			structuredClone(quotaCacheState),
 		);
 
 		const releaseFirstRefresh = createDeferred<void>();
-		saveQuotaCacheMock.mockImplementation(async (nextCache) => {
+		quotaCacheMocks.saveQuotaCache.mockImplementation(async (nextCache) => {
 			quotaCacheState = structuredClone(nextCache);
 		});
-		fetchCodexQuotaSnapshotMock.mockImplementation(
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockImplementation(
 			async ({ accountId }: { accountId?: string }) => {
 				if (accountId === "acc_becomes_degraded") {
 					await releaseFirstRefresh.promise;
@@ -8903,7 +8893,7 @@ describe("codex manager cli commands", () => {
 
 				releaseFirstRefresh.resolve();
 				await vi.waitFor(() => {
-					expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+					expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
 				});
 				return { mode: "manage", deleteAccountIndex: 99 };
 			})
@@ -8931,8 +8921,8 @@ describe("codex manager cli commands", () => {
 		expect(exitCode).toBe(0);
 		expect(promptLoginModeMock).toHaveBeenCalledTimes(2);
 		expect(promptCallCount).toBe(2);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(2);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(4);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(2);
 	});
 
 	it("does not let stale refresh completions re-enable the next menu auto-fetch skip", async () => {
@@ -8964,10 +8954,10 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 
@@ -9014,19 +9004,19 @@ describe("codex manager cli commands", () => {
 				},
 			},
 		};
-		loadQuotaCacheMock.mockImplementation(async () =>
+		quotaCacheMocks.loadQuotaCache.mockImplementation(async () =>
 			structuredClone(quotaCacheState),
 		);
 
 		const releaseFirstRefresh = createDeferred<void>();
 		const releaseSecondRefresh = createDeferred<void>();
-		saveQuotaCacheMock.mockImplementation(async (nextCache) => {
+		quotaCacheMocks.saveQuotaCache.mockImplementation(async (nextCache) => {
 			quotaCacheState = structuredClone(nextCache);
 		});
 
 		let degradedProbeCount = 0;
 		let healthyProbeCount = 0;
-		fetchCodexQuotaSnapshotMock.mockImplementation(
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockImplementation(
 			async ({ accountId }: { accountId?: string }) => {
 				if (accountId === "acc_becomes_degraded") {
 					degradedProbeCount += 1;
@@ -9101,7 +9091,7 @@ describe("codex manager cli commands", () => {
 
 				releaseSecondRefresh.resolve();
 				await vi.waitFor(() => {
-					expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
+					expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(4);
 				});
 				return { mode: "cancel" };
 			});
@@ -9111,8 +9101,8 @@ describe("codex manager cli commands", () => {
 
 		expect(exitCode).toBe(0);
 		expect(promptLoginModeMock).toHaveBeenCalledTimes(2);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(2);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(4);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(2);
 	});
 
 	it("does not get stuck skipping menu auto-fetch when quota cache saves fail with EBUSY", async () => {
@@ -9144,10 +9134,10 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
 
@@ -9194,14 +9184,14 @@ describe("codex manager cli commands", () => {
 				},
 			},
 		};
-		loadQuotaCacheMock.mockImplementation(async () =>
+		quotaCacheMocks.loadQuotaCache.mockImplementation(async () =>
 			structuredClone(quotaCacheState),
 		);
 
 		const releaseFirstRefresh = createDeferred<void>();
 		const releaseSecondRefresh = createDeferred<void>();
 		let saveAttemptCount = 0;
-		saveQuotaCacheMock.mockImplementation(async (nextCache) => {
+		quotaCacheMocks.saveQuotaCache.mockImplementation(async (nextCache) => {
 			saveAttemptCount += 1;
 			if (saveAttemptCount === 1) {
 				throw makeErrnoError("quota cache busy", "EBUSY");
@@ -9211,7 +9201,7 @@ describe("codex manager cli commands", () => {
 
 		let degradedProbeCount = 0;
 		let healthyProbeCount = 0;
-		fetchCodexQuotaSnapshotMock.mockImplementation(
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockImplementation(
 			async ({ accountId }: { accountId?: string }) => {
 				if (accountId === "acc_becomes_degraded") {
 					degradedProbeCount += 1;
@@ -9274,7 +9264,7 @@ describe("codex manager cli commands", () => {
 
 				releaseSecondRefresh.resolve();
 				await vi.waitFor(() => {
-					expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
+					expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(4);
 				});
 				return { mode: "cancel" };
 			});
@@ -9284,13 +9274,13 @@ describe("codex manager cli commands", () => {
 
 		expect(exitCode).toBe(0);
 		expect(promptLoginModeMock).toHaveBeenCalledTimes(2);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(4);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(2);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(4);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(2);
 	});
 
 	it("prefers email-scoped quota cache entries for shared workspace accounts", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -9329,7 +9319,7 @@ describe("codex manager cli commands", () => {
 			menuSortPinCurrent: false,
 			menuSortQuickSwitchVisibleRow: true,
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {
 				"shared-workspace": {
 					updatedAt: now,
@@ -9397,7 +9387,7 @@ describe("codex manager cli commands", () => {
 
 	it("prefers accountId-scoped quota cache entries when one email spans multiple workspaces", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -9436,7 +9426,7 @@ describe("codex manager cli commands", () => {
 			menuSortPinCurrent: false,
 			menuSortQuickSwitchVisibleRow: true,
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {
 				"workspace-alpha": {
 					updatedAt: now,
@@ -9508,7 +9498,7 @@ describe("codex manager cli commands", () => {
 
 	it("uses source-number quick switch mapping when visible-row quick switch is disabled", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -9547,7 +9537,7 @@ describe("codex manager cli commands", () => {
 			menuSortPinCurrent: false,
 			menuSortQuickSwitchVisibleRow: false,
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"a@example.com": {
@@ -9603,7 +9593,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs doctor command in json mode", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -9617,7 +9607,7 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "doctor", "--json"]);
@@ -9637,7 +9627,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs doctor command in json mode with malformed token rows", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -9657,7 +9647,7 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "doctor", "--json"]);
@@ -9680,7 +9670,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs doctor --fix in dry-run mode", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 4,
 			activeIndexByFamily: { codex: 4 },
@@ -9704,7 +9694,7 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
 			"auth",
@@ -9715,7 +9705,7 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			fix: {
 				enabled: boolean;
@@ -9753,22 +9743,22 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-doctor-next",
 			refresh: "refresh-doctor-next",
 			expires: now + 3_600_000,
 			idToken: "id-doctor-next",
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
 			"auth",
@@ -9778,9 +9768,9 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).toHaveBeenCalledTimes(1);
 		expect(storageState.activeIndex).toBe(1);
 		expect(storageState.activeIndexByFamily.codex).toBe(1);
 		expect(storageState.accounts[1]?.enabled).toBe(true);
@@ -9850,20 +9840,20 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock
+		storageMocks.loadAccounts
 			.mockResolvedValueOnce(structuredClone(initialStorage))
 			.mockImplementation(async () => structuredClone(storageState));
-		saveAccountsMock.mockImplementation(async (nextStorage) => {
+		storageMocks.saveAccounts.mockImplementation(async (nextStorage) => {
 			storageState = structuredClone(nextStorage);
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "doctor-access-next",
 			refresh: "doctor-refresh-next",
 			expires: now + 3_600_000,
 			idToken: "doctor-id-next",
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
@@ -9874,9 +9864,9 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock).toHaveBeenCalledWith(
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledWith(
 			expect.objectContaining({
 				accounts: expect.arrayContaining([
 					expect.objectContaining({
@@ -9896,7 +9886,7 @@ describe("codex manager cli commands", () => {
 
 	it("skips doctor --fix Codex sync when active refresh fails", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -9914,14 +9904,14 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "http_error",
 			statusCode: 401,
 			message: "refresh expired",
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
 			"auth",
@@ -9931,9 +9921,9 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(withAccountStorageTransactionMock).not.toHaveBeenCalled();
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(storageMocks.withAccountStorageTransaction).not.toHaveBeenCalled();
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			checks: Array<{ key: string; severity: string; message: string }>;
 			fix: {
@@ -9977,20 +9967,20 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		saveAccountsMock.mockRejectedValueOnce(
+		storageMocks.saveAccounts.mockRejectedValueOnce(
 			new Error("transaction save failed"),
 		);
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-doctor-next",
 			refresh: "refresh-doctor-next",
 			expires: now + 3_600_000,
 			idToken: "id-doctor-next",
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
 
 		const originalStorage = structuredClone(storageState);
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
@@ -9998,14 +9988,14 @@ describe("codex manager cli commands", () => {
 		await expect(
 			runCodexMultiAuthCli(["auth", "doctor", "--fix", "--json"]),
 		).rejects.toThrow("transaction save failed");
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		expect(storageState).toEqual(originalStorage);
 	});
 
 	it("dispatches why-selected --json command", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -10027,7 +10017,7 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
 			"auth",
@@ -10048,7 +10038,7 @@ describe("codex manager cli commands", () => {
 	});
 
 	it("dispatches verify --paths --json command", async () => {
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
 			"auth",
@@ -10078,7 +10068,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs report command in json mode", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -10100,7 +10090,7 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "report", "--json"]);
 
@@ -10139,7 +10129,7 @@ describe("codex manager cli commands", () => {
 
 	it("reports normalized model routing and capabilities for remapped report probes", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -10154,7 +10144,7 @@ describe("codex manager cli commands", () => {
 			],
 		});
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
 			"auth",
@@ -10210,19 +10200,19 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		};
-		loadAccountsMock.mockImplementation(async () =>
+		storageMocks.loadAccounts.mockImplementation(async () =>
 			structuredClone(storageState),
 		);
-		loadQuotaCacheMock.mockResolvedValue({ byAccountId: {}, byEmail: {} });
-		saveQuotaCacheMock.mockResolvedValue(undefined);
-		queuedRefreshMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({ byAccountId: {}, byEmail: {} });
+		quotaCacheMocks.saveQuotaCache.mockResolvedValue(undefined);
+		refreshQueueMocks.queuedRefresh.mockResolvedValue({
 			type: "success",
 			access: "access-probe-refresh",
 			refresh: "refresh-probe-refresh",
 			expires: now + 7_200_000,
 			idToken: "id-probe-refresh",
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValue({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValue({
 			status: 200,
 			model: "gpt-5.4-mini",
 			primary: {
@@ -10236,10 +10226,10 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		setCodexCliActiveSelectionMock.mockResolvedValue(true);
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValue(true);
+		const logSpy = silenceConsole("log");
+		const warnSpy = silenceConsole("warn");
+		const errorSpy = silenceConsole("error");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const commands = [
 			["auth", "report", "--live", "--json", "--model", "gpt-5.4-mini-high"],
@@ -10249,12 +10239,12 @@ describe("codex manager cli commands", () => {
 		];
 
 		for (const command of commands) {
-			fetchCodexQuotaSnapshotMock.mockClear();
+			quotaProbeMocks.fetchCodexQuotaSnapshot.mockClear();
 			const exitCode = await runCodexMultiAuthCli(command);
 
 			expect(exitCode).toBe(0);
-			expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalled();
-			for (const [request] of fetchCodexQuotaSnapshotMock.mock.calls) {
+			expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalled();
+			for (const [request] of quotaProbeMocks.fetchCodexQuotaSnapshot.mock.calls) {
 				expect(request).toMatchObject({ model: "gpt-5.4-mini" });
 			}
 		}
@@ -10392,7 +10382,7 @@ describe("codex manager cli commands", () => {
 		expect(selectSequence.remaining()).toBe(0);
 		expect(planOcChatgptSyncMock).toHaveBeenCalledOnce();
 		expect(applyOcChatgptSyncMock).toHaveBeenCalledOnce();
-		expect(selectMock).toHaveBeenCalledWith(
+		expect(uiMocks.select).toHaveBeenCalledWith(
 			expect.arrayContaining([
 				expect.objectContaining({
 					label: expect.stringContaining(
@@ -10607,7 +10597,7 @@ describe("codex manager cli commands", () => {
 				resolution: "accounts",
 			},
 		});
-		normalizeAccountStorageMock.mockReturnValue({
+		storageMocks.normalizeAccountStorage.mockReturnValue({
 			version: 3,
 			accounts: [],
 			activeIndex: 0,
@@ -11124,7 +11114,7 @@ describe("codex manager cli commands", () => {
 					refresh: string;
 					expires: number;
 				}>();
-				queuedRefreshMock.mockImplementation(
+				refreshQueueMocks.queuedRefresh.mockImplementation(
 					async () => refreshDeferred.promise,
 				);
 				queueMicrotask(() => {
@@ -11247,7 +11237,7 @@ describe("codex manager cli commands", () => {
 			retryAfterMs: 1,
 		});
 		saveDashboardDisplaySettingsMock.mockRejectedValue(rateLimitError);
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = silenceConsole("warn");
 
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
@@ -11370,7 +11360,7 @@ describe("codex manager cli commands", () => {
 
 	it("keeps last account enabled during fix to avoid lockout", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -11384,19 +11374,19 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "http_error",
 			statusCode: 401,
 			message: "unauthorized",
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "fix", "--json"]);
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts?.[0]?.enabled).toBe(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts?.[0]?.enabled).toBe(
 			true,
 		);
 
@@ -11409,7 +11399,7 @@ describe("codex manager cli commands", () => {
 
 	it("runs live fix path with probe success and probe fallback warning", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -11436,13 +11426,13 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-live-warn-next",
 			refresh: "refresh-live-warn-next",
 			expires: now + 7_200_000,
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -11459,7 +11449,7 @@ describe("codex manager cli commands", () => {
 			})
 			.mockRejectedValueOnce(new Error("live probe temporary failure"));
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 		const exitCode = await runCodexMultiAuthCli([
 			"auth",
@@ -11469,9 +11459,9 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(2);
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
 
 		const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
 			reports: Array<{ outcome: string; message: string }>;
@@ -11501,7 +11491,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		};
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -11518,14 +11508,14 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
-		queuedRefreshMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(originalQuotaCache);
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-live-fix-next",
 			refresh: "refresh-live-fix-next",
 			expires: now + 7_200_000,
 		});
-		saveAccountsMock.mockRejectedValueOnce(
+		storageMocks.saveAccounts.mockRejectedValueOnce(
 			makeErrnoError("save failed", "EBUSY"),
 		);
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
@@ -11540,7 +11530,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		});
-		expect(saveQuotaCacheMock).not.toHaveBeenCalled();
+		expect(quotaCacheMocks.saveQuotaCache).not.toHaveBeenCalled();
 	});
 
 	it("does not mutate loaded quota cache when live fix display save fails", async () => {
@@ -11549,7 +11539,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		};
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -11566,8 +11556,8 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(originalQuotaCache);
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {
@@ -11581,7 +11571,7 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		saveQuotaCacheMock.mockRejectedValueOnce(
+		quotaCacheMocks.saveQuotaCache.mockRejectedValueOnce(
 			makeErrnoError("save failed", "EBUSY"),
 		);
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
@@ -11596,9 +11586,9 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		});
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				acc_live_fix: {
 					updatedAt: expect.any(Number),
@@ -11632,7 +11622,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		};
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -11651,14 +11641,14 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-live-fix-fresh",
 			refresh: "refresh-live-fix-next",
 			expires: now + 60 * 60 * 1000,
 		});
-		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(originalQuotaCache);
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: { usedPercent: 35, windowMinutes: 300, resetAtMs: now + 1_000 },
@@ -11668,9 +11658,9 @@ describe("codex manager cli commands", () => {
 		const ebusy = Object.assign(new Error("EBUSY: resource busy"), {
 			code: "EBUSY",
 		});
-		saveQuotaCacheMock.mockRejectedValueOnce(ebusy);
+		quotaCacheMocks.saveQuotaCache.mockRejectedValueOnce(ebusy);
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "fix", "--live", "--json"]);
@@ -11682,8 +11672,8 @@ describe("codex manager cli commands", () => {
 		// downgraded the run to partial-success. saveAccounts is called from
 		// inside withAccountStorageTransaction, which runs strictly before
 		// saveQuotaCache. Asserting both call counts pins that ordering.
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		const persistedAccounts = saveAccountsMock.mock.calls[0]?.[0] as {
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		const persistedAccounts = storageMocks.saveAccounts.mock.calls[0]?.[0] as {
 			accounts: Array<{ accessToken?: string; refreshToken?: string }>;
 		};
 		expect(persistedAccounts.accounts[0]?.accessToken).toBe(
@@ -11692,7 +11682,7 @@ describe("codex manager cli commands", () => {
 		expect(persistedAccounts.accounts[0]?.refreshToken).toBe(
 			"refresh-live-fix-next",
 		);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
 
 		// JSON payload surfaces the cache save error so callers can act on it.
 		const firstCall = logSpy.mock.calls[0]?.[0];
@@ -11710,7 +11700,7 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		};
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -11727,8 +11717,8 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValueOnce(originalQuotaCache);
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(originalQuotaCache);
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {
@@ -11742,7 +11732,7 @@ describe("codex manager cli commands", () => {
 				resetAtMs: now + 2_000,
 			},
 		});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli(["auth", "fix", "--live"]);
@@ -11752,9 +11742,9 @@ describe("codex manager cli commands", () => {
 			byAccountId: {},
 			byEmail: {},
 		});
-		expect(saveAccountsMock).not.toHaveBeenCalled();
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(storageMocks.saveAccounts).not.toHaveBeenCalled();
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				acc_live_fix: {
 					updatedAt: expect.any(Number),
@@ -11784,7 +11774,7 @@ describe("codex manager cli commands", () => {
 
 	it("recomputes live quota fallback state after refresh changes a shared-workspace email", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -11811,7 +11801,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"owner@example.com": {
@@ -11831,7 +11821,7 @@ describe("codex manager cli commands", () => {
 				},
 			},
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-alpha-refreshed",
 			refresh: "refresh-alpha-next",
@@ -11854,7 +11844,7 @@ describe("codex manager cli commands", () => {
 				return undefined;
 			},
 		);
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -11883,7 +11873,7 @@ describe("codex manager cli commands", () => {
 					resetAtMs: now + 4_000,
 				},
 			});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -11894,15 +11884,15 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(2);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {},
 			byEmail: {},
 		});
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts?.[0]?.email).toBe(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts?.[0]?.email).toBe(
 			"owner@example.com",
 		);
 
@@ -11916,7 +11906,7 @@ describe("codex manager cli commands", () => {
 
 	it("prunes stale quota email cache entries during auth fix after refresh changes a shared-workspace email", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -11943,7 +11933,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"alpha@example.com": {
@@ -11963,7 +11953,7 @@ describe("codex manager cli commands", () => {
 				},
 			},
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-alpha-refreshed",
 			refresh: "refresh-alpha-next",
@@ -11985,7 +11975,7 @@ describe("codex manager cli commands", () => {
 			if (accessToken === "access-alpha-refreshed") return "owner@example.com";
 			return undefined;
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -12014,7 +12004,7 @@ describe("codex manager cli commands", () => {
 					resetAtMs: now + 4_000,
 				},
 			});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		try {
@@ -12026,8 +12016,8 @@ describe("codex manager cli commands", () => {
 			]);
 
 			expect(exitCode).toBe(0);
-			expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-			expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+			expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+			expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 				byAccountId: {},
 				byEmail: {
 					"beta@example.com": {
@@ -12081,7 +12071,7 @@ describe("codex manager cli commands", () => {
 
 	it("recomputes live quota fallback state after refresh changes accountId for the same email", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -12108,7 +12098,7 @@ describe("codex manager cli commands", () => {
 				},
 			],
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
 			byAccountId: {},
 			byEmail: {
 				"owner@example.com": {
@@ -12128,7 +12118,7 @@ describe("codex manager cli commands", () => {
 				},
 			},
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-alpha-refreshed",
 			refresh: "refresh-alpha-next",
@@ -12151,7 +12141,7 @@ describe("codex manager cli commands", () => {
 				return undefined;
 			},
 		);
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockResolvedValueOnce({
 				status: 200,
 				model: "gpt-5-codex",
@@ -12180,7 +12170,7 @@ describe("codex manager cli commands", () => {
 					resetAtMs: now + 4_000,
 				},
 			});
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = silenceConsole("log");
 		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
 
 		const exitCode = await runCodexMultiAuthCli([
@@ -12191,10 +12181,10 @@ describe("codex manager cli commands", () => {
 		]);
 
 		expect(exitCode).toBe(0);
-		expect(queuedRefreshMock).toHaveBeenCalledTimes(1);
-		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledTimes(2);
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
-		expect(saveQuotaCacheMock).toHaveBeenCalledWith({
+		expect(refreshQueueMocks.queuedRefresh).toHaveBeenCalledTimes(1);
+		expect(quotaProbeMocks.fetchCodexQuotaSnapshot).toHaveBeenCalledTimes(2);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledWith({
 			byAccountId: {
 				"workspace-alpha": {
 					updatedAt: expect.any(Number),
@@ -12231,8 +12221,8 @@ describe("codex manager cli commands", () => {
 			},
 			byEmail: {},
 		});
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts?.[0]?.accountId).toBe(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts?.[0]?.accountId).toBe(
 			"workspace-alpha",
 		);
 
@@ -12246,7 +12236,7 @@ describe("codex manager cli commands", () => {
 
 	it("deletes an account from manage mode and persists storage", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 1,
 			activeIndexByFamily: { codex: 1 },
@@ -12282,23 +12272,23 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts).toHaveLength(2);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts?.[0]?.email).toBe(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts).toHaveLength(2);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts?.[0]?.email).toBe(
 			"first@example.com",
 		);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts?.[1]?.email).toBe(
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts?.[1]?.email).toBe(
 			"third@example.com",
 		);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.activeIndex).toBe(1);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.activeIndex).toBe(1);
 		expect(
-			saveAccountsMock.mock.calls[0]?.[0]?.activeIndexByFamily?.codex,
+			storageMocks.saveAccounts.mock.calls[0]?.[0]?.activeIndexByFamily?.codex,
 		).toBe(1);
 	});
 
 	it("preserves the active selection when deleting a different account", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 2,
 			activeIndexByFamily: { codex: 2 },
@@ -12334,17 +12324,17 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts).toHaveLength(2);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.activeIndex).toBe(1);
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts).toHaveLength(2);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.activeIndex).toBe(1);
 		expect(
-			saveAccountsMock.mock.calls[0]?.[0]?.activeIndexByFamily?.codex,
+			storageMocks.saveAccounts.mock.calls[0]?.[0]?.activeIndexByFamily?.codex,
 		).toBe(1);
 	});
 
 	it("toggles account enabled state from manage mode", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
@@ -12366,15 +12356,15 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
-		expect(saveAccountsMock.mock.calls[0]?.[0]?.accounts?.[0]?.enabled).toBe(
+		expect(storageMocks.saveAccounts).toHaveBeenCalledTimes(1);
+		expect(storageMocks.saveAccounts.mock.calls[0]?.[0]?.accounts?.[0]?.enabled).toBe(
 			false,
 		);
 	});
 
 	it("keeps settings unchanged in non-interactive mode and returns to menu", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValue(
+		storageMocks.loadAccounts.mockResolvedValue(
 			createSettingsStorage(now, {
 				email: "non-tty@example.com",
 				accountId: "acc_non_tty",
@@ -12390,7 +12380,7 @@ describe("codex manager cli commands", () => {
 		const exitCode = await runCodexMultiAuthCli(["auth", "login"]);
 
 		expect(exitCode).toBe(0);
-		expect(selectMock).not.toHaveBeenCalled();
+		expect(uiMocks.select).not.toHaveBeenCalled();
 		expect(saveDashboardDisplaySettingsMock).not.toHaveBeenCalled();
 		expect(savePluginConfigMock).not.toHaveBeenCalled();
 	});

--- a/test/codex-manager-uninstall-dispatch.test.ts
+++ b/test/codex-manager-uninstall-dispatch.test.ts
@@ -25,13 +25,11 @@ vi.mock("../lib/codex-manager/commands/uninstall.js", () => ({
 
 const clearAccountsSpy = vi.fn(async () => undefined);
 
-vi.mock("../lib/storage.js", async () => {
-	const actual = await vi.importActual("../lib/storage.js");
-	return {
-		...(actual as Record<string, unknown>),
+vi.mock("../lib/storage.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).storageModuleMock({
 		clearAccounts: clearAccountsSpy,
-	};
-});
+	}),
+);
 
 beforeEach(() => {
 	captured.length = 0;

--- a/test/helpers/cli-test-fixtures.ts
+++ b/test/helpers/cli-test-fixtures.ts
@@ -74,6 +74,10 @@ export type StorageMocks = ReturnType<typeof createStorageMocks>;
 export async function storageModuleMock(
 	overrides: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
+	// Resolved relative to test/helpers/ (this file), so it is "../../lib"
+	// here while callers register vi.mock with "../lib" relative to test/.
+	// Vitest canonicalises both to the same module; if this helper moves,
+	// update these specifiers together with the doc comments above.
 	const actual = await vi.importActual<Record<string, unknown>>(
 		"../../lib/storage.js",
 	);
@@ -115,6 +119,7 @@ export type QuotaProbeMocks = ReturnType<typeof createQuotaProbeMocks>;
 export async function quotaProbeModuleMock(
 	overrides: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
+	// Same test/helpers/-relative resolution note as storageModuleMock above.
 	const actual = await vi.importActual<Record<string, unknown>>(
 		"../../lib/quota-probe.js",
 	);

--- a/test/helpers/cli-test-fixtures.ts
+++ b/test/helpers/cli-test-fixtures.ts
@@ -1,0 +1,317 @@
+import { vi } from "vitest";
+import type { MockInstance } from "vitest";
+import type { AccountStorageV3 } from "../../lib/storage.js";
+
+/**
+ * Shared mock factories for the codex-manager CLI suites (audit roadmap
+ * §4.4.2). The manager suites used to duplicate 40+ module-level `vi.fn()`
+ * declarations plus near-identical `vi.mock()` module shapes for storage,
+ * refresh-queue, quota probe/cache, runtime observability, app bind, the
+ * Codex CLI state/writer and the select/confirm UI prompts. Each
+ * `create*Mocks()` factory below returns the per-suite mock instances and the
+ * matching `*ModuleMock()` builds the module shape for `vi.mock()`.
+ *
+ * Hoisting contract: `vi.mock()` calls are hoisted above imports, so the
+ * factory passed to `vi.mock()` must not capture static import bindings of
+ * this module at hoist time. The safe pattern (used by every migrated suite)
+ * keeps the mock instances in a module-level const and resolves this helper
+ * lazily inside the factory:
+ *
+ *	const storageMocks = createStorageMocks();
+ *	vi.mock("../lib/storage.js", async () =>
+ *		(await import("./helpers/cli-test-fixtures.js")).storageModuleMock(
+ *			storageMocks,
+ *		),
+ *	);
+ *
+ * The factory body only runs when the mocked module is first imported (after
+ * the test module finished evaluating), so both the dynamic import and the
+ * `storageMocks` const are initialized by then.
+ */
+
+/** Pick a subset of a mock group so a suite only overrides what it used to. */
+export function pickMocks<T extends object, K extends keyof T>(
+	mocks: T,
+	keys: readonly K[],
+): Pick<T, K> {
+	const picked = {} as Pick<T, K>;
+	for (const key of keys) {
+		picked[key] = mocks[key];
+	}
+	return picked;
+}
+
+// ---------------------------------------------------------------------------
+// lib/storage.js
+// ---------------------------------------------------------------------------
+
+export function createStorageMocks() {
+	return {
+		loadAccounts: vi.fn(),
+		loadFlaggedAccounts: vi.fn(),
+		saveAccounts: vi.fn(),
+		saveFlaggedAccounts: vi.fn(),
+		setStoragePath: vi.fn(),
+		getStoragePath: vi.fn(() => "/mock/openai-codex-accounts.json"),
+		inspectStorageHealth: vi.fn(),
+		getNamedBackups: vi.fn(),
+		restoreAccountsFromBackup: vi.fn(),
+		exportNamedBackup: vi.fn(),
+		normalizeAccountStorage: vi.fn((value: unknown) => value),
+		withAccountStorageTransaction: vi.fn(),
+		withAccountAndFlaggedStorageTransaction: vi.fn(),
+		withFlaggedStorageTransaction: vi.fn(),
+	};
+}
+
+export type StorageMocks = ReturnType<typeof createStorageMocks>;
+
+/**
+ * Module shape for `vi.mock("../lib/storage.js", ...)`: the actual module
+ * spread plus the given overrides (typically a `createStorageMocks()` result,
+ * optionally narrowed via `pickMocks` or extended with wrapped functions).
+ */
+export async function storageModuleMock(
+	overrides: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const actual = await vi.importActual<Record<string, unknown>>(
+		"../../lib/storage.js",
+	);
+	return { ...actual, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// lib/refresh-queue.js
+// ---------------------------------------------------------------------------
+
+export function createRefreshQueueMocks() {
+	return {
+		queuedRefresh: vi.fn(),
+	};
+}
+
+export type RefreshQueueMocks = ReturnType<typeof createRefreshQueueMocks>;
+
+export function refreshQueueModuleMock(
+	mocks: RefreshQueueMocks,
+): Record<string, unknown> {
+	return { queuedRefresh: mocks.queuedRefresh };
+}
+
+// ---------------------------------------------------------------------------
+// lib/quota-probe.js
+// ---------------------------------------------------------------------------
+
+export function createQuotaProbeMocks() {
+	return {
+		fetchCodexQuotaSnapshot: vi.fn(),
+		formatQuotaSnapshotLine: vi.fn(() => "probe-ok"),
+	};
+}
+
+export type QuotaProbeMocks = ReturnType<typeof createQuotaProbeMocks>;
+
+/** Actual quota-probe module spread plus the given overrides. */
+export async function quotaProbeModuleMock(
+	overrides: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const actual = await vi.importActual<Record<string, unknown>>(
+		"../../lib/quota-probe.js",
+	);
+	return { ...actual, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// lib/quota-cache.js
+// ---------------------------------------------------------------------------
+
+export function createQuotaCacheMocks() {
+	return {
+		loadQuotaCache: vi.fn(),
+		saveQuotaCache: vi.fn(),
+	};
+}
+
+export type QuotaCacheMocks = ReturnType<typeof createQuotaCacheMocks>;
+
+export function quotaCacheModuleMock(
+	mocks: QuotaCacheMocks,
+): Record<string, unknown> {
+	return {
+		loadQuotaCache: mocks.loadQuotaCache,
+		saveQuotaCache: mocks.saveQuotaCache,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// lib/runtime/runtime-observability.js
+// ---------------------------------------------------------------------------
+
+export function createRuntimeObservabilityMocks() {
+	return {
+		loadPersistedRuntimeObservabilitySnapshot: vi.fn(),
+	};
+}
+
+export type RuntimeObservabilityMocks = ReturnType<
+	typeof createRuntimeObservabilityMocks
+>;
+
+export function runtimeObservabilityModuleMock(
+	mocks: RuntimeObservabilityMocks,
+): Record<string, unknown> {
+	return {
+		loadPersistedRuntimeObservabilitySnapshot:
+			mocks.loadPersistedRuntimeObservabilitySnapshot,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// lib/runtime/app-bind.js
+// ---------------------------------------------------------------------------
+
+export function createAppBindMocks() {
+	return {
+		bindCodexAppRuntimeRotation: vi.fn(),
+		getAppBindStatus: vi.fn(),
+		unbindCodexAppRuntimeRotation: vi.fn(),
+	};
+}
+
+export type AppBindMocks = ReturnType<typeof createAppBindMocks>;
+
+export function appBindModuleMock(
+	mocks: AppBindMocks,
+): Record<string, unknown> {
+	return {
+		bindCodexAppRuntimeRotation: mocks.bindCodexAppRuntimeRotation,
+		getAppBindStatus: mocks.getAppBindStatus,
+		unbindCodexAppRuntimeRotation: mocks.unbindCodexAppRuntimeRotation,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// lib/codex-cli/state.js
+// ---------------------------------------------------------------------------
+
+export function createCodexCliStateMocks(
+	paths: { authPath?: string; configPath?: string } = {},
+) {
+	const authPath = paths.authPath ?? "/mock/.codex/auth.json";
+	const configPath = paths.configPath ?? "/mock/.codex/config.toml";
+	return {
+		getCodexCliAuthPath: vi.fn(() => authPath),
+		getCodexCliConfigPath: vi.fn(() => configPath),
+		loadCodexCliState: vi.fn(),
+	};
+}
+
+export type CodexCliStateMocks = ReturnType<typeof createCodexCliStateMocks>;
+
+export function codexCliStateModuleMock(
+	mocks: CodexCliStateMocks,
+): Record<string, unknown> {
+	return {
+		getCodexCliAuthPath: mocks.getCodexCliAuthPath,
+		getCodexCliConfigPath: mocks.getCodexCliConfigPath,
+		loadCodexCliState: mocks.loadCodexCliState,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// lib/codex-cli/writer.js
+// ---------------------------------------------------------------------------
+
+export function createCodexCliWriterMocks() {
+	return {
+		setCodexCliActiveSelection: vi.fn(),
+	};
+}
+
+export type CodexCliWriterMocks = ReturnType<typeof createCodexCliWriterMocks>;
+
+export function codexCliWriterModuleMock(
+	mocks: CodexCliWriterMocks,
+): Record<string, unknown> {
+	return { setCodexCliActiveSelection: mocks.setCodexCliActiveSelection };
+}
+
+// ---------------------------------------------------------------------------
+// lib/ui/select.js + lib/ui/confirm.js
+// ---------------------------------------------------------------------------
+
+export function createUiPromptMocks() {
+	return {
+		select: vi.fn(),
+		confirm: vi.fn(async () => true),
+	};
+}
+
+export type UiPromptMocks = ReturnType<typeof createUiPromptMocks>;
+
+export function uiSelectModuleMock(
+	mocks: UiPromptMocks,
+): Record<string, unknown> {
+	return { select: mocks.select };
+}
+
+export function uiConfirmModuleMock(
+	mocks: UiPromptMocks,
+): Record<string, unknown> {
+	return { confirm: mocks.confirm };
+}
+
+// ---------------------------------------------------------------------------
+// stdout/stderr capture
+// ---------------------------------------------------------------------------
+
+/**
+ * Spy on a console method and silence it — the inline
+ * `vi.spyOn(console, "log").mockImplementation(() => {})` pattern duplicated
+ * across the manager suites. Restored by each suite's `vi.restoreAllMocks()`.
+ */
+export function silenceConsole(
+	method: "log" | "error" | "warn",
+): MockInstance<(...args: unknown[]) => void> {
+	return vi.spyOn(console, method).mockImplementation(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Minimal AccountStorageV3 fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal stored-account fixture. Only the fields a test cares about need to
+ * be provided; pass the result through `accountStorageV3Fixture` (which uses
+ * the repo's sanctioned `as never` minimal-fixture cast) where a full
+ * `AccountStorageV3` is required.
+ */
+export function storageAccountFixture(
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	const now = Date.now();
+	return {
+		refreshToken: "refresh-test",
+		addedAt: now,
+		lastUsed: now,
+		...overrides,
+	};
+}
+
+/**
+ * Minimal `AccountStorageV3` fixture builder. Accounts may be minimal
+ * partials (see `storageAccountFixture`); the single `as never` cast below is
+ * the repo's sanctioned escape hatch for minimal fixtures.
+ */
+export function accountStorageV3Fixture(
+	accounts: ReadonlyArray<Record<string, unknown>> = [],
+	overrides: Record<string, unknown> = {},
+): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { codex: 0 },
+		accounts,
+		...overrides,
+	} as never;
+}

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -2,6 +2,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { RepairCommandDeps } from "../lib/codex-manager/repair-commands.js";
 import { CodexUnavailableError } from "../lib/errors.js";
+import {
+	createCodexCliStateMocks,
+	createCodexCliWriterMocks,
+	createQuotaCacheMocks,
+	createQuotaProbeMocks,
+	createRefreshQueueMocks,
+	createRuntimeObservabilityMocks,
+	createStorageMocks,
+	pickMocks,
+	silenceConsole,
+} from "./helpers/cli-test-fixtures.js";
 // Note: do not statically import from ../lib/quota-probe.js here — it is mocked
 // below via vi.mock and a top-level import would race the hoisted factory.
 const CODEX_UNAVAILABLE_PROBE_NOTE = "Codex not available for this account";
@@ -26,24 +37,28 @@ const sanitizeEmailMock = vi.fn((email: string | undefined) =>
 	typeof email === "string" ? email.toLowerCase() : undefined,
 );
 
-const loadQuotaCacheMock = vi.fn();
-const saveQuotaCacheMock = vi.fn();
-const fetchCodexQuotaSnapshotMock = vi.fn();
-const queuedRefreshMock = vi.fn();
-
-const loadAccountsMock = vi.fn();
-const loadFlaggedAccountsMock = vi.fn();
-const setStoragePathMock = vi.fn();
-const getStoragePathMock = vi.fn(() => "/mock/openai-codex-accounts.json");
-const withAccountStorageTransactionMock = vi.fn();
-const withAccountAndFlaggedStorageTransactionMock = vi.fn();
-const withFlaggedStorageTransactionMock = vi.fn();
-
-const getCodexCliAuthPathMock = vi.fn(() => "/mock/auth.json");
-const getCodexCliConfigPathMock = vi.fn(() => "/mock/config.toml");
-const loadCodexCliStateMock = vi.fn();
-const setCodexCliActiveSelectionMock = vi.fn();
-const loadPersistedRuntimeObservabilitySnapshotMock = vi.fn();
+// Shared mock groups (test/helpers/cli-test-fixtures.ts); the vi.mock
+// factories below resolve the helper lazily so hoisting stays safe. Storage is
+// narrowed to the exact set this suite used to override so every other
+// storage export stays the actual implementation.
+const quotaCacheMocks = createQuotaCacheMocks();
+const quotaProbeMocks = createQuotaProbeMocks();
+const refreshQueueMocks = createRefreshQueueMocks();
+const storageMocks = pickMocks(createStorageMocks(), [
+	"loadAccounts",
+	"loadFlaggedAccounts",
+	"setStoragePath",
+	"getStoragePath",
+	"withAccountStorageTransaction",
+	"withAccountAndFlaggedStorageTransaction",
+	"withFlaggedStorageTransaction",
+]);
+const codexCliStateMocks = createCodexCliStateMocks({
+	authPath: "/mock/auth.json",
+	configPath: "/mock/config.toml",
+});
+const codexCliWriterMocks = createCodexCliWriterMocks();
+const runtimeObservabilityMocks = createRuntimeObservabilityMocks();
 
 vi.mock("node:fs", () => ({
 	existsSync: existsSyncMock,
@@ -66,49 +81,47 @@ vi.mock("../lib/accounts.js", () => ({
 	sanitizeEmail: sanitizeEmailMock,
 }));
 
-vi.mock("../lib/quota-cache.js", () => ({
-	loadQuotaCache: loadQuotaCacheMock,
-	saveQuotaCache: saveQuotaCacheMock,
-}));
+vi.mock("../lib/quota-cache.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).quotaCacheModuleMock(
+		quotaCacheMocks,
+	),
+);
 
-vi.mock("../lib/quota-probe.js", async (importOriginal) => ({
-	...(await importOriginal<typeof import("../lib/quota-probe.js")>()),
-	fetchCodexQuotaSnapshot: fetchCodexQuotaSnapshotMock,
-}));
+vi.mock("../lib/quota-probe.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).quotaProbeModuleMock({
+		fetchCodexQuotaSnapshot: quotaProbeMocks.fetchCodexQuotaSnapshot,
+	}),
+);
 
-vi.mock("../lib/refresh-queue.js", () => ({
-	queuedRefresh: queuedRefreshMock,
-}));
+vi.mock("../lib/refresh-queue.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).refreshQueueModuleMock(
+		refreshQueueMocks,
+	),
+);
 
-vi.mock("../lib/storage.js", async () => {
-	const actual = await vi.importActual("../lib/storage.js");
-	return {
-		...(actual as Record<string, unknown>),
-		loadAccounts: loadAccountsMock,
-		loadFlaggedAccounts: loadFlaggedAccountsMock,
-		setStoragePath: setStoragePathMock,
-		getStoragePath: getStoragePathMock,
-		withAccountStorageTransaction: withAccountStorageTransactionMock,
-		withAccountAndFlaggedStorageTransaction:
-			withAccountAndFlaggedStorageTransactionMock,
-		withFlaggedStorageTransaction: withFlaggedStorageTransactionMock,
-	};
-});
+vi.mock("../lib/storage.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).storageModuleMock(
+		storageMocks,
+	),
+);
 
-vi.mock("../lib/codex-cli/state.js", () => ({
-	getCodexCliAuthPath: getCodexCliAuthPathMock,
-	getCodexCliConfigPath: getCodexCliConfigPathMock,
-	loadCodexCliState: loadCodexCliStateMock,
-}));
+vi.mock("../lib/codex-cli/state.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).codexCliStateModuleMock(
+		codexCliStateMocks,
+	),
+);
 
-vi.mock("../lib/codex-cli/writer.js", () => ({
-	setCodexCliActiveSelection: setCodexCliActiveSelectionMock,
-}));
+vi.mock("../lib/codex-cli/writer.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).codexCliWriterModuleMock(
+		codexCliWriterMocks,
+	),
+);
 
-vi.mock("../lib/runtime/runtime-observability.js", () => ({
-	loadPersistedRuntimeObservabilitySnapshot:
-		loadPersistedRuntimeObservabilitySnapshotMock,
-}));
+vi.mock("../lib/runtime/runtime-observability.js", async () =>
+	(
+		await import("./helpers/cli-test-fixtures.js")
+	).runtimeObservabilityModuleMock(runtimeObservabilityMocks),
+);
 
 const {
 	runDoctor,
@@ -146,11 +159,11 @@ describe("repair-commands direct deps coverage", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		existsSyncMock.mockReturnValue(false);
-		loadQuotaCacheMock.mockResolvedValue(null);
-		loadCodexCliStateMock.mockResolvedValue(null);
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue(null);
+		codexCliStateMocks.loadCodexCliState.mockResolvedValue(null);
 		extractAccountEmailMock.mockReturnValue(undefined);
 		extractAccountIdMock.mockReturnValue(undefined);
-		loadPersistedRuntimeObservabilitySnapshotMock.mockResolvedValue(null);
+		runtimeObservabilityMocks.loadPersistedRuntimeObservabilitySnapshot.mockResolvedValue(null);
 		evaluateForecastAccountsMock.mockImplementation(() => []);
 		recommendForecastAccountMock.mockReturnValue({
 			recommendedIndex: null,
@@ -204,11 +217,11 @@ describe("repair-commands direct deps coverage", () => {
 		};
 		let persistedFlaggedStorage: unknown;
 
-		loadFlaggedAccountsMock.mockResolvedValue({
+		storageMocks.loadFlaggedAccounts.mockResolvedValue({
 			version: 1,
 			accounts: [structuredClone(flaggedAccount)],
 		});
-		queuedRefreshMock.mockResolvedValue({
+		refreshQueueMocks.queuedRefresh.mockResolvedValue({
 			type: "success",
 			access: "fresh-access",
 			refresh: "fresh-refresh",
@@ -217,7 +230,7 @@ describe("repair-commands direct deps coverage", () => {
 		});
 		extractAccountEmailMock.mockReturnValue("Recovered@example.com");
 		extractAccountIdMock.mockReturnValue("token-account");
-		withFlaggedStorageTransactionMock.mockImplementation(async (handler) =>
+		storageMocks.withFlaggedStorageTransaction.mockImplementation(async (handler) =>
 			handler(
 				{ version: 1, accounts: [structuredClone(flaggedAccount)] },
 				async (nextStorage: unknown) => {
@@ -229,7 +242,7 @@ describe("repair-commands direct deps coverage", () => {
 			accountId: "resolved-account",
 			accountIdSource: "token" as const,
 		}));
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runVerifyFlagged(
 			["--json", "--no-restore"],
@@ -242,7 +255,7 @@ describe("repair-commands direct deps coverage", () => {
 			"manual",
 			"token-account",
 		);
-		expect(withFlaggedStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withFlaggedStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(persistedFlaggedStorage).toMatchObject({
 			version: 1,
 			accounts: [
@@ -263,9 +276,9 @@ describe("repair-commands direct deps coverage", () => {
 	});
 
 	it("runVerifyFlagged keeps remainingFlagged in the JSON schema for empty and no-op paths", async () => {
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [],
 		});
@@ -293,11 +306,11 @@ describe("repair-commands direct deps coverage", () => {
 			lastError: "still broken",
 			lastUsed: 1,
 		};
-		loadFlaggedAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadFlaggedAccounts.mockResolvedValueOnce({
 			version: 1,
 			accounts: [structuredClone(flaggedAccount)],
 		});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "failed",
 			reason: "revoked",
 			message: "still broken",
@@ -309,7 +322,7 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(0);
-		expect(withFlaggedStorageTransactionMock).not.toHaveBeenCalled();
+		expect(storageMocks.withFlaggedStorageTransaction).not.toHaveBeenCalled();
 		expect(
 			JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")),
 		).toMatchObject({
@@ -333,11 +346,11 @@ describe("repair-commands direct deps coverage", () => {
 		};
 		const persistSpy = vi.fn();
 
-		loadFlaggedAccountsMock.mockResolvedValue({
+		storageMocks.loadFlaggedAccounts.mockResolvedValue({
 			version: 1,
 			accounts: [structuredClone(flaggedAccount)],
 		});
-		queuedRefreshMock.mockResolvedValue({
+		refreshQueueMocks.queuedRefresh.mockResolvedValue({
 			type: "success",
 			access: "fresh-access",
 			refresh: "fresh-refresh",
@@ -346,7 +359,7 @@ describe("repair-commands direct deps coverage", () => {
 		});
 		extractAccountEmailMock.mockReturnValue("flagged@example.com");
 		extractAccountIdMock.mockReturnValue("token-account");
-		withAccountAndFlaggedStorageTransactionMock.mockImplementation(async (handler) =>
+		storageMocks.withAccountAndFlaggedStorageTransaction.mockImplementation(async (handler) =>
 			handler(
 				null,
 				persistSpy,
@@ -361,7 +374,7 @@ describe("repair-commands direct deps coverage", () => {
 				},
 			),
 		);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runVerifyFlagged(
 			["--json"],
@@ -369,7 +382,7 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountAndFlaggedStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountAndFlaggedStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(persistSpy).not.toHaveBeenCalled();
 		expect(
 			JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")),
@@ -400,11 +413,11 @@ describe("repair-commands direct deps coverage", () => {
 		};
 		const persistSpy = vi.fn();
 
-		loadFlaggedAccountsMock.mockResolvedValue({
+		storageMocks.loadFlaggedAccounts.mockResolvedValue({
 			version: 1,
 			accounts: [structuredClone(flaggedAccount)],
 		});
-		queuedRefreshMock.mockResolvedValue({
+		refreshQueueMocks.queuedRefresh.mockResolvedValue({
 			type: "success",
 			access: "fresh-access",
 			refresh: "fresh-refresh",
@@ -413,7 +426,7 @@ describe("repair-commands direct deps coverage", () => {
 		});
 		extractAccountEmailMock.mockReturnValue("flagged@example.com");
 		extractAccountIdMock.mockReturnValue("token-account");
-		withFlaggedStorageTransactionMock.mockImplementation(async (handler) =>
+		storageMocks.withFlaggedStorageTransaction.mockImplementation(async (handler) =>
 			handler(
 				{
 					version: 1,
@@ -427,7 +440,7 @@ describe("repair-commands direct deps coverage", () => {
 				persistSpy,
 			),
 		);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runVerifyFlagged(
 			["--json", "--no-restore"],
@@ -435,7 +448,7 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(0);
-		expect(withFlaggedStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withFlaggedStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(persistSpy).not.toHaveBeenCalled();
 		expect(
 			JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")),
@@ -497,8 +510,8 @@ describe("repair-commands direct deps coverage", () => {
 		};
 		let persistedAccountStorage: unknown;
 
-		loadAccountsMock.mockResolvedValue(structuredClone(prescanStorage));
-		queuedRefreshMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue(structuredClone(prescanStorage));
+		refreshQueueMocks.queuedRefresh.mockResolvedValue({
 			type: "success",
 			access: "new-access",
 			refresh: "new-refresh",
@@ -507,7 +520,7 @@ describe("repair-commands direct deps coverage", () => {
 		});
 		extractAccountEmailMock.mockReturnValue("fresh@example.com");
 		extractAccountIdMock.mockReturnValue("token-account");
-		withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+		storageMocks.withAccountStorageTransaction.mockImplementation(async (handler) =>
 			handler(structuredClone(inTransactionStorage), async (nextStorage: unknown) => {
 				persistedAccountStorage = nextStorage;
 			}),
@@ -517,7 +530,7 @@ describe("repair-commands direct deps coverage", () => {
 			account.accountIdSource = "token";
 			return true;
 		});
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runFix(
 			["--json"],
@@ -526,7 +539,7 @@ describe("repair-commands direct deps coverage", () => {
 
 		expect(exitCode).toBe(0);
 		expect(applyTokenAccountIdentity).toHaveBeenCalled();
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(persistedAccountStorage).toMatchObject({
 			accounts: [
 				expect.objectContaining({
@@ -551,9 +564,9 @@ describe("repair-commands direct deps coverage", () => {
 	});
 
 	it("runFix keeps JSON output consistent for no-account and quota-cache-only changes", async () => {
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
-		loadAccountsMock.mockResolvedValueOnce(null);
+		storageMocks.loadAccounts.mockResolvedValueOnce(null);
 		let exitCode = await runFix(["--json"], createDeps());
 
 		expect(exitCode).toBe(0);
@@ -571,11 +584,11 @@ describe("repair-commands direct deps coverage", () => {
 			reports: [],
 		});
 
-		loadQuotaCacheMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce({
 			byAccountId: {},
 			byEmail: {},
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -591,7 +604,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: {},
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {},
@@ -607,8 +620,8 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).not.toHaveBeenCalled();
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).not.toHaveBeenCalled();
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
 		expect(
 			JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")),
 		).toMatchObject({
@@ -622,13 +635,13 @@ describe("repair-commands direct deps coverage", () => {
 	});
 
 	it("runFix reports quota-cache-only live changes distinctly in display mode", async () => {
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
-		loadQuotaCacheMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce({
 			byAccountId: {},
 			byEmail: {},
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -644,7 +657,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: {},
 		});
-		fetchCodexQuotaSnapshotMock.mockResolvedValueOnce({
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockResolvedValueOnce({
 			status: 200,
 			model: "gpt-5-codex",
 			primary: {},
@@ -660,8 +673,8 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).not.toHaveBeenCalled();
-		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).not.toHaveBeenCalled();
+		expect(quotaCacheMocks.saveQuotaCache).toHaveBeenCalledTimes(1);
 		const output = consoleSpy.mock.calls
 			.map((call) => call.map((value) => String(value)).join(" "))
 			.join("\n");
@@ -671,11 +684,11 @@ describe("repair-commands direct deps coverage", () => {
 	});
 
 	it("runFix does not double-count a live probe failure followed by refresh fallback", async () => {
-		loadQuotaCacheMock.mockResolvedValueOnce({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce({
 			byAccountId: {},
 			byEmail: {},
 		});
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -691,7 +704,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: {},
 		});
-		fetchCodexQuotaSnapshotMock
+		quotaProbeMocks.fetchCodexQuotaSnapshot
 			.mockRejectedValueOnce(new Error("probe unavailable"))
 			.mockResolvedValueOnce({
 				status: 200,
@@ -699,7 +712,7 @@ describe("repair-commands direct deps coverage", () => {
 				primary: {},
 				secondary: {},
 			});
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-fallback-next",
 			refresh: "refresh-fallback-next",
@@ -708,7 +721,7 @@ describe("repair-commands direct deps coverage", () => {
 		});
 		extractAccountEmailMock.mockReturnValue("fallback@example.com");
 		extractAccountIdMock.mockReturnValue("fallback-account");
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runFix(
 			["--json", "--live"],
@@ -726,7 +739,7 @@ describe("repair-commands direct deps coverage", () => {
 	});
 
 	it("runFix marks codex-unavailable live probe as a soft warning and keeps the account enabled", async () => {
-		loadQuotaCacheMock.mockResolvedValueOnce({ byAccountId: {}, byEmail: {} });
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce({ byAccountId: {}, byEmail: {} });
 		const storage = {
 			version: 3 as const,
 			accounts: [
@@ -743,22 +756,22 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: {},
 		};
-		loadAccountsMock.mockResolvedValue(storage);
-		queuedRefreshMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValue(storage);
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "access-unavailable-next",
 			refresh: "refresh-unavailable-next",
 			expires: Date.now() + 120_000,
 			idToken: "id-token-unavailable",
 		});
-		fetchCodexQuotaSnapshotMock.mockRejectedValue(
+		quotaProbeMocks.fetchCodexQuotaSnapshot.mockRejectedValue(
 			new CodexUnavailableError(
 				"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
 			),
 		);
 		extractAccountEmailMock.mockReturnValue("unavailable@example.com");
 		extractAccountIdMock.mockReturnValue("unavailable-account");
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runFix(
 			["--json", "--live"],
@@ -782,7 +795,7 @@ describe("repair-commands direct deps coverage", () => {
 	});
 
 	it("runDoctor uses the injected refresh-token validator in JSON diagnostics", async () => {
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			accounts: [
 				{
@@ -799,7 +812,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndexByFamily: {},
 		});
 		const hasLikelyInvalidRefreshToken = vi.fn(() => true);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(
 			["--json"],
@@ -831,8 +844,8 @@ describe("repair-commands direct deps coverage", () => {
 			},
 			byEmail: {},
 		};
-		loadQuotaCacheMock.mockResolvedValueOnce(quotaCache);
-		loadAccountsMock.mockResolvedValue({
+		quotaCacheMocks.loadQuotaCache.mockResolvedValueOnce(quotaCache);
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			accounts: [
 				{
@@ -847,7 +860,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: {},
 		});
-		loadPersistedRuntimeObservabilitySnapshotMock.mockResolvedValue({
+		runtimeObservabilityMocks.loadPersistedRuntimeObservabilitySnapshot.mockResolvedValue({
 			lastPoolExhaustionSkipReasons: { "0": "circuit-open" },
 		});
 		evaluateForecastAccountsMock.mockImplementation((inputs) =>
@@ -870,12 +883,12 @@ describe("repair-commands direct deps coverage", () => {
 			recommendedIndex: 0,
 			reason: "stay",
 		});
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(["--json"], createDeps());
 
 		expect(exitCode).toBe(0);
-		expect(loadQuotaCacheMock).toHaveBeenCalledTimes(1);
+		expect(quotaCacheMocks.loadQuotaCache).toHaveBeenCalledTimes(1);
 		expect(evaluateForecastAccountsMock).toHaveBeenCalledWith(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -898,7 +911,7 @@ describe("repair-commands direct deps coverage", () => {
 	});
 
 	it("runDoctor treats failed runtime snapshot loads as aligned diagnostics", async () => {
-		loadAccountsMock.mockResolvedValue({
+		storageMocks.loadAccounts.mockResolvedValue({
 			version: 3,
 			accounts: [
 				{
@@ -913,7 +926,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: {},
 		});
-		loadPersistedRuntimeObservabilitySnapshotMock.mockRejectedValue(
+		runtimeObservabilityMocks.loadPersistedRuntimeObservabilitySnapshot.mockRejectedValue(
 			new Error("snapshot busy"),
 		);
 		evaluateForecastAccountsMock.mockImplementation((inputs) =>
@@ -930,7 +943,7 @@ describe("repair-commands direct deps coverage", () => {
 				disabled: false,
 			})),
 		);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(["--json"], createDeps());
 
@@ -948,7 +961,7 @@ describe("repair-commands direct deps coverage", () => {
 	});
 
 	it("runDoctor checks refresh token shape even when email is missing", async () => {
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -964,7 +977,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndexByFamily: {},
 		});
 		const hasLikelyInvalidRefreshToken = vi.fn(() => true);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(
 			["--json"],
@@ -986,7 +999,7 @@ describe("repair-commands direct deps coverage", () => {
 	it("runDoctor marks malformed codex auth payloads as invalid instead of healthy", async () => {
 		existsSyncMock.mockImplementation((path) => path === "/mock/auth.json");
 		readFileMock.mockResolvedValueOnce("[]");
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(["--json"], createDeps());
 
@@ -1005,7 +1018,7 @@ describe("repair-commands direct deps coverage", () => {
 	it("runDoctor derives auto-fix state from the final action set", async () => {
 		const now = Date.now();
 		let persistedAccountStorage: unknown;
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -1021,7 +1034,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 		});
-		withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+		storageMocks.withAccountStorageTransaction.mockImplementation(async (handler) =>
 			handler(
 				{
 					version: 3,
@@ -1051,7 +1064,7 @@ describe("repair-commands direct deps coverage", () => {
 				},
 			),
 		);
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "doctor-access-next",
 			refresh: "doctor-refresh-next",
@@ -1064,8 +1077,8 @@ describe("repair-commands direct deps coverage", () => {
 		extractAccountIdMock.mockImplementation((accessToken: string | undefined) =>
 			accessToken === "doctor-access-next" ? "doctor-token-account" : "doctor-account"
 		);
-		setCodexCliActiveSelectionMock.mockResolvedValueOnce(true);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		codexCliWriterMocks.setCodexCliActiveSelection.mockResolvedValueOnce(true);
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(
 			["--json", "--fix"],
@@ -1075,7 +1088,7 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(persistedAccountStorage).toMatchObject({
 			accounts: [
 				expect.objectContaining({
@@ -1111,7 +1124,7 @@ describe("repair-commands direct deps coverage", () => {
 	it("runDoctor records active-index fixes when normalization changes the snapshot", async () => {
 		const now = Date.now();
 		let persistedAccountStorage: unknown;
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -1131,7 +1144,7 @@ describe("repair-commands direct deps coverage", () => {
 				"gpt-5-codex": 7,
 			},
 		});
-		withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+		storageMocks.withAccountStorageTransaction.mockImplementation(async (handler) =>
 			handler(
 				{
 					version: 3,
@@ -1158,7 +1171,7 @@ describe("repair-commands direct deps coverage", () => {
 				},
 			),
 		);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(
 			["--json", "--fix"],
@@ -1168,7 +1181,7 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(persistedAccountStorage).toMatchObject({
 			activeIndex: 0,
 			activeIndexByFamily: {
@@ -1217,8 +1230,8 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 		};
-		loadAccountsMock.mockResolvedValueOnce(prescanStorage);
-		withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+		storageMocks.loadAccounts.mockResolvedValueOnce(prescanStorage);
+		storageMocks.withAccountStorageTransaction.mockImplementation(async (handler) =>
 			handler(
 				{
 					version: 3,
@@ -1256,7 +1269,7 @@ describe("repair-commands direct deps coverage", () => {
 				},
 			),
 		);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(
 			["--json", "--fix"],
@@ -1266,7 +1279,7 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(0);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
 		expect(persistedAccountStorage).toBeUndefined();
 		expect(prescanStorage.accounts[1]?.enabled).toBe(true);
 		const payload = JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")) as {
@@ -1281,7 +1294,7 @@ describe("repair-commands direct deps coverage", () => {
 
 	it("runDoctor skips Codex sync when the refreshed account disappears before persistence", async () => {
 		const now = Date.now();
-		loadAccountsMock.mockResolvedValueOnce({
+		storageMocks.loadAccounts.mockResolvedValueOnce({
 			version: 3,
 			accounts: [
 				{
@@ -1297,7 +1310,7 @@ describe("repair-commands direct deps coverage", () => {
 			activeIndex: 0,
 			activeIndexByFamily: { codex: 0 },
 		});
-		withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+		storageMocks.withAccountStorageTransaction.mockImplementation(async (handler) =>
 			handler(
 				{
 					version: 3,
@@ -1324,7 +1337,7 @@ describe("repair-commands direct deps coverage", () => {
 				async () => undefined,
 			),
 		);
-		queuedRefreshMock.mockResolvedValueOnce({
+		refreshQueueMocks.queuedRefresh.mockResolvedValueOnce({
 			type: "success",
 			access: "doctor-access-next",
 			refresh: "doctor-refresh-next",
@@ -1337,7 +1350,7 @@ describe("repair-commands direct deps coverage", () => {
 		extractAccountIdMock.mockImplementation((accessToken: string | undefined) =>
 			accessToken === "doctor-access-next" ? "doctor-token-account" : "doctor-account"
 		);
-		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleSpy = silenceConsole("log");
 
 		const exitCode = await runDoctor(
 			["--json", "--fix"],
@@ -1348,8 +1361,8 @@ describe("repair-commands direct deps coverage", () => {
 		);
 
 		expect(exitCode).toBe(1);
-		expect(withAccountStorageTransactionMock).toHaveBeenCalledTimes(1);
-		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+		expect(storageMocks.withAccountStorageTransaction).toHaveBeenCalledTimes(1);
+		expect(codexCliWriterMocks.setCodexCliActiveSelection).not.toHaveBeenCalled();
 		const payload = JSON.parse(String(consoleSpy.mock.calls.at(-1)?.[0] ?? "{}")) as {
 			fix: {
 				changed: boolean;

--- a/test/repair-commands.test.ts
+++ b/test/repair-commands.test.ts
@@ -158,6 +158,12 @@ function createDeps(
 describe("repair-commands direct deps coverage", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// clearAllMocks wipes call history but keeps mockImplementation, so the
+		// transaction mocks set inline by individual tests must be reset here or
+		// they bleed into later tests that rely on the default behavior.
+		storageMocks.withAccountStorageTransaction.mockReset();
+		storageMocks.withFlaggedStorageTransaction.mockReset();
+		storageMocks.withAccountAndFlaggedStorageTransaction.mockReset();
 		existsSyncMock.mockReturnValue(false);
 		quotaCacheMocks.loadQuotaCache.mockResolvedValue(null);
 		codexCliStateMocks.loadCodexCliState.mockResolvedValue(null);


### PR DESCRIPTION
## Summary

Extracts shared mock factories for the codex-manager test suites — audit roadmap §4.4.2 (`docs/audits/AUDIT_2026-06-10.md`, PR #522). **Zero test-semantics change**: identical test counts before/after on every migrated suite, verified against clean main.

## Duplication found

`vi.mock` targets counted across `test/`: `lib/storage.js` re-mocked in **10** suites; `accounts.js`/`ui/select.js` in 5; `refresh-queue`/`codex-cli state`/`writer` in 4; `quota-cache`/`ui/confirm` and others in 3+; plus **128 identical inline console-silencer spies** (110 in the CLI suite alone).

## Changes

- **New `test/helpers/cli-test-fixtures.ts`** (317 lines): `create*Mocks()` + `*ModuleMock()` pairs for storage, refresh-queue, quota-probe, quota-cache, runtime-observability, app-bind, codex-cli state/writer, and the select/confirm UI prompts; `pickMocks()` for partial overrides; `silenceConsole()`; the sanctioned minimal `AccountStorageV3` fixture builders (single `as never` cast per test/AGENTS.md convention).
- **Hoisting-safe pattern** (verified on a scratch test before mass-applying): mock instances are module-level factory results; `vi.mock("../lib/x.js", async () => (await import("./helpers/cli-test-fixtures.js")).xModuleMock(mocks))` — the hoisted call never touches static import bindings.
- **Migrated**: `codex-manager-cli.test.ts` (42 vi.fn consts → 16 local + 9 shared groups; 22 mock blocks → 12 bespoke + 10 one-line delegations; 110 console spies → one helper), `repair-commands.test.ts`, `codex-manager-uninstall-dispatch`, `auth-menu-hotkeys`, `auth-menu-quota-bar`.
- **Deliberately deferred** (follow-up PR): `index.test.ts` (6.7k lines, divergent shapes), `index-retry`, `accounts-edge`, `accounts-load-from-disk`, `runtime-rotation-proxy`, `issue-474-pin-end-to-end`, `dashboard-display-panel`. Suites with materially different mock shapes (`accounts.js`, `auth.js`, `logger.js`, `config.js`) were intentionally not force-unified.

## Validation

- [x] `npm run typecheck`; eslint `--max-warnings=0` on all 6 touched files
- [x] Identical counts vs origin/main via stash comparison: migrated suites + canaries, **273/273 both sides**
- [x] Independently re-verified: cli + repair-commands, 220/220

## Risk / Rollback

Test-infrastructure only; revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

extracts shared mock factory pairs (`create*Mocks()` / `*ModuleMock()`) into a new `test/helpers/cli-test-fixtures.ts` helper and migrates five manager-suite test files onto them, eliminating ~40 duplicated `vi.fn()` declarations, ten near-identical `vi.mock()` blocks, and 128 inline console-silencer spies with zero test-semantics change.

- **new `test/helpers/cli-test-fixtures.ts`** (317 lines): typed factory pairs for storage, refresh-queue, quota-probe/cache, runtime-observability, app-bind, codex-cli state/writer, and ui-prompt mocks; `pickMocks()` for partial overrides; `silenceConsole()`; minimal `AccountStorageV3` fixture builders with the repo's sanctioned `as never` cast.
- **hoisting pattern**: mock instances live at module scope; `vi.mock` factories resolve the helper lazily via `async () => (await import(\"./helpers/cli-test-fixtures.js\")).xModuleMock(mocks)`, avoiding static-import binding races with vitest's hoist.
- **five migrated suites**: `codex-manager-cli`, `repair-commands`, `codex-manager-uninstall-dispatch`, `auth-menu-hotkeys`, `auth-menu-quota-bar` — each retains its own `beforeEach`/`afterEach` with explicit `mockReset()` for every shared mock (transaction mocks included).

<h3>Confidence Score: 5/5</h3>

test-infrastructure-only change with no production code touched; all migrated suites keep explicit mockReset() on every shared mock and the hoisting pattern is verified safe.

the refactoring is mechanical, the hoisting contract is correctly documented and applied, all five migrated suites have comprehensive beforeEach/afterEach cleanup including explicit mockReset() on every shared mock group — including the three storage transaction mocks. no new test-semantic behaviour is introduced.

no files require special attention; the only note is the live Date.now() call in storageAccountFixture which callers should override for timestamp-sensitive assertions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| test/helpers/cli-test-fixtures.ts | new shared factory file; well-typed, hoisting-safe, correctly uses vi.importActual for storage/quota-probe while returning plain objects for fully-mocked modules; as never cast in accountStorageV3Fixture is repo-sanctioned. |
| test/codex-manager-cli.test.ts | migrated to shared factories; beforeEach calls mockReset() on every shared mock including all three transaction mocks; loadAccounts/loadFlaggedAccounts are correctly wrapped to maintain snapshot-state tracking. |
| test/repair-commands.test.ts | uses pickMocks() to narrow storage to exactly the seven functions this suite exercises; beforeEach explicitly mockReset()s all three transaction mocks to prevent implementation bleed — the previously flagged gap is addressed. |
| test/codex-manager-uninstall-dispatch.test.ts | passes bespoke {clearAccounts: spy} to storageModuleMock so the actual module is spread with only that targeted override; clean beforeEach/afterEach with no module-level state concerns. |
| test/auth-menu-hotkeys.test.ts | delegates select/confirm mocks to createUiPromptMocks(); beforeEach correctly calls vi.resetModules() + mockReset() + mockResolvedValue(true) on confirm; afterEach restores env and mocks. |
| test/auth-menu-quota-bar.test.ts | same ui-prompt delegation; beforeEach resets both mocks and restores isTTY descriptors; afterEach properly resets UI runtime options via async dynamic import before restoreAllMocks. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["test file (module scope)"]
    A -->|"createStorageMocks()"| B["storageMocks\n(vi.fn instances)"]
    A -->|"createUiPromptMocks()"| C["uiMocks\n(vi.fn instances)"]
    A -->|"createRefreshQueueMocks() etc."| D["other mock groups"]

    A -->|"vi.mock() hoisted"| E["vi.mock factory\n(async)"]
    E -->|"await import(./helpers/cli-test-fixtures.js)"| F["cli-test-fixtures.ts\n(lazy dynamic import)"]
    F -->|"storageModuleMock(storageMocks)"| G["vi.importActual + overrides\n→ mocked module shape"]

    B --> E
    C --> E
    D --> E

    H["beforeEach"] -->|"mockReset() on every shared mock"| B
    H --> C
    H --> D

    I["afterEach"] -->|"vi.restoreAllMocks()"| J["console spies restored"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/repair-commands.test.ts`, line 158-172 ([link](https://github.com/ndycode/codex-multi-auth/blob/cbf76aa9ae282e75da945c661b8bb4c9a6ce903e/test/repair-commands.test.ts#L158-L172)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`vi.clearAllMocks()` doesn't reset `mockImplementation` — possible bleed between tests**

   `vi.clearAllMocks()` wipes call history only; implementations set via `mockImplementation` persist. several tests inline `storageMocks.withAccountStorageTransaction.mockImplementation(...)` and a later test without its own setup silently inherits the previous one. adding `mockReset()` for the three storage transaction mocks in `beforeEach` would match the pattern in `codex-manager-cli.test.ts` and guarantee a clean slate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/repair-commands.test.ts
   Line: 158-172

   Comment:
   **`vi.clearAllMocks()` doesn't reset `mockImplementation` — possible bleed between tests**

   `vi.clearAllMocks()` wipes call history only; implementations set via `mockImplementation` persist. several tests inline `storageMocks.withAccountStorageTransaction.mockImplementation(...)` and a later test without its own setup silently inherits the previous one. adding `mockReset()` for the three storage transaction mocks in `beforeEach` would match the pattern in `codex-manager-cli.test.ts` and guarantee a clean slate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-19-cli-test-fixtures%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-19-cli-test-fixtures%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Frepair-commands.test.ts%0ALine%3A%20158-172%0A%0AComment%3A%0A**%60vi.clearAllMocks%28%29%60%20doesn't%20reset%20%60mockImplementation%60%20%E2%80%94%20possible%20bleed%20between%20tests**%0A%0A%60vi.clearAllMocks%28%29%60%20wipes%20call%20history%20only%3B%20implementations%20set%20via%20%60mockImplementation%60%20persist.%20several%20tests%20inline%20%60storageMocks.withAccountStorageTransaction.mockImplementation%28...%29%60%20and%20a%20later%20test%20without%20its%20own%20setup%20silently%20inherits%20the%20previous%20one.%20adding%20%60mockReset%28%29%60%20for%20the%20three%20storage%20transaction%20mocks%20in%20%60beforeEach%60%20would%20match%20the%20pattern%20in%20%60codex-manager-cli.test.ts%60%20and%20guarantee%20a%20clean%20slate.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth&pr=537&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-19-cli-test-fixtures%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-19-cli-test-fixtures%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fhelpers%2Fcli-test-fixtures.ts%3A294-304%0A%60storageAccountFixture%60%20calls%20%60Date.now%28%29%60%20at%20fixture-creation%20time%2C%20so%20%60addedAt%60%2F%60lastUsed%60%20are%20real%20wall-clock%20values%20that%20shift%20on%20every%20run.%20any%20test%20that%20compares%20these%20fields%20against%20a%20literal%20or%20sorts%20accounts%20by%20%60lastUsed%60%20without%20overriding%20them%20will%20be%20non-deterministic.%20a%20stable%20sentinel%20value%20keeps%20fixture%20behaviour%20identical%20across%20machines%20and%20ci%20reruns.%0A%0A%60%60%60suggestion%0Aexport%20function%20storageAccountFixture%28%0A%09overrides%3A%20Record%3Cstring%2C%20unknown%3E%20%3D%20%7B%7D%2C%0A%29%3A%20Record%3Cstring%2C%20unknown%3E%20%7B%0A%09return%20%7B%0A%09%09refreshToken%3A%20%22refresh-test%22%2C%0A%09%09addedAt%3A%201_700_000_000_000%2C%0A%09%09lastUsed%3A%201_700_000_000_000%2C%0A%09%09...overrides%2C%0A%09%7D%3B%0A%7D%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=537&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/helpers/cli-test-fixtures.ts:294-304
`storageAccountFixture` calls `Date.now()` at fixture-creation time, so `addedAt`/`lastUsed` are real wall-clock values that shift on every run. any test that compares these fields against a literal or sorts accounts by `lastUsed` without overriding them will be non-deterministic. a stable sentinel value keeps fixture behaviour identical across machines and ci reruns.

```suggestion
export function storageAccountFixture(
	overrides: Record<string, unknown> = {},
): Record<string, unknown> {
	return {
		refreshToken: "refresh-test",
		addedAt: 1_700_000_000_000,
		lastUsed: 1_700_000_000_000,
		...overrides,
	};
}
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test: reset transaction mock implementat..."](https://github.com/ndycode/codex-multi-auth/commit/171511612f96c525db887d44961909b7484acbae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36672686)</sub>

<!-- /greptile_comment -->