### PR TITLE
docs(errors): record typed-error adoption in the contracts reference

### DIFF
--- a/docs/reference/error-contracts.md
+++ b/docs/reference/error-contracts.md
@@ -62,6 +62,14 @@ Compatibility guarantees:
 - Error responses are normalized to JSON error payloads with a stable `error.message` field.
 - Diagnostics may include request/correlation IDs when available.
 
+### Typed Errors
+
+The request layer's thrown errors are backed by the typed hierarchy in `lib/errors.ts` (base class `CodexError`, which extends `Error` and carries a stable `code` string):
+
+- `refreshAndUpdateToken` throws `CodexAuthError` (`code: "CODEX_AUTH_ERROR"`) with the message `Failed to refresh token, authentication required` on any refresh failure. The error carries a `retryable` boolean (transient network/lock failures are retryable; invalid-grant style failures are not) and, where available, `cause` and `context` (`refreshFailureReason`, `statusCode`).
+- Catch sites may rely on `instanceof CodexAuthError` (or the structural `code` property) plus `retryable` to decide whether to re-attempt or force re-authentication.
+- HTTP error responses are returned as normalized `Response` payloads (see above), not thrown, so they intentionally have no `Error` class.
+
 ---
 
 ## Runtime Rotation Proxy Error Contract
@@ -93,6 +101,8 @@ Supported dual-call forms include:
 - `createCodexHeaders(...)` and `createCodexHeaders({ ... })`
 - `getRateLimitBackoffWithReason(...)` and `getRateLimitBackoffWithReason({ ... })`
 - `transformRequestBody(...)` and `transformRequestBody({ ... })`
+
+Invalid named-parameter calls (missing or wrongly typed required fields, or unknown keys) throw a native `TypeError` with a `<helper> requires ...` message — for example, `createCodexHeaders` throws `TypeError: createCodexHeaders requires accountId and accessToken`. This is a deliberate, shared convention across the dual-call helpers and is not wrapped in a `CodexError` subclass.
 
 ---
 

--- a/lib/request/error-classification.ts
+++ b/lib/request/error-classification.ts
@@ -1,0 +1,366 @@
+/**
+ * Error classification helpers for the custom fetch implementation
+ * Extracted from fetch-helpers.ts (audit roadmap §4.1.2); fetch-helpers.ts
+ * re-exports the public symbols so existing importers are unchanged.
+ */
+
+import { isRecord } from "../utils.js";
+import { HTTP_STATUS } from "../constants.js";
+
+export interface EntitlementError {
+        isEntitlement: true;
+        code: string;
+        message: string;
+}
+
+export const CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE = "model_not_supported_with_chatgpt_account";
+const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
+	/model is not supported when using codex with a chatgpt account/i;
+const NORMALIZED_UNSUPPORTED_MODEL_PATTERN =
+	/the model ['"]([^'"]+)['"] is not currently available for this chatgpt account/i;
+const MODEL_ACCESS_DENIED_PATTERN =
+	/the model [`'"]([^`'"]+)[`'"] does not exist or you do not have access to it/i;
+
+export const DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN: Record<string, string[]> = {
+	"gpt-5": ["gpt-5.5"],
+	"gpt-5-pro": ["gpt-5.5-pro"],
+	"gpt-5-chat-latest": ["gpt-5.5"],
+	"gpt-5.5": ["gpt-5.4"],
+	"gpt-5.5-pro": ["gpt-5.4"],
+	"gpt-5.5-2026-04-23": ["gpt-5.4"],
+	"gpt-5.5-pro-2026-04-23": ["gpt-5.4"],
+	"gpt-5.5-20260423": ["gpt-5.4"],
+	"gpt-5.5-pro-20260423": ["gpt-5.4"],
+	"gpt-5.3-codex-spark": ["gpt-5.3-codex", "gpt-5.2-codex"],
+	"gpt-5.3-codex": ["gpt-5.2-codex"],
+	"codex-max": ["gpt-5.3-codex"],
+	"gpt-5.1-codex-max": ["gpt-5.3-codex"],
+	"codex-mini-latest": ["gpt-5.3-codex"],
+	"gpt-5-codex-mini": ["gpt-5.3-codex"],
+	"gpt-5.1-codex-mini": ["gpt-5.3-codex"],
+	"gpt-5-codex": ["gpt-5.3-codex", "gpt-5.2-codex"],
+	"gpt-5.2-codex": ["gpt-5.3-codex"],
+	"gpt-5.1-codex": ["gpt-5.3-codex"],
+};
+
+export interface UnsupportedCodexModelInfo {
+	isUnsupported: boolean;
+	code?: string;
+	message?: string;
+	unsupportedModel?: string;
+}
+
+export interface ResolveUnsupportedCodexFallbackOptions {
+	requestedModel: string | undefined;
+	errorBody: unknown;
+	attemptedModels?: Iterable<string>;
+	fallbackOnUnsupportedCodexModel: boolean;
+	fallbackToGpt52OnUnsupportedGpt53: boolean;
+	customChain?: Record<string, string[]>;
+}
+
+function canonicalizeModelName(model: string | undefined): string | undefined {
+	if (!model) return undefined;
+	const trimmed = model.trim().toLowerCase();
+	if (!trimmed) return undefined;
+	const stripped = trimmed.includes("/")
+		? (trimmed.split("/").pop() ?? trimmed)
+		: trimmed;
+	return stripped.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
+}
+
+function normalizeFallbackChain(
+	customChain: Record<string, string[]> | undefined,
+): Record<string, string[]> {
+	const normalized: Record<string, string[]> = {};
+	for (const [key, values] of Object.entries(DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN)) {
+		const normalizedKey = canonicalizeModelName(key);
+		if (!normalizedKey) continue;
+		normalized[normalizedKey] = values
+			.map((value) => canonicalizeModelName(value))
+			.filter((value): value is string => !!value);
+	}
+
+	if (!customChain) {
+		return normalized;
+	}
+
+	for (const [key, values] of Object.entries(customChain)) {
+		const normalizedKey = canonicalizeModelName(key);
+		if (!normalizedKey || !Array.isArray(values)) continue;
+		const normalizedValues = values
+			.map((value) => canonicalizeModelName(value))
+			.filter((value): value is string => !!value);
+		if (normalizedValues.length > 0) {
+			normalized[normalizedKey] = normalizedValues;
+		}
+	}
+
+	return normalized;
+}
+
+export function extractUnsupportedCodexModelFromText(bodyText: string): string | undefined {
+	const directMatch = bodyText.match(
+		/['"]([^'"]+)['"]\s+model is not supported when using codex with a chatgpt account/i,
+	);
+	if (directMatch?.[1]) {
+		return canonicalizeModelName(directMatch[1]);
+	}
+	const normalizedMatch = bodyText.match(NORMALIZED_UNSUPPORTED_MODEL_PATTERN);
+	if (normalizedMatch?.[1]) {
+		return canonicalizeModelName(normalizedMatch[1]);
+	}
+	const accessDeniedMatch = bodyText.match(MODEL_ACCESS_DENIED_PATTERN);
+	if (accessDeniedMatch?.[1]) {
+		return canonicalizeModelName(accessDeniedMatch[1]);
+	}
+	return undefined;
+}
+
+export function isUnsupportedCodexModelForChatGpt(status: number, bodyText: string): boolean {
+	if (status !== HTTP_STATUS.BAD_REQUEST) return false;
+	if (!bodyText) return false;
+	return (
+		CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(bodyText) ||
+		NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(bodyText) ||
+		MODEL_ACCESS_DENIED_PATTERN.test(bodyText)
+	);
+}
+
+export function getUnsupportedCodexModelInfo(
+	errorBody: unknown,
+): UnsupportedCodexModelInfo {
+	if (!isRecord(errorBody)) {
+		return { isUnsupported: false };
+	}
+
+	const maybeError = errorBody.error;
+	if (!isRecord(maybeError)) {
+		// Some upstreams (e.g. the Codex quota endpoint) return the flat
+		// `{ "detail": "...model is not supported..." }` shape instead of the
+		// nested `{ "error": { "message": "..." } }` envelope. Fall back to the
+		// top-level `detail` string so model-fallback detection still works.
+		const detail = typeof errorBody.detail === "string" ? errorBody.detail : undefined;
+		if (!detail) {
+			return { isUnsupported: false };
+		}
+		const isUnsupportedDetail =
+			CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
+			NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
+			MODEL_ACCESS_DENIED_PATTERN.test(detail);
+		if (!isUnsupportedDetail) {
+			return { isUnsupported: false };
+		}
+		return {
+			isUnsupported: true,
+			message: detail,
+			unsupportedModel: extractUnsupportedCodexModelFromText(detail) ?? undefined,
+		};
+	}
+
+	const code = typeof maybeError.code === "string" ? maybeError.code : undefined;
+	const message =
+		typeof maybeError.message === "string" ? maybeError.message : undefined;
+	const unsupportedModelFromPayload =
+		typeof maybeError.unsupported_model === "string"
+			? maybeError.unsupported_model
+			: undefined;
+	const unsupportedModel = unsupportedModelFromPayload
+		? canonicalizeModelName(unsupportedModelFromPayload)
+		: extractUnsupportedCodexModelFromText(message ?? "");
+	const isUnsupported =
+		code === CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE ||
+		(message
+			? CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(message) ||
+				NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(message) ||
+				MODEL_ACCESS_DENIED_PATTERN.test(message)
+			: false);
+
+	return {
+		isUnsupported,
+		code,
+		message,
+		unsupportedModel: unsupportedModel ?? undefined,
+	};
+}
+
+export function resolveUnsupportedCodexFallbackModel(
+	options: ResolveUnsupportedCodexFallbackOptions,
+): string | undefined {
+	if (!options.fallbackOnUnsupportedCodexModel) return undefined;
+
+	const unsupported = getUnsupportedCodexModelInfo(options.errorBody);
+	if (!unsupported.isUnsupported) return undefined;
+
+	const requestedModel = canonicalizeModelName(options.requestedModel);
+	const currentModel = requestedModel ?? unsupported.unsupportedModel;
+	if (!currentModel) return undefined;
+
+	const attempted = new Set<string>();
+	for (const model of options.attemptedModels ?? []) {
+		const normalized = canonicalizeModelName(model);
+		if (normalized) attempted.add(normalized);
+	}
+
+	const chain = normalizeFallbackChain(options.customChain);
+	const targets = chain[currentModel] ?? [];
+	if (targets.length === 0) return undefined;
+
+	for (const target of targets) {
+		if (!options.fallbackToGpt52OnUnsupportedGpt53 &&
+			currentModel === "gpt-5.3-codex" &&
+			target === "gpt-5.2-codex") {
+			continue;
+		}
+		if (target === currentModel) continue;
+		if (attempted.has(target)) continue;
+		return target;
+	}
+
+	return undefined;
+}
+
+/**
+ * Returns true when the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge is available.
+ */
+export function shouldFallbackToGpt52OnUnsupportedGpt53(
+	requestedModel: string | undefined,
+	errorBody: unknown,
+): boolean {
+	if (canonicalizeModelName(requestedModel) !== "gpt-5.3-codex") {
+		return false;
+	}
+
+	return (
+		resolveUnsupportedCodexFallbackModel({
+			requestedModel,
+			errorBody,
+			// Probe whether the legacy gpt-5.2 edge is still active under current
+			// policy/toggles when the current Codex model is blocked.
+			attemptedModels: [],
+			fallbackOnUnsupportedCodexModel: true,
+			fallbackToGpt52OnUnsupportedGpt53: true,
+		}) === "gpt-5.2-codex"
+	);
+}
+
+/**
+ * Detects whether an error code or response body indicates an entitlement/subscription issue for Codex models.
+ *
+ * Entitlement errors signal that the requested feature is not included in the user's plan and should not be treated as rate limits.
+ * This function is pure and safe to call concurrently; it performs no filesystem access (including on Windows) and does not read or redact tokens — callers must avoid passing sensitive credentials in `code` or `bodyText`.
+ *
+ * @param code - The error code string returned by the service
+ * @param bodyText - The response body text to inspect for entitlement-related phrases
+ * @returns `true` if the combined `code` or `bodyText` indicates an entitlement/subscription issue, `false` otherwise
+ */
+export function isEntitlementError(code: string, bodyText: string): boolean {
+        const haystack = `${code} ${bodyText}`.toLowerCase();
+        // "usage_not_included" means the subscription doesn't include this feature
+        // This is different from "usage_limit_reached" which is a temporary quota limit
+        return /usage_not_included|not.included.in.your.plan|subscription.does.not.include/i.test(haystack);
+}
+
+/**
+ * Detects whether an error indicates the workspace/account has been disabled or expired.
+ *
+ * Workspace disabled errors signal that the current workspace is no longer accessible
+ * (expired, disabled, or removed) and the plugin should automatically switch to another account.
+ *
+ * @param status - HTTP status code
+ * @param code - The error code string returned by the service
+ * @param bodyText - The response body text to inspect for workspace-related phrases
+ * @returns `true` if the error indicates a disabled/expired workspace
+ */
+export function isWorkspaceDisabledError(
+        status: number,
+        code: unknown,
+        bodyText: string,
+): boolean {
+        const normalizedCode = typeof code === "string" ? code.trim().toLowerCase() : "";
+
+        if (status === 402) {
+                const normalizedTokens = normalizedCode
+                        .split(/[^a-z0-9_]+/i)
+                        .map((token) => token.trim())
+                        .filter((token) => token.length > 0);
+                return (
+                        normalizedTokens.includes("deactivated_workspace") ||
+                        /\bdeactivated_workspace\b/i.test(bodyText)
+                );
+        }
+
+        if (status !== 403) {
+                return false;
+        }
+
+        const haystack = `${normalizedCode} ${bodyText}`.toLowerCase();
+        const normalizedTokens = normalizedCode
+                .split(/[^a-z0-9_]+/i)
+                .map((token) => token.trim())
+                .filter((token) => token.length > 0);
+
+		const disabledPatterns = [
+				/workspace.*(?:disabled|expired|deactivated|terminated)/i,
+				/account\s+(?:has\s+been|is)\s+(?:disabled|expired|deactivated|terminated|closed)/i,
+				/(?:workspace|org(?:anization)?).*no longer.*(?:active|available|valid)/i,
+				/(?:workspace|org(?:anization)?).*has been.*(?:disabled|expired|closed)/i,
+				/workspace.*(?:access|subscription).*expired/i,
+				/org(?:anization)?.*(?:disabled|expired|inactive)/i,
+		];
+
+        for (const pattern of disabledPatterns) {
+                if (pattern.test(haystack)) {
+                        return true;
+                }
+        }
+
+        const workspaceErrorCodes = new Set([
+                "workspace_disabled",
+                "workspace_expired",
+                "workspace_terminated",
+                "account_disabled",
+                "account_expired",
+                "organization_disabled",
+        ]);
+        if (workspaceErrorCodes.has(normalizedCode)) {
+                return true;
+        }
+
+        return normalizedTokens.some((token) => workspaceErrorCodes.has(token));
+}
+
+/**
+ * Constructs a standardized 403 entitlement error Response indicating the user lacks access to Codex models.
+ *
+ * This function returns a JSON Response with an `error` payload containing a user-facing message, a
+ * `type` of `"entitlement_error"`, and a `code` of `"usage_not_included"`. The message suggests checking
+ * account/workspace access and re-authenticating with `codex-multi-auth login`.
+ *
+ * Concurrency: stateless and safe to call concurrently from multiple threads or requests.
+ * Windows filesystem behavior: none (function does not access the filesystem).
+ * Token redaction: any tokens are not included in the generated payload; do not pass sensitive tokens in `_bodyText`.
+ *
+ * @param _bodyText - Original response body text (accepted for compatibility; ignored when building the response)
+ * @returns A 403 Response with a JSON body describing the entitlement error and guidance for resolving it
+ */
+export function createEntitlementErrorResponse(_bodyText: string): Response {
+        const message = 
+                "This model is not included in your ChatGPT subscription. " +
+                "Please check that your account or workspace has access to Codex models (Plus/Pro/Business/Enterprise). " +
+                "If you recently subscribed or switched workspaces, try logging out and back in with `codex-multi-auth login`.";
+        
+        const payload = {
+                error: {
+                        message,
+                        type: "entitlement_error",
+                        code: "usage_not_included",
+                },
+        };
+
+        return new Response(JSON.stringify(payload), {
+                status: 403, // Forbidden - not a rate limit
+                statusText: "Forbidden",
+                headers: { "content-type": "application/json; charset=utf-8" },
+        });
+}

--- a/lib/request/error-classification.ts
+++ b/lib/request/error-classification.ts
@@ -13,6 +13,7 @@ export interface EntitlementError {
         message: string;
 }
 
+/** @internal Exported only for sibling lib/request modules; import via fetch-helpers.ts elsewhere. */
 export const CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE = "model_not_supported_with_chatgpt_account";
 const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
 	/model is not supported when using codex with a chatgpt account/i;
@@ -117,6 +118,7 @@ export function extractUnsupportedCodexModelFromText(bodyText: string): string |
 	return undefined;
 }
 
+/** @internal Exported only for sibling lib/request modules; import via fetch-helpers.ts elsewhere. */
 export function isUnsupportedCodexModelForChatGpt(status: number, bodyText: string): boolean {
 	if (status !== HTTP_STATUS.BAD_REQUEST) return false;
 	if (!bodyText) return false;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -3,9 +3,6 @@
  * These functions break down the complex fetch logic into manageable, testable units
  */
 
-import type { Auth, CodexClient } from "@codex-ai/sdk";
-import { ProxyAgent } from "undici";
-import { queuedRefresh } from "../refresh-queue.js";
 import { logRequest, logError, logWarn } from "../logger.js";
 import { getCodexInstructions, getModelFamily } from "../prompts/codex.js";
 import {
@@ -19,422 +16,67 @@ import {
 	convertSseToJson,
 	ensureContentType,
 } from "./response-handler.js";
-import type { UserConfig, RequestBody, TokenResult } from "../types.js";
-import { registerCleanup } from "../shutdown.js";
-import { CodexAuthError } from "../errors.js";
+import type { UserConfig, RequestBody } from "../types.js";
 import { isRecord } from "../utils.js";
 import {
-        CODEX_BASE_URL,
-        HTTP_STATUS,
-        OPENAI_HEADERS,
-        OPENAI_HEADER_VALUES,
-        URL_PATHS,
-        ERROR_MESSAGES,
-        LOG_STAGES,
+	HTTP_STATUS,
+	ERROR_MESSAGES,
+	LOG_STAGES,
 } from "../constants.js";
+import {
+	CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE,
+	createEntitlementErrorResponse,
+	extractUnsupportedCodexModelFromText,
+	isEntitlementError,
+	isUnsupportedCodexModelForChatGpt,
+} from "./error-classification.js";
+import { logDeprecationHeaders } from "./headers.js";
 
-interface CodexAuthSetter {
-	auth: {
-		set(args: {
-			path: { id: string };
-			body: {
-				type: "oauth";
-				access: string;
-				refresh: string;
-				expires: number;
-				multiAccount: boolean;
-			};
-		}): Promise<unknown>;
-	};
-}
+export { shouldRefreshToken, refreshAndUpdateToken } from "./token-refresh.js";
+export {
+	DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN,
+	extractUnsupportedCodexModelFromText,
+	getUnsupportedCodexModelInfo,
+	resolveUnsupportedCodexFallbackModel,
+	shouldFallbackToGpt52OnUnsupportedGpt53,
+	isEntitlementError,
+	isWorkspaceDisabledError,
+	createEntitlementErrorResponse,
+} from "./error-classification.js";
+export type {
+	EntitlementError,
+	UnsupportedCodexModelInfo,
+	ResolveUnsupportedCodexFallbackOptions,
+} from "./error-classification.js";
+export {
+	extractRequestUrl,
+	rewriteUrlForCodex,
+	resolveProxyUrlForRequest,
+	closeSharedProxyDispatchers,
+	applyProxyCompatibleInit,
+} from "./url-rewriting.js";
+export type { ProxyCompatibleRequestInit } from "./url-rewriting.js";
+export { createCodexHeaders } from "./headers.js";
+export type {
+	CreateCodexHeadersOptions,
+	CreateCodexHeadersParams,
+} from "./headers.js";
+
 export interface RateLimitInfo {
         retryAfterMs: number;
         code?: string;
 }
 
-export interface EntitlementError {
-        isEntitlement: true;
-        code: string;
-        message: string;
-}
-
-const CODEX_BASE_URL_OBJECT = new URL(CODEX_BASE_URL);
-const CODEX_BASE_PATH_PREFIX = CODEX_BASE_URL_OBJECT.pathname.endsWith("/")
-	? CODEX_BASE_URL_OBJECT.pathname.slice(0, -1)
-	: CODEX_BASE_URL_OBJECT.pathname;
-
-const CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE = "model_not_supported_with_chatgpt_account";
-const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
-	/model is not supported when using codex with a chatgpt account/i;
-const NORMALIZED_UNSUPPORTED_MODEL_PATTERN =
-	/the model ['"]([^'"]+)['"] is not currently available for this chatgpt account/i;
-const MODEL_ACCESS_DENIED_PATTERN =
-	/the model [`'"]([^`'"]+)[`'"] does not exist or you do not have access to it/i;
 const MAX_RATE_LIMIT_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
 const RETRY_AFTER_DURATION_PATTERN =
 	/\b(?:try|retry)\s+again\s+in\s+(\d+)\s*(second|minute|hour|day)s?\b/i;
 const RETRY_AFTER_CLOCK_TIME_PATTERN =
 	/\b(?:try|retry)\s+again\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b/i;
-const CREATE_CODEX_HEADERS_PARAM_KEYS = new Set(["init", "accountId", "accessToken", "opts"]);
-const DEFAULT_PROXY_PORTS: Record<string, number> = {
-	"http:": 80,
-	"https:": 443,
-};
-type ProxyDispatcher = NonNullable<RequestInit["dispatcher"]>;
-const sharedProxyDispatchers = new Map<string, ProxyDispatcher>();
-
-type ClosableDispatcher = ProxyDispatcher & {
-	close?: () => Promise<void> | void;
-};
-
-export const DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN: Record<string, string[]> = {
-	"gpt-5": ["gpt-5.5"],
-	"gpt-5-pro": ["gpt-5.5-pro"],
-	"gpt-5-chat-latest": ["gpt-5.5"],
-	"gpt-5.5": ["gpt-5.4"],
-	"gpt-5.5-pro": ["gpt-5.4"],
-	"gpt-5.5-2026-04-23": ["gpt-5.4"],
-	"gpt-5.5-pro-2026-04-23": ["gpt-5.4"],
-	"gpt-5.5-20260423": ["gpt-5.4"],
-	"gpt-5.5-pro-20260423": ["gpt-5.4"],
-	"gpt-5.3-codex-spark": ["gpt-5.3-codex", "gpt-5.2-codex"],
-	"gpt-5.3-codex": ["gpt-5.2-codex"],
-	"codex-max": ["gpt-5.3-codex"],
-	"gpt-5.1-codex-max": ["gpt-5.3-codex"],
-	"codex-mini-latest": ["gpt-5.3-codex"],
-	"gpt-5-codex-mini": ["gpt-5.3-codex"],
-	"gpt-5.1-codex-mini": ["gpt-5.3-codex"],
-	"gpt-5-codex": ["gpt-5.3-codex", "gpt-5.2-codex"],
-	"gpt-5.2-codex": ["gpt-5.3-codex"],
-	"gpt-5.1-codex": ["gpt-5.3-codex"],
-};
-
-export interface UnsupportedCodexModelInfo {
-	isUnsupported: boolean;
-	code?: string;
-	message?: string;
-	unsupportedModel?: string;
-}
-
-export interface ResolveUnsupportedCodexFallbackOptions {
-	requestedModel: string | undefined;
-	errorBody: unknown;
-	attemptedModels?: Iterable<string>;
-	fallbackOnUnsupportedCodexModel: boolean;
-	fallbackToGpt52OnUnsupportedGpt53: boolean;
-	customChain?: Record<string, string[]>;
-}
 
 export interface TransformRequestForCodexResult {
 	body: RequestBody;
 	updatedInit: RequestInit;
 	deferredFastSessionInputTrim?: FastSessionInputTrimPlan["trim"];
-}
-
-function canonicalizeModelName(model: string | undefined): string | undefined {
-	if (!model) return undefined;
-	const trimmed = model.trim().toLowerCase();
-	if (!trimmed) return undefined;
-	const stripped = trimmed.includes("/")
-		? (trimmed.split("/").pop() ?? trimmed)
-		: trimmed;
-	return stripped.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
-}
-
-function normalizeFallbackChain(
-	customChain: Record<string, string[]> | undefined,
-): Record<string, string[]> {
-	const normalized: Record<string, string[]> = {};
-	for (const [key, values] of Object.entries(DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN)) {
-		const normalizedKey = canonicalizeModelName(key);
-		if (!normalizedKey) continue;
-		normalized[normalizedKey] = values
-			.map((value) => canonicalizeModelName(value))
-			.filter((value): value is string => !!value);
-	}
-
-	if (!customChain) {
-		return normalized;
-	}
-
-	for (const [key, values] of Object.entries(customChain)) {
-		const normalizedKey = canonicalizeModelName(key);
-		if (!normalizedKey || !Array.isArray(values)) continue;
-		const normalizedValues = values
-			.map((value) => canonicalizeModelName(value))
-			.filter((value): value is string => !!value);
-		if (normalizedValues.length > 0) {
-			normalized[normalizedKey] = normalizedValues;
-		}
-	}
-
-	return normalized;
-}
-
-export function extractUnsupportedCodexModelFromText(bodyText: string): string | undefined {
-	const directMatch = bodyText.match(
-		/['"]([^'"]+)['"]\s+model is not supported when using codex with a chatgpt account/i,
-	);
-	if (directMatch?.[1]) {
-		return canonicalizeModelName(directMatch[1]);
-	}
-	const normalizedMatch = bodyText.match(NORMALIZED_UNSUPPORTED_MODEL_PATTERN);
-	if (normalizedMatch?.[1]) {
-		return canonicalizeModelName(normalizedMatch[1]);
-	}
-	const accessDeniedMatch = bodyText.match(MODEL_ACCESS_DENIED_PATTERN);
-	if (accessDeniedMatch?.[1]) {
-		return canonicalizeModelName(accessDeniedMatch[1]);
-	}
-	return undefined;
-}
-
-function isUnsupportedCodexModelForChatGpt(status: number, bodyText: string): boolean {
-	if (status !== HTTP_STATUS.BAD_REQUEST) return false;
-	if (!bodyText) return false;
-	return (
-		CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(bodyText) ||
-		NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(bodyText) ||
-		MODEL_ACCESS_DENIED_PATTERN.test(bodyText)
-	);
-}
-
-export function getUnsupportedCodexModelInfo(
-	errorBody: unknown,
-): UnsupportedCodexModelInfo {
-	if (!isRecord(errorBody)) {
-		return { isUnsupported: false };
-	}
-
-	const maybeError = errorBody.error;
-	if (!isRecord(maybeError)) {
-		// Some upstreams (e.g. the Codex quota endpoint) return the flat
-		// `{ "detail": "...model is not supported..." }` shape instead of the
-		// nested `{ "error": { "message": "..." } }` envelope. Fall back to the
-		// top-level `detail` string so model-fallback detection still works.
-		const detail = typeof errorBody.detail === "string" ? errorBody.detail : undefined;
-		if (!detail) {
-			return { isUnsupported: false };
-		}
-		const isUnsupportedDetail =
-			CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
-			NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(detail) ||
-			MODEL_ACCESS_DENIED_PATTERN.test(detail);
-		if (!isUnsupportedDetail) {
-			return { isUnsupported: false };
-		}
-		return {
-			isUnsupported: true,
-			message: detail,
-			unsupportedModel: extractUnsupportedCodexModelFromText(detail) ?? undefined,
-		};
-	}
-
-	const code = typeof maybeError.code === "string" ? maybeError.code : undefined;
-	const message =
-		typeof maybeError.message === "string" ? maybeError.message : undefined;
-	const unsupportedModelFromPayload =
-		typeof maybeError.unsupported_model === "string"
-			? maybeError.unsupported_model
-			: undefined;
-	const unsupportedModel = unsupportedModelFromPayload
-		? canonicalizeModelName(unsupportedModelFromPayload)
-		: extractUnsupportedCodexModelFromText(message ?? "");
-	const isUnsupported =
-		code === CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE ||
-		(message
-			? CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN.test(message) ||
-				NORMALIZED_UNSUPPORTED_MODEL_PATTERN.test(message) ||
-				MODEL_ACCESS_DENIED_PATTERN.test(message)
-			: false);
-
-	return {
-		isUnsupported,
-		code,
-		message,
-		unsupportedModel: unsupportedModel ?? undefined,
-	};
-}
-
-export function resolveUnsupportedCodexFallbackModel(
-	options: ResolveUnsupportedCodexFallbackOptions,
-): string | undefined {
-	if (!options.fallbackOnUnsupportedCodexModel) return undefined;
-
-	const unsupported = getUnsupportedCodexModelInfo(options.errorBody);
-	if (!unsupported.isUnsupported) return undefined;
-
-	const requestedModel = canonicalizeModelName(options.requestedModel);
-	const currentModel = requestedModel ?? unsupported.unsupportedModel;
-	if (!currentModel) return undefined;
-
-	const attempted = new Set<string>();
-	for (const model of options.attemptedModels ?? []) {
-		const normalized = canonicalizeModelName(model);
-		if (normalized) attempted.add(normalized);
-	}
-
-	const chain = normalizeFallbackChain(options.customChain);
-	const targets = chain[currentModel] ?? [];
-	if (targets.length === 0) return undefined;
-
-	for (const target of targets) {
-		if (!options.fallbackToGpt52OnUnsupportedGpt53 &&
-			currentModel === "gpt-5.3-codex" &&
-			target === "gpt-5.2-codex") {
-			continue;
-		}
-		if (target === currentModel) continue;
-		if (attempted.has(target)) continue;
-		return target;
-	}
-
-	return undefined;
-}
-
-/**
- * Returns true when the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge is available.
- */
-export function shouldFallbackToGpt52OnUnsupportedGpt53(
-	requestedModel: string | undefined,
-	errorBody: unknown,
-): boolean {
-	if (canonicalizeModelName(requestedModel) !== "gpt-5.3-codex") {
-		return false;
-	}
-
-	return (
-		resolveUnsupportedCodexFallbackModel({
-			requestedModel,
-			errorBody,
-			// Probe whether the legacy gpt-5.2 edge is still active under current
-			// policy/toggles when the current Codex model is blocked.
-			attemptedModels: [],
-			fallbackOnUnsupportedCodexModel: true,
-			fallbackToGpt52OnUnsupportedGpt53: true,
-		}) === "gpt-5.2-codex"
-	);
-}
-
-/**
- * Detects whether an error code or response body indicates an entitlement/subscription issue for Codex models.
- *
- * Entitlement errors signal that the requested feature is not included in the user's plan and should not be treated as rate limits.
- * This function is pure and safe to call concurrently; it performs no filesystem access (including on Windows) and does not read or redact tokens — callers must avoid passing sensitive credentials in `code` or `bodyText`.
- *
- * @param code - The error code string returned by the service
- * @param bodyText - The response body text to inspect for entitlement-related phrases
- * @returns `true` if the combined `code` or `bodyText` indicates an entitlement/subscription issue, `false` otherwise
- */
-export function isEntitlementError(code: string, bodyText: string): boolean {
-        const haystack = `${code} ${bodyText}`.toLowerCase();
-        // "usage_not_included" means the subscription doesn't include this feature
-        // This is different from "usage_limit_reached" which is a temporary quota limit
-        return /usage_not_included|not.included.in.your.plan|subscription.does.not.include/i.test(haystack);
-}
-
-/**
- * Detects whether an error indicates the workspace/account has been disabled or expired.
- *
- * Workspace disabled errors signal that the current workspace is no longer accessible
- * (expired, disabled, or removed) and the plugin should automatically switch to another account.
- *
- * @param status - HTTP status code
- * @param code - The error code string returned by the service
- * @param bodyText - The response body text to inspect for workspace-related phrases
- * @returns `true` if the error indicates a disabled/expired workspace
- */
-export function isWorkspaceDisabledError(
-        status: number,
-        code: unknown,
-        bodyText: string,
-): boolean {
-        const normalizedCode = typeof code === "string" ? code.trim().toLowerCase() : "";
-
-        if (status === 402) {
-                const normalizedTokens = normalizedCode
-                        .split(/[^a-z0-9_]+/i)
-                        .map((token) => token.trim())
-                        .filter((token) => token.length > 0);
-                return (
-                        normalizedTokens.includes("deactivated_workspace") ||
-                        /\bdeactivated_workspace\b/i.test(bodyText)
-                );
-        }
-
-        if (status !== 403) {
-                return false;
-        }
-
-        const haystack = `${normalizedCode} ${bodyText}`.toLowerCase();
-        const normalizedTokens = normalizedCode
-                .split(/[^a-z0-9_]+/i)
-                .map((token) => token.trim())
-                .filter((token) => token.length > 0);
-
-		const disabledPatterns = [
-				/workspace.*(?:disabled|expired|deactivated|terminated)/i,
-				/account\s+(?:has\s+been|is)\s+(?:disabled|expired|deactivated|terminated|closed)/i,
-				/(?:workspace|org(?:anization)?).*no longer.*(?:active|available|valid)/i,
-				/(?:workspace|org(?:anization)?).*has been.*(?:disabled|expired|closed)/i,
-				/workspace.*(?:access|subscription).*expired/i,
-				/org(?:anization)?.*(?:disabled|expired|inactive)/i,
-		];
-
-        for (const pattern of disabledPatterns) {
-                if (pattern.test(haystack)) {
-                        return true;
-                }
-        }
-
-        const workspaceErrorCodes = new Set([
-                "workspace_disabled",
-                "workspace_expired",
-                "workspace_terminated",
-                "account_disabled",
-                "account_expired",
-                "organization_disabled",
-        ]);
-        if (workspaceErrorCodes.has(normalizedCode)) {
-                return true;
-        }
-
-        return normalizedTokens.some((token) => workspaceErrorCodes.has(token));
-}
-
-/**
- * Constructs a standardized 403 entitlement error Response indicating the user lacks access to Codex models.
- *
- * This function returns a JSON Response with an `error` payload containing a user-facing message, a
- * `type` of `"entitlement_error"`, and a `code` of `"usage_not_included"`. The message suggests checking
- * account/workspace access and re-authenticating with `codex-multi-auth login`.
- *
- * Concurrency: stateless and safe to call concurrently from multiple threads or requests.
- * Windows filesystem behavior: none (function does not access the filesystem).
- * Token redaction: any tokens are not included in the generated payload; do not pass sensitive tokens in `_bodyText`.
- *
- * @param _bodyText - Original response body text (accepted for compatibility; ignored when building the response)
- * @returns A 403 Response with a JSON body describing the entitlement error and guidance for resolving it
- */
-export function createEntitlementErrorResponse(_bodyText: string): Response {
-        const message = 
-                "This model is not included in your ChatGPT subscription. " +
-                "Please check that your account or workspace has access to Codex models (Plus/Pro/Business/Enterprise). " +
-                "If you recently subscribed or switched workspaces, try logging out and back in with `codex-multi-auth login`.";
-        
-        const payload = {
-                error: {
-                        message,
-                        type: "entitlement_error",
-                        code: "usage_not_included",
-                },
-        };
-
-        return new Response(JSON.stringify(payload), {
-                status: 403, // Forbidden - not a rate limit
-                statusText: "Forbidden",
-                headers: { "content-type": "application/json; charset=utf-8" },
-        });
 }
 
 export interface ErrorHandlingResult {
@@ -454,319 +96,6 @@ export interface ErrorDiagnostics {
 	correlationId?: string;
 	threadId?: string;
 	httpStatus?: number;
-}
-
-export interface CreateCodexHeadersOptions {
-	model?: string;
-	promptCacheKey?: string;
-}
-
-export interface ProxyCompatibleRequestInit extends RequestInit {
-	agent?: unknown;
-}
-
-export interface CreateCodexHeadersParams {
-	init?: RequestInit;
-	accountId: string;
-	accessToken: string;
-	opts?: CreateCodexHeadersOptions;
-}
-
-function isCreateCodexHeadersNamedParams(value: unknown): value is CreateCodexHeadersParams {
-	if (!isRecord(value)) return false;
-	if (typeof value.accountId !== "string" || typeof value.accessToken !== "string") return false;
-	return Object.keys(value).every((key) => CREATE_CODEX_HEADERS_PARAM_KEYS.has(key));
-}
-
-/**
- * Determines if the current auth token needs to be refreshed
- * @param auth - Current authentication state
- * @returns True if token is expired or invalid
- */
-export function shouldRefreshToken(auth: Auth, skewMs = 0): boolean {
-	if (auth.type !== "oauth") return true;
-	if (!auth.access) return true;
-
-	const safeSkewMs = Math.max(0, Math.floor(skewMs));
-	return auth.expires <= Date.now() + safeSkewMs;
-}
-
-function isRetryableRefreshFailure(
-	result: Extract<TokenResult, { type: "failed" }>,
-): boolean {
-	switch (result.reason) {
-		case "network_error":
-		case "unknown":
-		case "invalid_response":
-			return true;
-		case "missing_refresh":
-			return false;
-		case "http_error":
-			return !(
-				result.statusCode === HTTP_STATUS.BAD_REQUEST ||
-				result.statusCode === HTTP_STATUS.UNAUTHORIZED ||
-				result.statusCode === HTTP_STATUS.FORBIDDEN
-			);
-		default:
-			return false;
-	}
-}
-
-function isRetryableAuthSetterError(error: unknown): boolean {
-	if (!error || typeof error !== "object") {
-		return false;
-	}
-
-	const candidate = error as {
-		code?: unknown;
-		status?: unknown;
-		cause?: unknown;
-	};
-	const code =
-		typeof candidate.code === "string"
-			? candidate.code.toUpperCase()
-			: undefined;
-	if (code === "EAGAIN" || code === "EBUSY" || code === "EPERM") {
-		return true;
-	}
-
-	if (candidate.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
-		return true;
-	}
-
-	if (candidate.cause && candidate.cause !== error) {
-		return isRetryableAuthSetterError(candidate.cause);
-	}
-
-	return false;
-}
-
-/**
- * Refreshes the OAuth token and updates stored credentials
- * @param currentAuth - Current auth state
- * @param client - Codex client for updating stored credentials
- * @returns Updated auth (throws on failure)
- */
-export async function refreshAndUpdateToken(
-	currentAuth: Auth,
-	client: CodexClient,
-): Promise<Auth> {
-	const authSetter = (client as Partial<CodexAuthSetter>).auth;
-	if (!authSetter || typeof authSetter.set !== "function") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-			retryable: false,
-		});
-	}
-
-	const refreshToken = currentAuth.type === "oauth" ? currentAuth.refresh : "";
-	const refreshResult = await queuedRefresh(refreshToken);
-
-	if (refreshResult.type === "failed") {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-			retryable: isRetryableRefreshFailure(refreshResult),
-			context: {
-				refreshFailureReason: refreshResult.reason,
-				statusCode: refreshResult.statusCode,
-			},
-		});
-	}
-
-	try {
-		await authSetter.set({
-			path: { id: "openai" },
-			body: {
-				type: "oauth",
-				access: refreshResult.access,
-				refresh: refreshResult.refresh,
-				expires: refreshResult.expires,
-				multiAccount: true,
-			},
-		});
-	} catch (error) {
-		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
-			retryable: isRetryableAuthSetterError(error),
-			cause: error,
-		});
-	}
-
-	// Update current auth reference if it's OAuth type
-	if (currentAuth.type === "oauth") {
-		currentAuth.access = refreshResult.access;
-		currentAuth.refresh = refreshResult.refresh;
-		currentAuth.expires = refreshResult.expires;
-	}
-
-	return currentAuth;
-}
-
-/**
- * Extracts URL string from various request input types
- * @param input - Request input (string, URL, or Request object)
- * @returns URL string
- */
-export function extractRequestUrl(input: Request | string | URL): string {
-	if (typeof input === "string") return input;
-	if (input instanceof URL) return input.toString();
-	return input.url;
-}
-
-/**
- * Rewrites OpenAI API URLs to Codex backend URLs
- * @param url - Original URL
- * @returns Rewritten URL for Codex backend
- */
-export function rewriteUrlForCodex(url: string): string {
-	const parsedUrl = new URL(url);
-	const rewrittenPath = parsedUrl.pathname.includes(URL_PATHS.RESPONSES)
-		? parsedUrl.pathname.replace(URL_PATHS.RESPONSES, URL_PATHS.CODEX_RESPONSES)
-		: parsedUrl.pathname;
-	const normalizedPath =
-		rewrittenPath === CODEX_BASE_PATH_PREFIX ||
-		rewrittenPath.startsWith(`${CODEX_BASE_PATH_PREFIX}/`)
-			? rewrittenPath
-			: `${CODEX_BASE_PATH_PREFIX}${rewrittenPath.startsWith("/") ? rewrittenPath : `/${rewrittenPath}`}`;
-
-	parsedUrl.protocol = CODEX_BASE_URL_OBJECT.protocol;
-	parsedUrl.username = "";
-	parsedUrl.password = "";
-	parsedUrl.host = CODEX_BASE_URL_OBJECT.host;
-	parsedUrl.pathname = normalizedPath;
-
-	return parsedUrl.toString();
-}
-
-function hasOwnEnvKey(env: NodeJS.ProcessEnv, key: string): boolean {
-	return Object.prototype.hasOwnProperty.call(env, key);
-}
-
-function resolveProxyEnvValue(
-	env: NodeJS.ProcessEnv,
-	lowerKey: string,
-	upperKey: string,
-): string | undefined {
-	if (hasOwnEnvKey(env, lowerKey)) {
-		const value = env[lowerKey]?.trim();
-		return value ? value : undefined;
-	}
-
-	const value = env[upperKey]?.trim();
-	return value ? value : undefined;
-}
-
-function parseNoProxyEntries(noProxyValue: string): Array<{ hostname: string; port: number }> {
-	return noProxyValue
-		.split(/[,\s]/)
-		.map((entry) => entry.trim())
-		.filter(Boolean)
-		.map((entry) => {
-			const parsed = entry.match(/^(.+):(\d+)$/);
-			const hostname = parsed?.[1] ?? entry;
-			const portText = parsed?.[2];
-			return {
-				hostname: hostname.toLowerCase(),
-				port: portText ? Number.parseInt(portText, 10) : 0,
-			};
-		});
-}
-
-function shouldBypassProxyForUrl(url: URL, noProxyValue: string | undefined): boolean {
-	if (!noProxyValue) return false;
-	if (noProxyValue === "*") return true;
-
-	const hostname = url.host.replace(/:\d*$/, "").toLowerCase();
-	const port = Number.parseInt(url.port, 10) || DEFAULT_PROXY_PORTS[url.protocol] || 0;
-
-	for (const entry of parseNoProxyEntries(noProxyValue)) {
-		if (entry.hostname === "*") return true;
-		if (entry.port && entry.port !== port) continue;
-
-		if (!/^[.*]/.test(entry.hostname)) {
-			if (hostname === entry.hostname) {
-				return true;
-			}
-			continue;
-		}
-
-		if (hostname.endsWith(entry.hostname.replace(/^\*/, ""))) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-export function resolveProxyUrlForRequest(
-	url: string,
-	env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-	const parsed = new URL(url);
-	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-		return undefined;
-	}
-
-	const httpProxy = resolveProxyEnvValue(env, "http_proxy", "HTTP_PROXY");
-	const httpsProxy = resolveProxyEnvValue(env, "https_proxy", "HTTPS_PROXY");
-	if (!httpProxy && !httpsProxy) {
-		return undefined;
-	}
-
-	const noProxy = resolveProxyEnvValue(env, "no_proxy", "NO_PROXY");
-	if (shouldBypassProxyForUrl(parsed, noProxy)) {
-		return undefined;
-	}
-
-	return parsed.protocol === "https:"
-		? (httpsProxy ?? httpProxy)
-		: httpProxy;
-}
-
-function getSharedProxyDispatcher(proxyUrl: string): ProxyDispatcher {
-	const existing = sharedProxyDispatchers.get(proxyUrl);
-	if (existing) {
-		return existing;
-	}
-
-	const dispatcher = new ProxyAgent(proxyUrl) as unknown as ProxyDispatcher;
-	sharedProxyDispatchers.set(proxyUrl, dispatcher);
-	return dispatcher;
-}
-
-export async function closeSharedProxyDispatchers(): Promise<void> {
-	while (sharedProxyDispatchers.size > 0) {
-		const dispatchers = [...sharedProxyDispatchers.values()] as ClosableDispatcher[];
-		sharedProxyDispatchers.clear();
-
-		await Promise.allSettled(
-			dispatchers.map(async (dispatcher) => {
-				if (typeof dispatcher.close === "function") {
-					await dispatcher.close();
-				}
-			}),
-		);
-	}
-}
-
-registerCleanup(closeSharedProxyDispatchers);
-
-export function applyProxyCompatibleInit(
-	url: string,
-	init?: ProxyCompatibleRequestInit,
-	env: NodeJS.ProcessEnv = process.env,
-): ProxyCompatibleRequestInit {
-	const resolvedInit = init ?? {};
-	if (resolvedInit.dispatcher || resolvedInit.agent) {
-		return resolvedInit;
-	}
-
-	const proxyUrl = resolveProxyUrlForRequest(url, env);
-	if (!proxyUrl) {
-		return resolvedInit;
-	}
-
-	return {
-		...resolvedInit,
-		dispatcher: getSharedProxyDispatcher(proxyUrl),
-	};
 }
 
 /**
@@ -888,80 +217,10 @@ export async function transformRequestForCodex(
 }
 
 /**
- * Creates headers for Codex API requests
- * @param init - Request init options
- * @param accountId - ChatGPT account ID
- * @param accessToken - OAuth access token
- * @returns Headers object with all required Codex headers
- */
-export function createCodexHeaders(
-	params: CreateCodexHeadersParams,
-): Headers;
-export function createCodexHeaders(
-    init: RequestInit | undefined,
-    accountId: string,
-    accessToken: string,
-    opts?: CreateCodexHeadersOptions,
-): Headers;
-export function createCodexHeaders(
-    initOrParams: RequestInit | undefined | CreateCodexHeadersParams,
-    accountId?: string,
-    accessToken?: string,
-    opts?: CreateCodexHeadersOptions,
-): Headers {
-	const useNamedParams =
-		typeof accountId === "undefined" &&
-		typeof accessToken === "undefined" &&
-		isCreateCodexHeadersNamedParams(initOrParams);
-	const namedParams = useNamedParams
-		? (initOrParams as CreateCodexHeadersParams)
-		: null;
-	const resolvedInit = useNamedParams
-		? namedParams?.init
-		: (initOrParams as RequestInit | undefined);
-	const resolvedAccountId = useNamedParams ? namedParams?.accountId : accountId;
-	const resolvedAccessToken = useNamedParams ? namedParams?.accessToken : accessToken;
-	const resolvedOpts = useNamedParams ? namedParams?.opts : opts;
-	if (!resolvedAccountId || !resolvedAccessToken) {
-		throw new TypeError("createCodexHeaders requires accountId and accessToken");
-	}
-	const headers = new Headers(resolvedInit?.headers ?? {});
-	headers.delete("x-api-key"); // Remove any existing API key
-	headers.set("Authorization", `Bearer ${resolvedAccessToken}`);
-	headers.set(OPENAI_HEADERS.ACCOUNT_ID, resolvedAccountId);
-	headers.set(OPENAI_HEADERS.BETA, OPENAI_HEADER_VALUES.BETA_RESPONSES);
-	headers.set(OPENAI_HEADERS.ORIGINATOR, OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
-
-    const cacheKey = resolvedOpts?.promptCacheKey;
-    if (cacheKey) {
-        headers.set(OPENAI_HEADERS.CONVERSATION_ID, cacheKey);
-        headers.set(OPENAI_HEADERS.SESSION_ID, cacheKey);
-    } else {
-        headers.delete(OPENAI_HEADERS.CONVERSATION_ID);
-        headers.delete(OPENAI_HEADERS.SESSION_ID);
-    }
-    headers.set("accept", "text/event-stream");
-    return headers;
-}
-
-/**
  * Handles error responses from the Codex API
  * @param response - Error response from API
  * @returns Original response or mapped retryable response
  */
-/**
- * Log RFC 8594 Deprecation/Sunset headers if present. Shared by the success and
- * error response handlers so a sunset notice is surfaced regardless of status
- * (request-01).
- */
-function logDeprecationHeaders(response: Response): void {
-        const deprecation = response.headers.get("Deprecation");
-        const sunset = response.headers.get("Sunset");
-        if (deprecation || sunset) {
-                logWarn(`API deprecation notice`, { deprecation, sunset });
-        }
-}
-
 export async function handleErrorResponse(
         response: Response,
         options?: ErrorHandlingOptions,

--- a/lib/request/headers.ts
+++ b/lib/request/headers.ts
@@ -1,0 +1,99 @@
+/**
+ * Header construction helpers for the custom fetch implementation
+ * Extracted from fetch-helpers.ts (audit roadmap §4.1.2); fetch-helpers.ts
+ * re-exports the public symbols so existing importers are unchanged.
+ */
+
+import { logWarn } from "../logger.js";
+import { isRecord } from "../utils.js";
+import { OPENAI_HEADERS, OPENAI_HEADER_VALUES } from "../constants.js";
+
+const CREATE_CODEX_HEADERS_PARAM_KEYS = new Set(["init", "accountId", "accessToken", "opts"]);
+
+export interface CreateCodexHeadersOptions {
+	model?: string;
+	promptCacheKey?: string;
+}
+
+export interface CreateCodexHeadersParams {
+	init?: RequestInit;
+	accountId: string;
+	accessToken: string;
+	opts?: CreateCodexHeadersOptions;
+}
+
+function isCreateCodexHeadersNamedParams(value: unknown): value is CreateCodexHeadersParams {
+	if (!isRecord(value)) return false;
+	if (typeof value.accountId !== "string" || typeof value.accessToken !== "string") return false;
+	return Object.keys(value).every((key) => CREATE_CODEX_HEADERS_PARAM_KEYS.has(key));
+}
+
+/**
+ * Creates headers for Codex API requests
+ * @param init - Request init options
+ * @param accountId - ChatGPT account ID
+ * @param accessToken - OAuth access token
+ * @returns Headers object with all required Codex headers
+ */
+export function createCodexHeaders(
+	params: CreateCodexHeadersParams,
+): Headers;
+export function createCodexHeaders(
+    init: RequestInit | undefined,
+    accountId: string,
+    accessToken: string,
+    opts?: CreateCodexHeadersOptions,
+): Headers;
+export function createCodexHeaders(
+    initOrParams: RequestInit | undefined | CreateCodexHeadersParams,
+    accountId?: string,
+    accessToken?: string,
+    opts?: CreateCodexHeadersOptions,
+): Headers {
+	const useNamedParams =
+		typeof accountId === "undefined" &&
+		typeof accessToken === "undefined" &&
+		isCreateCodexHeadersNamedParams(initOrParams);
+	const namedParams = useNamedParams
+		? (initOrParams as CreateCodexHeadersParams)
+		: null;
+	const resolvedInit = useNamedParams
+		? namedParams?.init
+		: (initOrParams as RequestInit | undefined);
+	const resolvedAccountId = useNamedParams ? namedParams?.accountId : accountId;
+	const resolvedAccessToken = useNamedParams ? namedParams?.accessToken : accessToken;
+	const resolvedOpts = useNamedParams ? namedParams?.opts : opts;
+	if (!resolvedAccountId || !resolvedAccessToken) {
+		throw new TypeError("createCodexHeaders requires accountId and accessToken");
+	}
+	const headers = new Headers(resolvedInit?.headers ?? {});
+	headers.delete("x-api-key"); // Remove any existing API key
+	headers.set("Authorization", `Bearer ${resolvedAccessToken}`);
+	headers.set(OPENAI_HEADERS.ACCOUNT_ID, resolvedAccountId);
+	headers.set(OPENAI_HEADERS.BETA, OPENAI_HEADER_VALUES.BETA_RESPONSES);
+	headers.set(OPENAI_HEADERS.ORIGINATOR, OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
+
+    const cacheKey = resolvedOpts?.promptCacheKey;
+    if (cacheKey) {
+        headers.set(OPENAI_HEADERS.CONVERSATION_ID, cacheKey);
+        headers.set(OPENAI_HEADERS.SESSION_ID, cacheKey);
+    } else {
+        headers.delete(OPENAI_HEADERS.CONVERSATION_ID);
+        headers.delete(OPENAI_HEADERS.SESSION_ID);
+    }
+    headers.set("accept", "text/event-stream");
+    return headers;
+}
+
+/**
+ * Log RFC 8594 Deprecation/Sunset headers if present. Shared by the success and
+ * error response handlers so a sunset notice is surfaced regardless of status
+ * (request-01).
+ */
+export function logDeprecationHeaders(response: Response): void {
+        const deprecation = response.headers.get("Deprecation");
+        const sunset = response.headers.get("Sunset");
+        if (deprecation || sunset) {
+                logWarn(`API deprecation notice`, { deprecation, sunset });
+        }
+}

--- a/lib/request/headers.ts
+++ b/lib/request/headers.ts
@@ -89,6 +89,8 @@ export function createCodexHeaders(
  * Log RFC 8594 Deprecation/Sunset headers if present. Shared by the success and
  * error response handlers so a sunset notice is surfaced regardless of status
  * (request-01).
+ *
+ * @internal Exported only for sibling lib/request modules; import via fetch-helpers.ts elsewhere.
  */
 export function logDeprecationHeaders(response: Response): void {
         const deprecation = response.headers.get("Deprecation");

--- a/lib/request/token-refresh.ts
+++ b/lib/request/token-refresh.ts
@@ -1,0 +1,147 @@
+/**
+ * Token refresh helpers for the custom fetch implementation
+ * Extracted from fetch-helpers.ts (audit roadmap §4.1.2); fetch-helpers.ts
+ * re-exports the public symbols so existing importers are unchanged.
+ */
+
+import type { Auth, CodexClient } from "@codex-ai/sdk";
+import { queuedRefresh } from "../refresh-queue.js";
+import type { TokenResult } from "../types.js";
+import { CodexAuthError } from "../errors.js";
+import { HTTP_STATUS, ERROR_MESSAGES } from "../constants.js";
+
+interface CodexAuthSetter {
+	auth: {
+		set(args: {
+			path: { id: string };
+			body: {
+				type: "oauth";
+				access: string;
+				refresh: string;
+				expires: number;
+				multiAccount: boolean;
+			};
+		}): Promise<unknown>;
+	};
+}
+
+/**
+ * Determines if the current auth token needs to be refreshed
+ * @param auth - Current authentication state
+ * @returns True if token is expired or invalid
+ */
+export function shouldRefreshToken(auth: Auth, skewMs = 0): boolean {
+	if (auth.type !== "oauth") return true;
+	if (!auth.access) return true;
+
+	const safeSkewMs = Math.max(0, Math.floor(skewMs));
+	return auth.expires <= Date.now() + safeSkewMs;
+}
+
+function isRetryableRefreshFailure(
+	result: Extract<TokenResult, { type: "failed" }>,
+): boolean {
+	switch (result.reason) {
+		case "network_error":
+		case "unknown":
+		case "invalid_response":
+			return true;
+		case "missing_refresh":
+			return false;
+		case "http_error":
+			return !(
+				result.statusCode === HTTP_STATUS.BAD_REQUEST ||
+				result.statusCode === HTTP_STATUS.UNAUTHORIZED ||
+				result.statusCode === HTTP_STATUS.FORBIDDEN
+			);
+		default:
+			return false;
+	}
+}
+
+function isRetryableAuthSetterError(error: unknown): boolean {
+	if (!error || typeof error !== "object") {
+		return false;
+	}
+
+	const candidate = error as {
+		code?: unknown;
+		status?: unknown;
+		cause?: unknown;
+	};
+	const code =
+		typeof candidate.code === "string"
+			? candidate.code.toUpperCase()
+			: undefined;
+	if (code === "EAGAIN" || code === "EBUSY" || code === "EPERM") {
+		return true;
+	}
+
+	if (candidate.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
+		return true;
+	}
+
+	if (candidate.cause && candidate.cause !== error) {
+		return isRetryableAuthSetterError(candidate.cause);
+	}
+
+	return false;
+}
+
+/**
+ * Refreshes the OAuth token and updates stored credentials
+ * @param currentAuth - Current auth state
+ * @param client - Codex client for updating stored credentials
+ * @returns Updated auth (throws on failure)
+ */
+export async function refreshAndUpdateToken(
+	currentAuth: Auth,
+	client: CodexClient,
+): Promise<Auth> {
+	const authSetter = (client as Partial<CodexAuthSetter>).auth;
+	if (!authSetter || typeof authSetter.set !== "function") {
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: false,
+		});
+	}
+
+	const refreshToken = currentAuth.type === "oauth" ? currentAuth.refresh : "";
+	const refreshResult = await queuedRefresh(refreshToken);
+
+	if (refreshResult.type === "failed") {
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: isRetryableRefreshFailure(refreshResult),
+			context: {
+				refreshFailureReason: refreshResult.reason,
+				statusCode: refreshResult.statusCode,
+			},
+		});
+	}
+
+	try {
+		await authSetter.set({
+			path: { id: "openai" },
+			body: {
+				type: "oauth",
+				access: refreshResult.access,
+				refresh: refreshResult.refresh,
+				expires: refreshResult.expires,
+				multiAccount: true,
+			},
+		});
+	} catch (error) {
+		throw new CodexAuthError(ERROR_MESSAGES.TOKEN_REFRESH_FAILED, {
+			retryable: isRetryableAuthSetterError(error),
+			cause: error,
+		});
+	}
+
+	// Update current auth reference if it's OAuth type
+	if (currentAuth.type === "oauth") {
+		currentAuth.access = refreshResult.access;
+		currentAuth.refresh = refreshResult.refresh;
+		currentAuth.expires = refreshResult.expires;
+	}
+
+	return currentAuth;
+}

--- a/lib/request/token-refresh.ts
+++ b/lib/request/token-refresh.ts
@@ -90,6 +90,16 @@ function isRetryableAuthSetterError(error: unknown): boolean {
 
 /**
  * Refreshes the OAuth token and updates stored credentials
+ *
+ * Mutation contract: on success the passed `currentAuth` object is updated
+ * IN PLACE (access/refresh/expires) after the persistence await, and the same
+ * reference is returned. Same-account refreshes are serialized by
+ * `queuedRefresh`, so two concurrent calls for one account coalesce rather
+ * than race; callers must still not share one Auth object across calls for
+ * DIFFERENT accounts, and must not read token fields from a shared reference
+ * while a refresh for it is in flight (the window between the persistence
+ * await and the mutation block exposes the pre-refresh values).
+ *
  * @param currentAuth - Current auth state
  * @param client - Codex client for updating stored credentials
  * @returns Updated auth (throws on failure)

--- a/lib/request/url-rewriting.ts
+++ b/lib/request/url-rewriting.ts
@@ -1,0 +1,199 @@
+/**
+ * URL rewriting and proxy resolution helpers for the custom fetch implementation
+ * Extracted from fetch-helpers.ts (audit roadmap §4.1.2); fetch-helpers.ts
+ * re-exports the public symbols so existing importers are unchanged.
+ */
+
+import { ProxyAgent } from "undici";
+import { registerCleanup } from "../shutdown.js";
+import { CODEX_BASE_URL, URL_PATHS } from "../constants.js";
+
+const CODEX_BASE_URL_OBJECT = new URL(CODEX_BASE_URL);
+const CODEX_BASE_PATH_PREFIX = CODEX_BASE_URL_OBJECT.pathname.endsWith("/")
+	? CODEX_BASE_URL_OBJECT.pathname.slice(0, -1)
+	: CODEX_BASE_URL_OBJECT.pathname;
+
+const DEFAULT_PROXY_PORTS: Record<string, number> = {
+	"http:": 80,
+	"https:": 443,
+};
+type ProxyDispatcher = NonNullable<RequestInit["dispatcher"]>;
+const sharedProxyDispatchers = new Map<string, ProxyDispatcher>();
+
+type ClosableDispatcher = ProxyDispatcher & {
+	close?: () => Promise<void> | void;
+};
+
+export interface ProxyCompatibleRequestInit extends RequestInit {
+	agent?: unknown;
+}
+
+/**
+ * Extracts URL string from various request input types
+ * @param input - Request input (string, URL, or Request object)
+ * @returns URL string
+ */
+export function extractRequestUrl(input: Request | string | URL): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	return input.url;
+}
+
+/**
+ * Rewrites OpenAI API URLs to Codex backend URLs
+ * @param url - Original URL
+ * @returns Rewritten URL for Codex backend
+ */
+export function rewriteUrlForCodex(url: string): string {
+	const parsedUrl = new URL(url);
+	const rewrittenPath = parsedUrl.pathname.includes(URL_PATHS.RESPONSES)
+		? parsedUrl.pathname.replace(URL_PATHS.RESPONSES, URL_PATHS.CODEX_RESPONSES)
+		: parsedUrl.pathname;
+	const normalizedPath =
+		rewrittenPath === CODEX_BASE_PATH_PREFIX ||
+		rewrittenPath.startsWith(`${CODEX_BASE_PATH_PREFIX}/`)
+			? rewrittenPath
+			: `${CODEX_BASE_PATH_PREFIX}${rewrittenPath.startsWith("/") ? rewrittenPath : `/${rewrittenPath}`}`;
+
+	parsedUrl.protocol = CODEX_BASE_URL_OBJECT.protocol;
+	parsedUrl.username = "";
+	parsedUrl.password = "";
+	parsedUrl.host = CODEX_BASE_URL_OBJECT.host;
+	parsedUrl.pathname = normalizedPath;
+
+	return parsedUrl.toString();
+}
+
+function hasOwnEnvKey(env: NodeJS.ProcessEnv, key: string): boolean {
+	return Object.prototype.hasOwnProperty.call(env, key);
+}
+
+function resolveProxyEnvValue(
+	env: NodeJS.ProcessEnv,
+	lowerKey: string,
+	upperKey: string,
+): string | undefined {
+	if (hasOwnEnvKey(env, lowerKey)) {
+		const value = env[lowerKey]?.trim();
+		return value ? value : undefined;
+	}
+
+	const value = env[upperKey]?.trim();
+	return value ? value : undefined;
+}
+
+function parseNoProxyEntries(noProxyValue: string): Array<{ hostname: string; port: number }> {
+	return noProxyValue
+		.split(/[,\s]/)
+		.map((entry) => entry.trim())
+		.filter(Boolean)
+		.map((entry) => {
+			const parsed = entry.match(/^(.+):(\d+)$/);
+			const hostname = parsed?.[1] ?? entry;
+			const portText = parsed?.[2];
+			return {
+				hostname: hostname.toLowerCase(),
+				port: portText ? Number.parseInt(portText, 10) : 0,
+			};
+		});
+}
+
+function shouldBypassProxyForUrl(url: URL, noProxyValue: string | undefined): boolean {
+	if (!noProxyValue) return false;
+	if (noProxyValue === "*") return true;
+
+	const hostname = url.host.replace(/:\d*$/, "").toLowerCase();
+	const port = Number.parseInt(url.port, 10) || DEFAULT_PROXY_PORTS[url.protocol] || 0;
+
+	for (const entry of parseNoProxyEntries(noProxyValue)) {
+		if (entry.hostname === "*") return true;
+		if (entry.port && entry.port !== port) continue;
+
+		if (!/^[.*]/.test(entry.hostname)) {
+			if (hostname === entry.hostname) {
+				return true;
+			}
+			continue;
+		}
+
+		if (hostname.endsWith(entry.hostname.replace(/^\*/, ""))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export function resolveProxyUrlForRequest(
+	url: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+	const parsed = new URL(url);
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		return undefined;
+	}
+
+	const httpProxy = resolveProxyEnvValue(env, "http_proxy", "HTTP_PROXY");
+	const httpsProxy = resolveProxyEnvValue(env, "https_proxy", "HTTPS_PROXY");
+	if (!httpProxy && !httpsProxy) {
+		return undefined;
+	}
+
+	const noProxy = resolveProxyEnvValue(env, "no_proxy", "NO_PROXY");
+	if (shouldBypassProxyForUrl(parsed, noProxy)) {
+		return undefined;
+	}
+
+	return parsed.protocol === "https:"
+		? (httpsProxy ?? httpProxy)
+		: httpProxy;
+}
+
+function getSharedProxyDispatcher(proxyUrl: string): ProxyDispatcher {
+	const existing = sharedProxyDispatchers.get(proxyUrl);
+	if (existing) {
+		return existing;
+	}
+
+	const dispatcher = new ProxyAgent(proxyUrl) as unknown as ProxyDispatcher;
+	sharedProxyDispatchers.set(proxyUrl, dispatcher);
+	return dispatcher;
+}
+
+export async function closeSharedProxyDispatchers(): Promise<void> {
+	while (sharedProxyDispatchers.size > 0) {
+		const dispatchers = [...sharedProxyDispatchers.values()] as ClosableDispatcher[];
+		sharedProxyDispatchers.clear();
+
+		await Promise.allSettled(
+			dispatchers.map(async (dispatcher) => {
+				if (typeof dispatcher.close === "function") {
+					await dispatcher.close();
+				}
+			}),
+		);
+	}
+}
+
+registerCleanup(closeSharedProxyDispatchers);
+
+export function applyProxyCompatibleInit(
+	url: string,
+	init?: ProxyCompatibleRequestInit,
+	env: NodeJS.ProcessEnv = process.env,
+): ProxyCompatibleRequestInit {
+	const resolvedInit = init ?? {};
+	if (resolvedInit.dispatcher || resolvedInit.agent) {
+		return resolvedInit;
+	}
+
+	const proxyUrl = resolveProxyUrlForRequest(url, env);
+	if (!proxyUrl) {
+		return resolvedInit;
+	}
+
+	return {
+		...resolvedInit,
+		dispatcher: getSharedProxyDispatcher(proxyUrl),
+	};
+}


### PR DESCRIPTION
## Summary

Closes out audit roadmap §4.3 for the request layer (`docs/audits/AUDIT_2026-06-10.md`, PR #522) — with an honest result: **the code portion is stale; the request layer already fully adopts the typed error contracts.** This PR is the verification record plus the documentation the contract reference was missing.

> Stacked on #524 (fetch-helpers split) since §4.3 was scoped against those files; merge #524 first.

## What the verification found (no code changes needed)

- `lib/errors.ts` already provides the full taxonomy (`CodexError` base, `CodexApiError`, `CodexAuthError`, `CodexNetworkError`, `CodexRateLimitError`, `StorageError`, `CodexUnavailableError` + guard).
- `token-refresh.ts` already throws `CodexAuthError` with `retryable`/`cause`/`context` at all three failure sites; the catch site (`refresh-guardian.ts`) relies on `instanceof CodexAuthError && !retryable` — verified intact.
- The HTTP error-mapping contract is correctly fulfilled by normalized `Response` payloads (stable `error.message`/`error.code`), not thrown errors — typed classes deliberately don't apply there.
- The one bare `TypeError` (`createCodexHeaders` argument misuse) is a deliberate convention shared by all six dual-call helpers across the codebase, pinned by tests; converting one in isolation would fracture it.

## Changes (docs only)

`docs/reference/error-contracts.md` (+10 lines): a "Typed Errors" subsection under the Fetch Helpers contract (documents `CodexAuthError`, its `CODEX_AUTH_ERROR` code, exact message, `retryable`/`cause`/`context` semantics, and that HTTP errors surface as Responses, not throws), and a note pinning the native-TypeError convention in the Options-Object Compatibility Contract.

## Validation

- [x] `npm run typecheck`
- [x] 8 suites (fetch-helpers, quota-probe, index, index-retry, public-api-contract, chaos, documentation, errors): **419/419, identical to base** via git-stash comparison
- [x] Independently re-verified: documentation + errors suites, 61/61

## Risk / Rollback

Docs-only; revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr closes audit §4.3 by verifying that the request layer already fully uses the typed error hierarchy, then adding the missing reference documentation to `docs/reference/error-contracts.md`. no runtime behaviour changes.

- adds a "typed errors" subsection documenting `CodexAuthError` throw semantics, `retryable`/`cause`/`context` fields, and why http errors surface as `Response` objects instead of thrown errors.
- adds a note pinning the native `TypeError` convention for invalid named-parameter calls across the six dual-call helpers.

<h3>Confidence Score: 5/5</h3>

docs-only change; every claim in the new sections is verified against the live code, and no runtime paths are altered

the new documentation is factually accurate: error message matches the constant, code matches ErrorCode.AUTH_ERROR, retryable logic is correctly described for all three throw sites, cause/context mutually-exclusive presence is correctly qualified as 'where available', and the TypeError message in headers.ts matches the pinned example exactly

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/reference/error-contracts.md | the only file with net-new content in this pr; +10 lines accurately document CodexAuthError throw sites, retryable semantics, and the TypeError convention |
| lib/request/token-refresh.ts | carries the three CodexAuthError throw sites referenced by the new docs; code unchanged in this pr, all three sites verified against the documented message, code, and retryable logic |
| lib/request/fetch-helpers.ts | re-export barrel for the split request-layer modules; confirms http errors are returned as normalized Response objects, not thrown — consistent with new doc section |
| lib/request/headers.ts | contains the createCodexHeaders TypeError that is now pinned in the options-object compatibility contract; exact message matches doc |
| lib/request/error-classification.ts | entitlement/unsupported-model classification helpers; unchanged and consistent with docs describing http errors as Response payloads, not throws |
| lib/request/url-rewriting.ts | proxy and url-rewriting helpers; no changes relevant to the error contract documentation |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[refreshAndUpdateToken called] --> B{authSetter present?}
    B -- no --> E1[throw CodexAuthError\nretryable: false\nno cause, no context]
    B -- yes --> C[queuedRefresh token]
    C --> D{result.type}
    D -- failed --> E2[throw CodexAuthError\nretryable: isRetryableRefreshFailure\ncontext: refreshFailureReason + statusCode]
    D -- success --> F[authSetter.set persist]
    F -- throws --> E3[throw CodexAuthError\nretryable: isRetryableAuthSetterError\ncause: error]
    F -- ok --> G[mutate currentAuth in-place\nreturn currentAuth]

    style E1 fill:#f66,color:#fff
    style E2 fill:#f66,color:#fff
    style E3 fill:#f66,color:#fff
    style G fill:#6a6,color:#fff
```

<sub>Reviews (2): Last reviewed commit: ["docs(request): pin refreshAndUpdateToken..."](https://github.com/ndycode/codex-multi-auth/commit/4c0e0b784662761a0a4000770b0afe3a1c1bd92b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36678697)</sub>

<!-- /greptile_comment -->