### PR TITLE
test(lib): cover the highest-value gaps in four logic modules

### DIFF
--- a/test/codex-manager-models-command.test.ts
+++ b/test/codex-manager-models-command.test.ts
@@ -52,5 +52,92 @@ describe("models command", () => {
 		expect(exitCode).toBe(1);
 		expect(String(logError.mock.calls[0]?.[0])).toContain("Unknown models option");
 	});
+
+	it("prints usage for --help without loading accounts", async () => {
+		const logInfo = vi.fn();
+		const loadAccounts = vi.fn(async () => storage);
+		const exitCode = await runModelsCommand(["--help"], {
+			setStoragePath: vi.fn(),
+			loadAccounts,
+			logInfo,
+			logError: vi.fn(),
+		});
+		expect(exitCode).toBe(0);
+		expect(loadAccounts).not.toHaveBeenCalled();
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain(
+			"codex-multi-auth models [--json] [--model <model>]",
+		);
+	});
+
+	it("rejects --model with a missing, empty, or flag-like value", async () => {
+		const run = async (args: string[]) => {
+			const logError = vi.fn();
+			const exitCode = await runModelsCommand(args, {
+				setStoragePath: vi.fn(),
+				loadAccounts: async () => storage,
+				logInfo: vi.fn(),
+				logError,
+			});
+			return { exitCode, message: String(logError.mock.calls[0]?.[0]) };
+		};
+
+		for (const args of [["--model"], ["--model", "--json"], ["--model="]]) {
+			const { exitCode, message } = await run(args);
+			expect(exitCode).toBe(1);
+			expect(message).toContain("Missing value for --model");
+		}
+	});
+
+	it("prints per-account availability lines in text mode", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runModelsCommand(["--model", "gpt-5.3-codex"], {
+			setStoragePath: vi.fn(),
+			loadAccounts: async () => storage,
+			loadQuotaCache: async () => ({ byAccountId: {}, byEmail: {} }),
+			logInfo,
+			logError: vi.fn(),
+			getNow: () => 123,
+		});
+		expect(exitCode).toBe(0);
+		expect(String(logInfo.mock.calls[0]?.[0])).toBe(
+			"Account 1 gpt-5.3-codex: available",
+		);
+	});
+
+	it("marks disabled accounts unavailable with the reason list", async () => {
+		const disabledStorage: AccountStorageV3 = {
+			...storage,
+			accounts: [{ ...storage.accounts[0]!, enabled: false }],
+		};
+		const logInfo = vi.fn();
+		const exitCode = await runModelsCommand(["--model", "gpt-5.3-codex"], {
+			setStoragePath: vi.fn(),
+			loadAccounts: async () => disabledStorage,
+			loadQuotaCache: async () => ({ byAccountId: {}, byEmail: {} }),
+			logInfo,
+			logError: vi.fn(),
+			getNow: () => 123,
+		});
+		expect(exitCode).toBe(0);
+		expect(String(logInfo.mock.calls[0]?.[0])).toBe(
+			"Account 1 gpt-5.3-codex: unavailable (account disabled)",
+		);
+	});
+
+	it("reports empty matrices and survives quota cache load failures", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runModelsCommand([], {
+			setStoragePath: vi.fn(),
+			loadAccounts: async () => null,
+			loadQuotaCache: async () => {
+				throw new Error("quota cache unreadable");
+			},
+			logInfo,
+			logError: vi.fn(),
+			getNow: () => 123,
+		});
+		expect(exitCode).toBe(0);
+		expect(String(logInfo.mock.calls[0]?.[0])).toBe("No accounts configured.");
+	});
 });
 

--- a/test/codex-manager-usage-command.test.ts
+++ b/test/codex-manager-usage-command.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { UsageLedgerRow, UsageSummary } from "../lib/usage/index.js";
 import { runUsageCommand } from "../lib/codex-manager/commands/usage.js";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 function makeSummary(overrides: Partial<UsageSummary> = {}): UsageSummary {
 	return {
@@ -225,6 +229,138 @@ describe("usage command", () => {
 		expect(String(logError.mock.calls[0]?.[0])).toContain(
 			"Failed to write usage report: disk full",
 		);
+	});
+});
+
+describe("usage command --since parsing", () => {
+	const NOW = 1_750_000_000_000;
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	async function sinceSentToLedger(
+		args: string[],
+	): Promise<number | Date | string | undefined> {
+		let captured: number | Date | string | undefined;
+		const exitCode = await runUsageCommand(args, {
+			logInfo: vi.fn(),
+			summarizeUsage: async (query) => {
+				captured = query?.since;
+				return makeSummary();
+			},
+		});
+		expect(exitCode).toBe(0);
+		return captured;
+	}
+
+	it("resolves relative durations against the current clock", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+
+		await expect(sinceSentToLedger(["--since", "30m"])).resolves.toBe(
+			NOW - 30 * 60_000,
+		);
+		await expect(sinceSentToLedger(["--since=24h"])).resolves.toBe(
+			NOW - 24 * 3_600_000,
+		);
+		await expect(sinceSentToLedger(["--since", "7d"])).resolves.toBe(
+			NOW - 7 * 86_400_000,
+		);
+		await expect(sinceSentToLedger(["--since", "2W"])).resolves.toBe(
+			NOW - 2 * 604_800_000,
+		);
+	});
+
+	it("passes epoch numbers through as numbers and dates as strings", async () => {
+		await expect(sinceSentToLedger(["--since", "12345"])).resolves.toBe(12345);
+		await expect(sinceSentToLedger(["--since", " 2026-01-02 "])).resolves.toBe(
+			"2026-01-02",
+		);
+	});
+
+	it("rejects --since without a value", async () => {
+		const logError = vi.fn();
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand(["--since"], { logError, logInfo });
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Missing value for --since",
+		);
+		// parse failures also re-print the usage help
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain("Usage:");
+	});
+});
+
+describe("usage command default file writer", () => {
+	let tempDir: string;
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await removeWithRetry(tempDir, { recursive: true, force: true });
+	});
+
+	function deps(overrides: { logError?: ReturnType<typeof vi.fn> } = {}) {
+		return {
+			logInfo: vi.fn(),
+			logError: vi.fn(),
+			getCwd: () => tempDir,
+			summarizeUsage: async () => makeSummary(),
+			...overrides,
+		};
+	}
+
+	it("writes the rendered report atomically into nested directories", async () => {
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-write-"));
+		const commandDeps = deps();
+		const exitCode = await runUsageCommand(
+			["--out", join("reports", "usage.txt")],
+			commandDeps,
+		);
+
+		expect(exitCode).toBe(0);
+		const written = await fs.readFile(
+			join(tempDir, "reports", "usage.txt"),
+			"utf8",
+		);
+		expect(written).toContain("Usage summary by model");
+		expect(written.endsWith("\n")).toBe(true);
+		// the staged .tmp file must be consumed by the rename
+		const leftovers = await fs.readdir(join(tempDir, "reports"));
+		expect(leftovers).toEqual(["usage.txt"]);
+	});
+
+	it("retries the final rename on transient EBUSY and still succeeds", async () => {
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-retry-"));
+		const renameSpy = vi
+			.spyOn(fs, "rename")
+			.mockRejectedValueOnce(Object.assign(new Error("busy"), { code: "EBUSY" }));
+		const exitCode = await runUsageCommand(["--out", "usage.txt"], deps());
+
+		expect(exitCode).toBe(0);
+		expect(renameSpy).toHaveBeenCalledTimes(2);
+		const written = await fs.readFile(join(tempDir, "usage.txt"), "utf8");
+		expect(written).toContain("Usage summary by model");
+		expect(await fs.readdir(tempDir)).toEqual(["usage.txt"]);
+	});
+
+	it("fails fast on non-retryable rename errors and removes the staged temp file", async () => {
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-fail-"));
+		vi.spyOn(fs, "rename").mockRejectedValue(
+			Object.assign(new Error("no space"), { code: "ENOSPC" }),
+		);
+		const logError = vi.fn();
+		const exitCode = await runUsageCommand(
+			["--out", "usage.txt"],
+			deps({ logError }),
+		);
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Failed to write usage report: no space",
+		);
+		// neither the target nor any secret/staging .tmp file may survive
+		expect(await fs.readdir(tempDir)).toEqual([]);
 	});
 });
 

--- a/test/runtime-current-account.test.ts
+++ b/test/runtime-current-account.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	appRuntimeHelperStatusToSignal,
+	readAppRuntimeHelperStatus,
 	resolveAccountCurrentMarkers,
 	resolveRuntimeCurrentAccount,
 } from "../lib/runtime/runtime-current-account.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 function createStorage(): AccountStorageV3 {
 	return {
@@ -347,5 +352,205 @@ describe("resolveRuntimeCurrentAccount", () => {
 			"in-use",
 		]);
 		expect(resolveAccountCurrentMarkers(0, 0, null)).toEqual(["current"]);
+	});
+
+	it("falls back to the reported index when id and email are absent", () => {
+		const now = 10_000;
+		const result = resolveRuntimeCurrentAccount(
+			createStorage(),
+			{
+				appHelperStatus: {
+					source: "app-helper",
+					lastAccountIndex: 1,
+					updatedAt: now,
+				},
+			},
+			{ now },
+		);
+
+		expect(result).toEqual({
+			index: 1,
+			source: "app-helper",
+			matchedBy: "index",
+			updatedAt: now,
+		});
+	});
+
+	it("truncates fractional indices and rejects negative or out-of-range ones", () => {
+		const now = 10_000;
+		const select = (lastAccountIndex: number) =>
+			resolveRuntimeCurrentAccount(
+				createStorage(),
+				{
+					appHelperStatus: {
+						source: "app-helper",
+						lastAccountIndex,
+						updatedAt: now,
+					},
+				},
+				{ now },
+			);
+
+		expect(select(1.9)).toMatchObject({ index: 1, matchedBy: "index" });
+		expect(select(-1)).toBeNull();
+		expect(select(2)).toBeNull();
+		expect(select(Number.NaN)).toBeNull();
+	});
+
+	it("rejects an index fallback that contradicts the signal account id or email", () => {
+		const now = 10_000;
+		// Account 0 is acc_selected/selected@example.com; the signal claims an id
+		// and email that exist nowhere in storage, so the index hint must not win.
+		expect(
+			resolveRuntimeCurrentAccount(
+				createStorage(),
+				{
+					appHelperStatus: {
+						source: "app-helper",
+						lastAccountId: "acc_ghost",
+						lastAccountIndex: 0,
+						updatedAt: now,
+					},
+				},
+				{ now },
+			),
+		).toBeNull();
+		expect(
+			resolveRuntimeCurrentAccount(
+				createStorage(),
+				{
+					appHelperStatus: {
+						source: "app-helper",
+						lastAccountEmail: "ghost@example.com",
+						lastAccountIndex: 0,
+						updatedAt: now,
+					},
+				},
+				{ now },
+			),
+		).toBeNull();
+	});
+
+	it("ignores whitespace-only ids and emails when matching by index", () => {
+		const now = 10_000;
+		const result = resolveRuntimeCurrentAccount(
+			createStorage(),
+			{
+				appHelperStatus: {
+					source: "app-helper",
+					lastAccountId: "   ",
+					lastAccountEmail: " ",
+					lastAccountIndex: 0,
+					updatedAt: now,
+				},
+			},
+			{ now },
+		);
+
+		expect(result).toEqual({
+			index: 0,
+			source: "app-helper",
+			matchedBy: "index",
+			updatedAt: now,
+		});
+	});
+
+});
+
+describe("readAppRuntimeHelperStatus", () => {
+	let tempDir: string;
+	let originalDir: string | undefined;
+	const statusFileName = "runtime-rotation-app-helper.json";
+
+	beforeEach(async () => {
+		originalDir = process.env.CODEX_MULTI_AUTH_DIR;
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-helper-status-"));
+		process.env.CODEX_MULTI_AUTH_DIR = tempDir;
+	});
+
+	afterEach(async () => {
+		if (originalDir === undefined) {
+			delete process.env.CODEX_MULTI_AUTH_DIR;
+		} else {
+			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
+		}
+		await removeWithRetry(tempDir, { recursive: true, force: true });
+	});
+
+	async function writeStatusFile(contents: string): Promise<void> {
+		await fs.writeFile(join(tempDir, statusFileName), contents, "utf8");
+	}
+
+	it("returns null when the status file is missing", () => {
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+	});
+
+	it("returns null for malformed JSON and non-record payloads", async () => {
+		await writeStatusFile("{nope");
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+
+		await writeStatusFile('"running"');
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+
+		await writeStatusFile("null");
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+	});
+
+	it("refuses status files larger than the 1 MB sanity cap", async () => {
+		const status = {
+			kind: "codex-app-runtime-rotation-helper",
+			state: "running",
+			pid: process.pid,
+			padding: "x".repeat(1024 * 1024),
+		};
+		await writeStatusFile(JSON.stringify(status));
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+	});
+
+	it("normalizes field types, trimming strings and dropping wrong-typed values", async () => {
+		await writeStatusFile(
+			JSON.stringify({
+				kind: "  codex-app-runtime-rotation-helper  ",
+				state: "running",
+				pid: 42,
+				lastAccountIndex: 1,
+				lastAccountLabel: "   ",
+				lastAccountEmail: " user@example.com ",
+				lastAccountId: 7,
+				lastAccountUpdatedAt: "soon",
+				updatedAt: 10_000,
+			}),
+		);
+		expect(readAppRuntimeHelperStatus()).toEqual({
+			kind: "codex-app-runtime-rotation-helper",
+			state: "running",
+			pid: 42,
+			lastAccountIndex: 1,
+			lastAccountLabel: null,
+			lastAccountEmail: "user@example.com",
+			lastAccountId: null,
+			lastAccountUpdatedAt: null,
+			updatedAt: 10_000,
+		});
+	});
+
+	it("treats a JSON array as a record and yields an all-null status", async () => {
+		// Pins current behavior: isRecord() accepts arrays, so `[]` produces a
+		// fully-null status object instead of null. Downstream
+		// appRuntimeHelperStatusToSignal still rejects it via the kind check.
+		await writeStatusFile("[]");
+		const status = readAppRuntimeHelperStatus();
+		expect(status).toEqual({
+			kind: null,
+			state: null,
+			pid: null,
+			lastAccountIndex: null,
+			lastAccountLabel: null,
+			lastAccountEmail: null,
+			lastAccountId: null,
+			lastAccountUpdatedAt: null,
+			updatedAt: null,
+		});
+		expect(appRuntimeHelperStatusToSignal(status)).toBeNull();
 	});
 });

--- a/test/runtime-current-account.test.ts
+++ b/test/runtime-current-account.test.ts
@@ -8,6 +8,7 @@ import {
 	resolveAccountCurrentMarkers,
 	resolveRuntimeCurrentAccount,
 } from "../lib/runtime/runtime-current-account.js";
+import { APP_RUNTIME_HELPER_STATUS_FILE } from "../lib/runtime-constants.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
@@ -460,7 +461,7 @@ describe("resolveRuntimeCurrentAccount", () => {
 describe("readAppRuntimeHelperStatus", () => {
 	let tempDir: string;
 	let originalDir: string | undefined;
-	const statusFileName = "runtime-rotation-app-helper.json";
+	const statusFileName = APP_RUNTIME_HELPER_STATUS_FILE;
 
 	beforeEach(async () => {
 		originalDir = process.env.CODEX_MULTI_AUTH_DIR;

--- a/test/snapshot-inspectors.test.ts
+++ b/test/snapshot-inspectors.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+import { describeAccountsWalSnapshot } from "../lib/storage/snapshot-inspectors.js";
+import type { SnapshotStats } from "../lib/storage/backup-metadata.js";
+
+type WalDeps = Parameters<typeof describeAccountsWalSnapshot>[1];
+
+const STATS: SnapshotStats = { exists: true, bytes: 64, mtimeMs: 1_111 };
+
+function fakeSha256(content: string): string {
+	return `sha:${content.length}:${content.slice(0, 8)}`;
+}
+
+function makeInnerStorage(): string {
+	return JSON.stringify({
+		version: 3,
+		accounts: [
+			{
+				email: "wal@example.com",
+				accountId: "acc_wal",
+				refreshToken: "refresh-wal",
+				addedAt: 1,
+				lastUsed: 1,
+			},
+		],
+		activeIndex: 0,
+	});
+}
+
+function makeJournalEntry(content: string, checksum = fakeSha256(content)): string {
+	return JSON.stringify({ version: 1, createdAt: 5, content, checksum });
+}
+
+function createDeps(overrides: Partial<WalDeps> = {}): WalDeps {
+	return {
+		statSnapshot: vi.fn(async () => STATS),
+		readFile: vi.fn(async () =>
+			makeJournalEntry(makeInnerStorage()),
+		) as unknown as WalDeps["readFile"],
+		isRecord: (value: unknown) => typeof value === "object" && value !== null,
+		computeSha256: fakeSha256,
+		parseAndNormalizeStorage: vi.fn((data: unknown) => ({
+			normalized: { accounts: (data as { accounts: unknown[] }).accounts },
+			storedVersion: (data as { version: unknown }).version,
+			schemaErrors: [] as string[],
+		})),
+		...overrides,
+	};
+}
+
+describe("describeAccountsWalSnapshot", () => {
+	it("returns a non-existing snapshot without touching the file", async () => {
+		const deps = createDeps({
+			statSnapshot: vi.fn(async () => ({ exists: false })),
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: false,
+			valid: false,
+		});
+		expect(deps.readFile).not.toHaveBeenCalled();
+	});
+
+	it("marks malformed journal JSON invalid but keeps the stat metadata", async () => {
+		const deps = createDeps({
+			readFile: vi.fn(async () => "{not json") as unknown as WalDeps["readFile"],
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+		});
+		expect(deps.parseAndNormalizeStorage).not.toHaveBeenCalled();
+	});
+
+	it("rejects journal entries that fail the WAL schema (missing checksum)", async () => {
+		const deps = createDeps({
+			readFile: vi.fn(async () =>
+				JSON.stringify({ version: 1, content: makeInnerStorage() }),
+			) as unknown as WalDeps["readFile"],
+		});
+		const result = await describeAccountsWalSnapshot("wal.json", deps);
+		expect(result.valid).toBe(false);
+		expect(deps.parseAndNormalizeStorage).not.toHaveBeenCalled();
+	});
+
+	it("rejects entries whose checksum does not match the content hash", async () => {
+		const deps = createDeps({
+			readFile: vi.fn(async () =>
+				makeJournalEntry(makeInnerStorage(), "sha:forged"),
+			) as unknown as WalDeps["readFile"],
+		});
+		const result = await describeAccountsWalSnapshot("wal.json", deps);
+		expect(result).toMatchObject({
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+		});
+		expect(deps.parseAndNormalizeStorage).not.toHaveBeenCalled();
+	});
+
+	it("describes a checksum-verified, schema-valid WAL snapshot", async () => {
+		const deps = createDeps();
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: true,
+			bytes: 64,
+			mtimeMs: 1_111,
+			version: 3,
+			accountCount: 1,
+			schemaErrors: undefined,
+		});
+		expect(deps.parseAndNormalizeStorage).toHaveBeenCalledWith(
+			expect.objectContaining({ version: 3, activeIndex: 0 }),
+		);
+	});
+
+	it("falls back to raw JSON for schema-unknown content and surfaces schema errors", async () => {
+		// version 99 fails AnyAccountStorageSchema, so the inspector must hand the
+		// raw JSON.parse result to parseAndNormalizeStorage (legacy-shape path).
+		const legacyContent = JSON.stringify({ version: 99, accounts: [] });
+		const parseAndNormalizeStorage = vi.fn(() => ({
+			normalized: null,
+			storedVersion: "ninety-nine",
+			schemaErrors: ["unsupported version"],
+		}));
+		const deps = createDeps({
+			readFile: vi.fn(async () =>
+				makeJournalEntry(legacyContent),
+			) as unknown as WalDeps["readFile"],
+			parseAndNormalizeStorage,
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+			// non-numeric storedVersion must not leak into the metadata
+			version: undefined,
+			accountCount: undefined,
+			schemaErrors: ["unsupported version"],
+		});
+		expect(parseAndNormalizeStorage).toHaveBeenCalledWith({
+			version: 99,
+			accounts: [],
+		});
+	});
+
+	it("marks entries invalid when the checksummed content is not JSON at all", async () => {
+		const content = "definitely-not-json";
+		const deps = createDeps({
+			readFile: vi.fn(async () =>
+				makeJournalEntry(content),
+			) as unknown as WalDeps["readFile"],
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+		});
+		expect(deps.parseAndNormalizeStorage).not.toHaveBeenCalled();
+	});
+
+	it("treats read failures (EACCES) as an existing-but-invalid snapshot", async () => {
+		const deps = createDeps({
+			readFile: vi.fn(async () => {
+				throw Object.assign(new Error("denied"), { code: "EACCES" });
+			}) as unknown as WalDeps["readFile"],
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Test-only PR closing the highest-value coverage gaps in `lib/`, found by ranking the full-suite coverage report by **absolute uncovered lines** and picking the modules whose gaps are real logic (parsers, validators, decision functions) rather than OS integration or env-failing suites' residue. Zero production-code changes; 632 new test lines across 1 new + 3 extended suites (47 tests).

## Per-file coverage (line metric, before → after)

| Module | Before | After |
| --- | --- | --- |
| `lib/storage/snapshot-inspectors.ts` | 34.7% | **100%** (`describeAccountsWalSnapshot` had zero coverage) |
| `lib/runtime/runtime-current-account.ts` | 77.6% | **99.0%** |
| `lib/codex-manager/commands/usage.ts` | 86.1% | **100%** |
| `lib/codex-manager/commands/models.ts` | 72.2% | **100%** |

Deliberately skipped despite ranking high: `storage.ts` (gap inflated by the environment-failing EACCES suites), `repair-commands.ts` (4% residue of a huge interactive module), `bridge.ts` (network/OS integration), `event-handler.ts` (thin facade).

## Behaviors now pinned (contracts derived from the implementations)

- **WAL snapshot inspector**: forged checksums and malformed journal JSON never reach the normalizer; schema-unknown content falls back to the legacy raw-parse path with `schemaErrors` surfaced; non-numeric `storedVersion` dropped; EACCES reads classified existing-but-invalid with stat metadata preserved.
- **Runtime current-account resolution**: fractional index hints truncate; negative/out-of-range/NaN rejected; an index hint contradicting the signal's id/email is refused. Helper-status file: 1 MB size cap, string trimming, wrong-typed fields → null.
- **`usage`**: `--since` relative durations (`30m`/`24h`/`7d`/`2W`, case-insensitive) resolved against fake-timer clocks; epoch and date-string passthrough; the atomic writer creates nested dirs, consumes `.tmp` on success, retries rename on EBUSY, and removes the staged temp on non-retryable ENOSPC.
- **`models`**: `--help` short-circuits before account loading; missing/empty/flag-like `--model` values error; `unavailable (account disabled)` availability lines; quota-cache load failures swallowed.

## Suspected bug (pinned, not fixed)

`runtime-current-account.ts`'s `isRecord()` accepts JSON arrays, so an `[]` helper-status file yields an all-null status object instead of `null`. Harmless today (the downstream `kind` check rejects it) but likely an oversight — the test pins current behavior with a comment so a deliberate fix shows up as an explicit diff.

## Validation

- [x] `npm run typecheck`; eslint `--max-warnings=0` on all 4 files
- [x] All 47 tests passed twice (determinism); canaries (`storage-flagged`, `backup-metadata-builder`, `codex-manager-status-command`) pass
- [x] Independently re-verified: all 4 suites, 47/47

## Risk / Rollback

Pure test addition; revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

test-only PR closing the top coverage gaps in four logic modules \u2014 WAL snapshot inspection, usage-command `--since` parsing + atomic writer retry, and runtime current-account resolution. zero production-code changes; 632 new test lines across one new suite and three extended ones.

- **`snapshot-inspectors.test.ts`** (new, 202 lines): pins all eight branches of `describeAccountsWalSnapshot` \u2014 non-existing snapshot, outer/inner JSON parse failures, forged checksum, schema-unknown legacy path, EACCES read error, and the happy path.
- **`runtime-current-account.test.ts`**: adds index-fallback resolution, fractional/negative/NaN rejection, id/email contradiction guard, whitespace-only field handling, and a full `readAppRuntimeHelperStatus` block (size cap, field normalization, the documented `isRecord`-accepts-arrays quirk).
- **`codex-manager-usage-command.test.ts` / `codex-manager-models-command.test.ts`**: cover `--since` relative/epoch/date-string parsing (fake-timer clock), `--help` short-circuit, `--model` flag-like-value rejection, disabled-account unavailability text, and the atomic writer\u2019s nested-dir creation, EBUSY retry, and ENOSPC fast-fail + temp-file cleanup paths.

<h3>Confidence Score: 5/5</h3>

pure test addition — no production code changes, all new tests isolated in temp dirs with correct env-var and spy cleanup

every new test exercises a clearly-defined branch of the implementation; assertions match the source logic; env mutations are saved/restored in beforeEach/afterEach; removeWithRetry is used throughout for windows-safe temp dir cleanup; no test shares mutable state across describe blocks

no files require special attention; the ebusy retry test in codex-manager-usage-command.test.ts uses a real 10 ms sleep that could be made deterministic with fake timers, but it is not a correctness issue

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/snapshot-inspectors.test.ts | new suite (202 lines): covers non-existing WAL, malformed journal JSON, bad/missing checksum, valid snapshot, legacy schema-fallback, non-JSON content, EACCES read failure — all paths in describeAccountsWalSnapshot are hit; assertions match source logic |
| test/runtime-current-account.test.ts | extends existing suite with index-fallback, fractional/negative/NaN index rejection, contradicting id/email guard, whitespace-only field handling, and a full readAppRuntimeHelperStatus block; env var isolation via beforeEach/afterEach is correct; removeWithRetry used for cleanup |
| test/codex-manager-usage-command.test.ts | extends suite with --since parsing (fake-timer clock), atomic writer nested-dir creation, EBUSY retry (real 10 ms sleep), and ENOSPC fast-fail + temp-file cleanup; removeWithRetry used for temp dirs |
| test/codex-manager-models-command.test.ts | extends suite with --help short-circuit, --model rejection, per-account availability text, disabled-account unavailability reason, and null-storage + quota-cache-throw resilience |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant runUsageCommand
    participant parseSinceValue
    participant defaultWriteFile
    participant fs_rename

    Note over Test,fs_rename: --since parsing (fake timers)
    Test->>+runUsageCommand: --since 30m
    runUsageCommand->>parseSinceValue: 30m
    parseSinceValue-->>runUsageCommand: NOW-30x60000
    runUsageCommand-->>-Test: captured since value

    Note over Test,fs_rename: atomic writer EBUSY retry
    Test->>+runUsageCommand: --out usage.txt
    runUsageCommand->>+defaultWriteFile: path, contents
    defaultWriteFile->>fs_rename: rename attempt 0
    fs_rename-->>defaultWriteFile: EBUSY
    defaultWriteFile->>defaultWriteFile: sleep 10ms
    defaultWriteFile->>fs_rename: rename attempt 1
    fs_rename-->>defaultWriteFile: ok
    defaultWriteFile-->>-runUsageCommand: resolved
    runUsageCommand-->>-Test: exitCode 0

    Note over Test,fs_rename: atomic writer ENOSPC fast-fail
    Test->>+runUsageCommand: --out usage.txt
    runUsageCommand->>+defaultWriteFile: path, contents
    defaultWriteFile->>fs_rename: rename
    fs_rename-->>defaultWriteFile: ENOSPC
    defaultWriteFile->>defaultWriteFile: unlink tmp
    defaultWriteFile-->>-runUsageCommand: throw
    runUsageCommand-->>-Test: exitCode 1 tmp removed
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-25-coverage-gaps%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-25-coverage-gaps%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fcodex-manager-usage-command.test.ts%3A333-338%0Athe%20EBUSY%20retry%20path%20calls%20%60sleep%2810%20*%202%20**%20attempt%29%60%20which%20runs%20as%20a%20real%2010%20ms%20pause%20here%20since%20no%20fake%20timers%20are%20installed.%20on%20a%20loaded%20windows%20ci%20runner%20that%20can%20be%20longer%20and%20is%20non-deterministic.%20the%20stream-failover%20suite%20uses%20%60vi.useFakeTimers%28%29%60%20for%20the%20same%20reason%20%E2%80%94%20install%20fake%20timers%20before%20the%20spy%20and%20advance%20with%20%60vi.advanceTimersByTimeAsync%60%20so%20the%20retry%20is%20instant%20and%20deterministic.%0A%0A%60%60%60suggestion%0A%09it%28%22retries%20the%20final%20rename%20on%20transient%20EBUSY%20and%20still%20succeeds%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%09%09tempDir%20%3D%20await%20fs.mkdtemp%28join%28tmpdir%28%29%2C%20%22codex-usage-retry-%22%29%29%3B%0A%09%09vi.useFakeTimers%28%29%3B%0A%09%09const%20renameSpy%20%3D%20vi%0A%09%09%09.spyOn%28fs%2C%20%22rename%22%29%0A%09%09%09.mockRejectedValueOnce%28Object.assign%28new%20Error%28%22busy%22%29%2C%20%7B%20code%3A%20%22EBUSY%22%20%7D%29%29%3B%0A%09%09const%20runPromise%20%3D%20runUsageCommand%28%5B%22--out%22%2C%20%22usage.txt%22%5D%2C%20deps%28%29%29%3B%0A%09%09await%20vi.advanceTimersByTimeAsync%28100%29%3B%0A%09%09vi.useRealTimers%28%29%3B%0A%09%09const%20exitCode%20%3D%20await%20runPromise%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fsnapshot-inspectors.test.ts%3A37-46%0A**%60isRecord%60%20dep%20is%20accepted%20by%20the%20function%20signature%20but%20never%20called%20in%20the%20body**%20%E2%80%94%20%60describeAccountsWalSnapshot%60%20takes%20%60deps.isRecord%60%20in%20its%20type%20but%20the%20implementation%20delegates%20all%20schema%20checks%20to%20%60safeParseJson%60%20%2B%20Zod%2C%20so%20the%20field%20is%20dead.%20the%20test%20correctly%20satisfies%20the%20type%2C%20but%20no%20spy%20assertion%20documents%20whether%20it%20should%20be%20called%20or%20not.%20worth%20either%20removing%20the%20dep%20from%20the%20source%20type%20or%20adding%20%60expect%28deps.isRecord%29.not.toHaveBeenCalled%28%29%60%20to%20make%20the%20contract%20explicit.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=543&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/codex-manager-usage-command.test.ts:333-338
the EBUSY retry path calls `sleep(10 * 2 ** attempt)` which runs as a real 10 ms pause here since no fake timers are installed. on a loaded windows ci runner that can be longer and is non-deterministic. the stream-failover suite uses `vi.useFakeTimers()` for the same reason — install fake timers before the spy and advance with `vi.advanceTimersByTimeAsync` so the retry is instant and deterministic.

```suggestion
	it("retries the final rename on transient EBUSY and still succeeds", async () => {
		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-retry-"));
		vi.useFakeTimers();
		const renameSpy = vi
			.spyOn(fs, "rename")
			.mockRejectedValueOnce(Object.assign(new Error("busy"), { code: "EBUSY" }));
		const runPromise = runUsageCommand(["--out", "usage.txt"], deps());
		await vi.advanceTimersByTimeAsync(100);
		vi.useRealTimers();
		const exitCode = await runPromise;
```

### Issue 2 of 2
test/snapshot-inspectors.test.ts:37-46
**`isRecord` dep is accepted by the function signature but never called in the body** — `describeAccountsWalSnapshot` takes `deps.isRecord` in its type but the implementation delegates all schema checks to `safeParseJson` + Zod, so the field is dead. the test correctly satisfies the type, but no spy assertion documents whether it should be called or not. worth either removing the dep from the source type or adding `expect(deps.isRecord).not.toHaveBeenCalled()` to make the contract explicit.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: import the helper status filename ..."](https://github.com/ndycode/codex-multi-auth/commit/029dd61b0fbadadbebb5ebaf6d2aa5944877435e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36683247)</sub>

<!-- /greptile_comment -->