### PR TITLE
feat(install): defer app detection to first run; keep postinstall thin

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ Selected runtime/environment overrides:
 | `CODEX_MODE=0/1` | Disable/enable Codex mode |
 | `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0/1` | Opt out/in of live Responses proxy rotation for forwarded Codex CLI/app sessions |
 | `CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS=<ms>` | Override automatic Codex app helper idle shutdown |
-| `CODEX_MULTI_AUTH_APP_BIND_INSTALL=0/1` | Opt out/in of packaged Codex app bind self-heal during install/update or rotation enable |
-| `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0/1` | Opt out/in of routing supported app shortcuts during install/update or rotation enable |
+| `CODEX_MULTI_AUTH_APP_BIND_INSTALL=0/1` | Opt out/in of packaged Codex app bind self-heal on first CLI run or rotation enable |
+| `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0/1` | Opt out/in of routing supported app shortcuts on first CLI run or rotation enable |
 | `CODEX_TUI_V2=0/1` | Disable/enable TUI v2 |
 | `CODEX_TUI_COLOR_PROFILE=truecolor\|ansi256\|ansi16` | TUI color profile |
 | `CODEX_TUI_GLYPHS=ascii\|unicode\|auto` | TUI glyph style |
@@ -295,7 +295,7 @@ codex-multi-auth forecast --live
 
 Responses background mode stays opt-in. Enable `backgroundResponses` in settings or `CODEX_AUTH_BACKGROUND_RESPONSES=1` only for callers that intentionally send `background: true`, because those requests switch from stateless `store=false` routing to stateful `store=true`. See [docs/upgrade.md](docs/upgrade.md) for rollout guidance.
 
-Runtime rotation is enabled by default for request-bearing wrapper-launched Codex sessions. Global install/update self-heals supported packaged Codex app binds and user-level launcher routing when possible, while `codex-multi-auth rotation enable` remains the explicit repair command. `codex-multi-auth rotation disable` turns the setting off and removes the persistent app bind. Set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0`, `CODEX_MULTI_AUTH_APP_BIND_INSTALL=0`, or `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0` to opt out of the matching default behavior.
+Runtime rotation is enabled by default for request-bearing wrapper-launched Codex sessions. Package install scripts stay side-effect-free: npm postinstall only prints a short notice (and stays silent in CI or non-interactive installs). The first CLI run after an install self-heals supported packaged Codex app binds and user-level launcher routing when possible (recorded once in a `first-run-setup.json` marker under the multi-auth runtime root), while `codex-multi-auth rotation enable` remains the explicit repair command. `codex-multi-auth rotation disable` turns the setting off and removes the persistent app bind. Set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0`, `CODEX_MULTI_AUTH_APP_BIND_INSTALL=0`, or `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0` to opt out of the matching default behavior.
 
 Installed wrappers may perform a best-effort daily npm version check during normal forwarded Codex startup. When a newer package is detected, the wrapper only prints a manual notice on an interactive TTY or when `CODEX_MULTI_AUTH_DEBUG=1`: `npm install -g codex-multi-auth@latest`. It never runs npm install or update commands for you.
 

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -212,10 +212,10 @@ Upgrade note:
 | `CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS` | Override idle timeout for the wrapper-launched Codex app runtime helper |
 | `CODEX_MULTI_AUTH_APP_ROTATION_OWNER_PID` | Internal owner PID used by the wrapper-launched app helper |
 | `CODEX_MULTI_AUTH_REAL_CODEX_HOME` | Internal original Codex home pointer used by runtime rotation helpers |
-| `CODEX_MULTI_AUTH_APP_BIND_INSTALL` | Opt out/in of packaged Codex app bind self-heal during install/update or rotation enable |
-| `CODEX_MULTI_AUTH_APP_BIND` | Legacy/manual app-bind install override consumed by postinstall |
+| `CODEX_MULTI_AUTH_APP_BIND_INSTALL` | Opt out/in of packaged Codex app bind self-heal on first CLI run or rotation enable |
+| `CODEX_MULTI_AUTH_APP_BIND` | Legacy/manual app-bind override consumed by the first-run setup hook (`lib/runtime/first-run.ts`) |
 | `CODEX_MULTI_AUTH_APP_BIND_CODEX_HOME` | Override Codex home used by packaged app bind helpers |
-| `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL` | Opt out/in of user-level app launcher routing during install/update or rotation enable |
+| `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL` | Opt out/in of user-level app launcher routing on first CLI run or rotation enable |
 | `CODEX_MULTI_AUTH_APP_LAUNCHER_WINDOWS_DESKTOP_DIR` | Override Windows desktop shortcut search root for launcher routing |
 | `CODEX_MULTI_AUTH_APP_LAUNCHER_MACOS_DIR` | Override macOS managed wrapper app install directory |
 | `CODEX_TUI_V2` | Toggle TUI v2 |

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -34,6 +34,26 @@ wrapper from this package, use `codex-multi-auth-codex ...`.
 
 ---
 
+## First-Run Setup Note (Unreleased)
+
+Installing the package no longer performs desktop-app detection, app bind, or
+launcher-shortcut setup during `npm install`. That work now runs once on your
+first `codex-multi-auth` invocation from a durable global install:
+
+```bash
+npm i -g codex-multi-auth
+codex-multi-auth status
+```
+
+Expected outcome: the first command claims a one-time marker at
+`~/.codex/multi-auth/first-run-setup.json` and performs the app bind and
+launcher setup (best-effort — a failure never blocks the command). `npx` runs
+and project-local installs deliberately skip this setup and do not consume the
+marker. The existing opt-outs are unchanged: `CODEX_MULTI_AUTH_APP_BIND=0`,
+`CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0`, and CI environments always skip.
+
+---
+
 ## Migration Checklist
 
 1. Install official Codex CLI:

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -122,6 +122,7 @@ import {
 	getAppBindStatus,
 	unbindCodexAppRuntimeRotation,
 } from "./runtime/app-bind.js";
+import { ensureFirstRunSetup } from "./runtime/first-run.js";
 import { ACCOUNT_LIMITS } from "./constants.js";
 import {
 	type DashboardAccountSortMode,
@@ -3569,6 +3570,13 @@ function buildSelectAccountTraced(): (
 }
 
 export async function runCodexMultiAuthCli(rawArgs: string[]): Promise<number> {
+	// Lazy install setup (audit roadmap §4.5.4): app detection, Codex app bind,
+	// and launcher routing moved out of npm postinstall to the first CLI run.
+	// ensureFirstRunSetup never throws; the catch is belt-and-braces so no
+	// command can ever fail because of first-run housekeeping.
+	await ensureFirstRunSetup({
+		notify: (message) => console.error(`codex-multi-auth: ${message}`),
+	}).catch(() => undefined);
 	const startupDisplaySettings = await loadDashboardDisplaySettings();
 	applyUiThemeFromDashboardSettings(startupDisplaySettings);
 

--- a/lib/codex-manager/commands/uninstall.ts
+++ b/lib/codex-manager/commands/uninstall.ts
@@ -94,7 +94,7 @@ export function printUninstallUsage(): void {
 			"  --clear-accounts   Also remove stored account credentials (irreversible)",
 			"",
 			"Behavior:",
-			"  Reverses all postinstall changes: unbinds Codex app, removes OS launchers,",
+			"  Reverses all first-run setup changes: unbinds Codex app, removes OS launchers,",
 			"  strips plugin from Codex.json, and clears the plugin cache.",
 			"",
 			"Recommended order (npm@7+ no longer fires preuninstall lifecycle scripts,",

--- a/lib/runtime/first-run.ts
+++ b/lib/runtime/first-run.ts
@@ -1,0 +1,429 @@
+// Lazy first-run setup (audit roadmap §4.5.4).
+//
+// The npm postinstall script used to detect the packaged Codex desktop app,
+// auto-bind runtime rotation, and install OS launcher shortcuts. That work now
+// runs here, on the first CLI invocation, so package installs stay
+// side-effect-free. The hook is guarded by a marker file under the runtime
+// root (~/.codex/multi-auth), claimed with an exclusive create so concurrent
+// first invocations run the setup at most once, and every step is best-effort:
+// a failure is debug-logged (messages only — never tokens or emails) and the
+// command proceeds normally.
+
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { open, rename, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, join, sep } from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { getCodexRuntimeRotationProxy, loadPluginConfig } from "../config.js";
+import { withFileOperationRetry } from "../fs-retry.js";
+import { createLogger } from "../logger.js";
+import { getCodexMultiAuthDir } from "../runtime-paths.js";
+import { bindCodexAppRuntimeRotation, getAppBindStatus } from "./app-bind.js";
+
+const log = createLogger("first-run");
+
+const FIRST_RUN_MARKER_FILE = "first-run-setup.json";
+export const FIRST_RUN_MARKER_VERSION = 1;
+
+const TRUE_VALUES = new Set(["1", "true", "yes"]);
+const FALSE_VALUES = new Set(["0", "false", "no"]);
+const CI_ENV_KEYS = [
+	"CI",
+	"GITHUB_ACTIONS",
+	"GITLAB_CI",
+	"CIRCLECI",
+	"BUILDKITE",
+	"TF_BUILD",
+	"TEAMCITY_VERSION",
+	"JENKINS_URL",
+	"TRAVIS",
+	"APPVEYOR",
+	"BITBUCKET_BUILD_NUMBER",
+];
+
+export type FirstRunStepStatus = "completed" | "skipped" | "failed";
+
+export interface FirstRunSetupOutcome {
+	appBind: FirstRunStepStatus;
+	launcher: FirstRunStepStatus;
+}
+
+export type FirstRunSkipReason =
+	| "ci"
+	| "not-installed"
+	| "already-done"
+	| "claim-race"
+	| "error";
+
+export type FirstRunResult =
+	| { ran: false; reason: FirstRunSkipReason }
+	| ({ ran: true } & FirstRunSetupOutcome);
+
+export interface FirstRunSetupDeps {
+	env?: NodeJS.ProcessEnv;
+	markerPath?: string;
+	installedContext?: boolean;
+	detectDesktopApp?: () => boolean;
+	resolveRotation?: () => boolean;
+	bindCodexApp?: () => Promise<FirstRunStepStatus>;
+	installLauncher?: () => Promise<FirstRunStepStatus>;
+	notify?: (message: string) => void;
+	now?: () => number;
+}
+
+export function readOptionalBoolean(value: string | undefined): boolean | null {
+	if (value === undefined || value.trim().length === 0) return null;
+	const normalized = value.trim().toLowerCase();
+	if (TRUE_VALUES.has(normalized)) return true;
+	if (FALSE_VALUES.has(normalized)) return false;
+	return null;
+}
+
+function isEnabledEnvFlag(env: NodeJS.ProcessEnv, key: string): boolean {
+	const value = env[key];
+	if (value === undefined || value.trim().length === 0) return false;
+	return readOptionalBoolean(value) !== false;
+}
+
+export function isCiEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (readOptionalBoolean(env.npm_config_ignore_scripts) === true) return true;
+	return CI_ENV_KEYS.some((key) => isEnabledEnvFlag(env, key));
+}
+
+function directoryContainsEntryWithPrefix(
+	directory: string,
+	prefix: string,
+): boolean {
+	try {
+		return readdirSync(directory, { withFileTypes: true }).some((entry) =>
+			entry.name.startsWith(prefix),
+		);
+	} catch {
+		return false;
+	}
+}
+
+export interface DesktopAppDetectionOptions {
+	env?: NodeJS.ProcessEnv;
+	platform?: NodeJS.Platform;
+	home?: string;
+}
+
+export function hasCodexDesktopApp(
+	options: DesktopAppDetectionOptions = {},
+): boolean {
+	const env = options.env ?? process.env;
+	const platform = options.platform ?? process.platform;
+	const home = options.home ?? homedir();
+
+	if (platform === "win32") {
+		const localAppData =
+			(env.LOCALAPPDATA ?? "").trim() || join(home, "AppData", "Local");
+		const programFiles =
+			(env.ProgramFiles ?? env.ProgramW6432 ?? "").trim() || "C:\\Program Files";
+		return (
+			directoryContainsEntryWithPrefix(
+				join(localAppData, "Packages"),
+				"OpenAI.Codex_",
+			) ||
+			directoryContainsEntryWithPrefix(
+				join(programFiles, "WindowsApps"),
+				"OpenAI.Codex_",
+			)
+		);
+	}
+
+	if (platform === "darwin") {
+		return (
+			existsSync("/Applications/Codex.app") ||
+			existsSync(join(home, "Applications", "Codex.app"))
+		);
+	}
+
+	return false;
+}
+
+export function resolveRotationEnabled(
+	env: NodeJS.ProcessEnv = process.env,
+	readConfigRotation: () => boolean = () =>
+		getCodexRuntimeRotationProxy(loadPluginConfig()) === true,
+): boolean {
+	const envOverride = readOptionalBoolean(
+		env.CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY,
+	);
+	if (envOverride !== null) return envOverride;
+	try {
+		return readConfigRotation();
+	} catch {
+		// Rotation defaults on; a malformed config must not block first-run setup.
+		return true;
+	}
+}
+
+export interface FirstRunBindGateOptions {
+	env?: NodeJS.ProcessEnv;
+	rotationEnabled: boolean;
+	appDetected: boolean;
+}
+
+export function shouldBindCodexAppOnFirstRun(
+	options: FirstRunBindGateOptions,
+): boolean {
+	const env = options.env ?? process.env;
+	if (isCiEnvironment(env)) return false;
+
+	const bindOverride = readOptionalBoolean(env.CODEX_MULTI_AUTH_APP_BIND);
+	if (bindOverride !== null) return bindOverride;
+
+	const installOverride = readOptionalBoolean(
+		env.CODEX_MULTI_AUTH_APP_BIND_INSTALL,
+	);
+	if (installOverride !== null) return installOverride;
+
+	if (!options.rotationEnabled) return false;
+	return options.appDetected;
+}
+
+export interface FirstRunLauncherGateOptions {
+	env?: NodeJS.ProcessEnv;
+	rotationEnabled: boolean;
+}
+
+export function shouldInstallCodexAppLauncherOnFirstRun(
+	options: FirstRunLauncherGateOptions,
+): boolean {
+	const env = options.env ?? process.env;
+	if (isCiEnvironment(env)) return false;
+
+	const installOverride = readOptionalBoolean(
+		env.CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL,
+	);
+	if (installOverride !== null) return installOverride;
+
+	return options.rotationEnabled;
+}
+
+/**
+ * First-run setup only fires when the module runs from an installed package
+ * (a path containing a `node_modules` segment, as with global and npx
+ * installs). Development checkouts and the test suite run straight from the
+ * repository tree and stay side-effect-free.
+ */
+export function isInstalledPackageContext(
+	modulePath: string = fileURLToPath(import.meta.url),
+): boolean {
+	return modulePath.split(sep).includes("node_modules");
+}
+
+export function getFirstRunMarkerPath(): string {
+	return join(getCodexMultiAuthDir(), FIRST_RUN_MARKER_FILE);
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function isErrnoCode(error: unknown, code: string): boolean {
+	return (
+		error instanceof Error &&
+		"code" in error &&
+		(error as NodeJS.ErrnoException).code === code
+	);
+}
+
+/**
+ * Claims the marker with an exclusive create so that, across processes, at
+ * most one first invocation runs the setup. Returns false when another
+ * process already holds (or completed) the claim.
+ */
+function claimFirstRunMarker(markerPath: string, startedAt: number): boolean {
+	mkdirSync(dirname(markerPath), { recursive: true });
+	const payload = `${JSON.stringify(
+		{ version: FIRST_RUN_MARKER_VERSION, startedAt },
+		null,
+		"\t",
+	)}\n`;
+	try {
+		writeFileSync(markerPath, payload, { flag: "wx", mode: 0o600 });
+		return true;
+	} catch (error) {
+		if (isErrnoCode(error, "EEXIST")) return false;
+		throw error;
+	}
+}
+
+async function atomicWriteMarker(target: string, content: string): Promise<void> {
+	await withFileOperationRetry(async () => {
+		const tempPath = join(
+			dirname(target),
+			[
+				`.${basename(target)}`,
+				String(process.pid),
+				String(Date.now()),
+				randomBytes(4).toString("hex"),
+				"tmp",
+			].join("."),
+		);
+		let moved = false;
+		let handle: Awaited<ReturnType<typeof open>> | null = null;
+		try {
+			handle = await open(tempPath, "w", 0o600);
+			await handle.writeFile(content, "utf8");
+			await handle.sync();
+			await handle.close();
+			handle = null;
+			await rename(tempPath, target);
+			moved = true;
+		} finally {
+			await handle?.close().catch(() => undefined);
+			if (!moved) {
+				await unlink(tempPath).catch(() => undefined);
+			}
+		}
+	});
+}
+
+async function finalizeFirstRunMarker(
+	markerPath: string,
+	startedAt: number,
+	outcome: FirstRunSetupOutcome,
+	now: () => number,
+): Promise<void> {
+	const payload = `${JSON.stringify(
+		{
+			version: FIRST_RUN_MARKER_VERSION,
+			startedAt,
+			completedAt: now(),
+			appBind: outcome.appBind,
+			launcher: outcome.launcher,
+		},
+		null,
+		"\t",
+	)}\n`;
+	try {
+		await atomicWriteMarker(markerPath, payload);
+	} catch (error) {
+		// The claim file already guarantees once-only behavior; losing the
+		// completion details is acceptable.
+		log.debug("first-run marker finalize failed", {
+			error: errorMessage(error),
+		});
+	}
+}
+
+type LauncherInstallFn = (options: {
+	log: (message: string) => void;
+}) => Promise<unknown>;
+
+async function loadLauncherInstall(): Promise<LauncherInstallFn | null> {
+	const candidates = [
+		fileURLToPath(new URL("../../../scripts/codex-app-launcher.js", import.meta.url)),
+		fileURLToPath(new URL("../../scripts/codex-app-launcher.js", import.meta.url)),
+	];
+	for (const candidate of candidates) {
+		if (!existsSync(candidate)) continue;
+		const launcherModule = (await import(
+			pathToFileURL(candidate).href
+		)) as Record<string, unknown>;
+		return typeof launcherModule.installCodexAppLauncher === "function"
+			? (launcherModule.installCodexAppLauncher as LauncherInstallFn)
+			: null;
+	}
+	return null;
+}
+
+async function defaultBindCodexApp(
+	env: NodeJS.ProcessEnv,
+	rotationEnabled: boolean,
+	detectDesktopApp: () => boolean,
+	notify: (message: string) => void,
+): Promise<FirstRunStepStatus> {
+	const currentStatus = await getAppBindStatus().catch(() => null);
+	const appDetected = detectDesktopApp() || currentStatus?.bound === true;
+	if (!shouldBindCodexAppOnFirstRun({ env, rotationEnabled, appDetected })) {
+		return "skipped";
+	}
+	const result = await bindCodexAppRuntimeRotation();
+	if (result?.message) {
+		notify(result.message);
+	}
+	return "completed";
+}
+
+async function defaultInstallLauncher(
+	env: NodeJS.ProcessEnv,
+	rotationEnabled: boolean,
+	notify: (message: string) => void,
+): Promise<FirstRunStepStatus> {
+	if (!shouldInstallCodexAppLauncherOnFirstRun({ env, rotationEnabled })) {
+		return "skipped";
+	}
+	const installLauncher = await loadLauncherInstall();
+	if (!installLauncher) return "skipped";
+	await installLauncher({ log: notify });
+	return "completed";
+}
+
+/**
+ * Runs the lazily deferred install setup (Codex app bind + launcher routing)
+ * exactly once per runtime root. Never throws and never blocks a command on
+ * failure: every error path resolves with a skip/failed status and only
+ * debug-logs sanitized messages.
+ */
+export async function ensureFirstRunSetup(
+	deps: FirstRunSetupDeps = {},
+): Promise<FirstRunResult> {
+	try {
+		const env = deps.env ?? process.env;
+		if (isCiEnvironment(env)) return { ran: false, reason: "ci" };
+		const installed = deps.installedContext ?? isInstalledPackageContext();
+		if (!installed) return { ran: false, reason: "not-installed" };
+		const markerPath = deps.markerPath ?? getFirstRunMarkerPath();
+		if (existsSync(markerPath)) return { ran: false, reason: "already-done" };
+		const now = deps.now ?? Date.now;
+		const startedAt = now();
+		if (!claimFirstRunMarker(markerPath, startedAt)) {
+			return { ran: false, reason: "claim-race" };
+		}
+
+		// Library default goes through the structured logger; the CLI entrypoint
+		// passes a stderr notify so interactive users still see bind messages.
+		const notify = deps.notify ?? ((message: string) => log.info(message));
+		const detectDesktopApp =
+			deps.detectDesktopApp ?? (() => hasCodexDesktopApp({ env }));
+		const rotationEnabled = deps.resolveRotation
+			? deps.resolveRotation()
+			: resolveRotationEnabled(env);
+
+		const outcome: FirstRunSetupOutcome = {
+			appBind: "skipped",
+			launcher: "skipped",
+		};
+		try {
+			outcome.appBind = await (deps.bindCodexApp
+				? deps.bindCodexApp()
+				: defaultBindCodexApp(env, rotationEnabled, detectDesktopApp, notify));
+		} catch (error) {
+			outcome.appBind = "failed";
+			log.debug("first-run app bind skipped", { error: errorMessage(error) });
+		}
+		try {
+			outcome.launcher = await (deps.installLauncher
+				? deps.installLauncher()
+				: defaultInstallLauncher(env, rotationEnabled, notify));
+		} catch (error) {
+			outcome.launcher = "failed";
+			log.debug("first-run launcher install skipped", {
+				error: errorMessage(error),
+			});
+		}
+
+		await finalizeFirstRunMarker(markerPath, startedAt, outcome, now);
+		return { ran: true, ...outcome };
+	} catch (error) {
+		log.debug("first-run setup skipped", { error: errorMessage(error) });
+		return { ran: false, reason: "error" };
+	}
+}

--- a/lib/runtime/first-run.ts
+++ b/lib/runtime/first-run.ts
@@ -13,7 +13,7 @@ import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { open, rename, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { getCodexRuntimeRotationProxy, loadPluginConfig } from "../config.js";
@@ -206,15 +206,31 @@ export function shouldInstallCodexAppLauncherOnFirstRun(
 }
 
 /**
- * First-run setup only fires when the module runs from an installed package
- * (a path containing a `node_modules` segment, as with global and npx
- * installs). Development checkouts and the test suite run straight from the
- * repository tree and stay side-effect-free.
+ * First-run setup only fires for a durable, global-style install. The old
+ * postinstall gate was `npm_config_global`, which does not exist at CLI
+ * runtime, so this approximates it from the module location instead:
+ *
+ * - must live under a `node_modules` segment (a dev checkout or the test
+ *   suite runs straight from the repository tree and stays side-effect-free)
+ * - must NOT be an npx cache run (`.../_npx/<hash>/node_modules/...`):
+ *   someone trying the tool once must not get app bind/launcher mutations,
+ *   and must not burn the once-only marker before a real install
+ * - must NOT be a project-local install (module path inside the invoking
+ *   working directory): `npm install` into an app's node_modules is not a
+ *   machine-level install either
  */
 export function isInstalledPackageContext(
 	modulePath: string = fileURLToPath(import.meta.url),
+	cwd: string = process.cwd(),
 ): boolean {
-	return modulePath.split(sep).includes("node_modules");
+	const segments = modulePath.split(sep);
+	if (!segments.includes("node_modules")) return false;
+	if (segments.includes("_npx")) return false;
+	const fromCwd = relative(cwd, modulePath);
+	if (fromCwd && !fromCwd.startsWith("..") && !isAbsolute(fromCwd)) {
+		return false;
+	}
+	return true;
 }
 
 export function getFirstRunMarkerPath(): string {
@@ -317,8 +333,17 @@ type LauncherInstallFn = (options: {
 	log: (message: string) => void;
 }) => Promise<unknown>;
 
-async function loadLauncherInstall(): Promise<LauncherInstallFn | null> {
-	const candidates = [
+/**
+ * Resolves the launcher installer from the packaged scripts/ directory,
+ * trying the dist layout first and the source layout second.
+ *
+ * @internal `candidateOverride` exists only so tests can exercise the
+ * fallback order and failure modes with real temp files.
+ */
+export async function loadLauncherInstall(
+	candidateOverride?: readonly string[],
+): Promise<LauncherInstallFn | null> {
+	const candidates = candidateOverride ?? [
 		fileURLToPath(new URL("../../../scripts/codex-app-launcher.js", import.meta.url)),
 		fileURLToPath(new URL("../../scripts/codex-app-launcher.js", import.meta.url)),
 	];

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -2,10 +2,16 @@
 
 // @ts-check
 
-import { existsSync, readdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+// Thin, CI-aware install notice (audit roadmap §4.5.4).
+//
+// All app detection, Codex app bind self-heal, and launcher routing that used
+// to run here now run lazily on the first CLI invocation — see
+// lib/runtime/first-run.ts (ensureFirstRunSetup). This script performs no
+// detection and no filesystem mutation: it exits 0 silently in CI/non-TTY
+// contexts and otherwise prints a short notice to stderr.
+
 import process from "node:process";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const TRUE_VALUES = new Set(["1", "true", "yes"]);
@@ -24,6 +30,11 @@ const CI_ENV_KEYS = [
 	"BITBUCKET_BUILD_NUMBER",
 ];
 
+export const INSTALL_NOTICE = [
+	"codex-multi-auth installed. Run `codex-multi-auth --help` to get started.",
+	"App integration (Codex app bind + launcher shortcuts) completes automatically on first run.",
+].join("\n");
+
 /**
  * @param {string | undefined} value
  */
@@ -33,15 +44,6 @@ export function readOptionalBoolean(value) {
 	if (TRUE_VALUES.has(normalized)) return true;
 	if (FALSE_VALUES.has(normalized)) return false;
 	return null;
-}
-
-/**
- * @param {NodeJS.ProcessEnv} env
- */
-export function isGlobalNpmInstall(env = process.env) {
-	const globalFlag = readOptionalBoolean(env.npm_config_global);
-	if (globalFlag === true) return true;
-	return (env.npm_config_location ?? "").trim().toLowerCase() === "global";
 }
 
 /**
@@ -64,261 +66,37 @@ export function isCiEnvironment(env = process.env) {
 }
 
 /**
- * @param {string} directory
- * @param {string} prefix
- */
-function directoryContainsEntryWithPrefix(directory, prefix) {
-	try {
-		return readdirSync(directory, { withFileTypes: true }).some((entry) =>
-			entry.name.startsWith(prefix),
-		);
-	} catch {
-		return false;
-	}
-}
-
-/**
- * @param {{ env?: NodeJS.ProcessEnv, platform?: NodeJS.Platform, home?: string }} [options]
- */
-export function hasCodexDesktopApp(options = {}) {
-	const env = options.env ?? process.env;
-	const platform = options.platform ?? process.platform;
-	const home = options.home ?? homedir();
-
-	if (platform === "win32") {
-		const localAppData =
-			(env.LOCALAPPDATA ?? "").trim() || join(home, "AppData", "Local");
-		const programFiles =
-			(env.ProgramFiles ?? env.ProgramW6432 ?? "").trim() || "C:\\Program Files";
-		return (
-			directoryContainsEntryWithPrefix(
-				join(localAppData, "Packages"),
-				"OpenAI.Codex_",
-			) ||
-			directoryContainsEntryWithPrefix(
-				join(programFiles, "WindowsApps"),
-				"OpenAI.Codex_",
-			)
-		);
-	}
-
-	if (platform === "darwin") {
-		return (
-			existsSync("/Applications/Codex.app") ||
-			existsSync(join(home, "Applications", "Codex.app"))
-		);
-	}
-
-	return false;
-}
-
-/**
- * @param {{
- *   env?: NodeJS.ProcessEnv,
- *   platform?: NodeJS.Platform,
- *   home?: string,
- *   rotationEnabled: boolean,
- *   appDetected?: boolean,
- * }} options
- */
-export function shouldAutoBindCodexAppOnInstall(options) {
-	const env = options.env ?? process.env;
-	if (isCiEnvironment(env)) return false;
-
-	const bindOverride = readOptionalBoolean(env.CODEX_MULTI_AUTH_APP_BIND);
-	if (bindOverride !== null) return bindOverride;
-
-	const installOverride = readOptionalBoolean(
-		env.CODEX_MULTI_AUTH_APP_BIND_INSTALL,
-	);
-	if (installOverride !== null) return installOverride;
-
-	if (!isGlobalNpmInstall(env)) return false;
-	if (!options.rotationEnabled) return false;
-	return (
-		options.appDetected ??
-		hasCodexDesktopApp({
-			env,
-			platform: options.platform,
-			home: options.home,
-		})
-	);
-}
-
-/**
- * @param {{
- *   env?: NodeJS.ProcessEnv,
- *   rotationEnabled: boolean,
- * }} options
- */
-export function shouldAutoInstallCodexAppLauncherOnInstall(options) {
-	const env = options.env ?? process.env;
-	if (isCiEnvironment(env)) return false;
-
-	const installOverride = readOptionalBoolean(
-		env.CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL,
-	);
-	if (installOverride !== null) return installOverride;
-
-	if (!isGlobalNpmInstall(env)) return false;
-	return options.rotationEnabled;
-}
-
-async function loadConfigModule() {
-	try {
-		return await import("../dist/lib/config.js");
-	} catch (error) {
-		if (
-			error &&
-			typeof error === "object" &&
-			"code" in error &&
-			error.code === "ERR_MODULE_NOT_FOUND"
-		) {
-			return null;
-		}
-		throw error;
-	}
-}
-
-async function loadAppBindModule() {
-	try {
-		return await import("../dist/lib/runtime/app-bind.js");
-	} catch (error) {
-		if (
-			error &&
-			typeof error === "object" &&
-			"code" in error &&
-			error.code === "ERR_MODULE_NOT_FOUND"
-		) {
-			return null;
-		}
-		throw error;
-	}
-}
-
-/**
- * @param {unknown} configModule
  * @param {NodeJS.ProcessEnv} [env]
+ * @param {boolean} [isTty]
  */
-export function resolveRotationEnabled(configModule, env = process.env) {
-	const envOverride = readOptionalBoolean(
-		env.CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY,
-	);
-	if (envOverride !== null) return envOverride;
-	if (
-		!configModule ||
-		typeof configModule.loadPluginConfig !== "function" ||
-		typeof configModule.getCodexRuntimeRotationProxy !== "function"
-	) {
-		return true;
-	}
-	return (
-		configModule.getCodexRuntimeRotationProxy(configModule.loadPluginConfig()) ===
-		true
-	);
-}
-
-function defaultPostinstallLog(message) {
-	console.error(`codex-multi-auth: ${message}`);
-}
-
-/**
- * @param {boolean} rotationEnabled
- */
-async function maybeBindCodexAppOnInstall(rotationEnabled) {
-	const appBindModule = await loadAppBindModule();
-	if (!appBindModule || typeof appBindModule.bindCodexAppRuntimeRotation !== "function") {
-		return;
-	}
-
-	const currentStatus =
-		typeof appBindModule.getAppBindStatus === "function"
-			? await appBindModule.getAppBindStatus().catch(() => null)
-			: null;
-	const appDetected = hasCodexDesktopApp() || currentStatus?.bound === true;
-	if (!shouldAutoBindCodexAppOnInstall({ rotationEnabled, appDetected })) {
-		return;
-	}
-
-	const result = await appBindModule.bindCodexAppRuntimeRotation();
-	if (result?.message) {
-		console.error(`codex-multi-auth: ${result.message}`);
-	}
-}
-
-/**
- * @param {boolean} rotationEnabled
- * @param {(message: string) => void} [log]
- */
-export async function maybeInstallCodexAppLauncherOnInstall(
-	rotationEnabled,
-	log = defaultPostinstallLog,
+export function shouldPrintInstallNotice(
+	env = process.env,
+	isTty = process.stderr.isTTY === true,
 ) {
-	if (!shouldAutoInstallCodexAppLauncherOnInstall({ rotationEnabled })) {
-		return;
-	}
-
-	try {
-		const launcherModule = await import("./codex-app-launcher.js");
-		if (typeof launcherModule.installCodexAppLauncher !== "function") {
-			return;
-		}
-		await launcherModule.installCodexAppLauncher({
-			log,
-		});
-	} catch (error) {
-		log(
-			`app launcher postinstall skipped: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
+	if (isCiEnvironment(env)) return false;
+	return isTty === true;
 }
 
 /**
  * @param {{
- *   loadConfigModule?: () => Promise<unknown>,
- *   bindCodexApp?: (rotationEnabled: boolean) => Promise<void>,
- *   installLauncher?: (rotationEnabled: boolean) => Promise<void>,
- *   log?: (message: string) => void,
  *   env?: NodeJS.ProcessEnv,
- * }} [deps]
+ *   isTty?: boolean,
+ *   log?: (message: string) => void,
+ * }} [options]
+ * @returns {number} always 0 — an install notice must never fail an install
  */
-export async function runPostinstallSelfHeal(deps = {}) {
-	const loadConfig = deps.loadConfigModule ?? loadConfigModule;
-	const bindCodexApp = deps.bindCodexApp ?? maybeBindCodexAppOnInstall;
-	const log = deps.log ?? defaultPostinstallLog;
-	const installLauncher =
-		deps.installLauncher ??
-		((rotationEnabled) =>
-			maybeInstallCodexAppLauncherOnInstall(rotationEnabled, log));
-	const configModule = await loadConfig();
-	const rotationEnabled = resolveRotationEnabled(configModule, deps.env);
-
+export function runPostinstall(options = {}) {
 	try {
-		await bindCodexApp(rotationEnabled);
-	} catch (error) {
-		log(
-			`app bind postinstall skipped: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
-
-	try {
-		await installLauncher(rotationEnabled);
-	} catch (error) {
-		log(
-			`app launcher postinstall skipped: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		const env = options.env ?? process.env;
+		const isTty = options.isTty ?? process.stderr.isTTY === true;
+		if (shouldPrintInstallNotice(env, isTty)) {
+			const log = options.log ?? ((message) => console.error(message));
+			log(INSTALL_NOTICE);
+		}
+	} catch {
+		// Best-effort notice only.
 	}
 	return 0;
-}
-
-async function main() {
-	return runPostinstallSelfHeal();
-}
-
-function normalizePostinstallExitCode(exitCode) {
-	return Number.isInteger(exitCode) && exitCode >= 0 && exitCode <= 255
-		? exitCode
-		: 0;
 }
 
 const isDirectRun = (() => {
@@ -330,14 +108,5 @@ const isDirectRun = (() => {
 })();
 
 if (isDirectRun) {
-	main()
-		.then((exitCode) => {
-			process.exitCode = normalizePostinstallExitCode(exitCode);
-		})
-		.catch((error) => {
-			defaultPostinstallLog(
-				`postinstall self-heal skipped: ${error instanceof Error ? error.message : String(error)}`,
-			);
-			process.exitCode = 0;
-		});
+	process.exitCode = runPostinstall();
 }

--- a/scripts/preuninstall.js
+++ b/scripts/preuninstall.js
@@ -62,7 +62,7 @@ export async function runPreuninstallCleanup(deps = {}) {
 	/** @type {"safe" | "uncertain"} */
 	let bunLockState = "uncertain";
 
-	// Unbind Codex app runtime rotation (reverses postinstall bind)
+	// Unbind Codex app runtime rotation (reverses install-time/first-run bind)
 	try {
 		if (deps.unbindCodexApp) {
 			await deps.unbindCodexApp(dryRun);
@@ -85,7 +85,7 @@ export async function runPreuninstallCleanup(deps = {}) {
 		);
 	}
 
-	// Remove OS-level launcher (reverses postinstall launcher install)
+	// Remove OS-level launcher (reverses install-time/first-run launcher install)
 	try {
 		if (deps.removeLauncher) {
 			await deps.removeLauncher({ dryRun, log });

--- a/test/first-run.test.ts
+++ b/test/first-run.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	ensureFirstRunSetup,
+	FIRST_RUN_MARKER_VERSION,
+	hasCodexDesktopApp,
+	isCiEnvironment,
+	isInstalledPackageContext,
+	resolveRotationEnabled,
+	shouldBindCodexAppOnFirstRun,
+	shouldInstallCodexAppLauncherOnFirstRun,
+} from "../lib/runtime/first-run.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	while (tempRoots.length > 0) {
+		const root = tempRoots.pop();
+		if (root) {
+			rmSync(root, { recursive: true, force: true });
+		}
+	}
+});
+
+function createMarkerPath(): string {
+	const root = mkdtempSync(path.join(tmpdir(), "codex-first-run-"));
+	tempRoots.push(root);
+	return path.join(root, "multi-auth", "first-run-setup.json");
+}
+
+describe("first-run detection and gates", () => {
+	it("detects the packaged Windows Codex app from LOCALAPPDATA packages", () => {
+		const home = mkdtempSync(path.join(tmpdir(), "codex-app-detect-"));
+		tempRoots.push(home);
+		const localAppData = path.join(home, "AppData", "Local");
+		mkdirSync(path.join(localAppData, "Packages", "OpenAI.Codex_test"), {
+			recursive: true,
+		});
+
+		expect(
+			hasCodexDesktopApp({
+				platform: "win32",
+				home,
+				env: { LOCALAPPDATA: localAppData },
+			}),
+		).toBe(true);
+		expect(
+			hasCodexDesktopApp({ platform: "linux", home, env: {} }),
+		).toBe(false);
+	});
+
+	it("binds the Codex app on first run only when detected with rotation enabled", () => {
+		expect(
+			shouldBindCodexAppOnFirstRun({
+				env: {},
+				rotationEnabled: true,
+				appDetected: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldBindCodexAppOnFirstRun({
+				env: {},
+				rotationEnabled: true,
+				appDetected: false,
+			}),
+		).toBe(false);
+		expect(
+			shouldBindCodexAppOnFirstRun({
+				env: {},
+				rotationEnabled: false,
+				appDetected: true,
+			}),
+		).toBe(false);
+		expect(
+			shouldBindCodexAppOnFirstRun({
+				env: { CODEX_MULTI_AUTH_APP_BIND: "0" },
+				rotationEnabled: true,
+				appDetected: true,
+			}),
+		).toBe(false);
+		expect(
+			shouldBindCodexAppOnFirstRun({
+				env: { CODEX_MULTI_AUTH_APP_BIND_INSTALL: "1" },
+				rotationEnabled: false,
+				appDetected: false,
+			}),
+		).toBe(true);
+	});
+
+	it("keeps CI and ignored-scripts guards ahead of explicit opt-ins", () => {
+		expect(isCiEnvironment({ CI: "true" })).toBe(true);
+		expect(isCiEnvironment({ npm_config_ignore_scripts: "true" })).toBe(true);
+		expect(
+			shouldBindCodexAppOnFirstRun({
+				env: { CI: "true", CODEX_MULTI_AUTH_APP_BIND: "1" },
+				rotationEnabled: true,
+				appDetected: true,
+			}),
+		).toBe(false);
+		expect(
+			shouldInstallCodexAppLauncherOnFirstRun({
+				env: { GITHUB_ACTIONS: "true", CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL: "1" },
+				rotationEnabled: true,
+			}),
+		).toBe(false);
+	});
+
+	it("installs launcher routing on first run when rotation is enabled", () => {
+		expect(
+			shouldInstallCodexAppLauncherOnFirstRun({ env: {}, rotationEnabled: true }),
+		).toBe(true);
+		expect(
+			shouldInstallCodexAppLauncherOnFirstRun({ env: {}, rotationEnabled: false }),
+		).toBe(false);
+		expect(
+			shouldInstallCodexAppLauncherOnFirstRun({
+				env: { CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL: "0" },
+				rotationEnabled: true,
+			}),
+		).toBe(false);
+		expect(
+			shouldInstallCodexAppLauncherOnFirstRun({
+				env: { CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL: "1" },
+				rotationEnabled: false,
+			}),
+		).toBe(true);
+	});
+
+	it("resolves rotation default-on with env override and config fallback", () => {
+		expect(
+			resolveRotationEnabled(
+				{ CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "0" },
+				() => true,
+			),
+		).toBe(false);
+		expect(
+			resolveRotationEnabled(
+				{ CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1" },
+				() => false,
+			),
+		).toBe(true);
+		expect(resolveRotationEnabled({}, () => false)).toBe(false);
+		expect(resolveRotationEnabled({}, () => true)).toBe(true);
+		expect(
+			resolveRotationEnabled({}, () => {
+				throw new Error("config unreadable");
+			}),
+		).toBe(true);
+	});
+
+	it("only treats node_modules installs as installed package contexts", () => {
+		expect(
+			isInstalledPackageContext(
+				path.join("usr", "lib", "node_modules", "codex-multi-auth", "dist", "lib", "runtime", "first-run.js"),
+			),
+		).toBe(true);
+		expect(
+			isInstalledPackageContext(
+				path.join("home", "dev", "codex-multi-auth", "lib", "runtime", "first-run.ts"),
+			),
+		).toBe(false);
+	});
+});
+
+describe("ensureFirstRunSetup", () => {
+	it("runs setup once and records the outcome in the marker", async () => {
+		const markerPath = createMarkerPath();
+		const bindCodexApp = vi.fn(async () => "completed" as const);
+		const installLauncher = vi.fn(async () => "completed" as const);
+
+		const result = await ensureFirstRunSetup({
+			env: {},
+			installedContext: true,
+			markerPath,
+			bindCodexApp,
+			installLauncher,
+		});
+
+		expect(result).toEqual({ ran: true, appBind: "completed", launcher: "completed" });
+		expect(bindCodexApp).toHaveBeenCalledTimes(1);
+		expect(installLauncher).toHaveBeenCalledTimes(1);
+		expect(existsSync(markerPath)).toBe(true);
+		const marker = JSON.parse(readFileSync(markerPath, "utf8")) as Record<string, unknown>;
+		expect(marker.version).toBe(FIRST_RUN_MARKER_VERSION);
+		expect(marker.appBind).toBe("completed");
+		expect(marker.launcher).toBe("completed");
+	});
+
+	it("skips setup on the second run once the marker exists", async () => {
+		const markerPath = createMarkerPath();
+		const bindCodexApp = vi.fn(async () => "completed" as const);
+		const installLauncher = vi.fn(async () => "completed" as const);
+		const deps = {
+			env: {},
+			installedContext: true,
+			markerPath,
+			bindCodexApp,
+			installLauncher,
+		};
+
+		await ensureFirstRunSetup(deps);
+		const second = await ensureFirstRunSetup(deps);
+
+		expect(second).toEqual({ ran: false, reason: "already-done" });
+		expect(bindCodexApp).toHaveBeenCalledTimes(1);
+		expect(installLauncher).toHaveBeenCalledTimes(1);
+	});
+
+	it("runs setup at most once under concurrent first invocations", async () => {
+		const markerPath = createMarkerPath();
+		const bindCodexApp = vi.fn(async () => "completed" as const);
+		const installLauncher = vi.fn(async () => "completed" as const);
+		const deps = {
+			env: {},
+			installedContext: true,
+			markerPath,
+			bindCodexApp,
+			installLauncher,
+		};
+
+		const results = await Promise.all([
+			ensureFirstRunSetup(deps),
+			ensureFirstRunSetup(deps),
+		]);
+
+		expect(results.filter((result) => result.ran)).toHaveLength(1);
+		expect(bindCodexApp).toHaveBeenCalledTimes(1);
+		expect(installLauncher).toHaveBeenCalledTimes(1);
+	});
+
+	it("never fails the command when setup steps throw, and still writes the marker", async () => {
+		const markerPath = createMarkerPath();
+
+		const result = await ensureFirstRunSetup({
+			env: {},
+			installedContext: true,
+			markerPath,
+			bindCodexApp: async () => {
+				throw new Error("bind exploded");
+			},
+			installLauncher: async () => {
+				throw new Error("launcher exploded");
+			},
+		});
+
+		expect(result).toEqual({ ran: true, appBind: "failed", launcher: "failed" });
+		expect(existsSync(markerPath)).toBe(true);
+		const marker = JSON.parse(readFileSync(markerPath, "utf8")) as Record<string, unknown>;
+		expect(marker.appBind).toBe("failed");
+		expect(marker.launcher).toBe("failed");
+	});
+
+	it("resolves instead of throwing when even the marker claim fails", async () => {
+		const markerPath = createMarkerPath();
+
+		await expect(
+			ensureFirstRunSetup({
+				env: {},
+				installedContext: true,
+				markerPath,
+				now: () => {
+					throw new Error("clock exploded");
+				},
+			}),
+		).resolves.toEqual({ ran: false, reason: "error" });
+		expect(existsSync(markerPath)).toBe(false);
+	});
+
+	it("skips entirely in CI without creating the marker", async () => {
+		const markerPath = createMarkerPath();
+		const bindCodexApp = vi.fn(async () => "completed" as const);
+
+		const result = await ensureFirstRunSetup({
+			env: { CI: "1" },
+			installedContext: true,
+			markerPath,
+			bindCodexApp,
+			installLauncher: async () => "completed" as const,
+		});
+
+		expect(result).toEqual({ ran: false, reason: "ci" });
+		expect(bindCodexApp).not.toHaveBeenCalled();
+		expect(existsSync(markerPath)).toBe(false);
+	});
+
+	it("skips outside installed package contexts without touching the filesystem", async () => {
+		const markerPath = createMarkerPath();
+		const bindCodexApp = vi.fn(async () => "completed" as const);
+
+		const result = await ensureFirstRunSetup({
+			env: {},
+			installedContext: false,
+			markerPath,
+			bindCodexApp,
+			installLauncher: async () => "completed" as const,
+		});
+
+		expect(result).toEqual({ ran: false, reason: "not-installed" });
+		expect(bindCodexApp).not.toHaveBeenCalled();
+		expect(existsSync(markerPath)).toBe(false);
+	});
+
+	it("is wired into the CLI entrypoint as a guarded best-effort call", () => {
+		const content = readFileSync("lib/codex-manager.ts", "utf8");
+		expect(content).toContain('from "./runtime/first-run.js"');
+		expect(content).toContain("await ensureFirstRunSetup({");
+		expect(content).toContain("}).catch(() => undefined);");
+	});
+});

--- a/test/first-run.test.ts
+++ b/test/first-run.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -11,16 +11,20 @@ import {
 	resolveRotationEnabled,
 	shouldBindCodexAppOnFirstRun,
 	shouldInstallCodexAppLauncherOnFirstRun,
+	loadLauncherInstall,
 } from "../lib/runtime/first-run.js";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 const tempRoots: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
 	vi.restoreAllMocks();
 	while (tempRoots.length > 0) {
 		const root = tempRoots.pop();
 		if (root) {
-			rmSync(root, { recursive: true, force: true });
+			// removeWithRetry per test/AGENTS.md: marker files written by these
+			// tests are exactly the kind of path Windows locks transiently.
+			await removeWithRetry(root, { recursive: true, force: true });
 		}
 	}
 });
@@ -151,17 +155,87 @@ describe("first-run detection and gates", () => {
 		).toBe(true);
 	});
 
-	it("only treats node_modules installs as installed package contexts", () => {
+	it("only treats durable global-style installs as installed package contexts", () => {
+		const globalModule = path.join(
+			path.sep,
+			"usr",
+			"lib",
+			"node_modules",
+			"codex-multi-auth",
+			"dist",
+			"lib",
+			"runtime",
+			"first-run.js",
+		);
+		const projectCwd = path.join(path.sep, "home", "dev", "my-app");
+
+		expect(isInstalledPackageContext(globalModule, projectCwd)).toBe(true);
+		// dev checkout / test suite: no node_modules segment
 		expect(
 			isInstalledPackageContext(
-				path.join("usr", "lib", "node_modules", "codex-multi-auth", "dist", "lib", "runtime", "first-run.js"),
-			),
-		).toBe(true);
-		expect(
-			isInstalledPackageContext(
-				path.join("home", "dev", "codex-multi-auth", "lib", "runtime", "first-run.ts"),
+				path.join(path.sep, "home", "dev", "codex-multi-auth", "lib", "runtime", "first-run.ts"),
+				projectCwd,
 			),
 		).toBe(false);
+		// npx cache run must not mutate the machine or burn the marker
+		expect(
+			isInstalledPackageContext(
+				path.join(
+					path.sep,
+					"home",
+					"dev",
+					".npm",
+					"_npx",
+					"abc123",
+					"node_modules",
+					"codex-multi-auth",
+					"dist",
+					"lib",
+					"runtime",
+					"first-run.js",
+				),
+				projectCwd,
+			),
+		).toBe(false);
+		// project-local install (module under the invoking cwd) is not global
+		expect(
+			isInstalledPackageContext(
+				path.join(projectCwd, "node_modules", "codex-multi-auth", "dist", "lib", "runtime", "first-run.js"),
+				projectCwd,
+			),
+		).toBe(false);
+	});
+});
+
+describe("loadLauncherInstall", () => {
+	function launcherDir(): string {
+		const root = mkdtempSync(path.join(tmpdir(), "codex-first-run-launcher-"));
+		tempRoots.push(root);
+		return root;
+	}
+
+	it("falls back to the second candidate when only it exists", async () => {
+		const dir = launcherDir();
+		const second = path.join(dir, "second.mjs");
+		writeFileSync(second, "export function installCodexAppLauncher() { return Promise.resolve('second'); }\n");
+		const install = await loadLauncherInstall([path.join(dir, "missing.mjs"), second]);
+		expect(install).toBeTypeOf("function");
+		await expect(install?.({ log: () => {} })).resolves.toBe("second");
+	});
+
+	it("rejects when an existing candidate fails to import", async () => {
+		const dir = launcherDir();
+		const broken = path.join(dir, "broken.mjs");
+		writeFileSync(broken, "this is not javascript {{{\n");
+		await expect(loadLauncherInstall([broken])).rejects.toThrow();
+	});
+
+	it("returns null when no candidate exists or the export is missing", async () => {
+		const dir = launcherDir();
+		expect(await loadLauncherInstall([path.join(dir, "missing.mjs")])).toBeNull();
+		const noExport = path.join(dir, "no-export.mjs");
+		writeFileSync(noExport, "export const unrelated = true;\n");
+		expect(await loadLauncherInstall([noExport])).toBeNull();
 	});
 });
 

--- a/test/install-codex-auth.test.ts
+++ b/test/install-codex-auth.test.ts
@@ -18,12 +18,11 @@ import {
 	resolveAppLauncherPlan,
 } from "../scripts/codex-app-launcher.js";
 import {
-	hasCodexDesktopApp,
+	INSTALL_NOTICE,
 	isCiEnvironment,
-	resolveRotationEnabled,
-	runPostinstallSelfHeal,
-	shouldAutoBindCodexAppOnInstall,
-	shouldAutoInstallCodexAppLauncherOnInstall,
+	readOptionalBoolean,
+	runPostinstall,
+	shouldPrintInstallNotice,
 } from "../scripts/postinstall.js";
 
 const scriptPath = "scripts/install-codex-auth.js";
@@ -393,245 +392,60 @@ describe("codex app launcher installer", () => {
 	});
 });
 
-describe("codex app bind postinstall gate", () => {
-	it("detects the packaged Windows Codex app from LOCALAPPDATA packages", () => {
-		const home = mkdtempSync(path.join(tmpdir(), "codex-app-bind-detect-"));
-		tempRoots.push(home);
-		const localAppData = path.join(home, "AppData", "Local");
-		mkdirSync(path.join(localAppData, "Packages", "OpenAI.Codex_test"), {
-			recursive: true,
-		});
-
-		expect(
-			hasCodexDesktopApp({
-				platform: "win32",
-				home,
-				env: { LOCALAPPDATA: localAppData },
-			}),
-		).toBe(true);
-	});
-
-	it("only auto-binds on install when opted in or globally installed with rotation enabled", () => {
-		expect(
-			shouldAutoBindCodexAppOnInstall({
-				env: {},
-				rotationEnabled: true,
-				appDetected: true,
-			}),
-		).toBe(false);
-		expect(
-			shouldAutoBindCodexAppOnInstall({
-				env: { npm_config_global: "true" },
-				rotationEnabled: false,
-				appDetected: true,
-			}),
-		).toBe(false);
-		expect(
-			shouldAutoBindCodexAppOnInstall({
-				env: { npm_config_global: "true" },
-				rotationEnabled: true,
-				appDetected: true,
-			}),
-		).toBe(true);
-		expect(
-			shouldAutoBindCodexAppOnInstall({
-				env: { CODEX_MULTI_AUTH_APP_BIND_INSTALL: "1" },
-				rotationEnabled: false,
-				appDetected: false,
-			}),
-		).toBe(true);
-		expect(
-			shouldAutoBindCodexAppOnInstall({
-				env: {
-					npm_config_global: "true",
-					CODEX_MULTI_AUTH_APP_BIND: "0",
-				},
-				rotationEnabled: true,
-				appDetected: true,
-			}),
-		).toBe(false);
-	});
-
-	it("skips desktop app auto-bind in CI and when npm scripts are ignored", () => {
+describe("thin postinstall notice", () => {
+	// Audit roadmap §4.5.4: postinstall is a CI-aware notice only. App
+	// detection, app bind, and launcher routing run lazily on first CLI
+	// invocation (lib/runtime/first-run.ts).
+	it("detects CI environments and ignored-scripts installs", () => {
 		expect(isCiEnvironment({ CI: "true" })).toBe(true);
 		expect(isCiEnvironment({ GITHUB_ACTIONS: "true" })).toBe(true);
 		expect(isCiEnvironment({ npm_config_ignore_scripts: "true" })).toBe(true);
-		expect(
-			shouldAutoBindCodexAppOnInstall({
-				env: {
-					CI: "true",
-					CODEX_MULTI_AUTH_APP_BIND_INSTALL: "1",
-					npm_config_global: "true",
-				},
-				rotationEnabled: true,
-				appDetected: true,
-			}),
-		).toBe(false);
-		expect(
-			shouldAutoBindCodexAppOnInstall({
-				env: {
-					GITHUB_ACTIONS: "true",
-					CODEX_MULTI_AUTH_APP_BIND: "1",
-				},
-				rotationEnabled: true,
-				appDetected: true,
-			}),
-		).toBe(false);
-		expect(
-			shouldAutoBindCodexAppOnInstall({
-				env: {
-					npm_config_ignore_scripts: "true",
-					CODEX_MULTI_AUTH_APP_BIND_INSTALL: "1",
-				},
-				rotationEnabled: true,
-				appDetected: true,
-			}),
-			).toBe(false);
+		expect(isCiEnvironment({ CI: "false" })).toBe(false);
+		expect(isCiEnvironment({})).toBe(false);
 	});
 
-	it("installs app launcher routing on global install when rotation is enabled", () => {
-		expect(
-			shouldAutoInstallCodexAppLauncherOnInstall({
-				env: {},
-				rotationEnabled: true,
-			}),
-		).toBe(false);
-		expect(
-			shouldAutoInstallCodexAppLauncherOnInstall({
-				env: { npm_config_global: "true" },
-				rotationEnabled: false,
-			}),
-		).toBe(false);
-		expect(
-			shouldAutoInstallCodexAppLauncherOnInstall({
-				env: { npm_config_global: "true" },
-				rotationEnabled: true,
-			}),
-		).toBe(true);
-		expect(
-			shouldAutoInstallCodexAppLauncherOnInstall({
-				env: {
-					npm_config_global: "true",
-					CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL: "0",
-				},
-				rotationEnabled: true,
-			}),
-		).toBe(false);
-		expect(
-			shouldAutoInstallCodexAppLauncherOnInstall({
-				env: { CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL: "1" },
-				rotationEnabled: false,
-			}),
-		).toBe(true);
-		expect(
-			shouldAutoInstallCodexAppLauncherOnInstall({
-				env: {
-					CI: "true",
-					CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL: "1",
-				},
-				rotationEnabled: true,
-			}),
-		).toBe(false);
-		// CI and ignored-scripts guards win over explicit launcher opt-in so
-		// package installs stay side-effect-free in automation.
+	it("parses optional boolean env flags", () => {
+		expect(readOptionalBoolean("1")).toBe(true);
+		expect(readOptionalBoolean("no")).toBe(false);
+		expect(readOptionalBoolean("")).toBe(null);
+		expect(readOptionalBoolean(undefined)).toBe(null);
+		expect(readOptionalBoolean("maybe")).toBe(null);
 	});
 
-	it("resolves runtime rotation as default-on for install/update self-heal", () => {
-		expect(resolveRotationEnabled(null, {})).toBe(true);
-		expect(resolveRotationEnabled({}, {})).toBe(true);
-		expect(
-			resolveRotationEnabled(null, {
-				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "0",
-			}),
-		).toBe(false);
-		expect(
-			resolveRotationEnabled(
-				{
-					loadPluginConfig: () => ({}),
-					getCodexRuntimeRotationProxy: () => true,
-				},
-				{},
-			),
-		).toBe(true);
-		expect(
-			resolveRotationEnabled(
-				{
-					loadPluginConfig: () => ({ codexRuntimeRotationProxy: true }),
-					getCodexRuntimeRotationProxy: () => true,
-				},
-				{
-					CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "0",
-				},
-			),
-		).toBe(false);
-		expect(
-			resolveRotationEnabled(
-				{
-					loadPluginConfig: () => ({ codexRuntimeRotationProxy: false }),
-					getCodexRuntimeRotationProxy: () => false,
-				},
-				{},
-			),
-		).toBe(false);
+	it("stays silent in CI and non-TTY contexts", () => {
+		expect(shouldPrintInstallNotice({ CI: "1" }, true)).toBe(false);
+		expect(shouldPrintInstallNotice({}, false)).toBe(false);
+		expect(shouldPrintInstallNotice({}, true)).toBe(true);
 	});
 
-	it("still runs launcher repair when app bind self-heal fails", async () => {
-		const bindCodexApp = vi.fn(async () => {
-			throw new Error("bind failed");
-		});
-		const installLauncher = vi.fn(async () => undefined);
+	it("exits 0 silently in CI", () => {
 		const log = vi.fn();
-
-		await expect(
-			runPostinstallSelfHeal({
-				loadConfigModule: async () => ({
-					loadPluginConfig: () => ({ codexRuntimeRotationProxy: true }),
-					getCodexRuntimeRotationProxy: () => true,
-				}),
-				bindCodexApp,
-				installLauncher,
-				log,
-				env: {},
-			}),
-		).resolves.toBe(0);
-
-		expect(bindCodexApp).toHaveBeenCalledWith(true);
-		expect(installLauncher).toHaveBeenCalledWith(true);
-		expect(log).toHaveBeenCalledWith(
-			"app bind postinstall skipped: bind failed",
-		);
+		expect(runPostinstall({ env: { CI: "1" }, isTty: true, log })).toBe(0);
+		expect(log).not.toHaveBeenCalled();
 	});
 
-	it("keeps postinstall self-heal successful when launcher repair fails", async () => {
-		const bindCodexApp = vi.fn(async () => undefined);
-		const installLauncher = vi.fn(async () => {
-			throw new Error("launcher failed");
-		});
+	it("prints only the short install notice on interactive installs", () => {
 		const log = vi.fn();
-
-		await expect(
-			runPostinstallSelfHeal({
-				loadConfigModule: async () => null,
-				bindCodexApp,
-				installLauncher,
-				log,
-				env: {},
-			}),
-		).resolves.toBe(0);
-
-		expect(bindCodexApp).toHaveBeenCalledWith(true);
-		expect(installLauncher).toHaveBeenCalledWith(true);
-		expect(log).toHaveBeenCalledWith(
-			"app launcher postinstall skipped: launcher failed",
-		);
+		expect(runPostinstall({ env: {}, isTty: true, log })).toBe(0);
+		expect(log).toHaveBeenCalledTimes(1);
+		expect(log).toHaveBeenCalledWith(INSTALL_NOTICE);
+		expect(INSTALL_NOTICE).toContain("first run");
 	});
 
-	it("preserves explicit postinstall return codes for direct runs", () => {
+	it("returns 0 even when the notice sink throws", () => {
+		const log = vi.fn(() => {
+			throw new Error("broken stderr");
+		});
+		expect(runPostinstall({ env: {}, isTty: true, log })).toBe(0);
+	});
+
+	it("performs no detection, no dist imports, and no filesystem mutation", () => {
 		const content = readFileSync("scripts/postinstall.js", "utf8");
 
-		expect(content).toContain(".then((exitCode) => {");
-		expect(content).toContain(
-			"process.exitCode = normalizePostinstallExitCode(exitCode);",
-		);
+		expect(content).toContain("process.exitCode = runPostinstall()");
+		expect(content).not.toContain("dist/lib");
+		expect(content).not.toContain("codex-app-launcher");
+		expect(content).not.toContain("bindCodexAppRuntimeRotation");
+		expect(content).not.toContain("node:fs");
 	});
 });


### PR DESCRIPTION
## Summary

Makes install lazy — audit roadmap §4.5.4 (`docs/audits/AUDIT_2026-06-10.md`, PR #522): the heavy app-bind/launcher detection moves out of `postinstall` into a once-only, never-throws first-run hook in the CLI, and `postinstall` becomes a thin CI-aware notice. This removes a whole class of install-time fragility (spawning the router, rewriting `config.toml`, scanning `LOCALAPPDATA`/`/Applications` during `npm install`).

## Before / after

| | Before | After |
| --- | --- | --- |
| `scripts/postinstall.js` | 343 lines: imports `dist/lib/config.js`, desktop-app detection, app bind (router spawn + config.toml rewrite + startup entries), launcher shortcut install | 112 lines: CI/ignored-scripts/non-TTY → silent exit 0; otherwise a two-line stderr notice. No detection, no dist imports, no `node:fs`, always exit 0 (invariants test-enforced) |
| First run | — | `ensureFirstRunSetup()` in `lib/runtime/first-run.ts`, called from `runCodexMultiAuthCli` before dispatch |

## First-run hook design

- Marker `~/.codex/multi-auth/first-run-setup.json`: claimed with exclusive `wx` create (cross-process at-most-once), finalized via the repo's temp+rename atomic pattern inside `withFileOperationRetry` (Windows-safe).
- **Never blocks or fails a command**: every step resolves to `completed`/`skipped`/`failed` statuses; even marker-claim failure resolves; belt-and-braces `.catch` at the call site. Debug-only logging, no tokens/emails.
- All existing gates preserved: CI wins over opt-ins; `CODEX_MULTI_AUTH_APP_BIND` / `_APP_BIND_INSTALL` / `_APP_LAUNCHER_INSTALL` / `_RUNTIME_ROTATION_PROXY` honored; bind still requires a detected or already-bound desktop app. The install-context check became "module path contains node_modules", keeping dev checkouts and tests side-effect-free.

## Tests + docs

- `test/first-run.test.ts` (new, 15 tests): gates, once-only + marker contents, second-run skip, concurrency at-most-once, step-failure-doesn't-fail, CI skip, dev-checkout skip, CLI wiring.
- Postinstall tests rewritten to the thin contract (silent in CI/non-TTY, notice-only on TTY, throwing sink still exits 0, no-detection source invariants).
- README/CONFIG_FIELDS/uninstall help/preuninstall comments updated to say the bind/launcher work happens on first CLI run.

## Validation

- [x] `npm run typecheck` + `typecheck:scripts`; eslint `--max-warnings=0`
- [x] documentation (25), codex-manager-cli (201), first-run (15), uninstall/preuninstall suites pass; the 2 remaining `install-codex-auth` failures are environment-only — **independently re-verified byte-identical on clean origin/main**
- [x] Manual rehearsal: `CI=1` postinstall silent exit 0; TTY notice-only; dist-module first run `completed→already-done`; failure injection resolves without throwing; real-defaults run produced correct marker JSON

## Risk / Rollback

Behavioral change to install flow (deliberate, per the audit): consumers get the bind/launcher setup on first `codex-multi-auth` invocation instead of during `npm install`. Revert the single commit to restore eager postinstall.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

moves desktop-app detection, Codex app bind, and launcher routing out of `npm postinstall` into a once-only first-run hook (`lib/runtime/first-run.ts`) called before CLI dispatch; `postinstall` becomes a thin, always-exit-0 TTY notice with no dist imports or filesystem mutations.

- `lib/runtime/first-run.ts` claims a per-user marker (`~/.codex/multi-auth/first-run-setup.json`) with an exclusive `writeFileSync(flag:"wx")` for cross-process at-most-once semantics, then finalizes it atomically via `withFileOperationRetry`+rename; every step is best-effort and failure only debug-logs sanitized messages.
- `isInstalledPackageContext` approximates the old `isGlobalNpmInstall` gate at CLI runtime using module path heuristics: requires a `node_modules` segment, excludes `_npx` cache runs, and excludes paths whose `relative(cwd, modulePath)` resolves without a `..` prefix; there is an edge-case false-negative for pnpm/yarn global installs when cwd is an ancestor of the global `node_modules` location (e.g., running from `~/`).
- test suite covers gates, once-only semantics, concurrency, step-failure resilience, CI/dev-checkout skips, `loadLauncherInstall` fallback/failure modes, and CLI wiring; uses `removeWithRetry` per `test/AGENTS.md`; missing a coverage case for the "partial marker" state (claim written, process killed before finalize).

<h3>Confidence Score: 5/5</h3>

safe to merge; the change is a deliberate behavioral shift from eager postinstall to lazy first-run, and every failure path resolves gracefully without blocking any CLI command

the core once-only guarantee is backed by OS-level exclusive file creation (wx flag) and the atomic temp+rename finalize; the belt-and-braces .catch at the call site means no first-run failure can ever surface to the user; the postinstall simplification removes an entire class of install-time fragility

lib/runtime/first-run.ts — the isInstalledPackageContext CWD-relative heuristic has a false-negative for pnpm/yarn global installs when the user's working directory is an ancestor of the global node_modules path

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime/first-run.ts | new module implementing the lazy first-run setup hook; well-structured with deps injection, atomic marker writes via withFileOperationRetry, and belt-and-braces error handling throughout. the isInstalledPackageContext CWD-relative check has a false-negative edge case for pnpm/yarn global installs when cwd is an ancestor of the global node_modules path (e.g., running from ~/) |
| test/first-run.test.ts | 15-test suite covering gates, once-only semantics, concurrency, step-failure resilience, CI skip, dev-checkout skip, and CLI wiring; uses removeWithRetry for Windows-safe cleanup per test/AGENTS.md; missing one coverage case for partial/incomplete marker (claim written, process killed before finalize) |
| scripts/postinstall.js | drastically simplified from 343 to ~112 lines; removes all dist imports, desktop-app detection, and filesystem mutations; now just a CI-aware TTY notice that always exits 0 |
| lib/codex-manager.ts | adds ensureFirstRunSetup call before CLI dispatch with belt-and-braces .catch; correctly placed before loadDashboardDisplaySettings, won't block any command on failure |
| test/install-codex-auth.test.ts | postinstall tests rewritten to the thin contract: CI-silent, TTY-notice-only, always-exit-0, and source invariants (no dist imports, no node:fs, no launcher references) |
| scripts/preuninstall.js | comment-only update: 'postinstall bind' → 'install-time/first-run bind', no logic changes |
| lib/codex-manager/commands/uninstall.ts | one-line help text update: 'postinstall changes' → 'first-run setup changes', no logic changes |
| docs/upgrade.md | adds 'First-Run Setup Note' section explaining deferred setup, expected marker location, and that npx/project-local installs skip; accurate to implementation |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as runCodexMultiAuthCli
    participant FRS as ensureFirstRunSetup
    participant FS as Filesystem
    participant Bind as defaultBindCodexApp
    participant Launch as defaultInstallLauncher

    CLI->>FRS: "await ensureFirstRunSetup({ notify }).catch(()=>undefined)"
    FRS->>FRS: isCiEnvironment(env)?
    alt CI / ignored-scripts
        FRS-->>CLI: "{ran:false, reason:"ci"}"
    else not installed package context
        FRS->>FRS: isInstalledPackageContext()
        FRS-->>CLI: "{ran:false, reason:"not-installed"}"
    else marker already exists
        FRS->>FS: existsSync(markerPath)
        FS-->>FRS: true
        FRS-->>CLI: "{ran:false, reason:"already-done"}"
    else first run
        FRS->>FS: "writeFileSync(markerPath, claim, {flag:"wx"})"
        Note over FS: exclusive create — at most one winner cross-process
        FRS->>Bind: bindCodexApp()
        Bind-->>FRS: "completed" | "skipped" | throws→"failed"
        FRS->>Launch: installLauncher()
        Launch-->>FRS: "completed" | "skipped" | throws→"failed"
        FRS->>FS: atomicWriteMarker (temp+rename via withFileOperationRetry)
        FRS-->>CLI: "{ran:true, appBind, launcher}"
    end
    CLI->>CLI: continue normal dispatch
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-20-lazy-postinstall%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-20-lazy-postinstall%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fruntime%2Ffirst-run.ts%3A229-233%0A**%60isInstalledPackageContext%60%20false-negative%20for%20pnpm%2Fyarn%20global%20installs%20when%20cwd%20is%20a%20home-directory%20ancestor**%0A%0A%60relative%28cwd%2C%20modulePath%29%60%20returns%20a%20path%20without%20a%20leading%20%60..%60%20whenever%20%60cwd%60%20is%20an%20ancestor%20of%20%60modulePath%60.%20pnpm's%20default%20global%20store%20on%20Linux%20is%20%60~%2F.local%2Fshare%2Fpnpm%2Fglobal%2Fnode_modules%2F%E2%80%A6%60%2C%20so%20any%20user%20who%20runs%20%60codex-multi-auth%60%20from%20%60~%2F%60%20%28or%20any%20ancestor%20of%20that%20path%29%20will%20get%20%60relative%28%22~%22%2C%20%22~%2F.local%2F%E2%80%A6%22%29%20%3D%20%22.local%2F%E2%80%A6%22%60%20%E2%80%94%20no%20leading%20%60..%60%2C%20not%20absolute%20%E2%80%94%20and%20the%20function%20returns%20%60false%60%2C%20silently%20skipping%20first-run%20setup%20with%20reason%20%60%22not-installed%22%60.%20the%20marker%20is%20never%20written%2C%20so%20every%20subsequent%20invocation%20from%20that%20cwd%20retries%20and%20skips%20again%20indefinitely.%20the%20same%20scenario%20applies%20to%20any%20configured%20npm%20prefix%20under%20the%20home%20dir%20%28e.g.%2C%20%60~%2F.npm-global%2Flib%2Fnode_modules%2F%E2%80%A6%60%29.%20the%20workaround%20is%20to%20run%20from%20a%20project%20subdirectory%2C%20but%20the%20user%20has%20no%20indication%20anything%20is%20wrong.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Ffirst-run.test.ts%3A1217-1235%0A**missing%20vitest%20coverage%20for%20partial%2Fincomplete%20marker%20%28claim%20written%2C%20process%20dies%20before%20finalize%29**%0A%0Athe%20second-run%20skip%20test%20exercises%20a%20marker%20produced%20by%20a%20successful%20finalize.%20there%20is%20no%20test%20that%20pre-creates%20a%20marker%20containing%20only%20%60%7B%20version%2C%20startedAt%20%7D%60%20%28i.e.%2C%20the%20claim%20was%20written%20but%20finalization%20never%20ran%20because%20the%20process%20was%20killed%20mid-setup%29%20and%20then%20asserts%20that%20%60ensureFirstRunSetup%60%20returns%20%60%7B%20ran%3A%20false%2C%20reason%3A%20%22already-done%22%20%7D%60.%20the%20design%20intention%20is%20that%20the%20claim%20itself%20is%20the%20idempotency%20gate%2C%20but%20that's%20an%20untested%20invariant%3A%20a%20test%20that%20writes%20the%20partial%20marker%20directly%20and%20calls%20%60ensureFirstRunSetup%60%20would%20pin%20this%20deliberately%20and%20guard%20against%20any%20future%20accidental%20%22re-run%20on%20incomplete%20marker%22%20logic.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=538&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/runtime/first-run.ts:229-233
**`isInstalledPackageContext` false-negative for pnpm/yarn global installs when cwd is a home-directory ancestor**

`relative(cwd, modulePath)` returns a path without a leading `..` whenever `cwd` is an ancestor of `modulePath`. pnpm's default global store on Linux is `~/.local/share/pnpm/global/node_modules/…`, so any user who runs `codex-multi-auth` from `~/` (or any ancestor of that path) will get `relative("~", "~/.local/…") = ".local/…"` — no leading `..`, not absolute — and the function returns `false`, silently skipping first-run setup with reason `"not-installed"`. the marker is never written, so every subsequent invocation from that cwd retries and skips again indefinitely. the same scenario applies to any configured npm prefix under the home dir (e.g., `~/.npm-global/lib/node_modules/…`). the workaround is to run from a project subdirectory, but the user has no indication anything is wrong.

### Issue 2 of 2
test/first-run.test.ts:1217-1235
**missing vitest coverage for partial/incomplete marker (claim written, process dies before finalize)**

the second-run skip test exercises a marker produced by a successful finalize. there is no test that pre-creates a marker containing only `{ version, startedAt }` (i.e., the claim was written but finalization never ran because the process was killed mid-setup) and then asserts that `ensureFirstRunSetup` returns `{ ran: false, reason: "already-done" }`. the design intention is that the claim itself is the idempotency gate, but that's an untested invariant: a test that writes the partial marker directly and calls `ensureFirstRunSetup` would pin this deliberately and guard against any future accidental "re-run on incomplete marker" logic.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(upgrade): note the first-run setup ..."](https://github.com/ndycode/codex-multi-auth/commit/0730b9a3245a9fb2bf8623e5632911bf49fd674e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36672737)</sub>

<!-- /greptile_comment -->