### PR TITLE
refactor(lib): break import cycles and enforce no-cycle in lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,7 @@
 import tseslint from "@typescript-eslint/eslint-plugin";
 import tsparser from "@typescript-eslint/parser";
+import importX from "eslint-plugin-import-x";
+import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
 
 export default [
   {
@@ -42,6 +44,28 @@ export default [
       "no-var": "error",
       "eqeqeq": ["error", "always"],
       "no-duplicate-imports": "error",
+    },
+  },
+  {
+    // audit 4.1.6: keep the lib/ module graph acyclic. The dependency direction
+    // is types/constants -> storage -> accounts -> runtime -> manager/CLI;
+    // shared types/helpers must live in (or move to) the lower layer instead of
+    // being imported back from a higher one. Scoped to lib/** and index.ts —
+    // scripts/ and test/ are intentionally out of scope for now.
+    files: ["index.ts", "lib/**/*.ts"],
+    plugins: {
+      "import-x": importX,
+    },
+    settings: {
+      // Without this, import-x treats .ts files as unparseable and silently
+      // skips cycle detection (its default ExportMap extensions are .js-only).
+      "import-x/extensions": [".ts"],
+      "import-x/resolver-next": [
+        createTypeScriptImportResolver({ project: "./tsconfig.json" }),
+      ],
+    },
+    rules: {
+      "import-x/no-cycle": ["error", { maxDepth: Infinity, ignoreExternal: true }],
     },
   },
   {

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -85,6 +85,10 @@ lib/
 ## CONVENTIONS
 
 - All public exports should flow through `lib/index.ts` or documented package subpaths.
+- Module dependencies must stay acyclic (enforced by `import-x/no-cycle` in lint) and follow the layering
+  `types/constants → storage → accounts → runtime → manager/CLI`: lower layers never import from higher ones.
+  Shared types/helpers belong in the lower layer (e.g. `storage/public-types.ts`), with higher layers re-exporting
+  for surface compatibility instead of lower layers importing back from facades like `lib/storage.ts`.
 - Runtime rotation code must preserve pass-through semantics except for auth/provider headers that intentionally change.
 - Node fetch returns decoded response bytes while preserving upstream `content-encoding`; do not forward stale decoded encoding metadata to local clients.
 - Runtime proxy client-facing headers must not expose account emails or tokens.

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -14,7 +14,7 @@ import {
 } from "./storage.js";
 import type { AccountIdSource, OAuthAuthDetails } from "./types.js";
 import type { Workspace } from "./storage/public-types.js";
-import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
+import { MODEL_FAMILIES, type ModelFamily } from "./request/helpers/model-map.js";
 import {
 	getHealthTracker,
 	getTokenTracker,

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,5 +1,5 @@
 import type { Auth } from "@codex-ai/sdk";
-import { saveAccountsWithRetry } from "./codex-manager/forecast-report-shared.js";
+import { saveAccountsWithRetry } from "./storage/save-retry.js";
 import { createLogger } from "./logger.js";
 import {
 	getStoragePath,
@@ -13,6 +13,7 @@ import {
 	withAccountStorageTransaction,
 } from "./storage.js";
 import type { AccountIdSource, OAuthAuthDetails } from "./types.js";
+import type { Workspace } from "./storage/public-types.js";
 import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
 import {
 	getHealthTracker,
@@ -231,13 +232,10 @@ function isRetryableAuthPersistenceError(error: unknown): boolean {
 	return false;
 }
 
-export interface Workspace {
-	id: string;
-	name?: string;
-	enabled: boolean;
-	disabledAt?: number;
-	isDefault?: boolean;
-}
+// Workspace is persisted inside the account storage shapes, so the interface
+// lives in lib/storage/public-types.ts (the layer below this module). It is
+// re-exported here to preserve the historical import surface.
+export type { Workspace } from "./storage/public-types.js";
 
 export interface ManagedAccount {
 	index: number;

--- a/lib/codex-cli/sync.ts
+++ b/lib/codex-cli/sync.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "../logger.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
-import { type AccountStorageV3 } from "../storage.js";
+import { type AccountStorageV3 } from "../storage/public-types.js";
 import { incrementCodexCliMetric } from "./observability.js";
 
 const log = createLogger("codex-cli-sync");

--- a/lib/codex-cli/sync.ts
+++ b/lib/codex-cli/sync.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "../logger.js";
-import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
+import { MODEL_FAMILIES, type ModelFamily } from "../request/helpers/model-map.js";
 import { type AccountStorageV3 } from "../storage/public-types.js";
 import { incrementCodexCliMetric } from "./observability.js";
 

--- a/lib/codex-manager/account-pool-write.ts
+++ b/lib/codex-manager/account-pool-write.ts
@@ -1,5 +1,5 @@
 import type { Workspace } from "../accounts.js";
-import type { AccountMetadataV3 } from "../storage/migrations.js";
+import type { AccountMetadataV3 } from "../storage/public-types.js";
 
 /**
  * Outcome of folding a single login result into the saved account pool.

--- a/lib/codex-manager/forecast-report-shared.ts
+++ b/lib/codex-manager/forecast-report-shared.ts
@@ -5,10 +5,16 @@ import {
 	type AccountMetadataV3,
 	type AccountStorageV3,
 } from "../storage.js";
+import {
+	isRetryableStorageWriteError,
+	saveAccountsWithRetry,
+} from "../storage/save-retry.js";
 import type { TokenFailure } from "../types.js";
-import { sleep } from "../utils.js";
 
-const RETRYABLE_STORAGE_WRITE_CODES = new Set(["EBUSY", "EPERM"]);
+// Moved to lib/storage/save-retry.ts so lib/accounts.ts can use the retry
+// helper without importing this codex-manager module; re-exported here to
+// preserve the historical import surface.
+export { isRetryableStorageWriteError, saveAccountsWithRetry };
 
 export type AccountIdentityMatch = Pick<
 	AccountMetadataV3,
@@ -23,28 +29,6 @@ export type RefreshedAccountPatch = Pick<
 	accountId?: AccountMetadataV3["accountId"];
 	accountIdSource?: AccountMetadataV3["accountIdSource"];
 };
-
-export function isRetryableStorageWriteError(error: unknown): boolean {
-	const code = (error as NodeJS.ErrnoException | undefined)?.code;
-	return typeof code === "string" && RETRYABLE_STORAGE_WRITE_CODES.has(code);
-}
-
-export async function saveAccountsWithRetry(
-	storage: AccountStorageV3,
-	saveAccounts: (storage: AccountStorageV3) => Promise<void>,
-): Promise<void> {
-	for (let attempt = 0; ; attempt += 1) {
-		try {
-			await saveAccounts(storage);
-			return;
-		} catch (error) {
-			if (!isRetryableStorageWriteError(error) || attempt >= 3) {
-				throw error;
-			}
-			await sleep(10 * 2 ** attempt);
-		}
-	}
-}
 
 export function applyRefreshedAccountPatch(
 	account: AccountMetadataV3,

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
 import type { CacheMetadata, GitHubRelease } from "../types.js";
 import { logWarn, logError, logDebug } from "../logger.js";
 import { getCodexCacheDir } from "../runtime-paths.js";
-import { DEFAULT_MODEL, getModelProfile, type PromptModelFamily } from "../request/helpers/model-map.js";
+import { DEFAULT_MODEL, getModelProfile, type ModelFamily } from "../request/helpers/model-map.js";
 import { fetchWithTimeout, readBodyTextGuarded, withBodyTimeout } from "./fetch-utils.js";
 import { withFileOperationRetry } from "../fs-retry.js";
 
@@ -99,23 +99,11 @@ function setCacheEntry(key: string, value: { content: string; timestamp: number 
 	memoryCache.set(key, value);
 }
 
-/**
- * Model family type for prompt selection
- * Maps to different system prompts in the Codex CLI
- */
-export type ModelFamily = PromptModelFamily;
-
-/**
- * All supported model families
- * Used for per-family account rotation and rate limit tracking
- */
-export const MODEL_FAMILIES: readonly ModelFamily[] = [
-	"gpt-5-codex",
-	"codex-max",
-	"codex",
-	"gpt-5.2",
-	"gpt-5.1",
-] as const;
+// ModelFamily/MODEL_FAMILIES live in the leaf model-map module so low-level
+// modules (schemas, storage types) can use them without importing this file.
+// Re-exported here to preserve the historical import surface.
+export { MODEL_FAMILIES } from "../request/helpers/model-map.js";
+export type { ModelFamily } from "../request/helpers/model-map.js";
 
 /**
  * Prompt file mapping for each model family

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -22,6 +22,24 @@ export type PromptModelFamily =
 	| "gpt-5.2"
 	| "gpt-5.1";
 
+/**
+ * Model family type for prompt selection
+ * Maps to different system prompts in the Codex CLI
+ */
+export type ModelFamily = PromptModelFamily;
+
+/**
+ * All supported model families
+ * Used for per-family account rotation and rate limit tracking
+ */
+export const MODEL_FAMILIES: readonly ModelFamily[] = [
+	"gpt-5-codex",
+	"codex-max",
+	"codex",
+	"gpt-5.2",
+	"gpt-5.1",
+] as const;
+
 export interface ModelCapabilities {
 	toolSearch: boolean;
 	computerUse: boolean;

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -5,7 +5,7 @@
  */
 import { z } from "zod";
 import { createLogger, type ScopedLogger } from "./logger.js";
-import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
+import { MODEL_FAMILIES, type ModelFamily } from "./request/helpers/model-map.js";
 
 // Lazy-init so partial `vi.mock("../lib/logger.js", ...)` stubs in tests that
 // do not export `createLogger` (e.g. `test/auth-logging.test.ts`) continue to

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -87,14 +87,15 @@ import {
 	getLegacyFlaggedAccountsPath as buildLegacyFlaggedAccountsPath,
 } from "./storage/file-paths.js";
 import {
-	type AccountMetadataV1,
-	type AccountMetadataV3,
 	type AccountStorageV1,
-	type AccountStorageV3,
-	type CooldownReason,
 	migrateV1ToV3,
-	type RateLimitStateV3,
 } from "./storage/migrations.js";
+import type {
+	AccountMetadataV3,
+	AccountStorageV3,
+	CooldownReason,
+	RateLimitStateV3,
+} from "./storage/public-types.js";
 import { exportNamedBackupEntry } from "./storage/named-backup-entry.js";
 import {
 	collectNamedBackups,
@@ -145,8 +146,6 @@ export type {
 	StorageHealthSummary,
 	CooldownReason,
 	RateLimitStateV3,
-	AccountMetadataV1,
-	AccountStorageV1,
 	AccountMetadataV3,
 	AccountStorageV3,
 	NamedBackupSummary,

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -30,9 +30,10 @@ import { saveAccountsToDisk } from "./storage/account-save.js";
 import { saveAccountsEntry } from "./storage/account-save-entry.js";
 import { buildBackupMetadata } from "./storage/backup-metadata-builder.js";
 import {
-	type BackupMetadataSection,
+	type BackupMetadata,
 	type BackupSnapshotKind,
 	type BackupSnapshotMetadata,
+	type RestoreAssessment,
 	buildMetadataSection,
 } from "./storage/backup-metadata.js";
 import { isCacheLikeBackupArtifactName } from "./storage/cache-artifacts.js";
@@ -94,6 +95,8 @@ import type {
 	AccountMetadataV3,
 	AccountStorageV3,
 	CooldownReason,
+	FlaggedAccountMetadataV1,
+	FlaggedAccountStorageV1,
 	RateLimitStateV3,
 } from "./storage/public-types.js";
 import { exportNamedBackupEntry } from "./storage/named-backup-entry.js";
@@ -148,6 +151,10 @@ export type {
 	RateLimitStateV3,
 	AccountMetadataV3,
 	AccountStorageV3,
+	FlaggedAccountMetadataV1,
+	FlaggedAccountStorageV1,
+	BackupMetadata,
+	RestoreAssessment,
 	NamedBackupSummary,
 };
 
@@ -160,32 +167,6 @@ const BACKUP_COPY_MAX_ATTEMPTS = 5;
 const BACKUP_COPY_BASE_DELAY_MS = 10;
 let storageBackupEnabled = true;
 let lastAccountsSaveTimestamp = 0;
-
-export interface FlaggedAccountMetadataV1 extends AccountMetadataV3 {
-	flaggedAt: number;
-	flaggedReason?: string;
-	lastError?: string;
-}
-
-export interface FlaggedAccountStorageV1 {
-	version: 1;
-	accounts: FlaggedAccountMetadataV1[];
-}
-
-type RestoreReason = "empty-storage" | "intentional-reset" | "missing-storage";
-
-export type BackupMetadata = {
-	accounts: BackupMetadataSection;
-	flaggedAccounts: BackupMetadataSection;
-};
-
-export type RestoreAssessment = {
-	storagePath: string;
-	restoreEligible: boolean;
-	restoreReason?: RestoreReason;
-	latestSnapshot?: BackupSnapshotMetadata;
-	backupMetadata: BackupMetadata;
-};
 
 type AnyAccountStorage = AccountStorageV1 | AccountStorageV3;
 

--- a/lib/storage/account-persistence.ts
+++ b/lib/storage/account-persistence.ts
@@ -1,4 +1,4 @@
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export function cloneAccountStorageForPersistence(
 	storage: AccountStorageV3 | null | undefined,

--- a/lib/storage/account-port.ts
+++ b/lib/storage/account-port.ts
@@ -1,4 +1,4 @@
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export async function exportAccountsSnapshot(params: {
 	resolvedPath: string;

--- a/lib/storage/account-save-entry.ts
+++ b/lib/storage/account-save-entry.ts
@@ -1,4 +1,4 @@
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export async function saveAccountsEntry(params: {
 	storage: AccountStorageV3;

--- a/lib/storage/account-save.ts
+++ b/lib/storage/account-save.ts
@@ -1,4 +1,4 @@
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export async function saveAccountsToDisk(
 	storage: AccountStorageV3,

--- a/lib/storage/backup-metadata-builder.ts
+++ b/lib/storage/backup-metadata-builder.ts
@@ -1,4 +1,4 @@
-import type { BackupMetadata } from "../storage.js";
+import type { BackupMetadata } from "./backup-metadata.js";
 
 type Snapshot = {
 	kind:

--- a/lib/storage/backup-metadata.ts
+++ b/lib/storage/backup-metadata.ts
@@ -31,6 +31,21 @@ export type BackupMetadataSection = {
 	snapshots: BackupSnapshotMetadata[];
 };
 
+type RestoreReason = "empty-storage" | "intentional-reset" | "missing-storage";
+
+export type BackupMetadata = {
+	accounts: BackupMetadataSection;
+	flaggedAccounts: BackupMetadataSection;
+};
+
+export type RestoreAssessment = {
+	storagePath: string;
+	restoreEligible: boolean;
+	restoreReason?: RestoreReason;
+	latestSnapshot?: BackupSnapshotMetadata;
+	backupMetadata: BackupMetadata;
+};
+
 export function latestValidSnapshot(
 	snapshots: BackupSnapshotMetadata[],
 ): BackupSnapshotMetadata | undefined {

--- a/lib/storage/backup-restore.ts
+++ b/lib/storage/backup-restore.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, relative } from "node:path";
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export async function restoreAccountsFromBackupPath(
 	path: string,

--- a/lib/storage/fixture-guards.ts
+++ b/lib/storage/fixture-guards.ts
@@ -1,4 +1,4 @@
-import type { AccountMetadataV3, AccountStorageV3 } from "../storage.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "./public-types.js";
 
 export function looksLikeSyntheticFixtureAccount(
 	account: AccountMetadataV3,

--- a/lib/storage/flagged-load-entry.ts
+++ b/lib/storage/flagged-load-entry.ts
@@ -1,4 +1,4 @@
-import type { FlaggedAccountStorageV1 } from "../storage.js";
+import type { FlaggedAccountStorageV1 } from "./public-types.js";
 
 export async function loadFlaggedAccountsEntry(params: {
 	getFlaggedAccountsPath: () => string;

--- a/lib/storage/flagged-save-entry.ts
+++ b/lib/storage/flagged-save-entry.ts
@@ -1,4 +1,4 @@
-import type { FlaggedAccountStorageV1 } from "../storage.js";
+import type { FlaggedAccountStorageV1 } from "./public-types.js";
 
 export async function saveFlaggedAccountsEntry(params: {
 	storage: FlaggedAccountStorageV1;

--- a/lib/storage/flagged-storage-file.ts
+++ b/lib/storage/flagged-storage-file.ts
@@ -1,5 +1,5 @@
 import { FlaggedAccountStorageV1Schema, safeParseJson } from "../schemas.js";
-import type { FlaggedAccountStorageV1 } from "../storage.js";
+import type { FlaggedAccountStorageV1 } from "./public-types.js";
 import { sleep } from "../utils.js";
 
 // Include EPERM: on Windows, antivirus + file-indexing briefly take an

--- a/lib/storage/flagged-storage-io.ts
+++ b/lib/storage/flagged-storage-io.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fs } from "node:fs";
 import { dirname } from "node:path";
 import { FlaggedAccountStorageV1Schema, safeParseJson } from "../schemas.js";
-import type { FlaggedAccountStorageV1 } from "../storage.js";
+import type { FlaggedAccountStorageV1 } from "./public-types.js";
 import { readFileWithRetry } from "./flagged-storage-file.js";
 import { FILE_RETRY_CODES } from "../fs-retry.js";
 

--- a/lib/storage/flagged-storage.ts
+++ b/lib/storage/flagged-storage.ts
@@ -2,7 +2,7 @@ import type {
 	AccountMetadataV3,
 	FlaggedAccountMetadataV1,
 	FlaggedAccountStorageV1,
-} from "../storage.js";
+} from "./public-types.js";
 
 export function normalizeFlaggedStorage(
 	data: unknown,

--- a/lib/storage/import-export.ts
+++ b/lib/storage/import-export.ts
@@ -2,7 +2,7 @@ import { existsSync, promises as fs } from "node:fs";
 import { dirname } from "node:path";
 import { AnyAccountStorageSchema, safeParseJson } from "../schemas.js";
 import { shouldRetryFileOperation } from "../fs-retry.js";
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 const EXPORT_RENAME_MAX_ATTEMPTS = 4;
 const EXPORT_RENAME_BASE_DELAY_MS = 25;

--- a/lib/storage/migrations.ts
+++ b/lib/storage/migrations.ts
@@ -1,17 +1,19 @@
 /**
  * Storage migration utilities for account data format upgrades.
  * Extracted from storage.ts to reduce module size.
+ *
+ * Historical migration-era shapes (v1) live here and are intentionally not
+ * exported from the lib/storage.ts facade; current-version shapes live in
+ * ./public-types.ts.
  */
 
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import type { AccountIdSource } from "../types.js";
-import type { Workspace } from "../accounts.js";
-
-export type CooldownReason = "auth-failure" | "network-error" | "server-error" | "rate-limit";
-
-export interface RateLimitStateV3 {
-	[key: string]: number | undefined;
-}
+import type {
+	AccountStorageV3,
+	CooldownReason,
+	RateLimitStateV3,
+} from "./public-types.js";
 
 export interface AccountMetadataV1 {
 	accountId?: string;
@@ -42,56 +44,6 @@ export interface AccountStorageV1 {
 	version: 1;
 	accounts: AccountMetadataV1[];
 	activeIndex: number;
-}
-
-export interface AccountMetadataV3 {
-	accountId?: string;
-	accountIdSource?: AccountIdSource;
-	accountLabel?: string;
-	email?: string;
-	refreshToken: string;
-	/** Optional cached access token (Codex CLI parity). */
-	accessToken?: string;
-	/** Optional access token expiry timestamp (ms since epoch). */
-	expiresAt?: number;
-	enabled?: boolean;
-	addedAt: number;
-	lastUsed: number;
-	lastSwitchReason?:
-		| "rate-limit"
-		| "initial"
-		| "rotation"
-		| "best"
-		| "restore"
-		| "manual";
-	rateLimitResetTimes?: RateLimitStateV3;
-	coolingDownUntil?: number;
-	cooldownReason?: CooldownReason;
-	workspaces?: Workspace[];
-	currentWorkspaceIndex?: number;
-}
-
-export interface AccountStorageV3 {
-	version: 3;
-	accounts: AccountMetadataV3[];
-	activeIndex: number;
-	activeIndexByFamily?: Partial<Record<ModelFamily, number>>;
-	/**
-	 * Optional manual pin set by `codex-multi-auth switch <n>` (0-based).
-	 * When set and valid, the runtime rotation proxy MUST route exclusively to
-	 * this account regardless of session affinity or hybrid scoring. Cleared by
-	 * `best` and the dedicated `unpin` command. See issue #474.
-	 */
-	pinnedAccountIndex?: number;
-	/**
-	 * Monotonically increasing counter bumped by user-initiated storage events
-	 * (`switch`, `unpin`, `best`) so the long-running runtime proxy can detect
-	 * a manual change and invalidate sticky session affinity. The proxy reads
-	 * this from disk via the same mtime-cached path as `pinnedAccountIndex` and
-	 * never bumps it from its own debounced writes. Treat `undefined` as
-	 * logically zero. See issue #474.
-	 */
-	affinityGeneration?: number;
 }
 
 function nowMs(): number {

--- a/lib/storage/migrations.ts
+++ b/lib/storage/migrations.ts
@@ -7,7 +7,7 @@
  * ./public-types.ts.
  */
 
-import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
+import { MODEL_FAMILIES, type ModelFamily } from "../request/helpers/model-map.js";
 import type { AccountIdSource } from "../types.js";
 import type {
 	AccountStorageV3,

--- a/lib/storage/named-backups-entry.ts
+++ b/lib/storage/named-backups-entry.ts
@@ -1,4 +1,4 @@
-import type { NamedBackupSummary } from "../storage.js";
+import type { NamedBackupSummary } from "./named-backups.js";
 
 export async function getNamedBackupsEntry(params: {
 	getStoragePath: () => string;

--- a/lib/storage/project-migration.ts
+++ b/lib/storage/project-migration.ts
@@ -1,4 +1,4 @@
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export async function loadNormalizedStorageFromPath(
 	path: string,

--- a/lib/storage/public-types.ts
+++ b/lib/storage/public-types.ts
@@ -1,0 +1,65 @@
+/**
+ * Current-version account storage shapes shared with external consumers via
+ * the lib/storage.ts facade. Historical migration-era shapes (v1) live in
+ * ./migrations.ts and are intentionally not exported from the facade.
+ */
+
+import type { Workspace } from "../accounts.js";
+import type { ModelFamily } from "../prompts/codex.js";
+import type { AccountIdSource } from "../types.js";
+
+export type CooldownReason = "auth-failure" | "network-error" | "server-error" | "rate-limit";
+
+export interface RateLimitStateV3 {
+	[key: string]: number | undefined;
+}
+
+export interface AccountMetadataV3 {
+	accountId?: string;
+	accountIdSource?: AccountIdSource;
+	accountLabel?: string;
+	email?: string;
+	refreshToken: string;
+	/** Optional cached access token (Codex CLI parity). */
+	accessToken?: string;
+	/** Optional access token expiry timestamp (ms since epoch). */
+	expiresAt?: number;
+	enabled?: boolean;
+	addedAt: number;
+	lastUsed: number;
+	lastSwitchReason?:
+		| "rate-limit"
+		| "initial"
+		| "rotation"
+		| "best"
+		| "restore"
+		| "manual";
+	rateLimitResetTimes?: RateLimitStateV3;
+	coolingDownUntil?: number;
+	cooldownReason?: CooldownReason;
+	workspaces?: Workspace[];
+	currentWorkspaceIndex?: number;
+}
+
+export interface AccountStorageV3 {
+	version: 3;
+	accounts: AccountMetadataV3[];
+	activeIndex: number;
+	activeIndexByFamily?: Partial<Record<ModelFamily, number>>;
+	/**
+	 * Optional manual pin set by `codex-multi-auth switch <n>` (0-based).
+	 * When set and valid, the runtime rotation proxy MUST route exclusively to
+	 * this account regardless of session affinity or hybrid scoring. Cleared by
+	 * `best` and the dedicated `unpin` command. See issue #474.
+	 */
+	pinnedAccountIndex?: number;
+	/**
+	 * Monotonically increasing counter bumped by user-initiated storage events
+	 * (`switch`, `unpin`, `best`) so the long-running runtime proxy can detect
+	 * a manual change and invalidate sticky session affinity. The proxy reads
+	 * this from disk via the same mtime-cached path as `pinnedAccountIndex` and
+	 * never bumps it from its own debounced writes. Treat `undefined` as
+	 * logically zero. See issue #474.
+	 */
+	affinityGeneration?: number;
+}

--- a/lib/storage/public-types.ts
+++ b/lib/storage/public-types.ts
@@ -4,9 +4,16 @@
  * ./migrations.ts and are intentionally not exported from the facade.
  */
 
-import type { Workspace } from "../accounts.js";
-import type { ModelFamily } from "../prompts/codex.js";
+import type { ModelFamily } from "../request/helpers/model-map.js";
 import type { AccountIdSource } from "../types.js";
+
+export interface Workspace {
+	id: string;
+	name?: string;
+	enabled: boolean;
+	disabledAt?: number;
+	isDefault?: boolean;
+}
 
 export type CooldownReason = "auth-failure" | "network-error" | "server-error" | "rate-limit";
 
@@ -62,4 +69,15 @@ export interface AccountStorageV3 {
 	 * logically zero. See issue #474.
 	 */
 	affinityGeneration?: number;
+}
+
+export interface FlaggedAccountMetadataV1 extends AccountMetadataV3 {
+	flaggedAt: number;
+	flaggedReason?: string;
+	lastError?: string;
+}
+
+export interface FlaggedAccountStorageV1 {
+	version: 1;
+	accounts: FlaggedAccountMetadataV1[];
 }

--- a/lib/storage/restore-assessment.ts
+++ b/lib/storage/restore-assessment.ts
@@ -1,4 +1,4 @@
-import type { BackupMetadata, RestoreAssessment } from "../storage.js";
+import type { BackupMetadata, RestoreAssessment } from "./backup-metadata.js";
 
 function findLatestSnapshot(backupMetadata: BackupMetadata) {
 	return backupMetadata.accounts.latestValidPath

--- a/lib/storage/restore-backup-entry.ts
+++ b/lib/storage/restore-backup-entry.ts
@@ -1,4 +1,4 @@
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export async function restoreAccountsFromBackupEntry(params: {
 	path: string;

--- a/lib/storage/restore-metadata.ts
+++ b/lib/storage/restore-metadata.ts
@@ -1,4 +1,4 @@
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 type RestoreReason = "empty-storage" | "intentional-reset" | "missing-storage";
 

--- a/lib/storage/restore.ts
+++ b/lib/storage/restore.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, relative } from "node:path";
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export interface RestoreAccountsFromBackupDeps {
 	realpath: typeof import("node:fs").promises.realpath;

--- a/lib/storage/save-retry.ts
+++ b/lib/storage/save-retry.ts
@@ -1,0 +1,33 @@
+/**
+ * Retry wrapper for account-storage writes. Lives in the storage layer so
+ * lower-level callers (lib/accounts.ts) can use it without importing the
+ * codex-manager layer; lib/codex-manager/forecast-report-shared.ts re-exports
+ * it for its historical consumers.
+ */
+
+import { sleep } from "../utils.js";
+import type { AccountStorageV3 } from "./public-types.js";
+
+const RETRYABLE_STORAGE_WRITE_CODES = new Set(["EBUSY", "EPERM"]);
+
+export function isRetryableStorageWriteError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return typeof code === "string" && RETRYABLE_STORAGE_WRITE_CODES.has(code);
+}
+
+export async function saveAccountsWithRetry(
+	storage: AccountStorageV3,
+	saveAccounts: (storage: AccountStorageV3) => Promise<void>,
+): Promise<void> {
+	for (let attempt = 0; ; attempt += 1) {
+		try {
+			await saveAccounts(storage);
+			return;
+		} catch (error) {
+			if (!isRetryableStorageWriteError(error) || attempt >= 3) {
+				throw error;
+			}
+			await sleep(10 * 2 ** attempt);
+		}
+	}
+}

--- a/lib/storage/snapshot-inspectors.ts
+++ b/lib/storage/snapshot-inspectors.ts
@@ -3,7 +3,7 @@ import {
 	AnyAccountStorageSchema,
 	safeParseJson,
 } from "../schemas.js";
-import type { FlaggedAccountStorageV1 } from "../storage.js";
+import type { FlaggedAccountStorageV1 } from "./public-types.js";
 import type {
 	BackupSnapshotMetadata,
 	SnapshotStats,

--- a/lib/storage/storage-parser.ts
+++ b/lib/storage/storage-parser.ts
@@ -5,7 +5,7 @@ import {
 	safeParseJson,
 } from "../schemas.js";
 import { withFileOperationRetry } from "../fs-retry.js";
-import type { AccountStorageV3 } from "../storage.js";
+import type { AccountStorageV3 } from "./public-types.js";
 
 export function parseAndNormalizeStorage(
 	data: unknown,

--- a/lib/storage/transactions.ts
+++ b/lib/storage/transactions.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { AccountStorageV3, FlaggedAccountStorageV1 } from "../storage.js";
+import type { AccountStorageV3, FlaggedAccountStorageV1 } from "./public-types.js";
 
 export type TransactionSnapshotState = {
 	snapshot: AccountStorageV3 | null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
 				"@vitest/coverage-v8": "^4.1.8",
 				"@vitest/ui": "^4.1.8",
 				"eslint": "^10.0.0",
+				"eslint-import-resolver-typescript": "^4.4.5",
+				"eslint-plugin-import-x": "^4.16.2",
 				"fast-check": "^4.5.3",
 				"husky": "^9.1.7",
 				"lint-staged": "^16.2.7",
@@ -116,6 +118,40 @@
 		"node_modules/@codex-ai/sdk": {
 			"resolved": "vendor/codex-ai-sdk",
 			"link": true
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.27.7",
@@ -756,6 +792,25 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
 		"node_modules/@openauthjs/openauth": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/@openauthjs/openauth/-/openauth-0.4.3.tgz",
@@ -821,6 +876,13 @@
 			"integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/@package-json/types": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+			"integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@polka/url": {
 			"version": "1.0.0-next.29",
@@ -1224,6 +1286,17 @@
 			"integrity": "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw==",
 			"license": "MIT"
 		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1538,6 +1611,319 @@
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
+		},
+		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+			"integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-android-arm64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+			"integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+			"integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-x64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+			"integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+			"integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+			"integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+			"integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+			"integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+			"integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+			"integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+			"integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+			"integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+			"integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+			"integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+			"integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+			"integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+			"integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-openharmony-arm64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+			"integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+			"integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+			"integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+			"integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+			"integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@vitest/coverage-v8": {
 			"version": "4.1.8",
@@ -1917,6 +2303,16 @@
 				"node": ">=20"
 			}
 		},
+		"node_modules/comment-parser": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+			"integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2098,6 +2494,104 @@
 			},
 			"peerDependenciesMeta": {
 				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-import-context": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+			"integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-tsconfig": "^4.10.1",
+				"stable-hash-x": "^0.2.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-import-context"
+			},
+			"peerDependencies": {
+				"unrs-resolver": "^1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"unrs-resolver": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-import-resolver-typescript": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+			"integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"debug": "^4.4.1",
+				"eslint-import-context": "^0.1.8",
+				"get-tsconfig": "^4.10.1",
+				"is-bun-module": "^2.0.0",
+				"stable-hash-x": "^0.2.0",
+				"tinyglobby": "^0.2.14",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^16.17.0 || >=18.6.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-import-resolver-typescript"
+			},
+			"peerDependencies": {
+				"eslint": "*",
+				"eslint-plugin-import": "*",
+				"eslint-plugin-import-x": "*"
+			},
+			"peerDependenciesMeta": {
+				"eslint-plugin-import": {
+					"optional": true
+				},
+				"eslint-plugin-import-x": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-plugin-import-x": {
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+			"integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@package-json/types": "^0.0.12",
+				"@typescript-eslint/types": "^8.56.0",
+				"comment-parser": "^1.4.1",
+				"debug": "^4.4.1",
+				"eslint-import-context": "^0.1.9",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.3 || ^10.1.2",
+				"semver": "^7.7.2",
+				"stable-hash-x": "^0.2.0",
+				"unrs-resolver": "^1.9.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-plugin-import-x"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/utils": "^8.56.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"eslint-import-resolver-node": "*"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/utils": {
+					"optional": true
+				},
+				"eslint-import-resolver-node": {
 					"optional": true
 				}
 			}
@@ -2404,6 +2898,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/get-tsconfig": {
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2477,6 +2984,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/is-bun-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+			"integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.7.1"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -2844,6 +3361,22 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"napi-postinstall": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/napi-postinstall"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3054,6 +3587,16 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/restore-cursor": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -3232,6 +3775,16 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stable-hash-x": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+			"integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/stackback": {
@@ -3415,6 +3968,14 @@
 				"typescript": ">=4.8.4"
 			}
 		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3470,6 +4031,44 @@
 			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/unrs-resolver": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+			"integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"napi-postinstall": "^0.3.4"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unrs-resolver"
+			},
+			"optionalDependencies": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+				"@unrs/resolver-binding-android-arm64": "1.12.2",
+				"@unrs/resolver-binding-darwin-arm64": "1.12.2",
+				"@unrs/resolver-binding-darwin-x64": "1.12.2",
+				"@unrs/resolver-binding-freebsd-x64": "1.12.2",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+				"@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+				"@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+			}
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,8 @@
 		"@vitest/coverage-v8": "^4.1.8",
 		"@vitest/ui": "^4.1.8",
 		"eslint": "^10.0.0",
+		"eslint-import-resolver-typescript": "^4.4.5",
+		"eslint-plugin-import-x": "^4.16.2",
 		"fast-check": "^4.5.3",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.2.7",

--- a/test/codex-manager-account-pool-write.test.ts
+++ b/test/codex-manager-account-pool-write.test.ts
@@ -8,7 +8,7 @@ import {
 	type ResolvedAccountWrite,
 	resolveCurrentWorkspaceIndex,
 } from "../lib/codex-manager/account-pool-write.js";
-import type { AccountMetadataV3 } from "../lib/storage/migrations.js";
+import type { AccountMetadataV3 } from "../lib/storage/public-types.js";
 
 // Regression coverage for issue #512: the CLI `login` path persists through
 // persistAccountPool() in codex-manager.ts, which delegates the workspace


### PR DESCRIPTION
## Summary

Breaks **all 23 import cycles** in `lib/` and enforces zero-cycles with lint — audit roadmap §4.1.6 (`docs/audits/AUDIT_2026-06-10.md`, PR #522). The audit's premise ("no cycles exist today") was wrong — madge reported 23 chains on main — so this PR first makes it true, then locks it. Zero behavior change; the storage facade surface is byte-for-byte unchanged (every moved name re-exported).

> **Stacked on #530** (storage public-types) — its `public-types.ts` is the foundation. Merge that first.

## Cycles broken, by technique

1. **Import retargets (19 cycles)** — all 22 `from "../storage.js"` back-imports inside `lib/storage/*` now point at the layer below (`./public-types.js`, `./backup-metadata.js`, sibling modules), with `import type` on type-only edges.
2. **Verbatim type moves** — `FlaggedAccount*V1`, `BackupMetadata`/`RestoreAssessment`/`RestoreReason` out of the facade; `Workspace` out of `accounts.ts` (it was the `public-types → accounts` back-edge); `ModelFamily`/`MODEL_FAMILIES` from `prompts/codex.ts` to the leaf `request/helpers/model-map.ts`. Originals re-export, so no importer changes.
3. **Value move** — `saveAccountsWithRetry`/`isRetryableStorageWriteError` to new `lib/storage/save-retry.ts`, fixing the `accounts → codex-manager` layering violation (forecast-report-shared re-exports).

## Enforcement

- `import-x/no-cycle: ["error", { maxDepth: Infinity, ignoreExternal: true }]` scoped to `index.ts` + `lib/**/*.ts`, with the TS resolver. New devDeps: `eslint-plugin-import-x@4.16.2` + `eslint-import-resolver-typescript@4.4.5` (flat-config native; lockfile diff is additions-only — the rollup `libc` entries the container npm strips were restored byte-identical).
- **Non-obvious config note**, documented in the eslint config: the rule silently no-ops on `.ts` files without `"import-x/extensions": [".ts"]` — import-x's traversal defaults to `.js` only. Verified the rule actually fires by temporarily reintroducing a cycle (eslint errored), then removing it.
- `lib/AGENTS.md` conventions now document the `types/constants → storage → accounts → runtime → manager/CLI` layering.

## Validation

- [x] `npx madge --circular lib/ index.ts` → **0 cycles** (was 23)
- [x] Full `npm run lint` (with the new rule active) + `npm run typecheck`
- [x] 22 storage/accounts/codex-cli suites (596 tests): failure lists identical to base via stash diff (all known environment-only EACCES)
- [x] Independently re-verified: madge 0, full lint, storage-parser + accounts 177/177

## Risk / Rollback

Re-export-preserving moves + a lint rule; revert the single commit. The rule prevents the 23-cycle situation from regrowing.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

breaks 23 import cycles in `lib/` and enforces zero-cycles via `import-x/no-cycle`. all public-facade surfaces are preserved via re-exports; no runtime behavior changes.

- moves `AccountMetadataV3`, `AccountStorageV3`, `FlaggedAccount*`, `Workspace`, `CooldownReason`, `RateLimitStateV3` to `lib/storage/public-types.ts` so sub-modules no longer back-import the `storage.ts` facade; moves `BackupMetadata`/`RestoreAssessment` to `backup-metadata.ts`; moves `ModelFamily`/`MODEL_FAMILIES` to the leaf `model-map.ts`.
- extracts `saveAccountsWithRetry`/`isRetryableStorageWriteError` from `codex-manager/forecast-report-shared.ts` into the new `lib/storage/save-retry.ts`, fixing the `accounts → codex-manager` layering violation; both original export paths re-export from the new location.
- wires up `eslint-plugin-import-x` + `eslint-import-resolver-typescript` in flat config, scoped to `index.ts` and `lib/**/*.ts` with `\"import-x/extensions\": [\".ts\"]` to ensure the plugin's ExportMap traversal includes TypeScript files.

<h3>Confidence Score: 5/5</h3>

safe to merge — pure structural refactor with all original export surfaces preserved via re-exports and no logic changes

every moved type and function is re-exported from its original location; the new no-cycle lint rule was author-verified by reintroducing a cycle; 596 tests pass with identical failure lists; no runtime behavior changed

lib/storage/save-retry.ts — new standalone module with no direct unit test

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage/save-retry.ts | new module housing saveAccountsWithRetry/isRetryableStorageWriteError; verbatim logic from forecast-report-shared.ts; retries EBUSY/EPERM only; no dedicated unit test |
| lib/storage/public-types.ts | new leaf module collecting current-version storage shapes; self-contained imports (model-map, types); no logic, pure type definitions |
| eslint.config.js | adds import-x/no-cycle rule scoped to lib/**; extensions setting correctly overridden to ['.ts'] so ExportMap traversal includes TypeScript files; TypeScript resolver wired in |
| lib/storage/backup-metadata.ts | BackupMetadata/RestoreAssessment/RestoreReason moved here from storage.ts; re-exported from facade; restore-metadata.ts retains its own local RestoreReason (pre-existing duplication) |
| lib/codex-manager/forecast-report-shared.ts | save-retry functions moved out; re-exported here to preserve historical surface; no behavior change |
| lib/storage/migrations.ts | AccountMetadataV3/AccountStorageV3 moved to public-types; now correctly imports ModelFamily from model-map.ts (leaf) instead of prompts/codex.ts; V1 shapes remain here |
| lib/storage.ts | facade updated: removes AccountMetadataV1/AccountStorageV1 from exports (no external consumers found), adds FlaggedAccount*/BackupMetadata/RestoreAssessment to explicit export block |
| lib/accounts.ts | saveAccountsWithRetry now imported from storage/save-retry (breaks manager→accounts cycle); Workspace moved to public-types and re-exported; ModelFamily from model-map |
| lib/request/helpers/model-map.ts | ModelFamily/MODEL_FAMILIES moved here from prompts/codex.ts; prompts/codex.ts re-exports; now importable from low-level storage/schema modules without creating upward cycles |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph "types/constants (leaf)"
        MM["request/helpers/model-map.ts\nModelFamily, MODEL_FAMILIES"]
        UT["utils.ts\nsleep"]
        TY["types.ts\nAccountIdSource …"]
    end

    subgraph "storage layer"
        PT["storage/public-types.ts\nWorkspace, AccountMetadataV3\nAccountStorageV3, FlaggedAccount*\nCooldownReason, RateLimitStateV3"]
        BM["storage/backup-metadata.ts\nBackupMetadata, RestoreAssessment"]
        SR["storage/save-retry.ts\nsaveAccountsWithRetry\nisRetryableStorageWriteError"]
        MG["storage/migrations.ts\nAccountStorageV1 (legacy)"]
        ST["storage.ts (facade)\nre-exports all above"]
    end

    subgraph "accounts layer"
        AC["accounts.ts\nWorkspace re-export"]
    end

    subgraph "manager/CLI layer"
        FRS["codex-manager/forecast-report-shared.ts\nre-exports save-retry"]
        APW["codex-manager/account-pool-write.ts"]
    end

    MM --> PT
    TY --> PT
    PT --> SR
    UT --> SR
    PT --> MG
    MM --> MG
    BM --> ST
    PT --> ST
    MG --> ST
    SR --> AC
    ST --> AC
    SR --> FRS
    ST --> FRS
    AC --> APW
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-21-no-cycle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-21-no-cycle%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fstorage%2Fsave-retry.ts%3A1-33%0A**no%20direct%20vitest%20coverage%20for%20the%20new%20module**%0A%0A%60save-retry.ts%60%20is%20now%20a%20standalone%20shared%20utility%20but%20has%20no%20test%20file.%20the%20retry%20cap%20%28%60attempt%20%3E%3D%203%60%20%E2%86%92%204%20total%20attempts%29%2C%20the%20exponential%20delay%20formula%20%28%6010%20*%202%20**%20attempt%60%20%E2%86%92%2010%2F20%2F40%20ms%29%2C%20and%20the%20exact%20set%20of%20retryable%20codes%20are%20all%20observable%20contracts.%20indirect%20coverage%20exists%20via%20%60codex-manager-cli.test.ts%60%20and%20%60issue-474-pin-safety.test.ts%60%2C%20but%20those%20tests%20go%20through%20many%20layers.%20a%20direct%20unit%20test%20would%20catch%20a%20future%20change%20to%20the%20retry%20set%20or%20cap%20without%20having%20to%20exercise%20the%20full%20manager%20stack.%0A%0Aalso%3A%20%60RETRYABLE_STORAGE_WRITE_CODES%60%20is%20%60%5B%22EBUSY%22%2C%20%22EPERM%22%5D%60%20%E2%80%94%20on%20windows%2C%20storage-path%20writes%20%28e.g.%20under%20%60AppData%5C%60%29%20can%20fail%20with%20%60EACCES%60%20when%20a%20competing%20process%20holds%20an%20exclusive%20lock.%20that%20code%20isn't%20retried%20today.%20this%20is%20verbatim%20from%20the%20original%20location%2C%20so%20not%20a%20regression%20here%2C%20but%20now%20that%20the%20set%20is%20a%20named%20shared%20constant%20it's%20a%20natural%20place%20to%20add%20it.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=541&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/storage/save-retry.ts:1-33
**no direct vitest coverage for the new module**

`save-retry.ts` is now a standalone shared utility but has no test file. the retry cap (`attempt >= 3` → 4 total attempts), the exponential delay formula (`10 * 2 ** attempt` → 10/20/40 ms), and the exact set of retryable codes are all observable contracts. indirect coverage exists via `codex-manager-cli.test.ts` and `issue-474-pin-safety.test.ts`, but those tests go through many layers. a direct unit test would catch a future change to the retry set or cap without having to exercise the full manager stack.

also: `RETRYABLE_STORAGE_WRITE_CODES` is `["EBUSY", "EPERM"]` — on windows, storage-path writes (e.g. under `AppData\`) can fail with `EACCES` when a competing process holds an exclusive lock. that code isn't retried today. this is verbatim from the original location, so not a regression here, but now that the set is a named shared constant it's a natural place to add it.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(lib): import MODEL\_FAMILIES fro..."](https://github.com/ndycode/codex-multi-auth/commit/1da22ba1154e72aea0a1605aa0a83a80ce579c16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36677006)</sub>

<!-- /greptile_comment -->