### PR TITLE
fix(runtime): reject array helper-status files; dedupe isRecord

### DIFF
--- a/lib/runtime/runtime-current-account.ts
+++ b/lib/runtime/runtime-current-account.ts
@@ -6,6 +6,7 @@ import type { AppBindRouterStatus } from "./app-bind.js";
 import { APP_RUNTIME_HELPER_STATUS_FILE } from "../runtime-constants.js";
 import { getCodexMultiAuthDir } from "../runtime-paths.js";
 import type { AccountStorageV3 } from "../storage.js";
+import { isRecord } from "../utils.js";
 
 export type RuntimeCurrentAccountSource =
 	| "runtime-observability"
@@ -95,10 +96,6 @@ function normalizeTimestamp(signal: RuntimeAccountSignal): number | null {
 		normalizeTimestampValue(signal.updatedAt),
 	].filter((timestamp): timestamp is number => timestamp !== null);
 	return timestamps.length > 0 ? Math.max(...timestamps) : null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
 }
 
 function readOptionalNumber(record: Record<string, unknown>, key: string): number | null {

--- a/test/codex-manager-models-command.test.ts
+++ b/test/codex-manager-models-command.test.ts
@@ -52,5 +52,92 @@ describe("models command", () => {
 		expect(exitCode).toBe(1);
 		expect(String(logError.mock.calls[0]?.[0])).toContain("Unknown models option");
 	});
+
+	it("prints usage for --help without loading accounts", async () => {
+		const logInfo = vi.fn();
+		const loadAccounts = vi.fn(async () => storage);
+		const exitCode = await runModelsCommand(["--help"], {
+			setStoragePath: vi.fn(),
+			loadAccounts,
+			logInfo,
+			logError: vi.fn(),
+		});
+		expect(exitCode).toBe(0);
+		expect(loadAccounts).not.toHaveBeenCalled();
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain(
+			"codex-multi-auth models [--json] [--model <model>]",
+		);
+	});
+
+	it("rejects --model with a missing, empty, or flag-like value", async () => {
+		const run = async (args: string[]) => {
+			const logError = vi.fn();
+			const exitCode = await runModelsCommand(args, {
+				setStoragePath: vi.fn(),
+				loadAccounts: async () => storage,
+				logInfo: vi.fn(),
+				logError,
+			});
+			return { exitCode, message: String(logError.mock.calls[0]?.[0]) };
+		};
+
+		for (const args of [["--model"], ["--model", "--json"], ["--model="]]) {
+			const { exitCode, message } = await run(args);
+			expect(exitCode).toBe(1);
+			expect(message).toContain("Missing value for --model");
+		}
+	});
+
+	it("prints per-account availability lines in text mode", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runModelsCommand(["--model", "gpt-5.3-codex"], {
+			setStoragePath: vi.fn(),
+			loadAccounts: async () => storage,
+			loadQuotaCache: async () => ({ byAccountId: {}, byEmail: {} }),
+			logInfo,
+			logError: vi.fn(),
+			getNow: () => 123,
+		});
+		expect(exitCode).toBe(0);
+		expect(String(logInfo.mock.calls[0]?.[0])).toBe(
+			"Account 1 gpt-5.3-codex: available",
+		);
+	});
+
+	it("marks disabled accounts unavailable with the reason list", async () => {
+		const disabledStorage: AccountStorageV3 = {
+			...storage,
+			accounts: [{ ...storage.accounts[0]!, enabled: false }],
+		};
+		const logInfo = vi.fn();
+		const exitCode = await runModelsCommand(["--model", "gpt-5.3-codex"], {
+			setStoragePath: vi.fn(),
+			loadAccounts: async () => disabledStorage,
+			loadQuotaCache: async () => ({ byAccountId: {}, byEmail: {} }),
+			logInfo,
+			logError: vi.fn(),
+			getNow: () => 123,
+		});
+		expect(exitCode).toBe(0);
+		expect(String(logInfo.mock.calls[0]?.[0])).toBe(
+			"Account 1 gpt-5.3-codex: unavailable (account disabled)",
+		);
+	});
+
+	it("reports empty matrices and survives quota cache load failures", async () => {
+		const logInfo = vi.fn();
+		const exitCode = await runModelsCommand([], {
+			setStoragePath: vi.fn(),
+			loadAccounts: async () => null,
+			loadQuotaCache: async () => {
+				throw new Error("quota cache unreadable");
+			},
+			logInfo,
+			logError: vi.fn(),
+			getNow: () => 123,
+		});
+		expect(exitCode).toBe(0);
+		expect(String(logInfo.mock.calls[0]?.[0])).toBe("No accounts configured.");
+	});
 });
 

--- a/test/codex-manager-usage-command.test.ts
+++ b/test/codex-manager-usage-command.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { UsageLedgerRow, UsageSummary } from "../lib/usage/index.js";
 import { runUsageCommand } from "../lib/codex-manager/commands/usage.js";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 function makeSummary(overrides: Partial<UsageSummary> = {}): UsageSummary {
 	return {
@@ -225,6 +229,138 @@ describe("usage command", () => {
 		expect(String(logError.mock.calls[0]?.[0])).toContain(
 			"Failed to write usage report: disk full",
 		);
+	});
+});
+
+describe("usage command --since parsing", () => {
+	const NOW = 1_750_000_000_000;
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	async function sinceSentToLedger(
+		args: string[],
+	): Promise<number | Date | string | undefined> {
+		let captured: number | Date | string | undefined;
+		const exitCode = await runUsageCommand(args, {
+			logInfo: vi.fn(),
+			summarizeUsage: async (query) => {
+				captured = query?.since;
+				return makeSummary();
+			},
+		});
+		expect(exitCode).toBe(0);
+		return captured;
+	}
+
+	it("resolves relative durations against the current clock", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+
+		await expect(sinceSentToLedger(["--since", "30m"])).resolves.toBe(
+			NOW - 30 * 60_000,
+		);
+		await expect(sinceSentToLedger(["--since=24h"])).resolves.toBe(
+			NOW - 24 * 3_600_000,
+		);
+		await expect(sinceSentToLedger(["--since", "7d"])).resolves.toBe(
+			NOW - 7 * 86_400_000,
+		);
+		await expect(sinceSentToLedger(["--since", "2W"])).resolves.toBe(
+			NOW - 2 * 604_800_000,
+		);
+	});
+
+	it("passes epoch numbers through as numbers and dates as strings", async () => {
+		await expect(sinceSentToLedger(["--since", "12345"])).resolves.toBe(12345);
+		await expect(sinceSentToLedger(["--since", " 2026-01-02 "])).resolves.toBe(
+			"2026-01-02",
+		);
+	});
+
+	it("rejects --since without a value", async () => {
+		const logError = vi.fn();
+		const logInfo = vi.fn();
+		const exitCode = await runUsageCommand(["--since"], { logError, logInfo });
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Missing value for --since",
+		);
+		// parse failures also re-print the usage help
+		expect(String(logInfo.mock.calls[0]?.[0])).toContain("Usage:");
+	});
+});
+
+describe("usage command default file writer", () => {
+	let tempDir: string;
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await removeWithRetry(tempDir, { recursive: true, force: true });
+	});
+
+	function deps(overrides: { logError?: ReturnType<typeof vi.fn> } = {}) {
+		return {
+			logInfo: vi.fn(),
+			logError: vi.fn(),
+			getCwd: () => tempDir,
+			summarizeUsage: async () => makeSummary(),
+			...overrides,
+		};
+	}
+
+	it("writes the rendered report atomically into nested directories", async () => {
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-write-"));
+		const commandDeps = deps();
+		const exitCode = await runUsageCommand(
+			["--out", join("reports", "usage.txt")],
+			commandDeps,
+		);
+
+		expect(exitCode).toBe(0);
+		const written = await fs.readFile(
+			join(tempDir, "reports", "usage.txt"),
+			"utf8",
+		);
+		expect(written).toContain("Usage summary by model");
+		expect(written.endsWith("\n")).toBe(true);
+		// the staged .tmp file must be consumed by the rename
+		const leftovers = await fs.readdir(join(tempDir, "reports"));
+		expect(leftovers).toEqual(["usage.txt"]);
+	});
+
+	it("retries the final rename on transient EBUSY and still succeeds", async () => {
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-retry-"));
+		const renameSpy = vi
+			.spyOn(fs, "rename")
+			.mockRejectedValueOnce(Object.assign(new Error("busy"), { code: "EBUSY" }));
+		const exitCode = await runUsageCommand(["--out", "usage.txt"], deps());
+
+		expect(exitCode).toBe(0);
+		expect(renameSpy).toHaveBeenCalledTimes(2);
+		const written = await fs.readFile(join(tempDir, "usage.txt"), "utf8");
+		expect(written).toContain("Usage summary by model");
+		expect(await fs.readdir(tempDir)).toEqual(["usage.txt"]);
+	});
+
+	it("fails fast on non-retryable rename errors and removes the staged temp file", async () => {
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-usage-fail-"));
+		vi.spyOn(fs, "rename").mockRejectedValue(
+			Object.assign(new Error("no space"), { code: "ENOSPC" }),
+		);
+		const logError = vi.fn();
+		const exitCode = await runUsageCommand(
+			["--out", "usage.txt"],
+			deps({ logError }),
+		);
+
+		expect(exitCode).toBe(1);
+		expect(String(logError.mock.calls[0]?.[0])).toContain(
+			"Failed to write usage report: no space",
+		);
+		// neither the target nor any secret/staging .tmp file may survive
+		expect(await fs.readdir(tempDir)).toEqual([]);
 	});
 });
 

--- a/test/runtime-current-account.test.ts
+++ b/test/runtime-current-account.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	appRuntimeHelperStatusToSignal,
+	readAppRuntimeHelperStatus,
 	resolveAccountCurrentMarkers,
 	resolveRuntimeCurrentAccount,
 } from "../lib/runtime/runtime-current-account.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 function createStorage(): AccountStorageV3 {
 	return {
@@ -347,5 +352,205 @@ describe("resolveRuntimeCurrentAccount", () => {
 			"in-use",
 		]);
 		expect(resolveAccountCurrentMarkers(0, 0, null)).toEqual(["current"]);
+	});
+
+	it("falls back to the reported index when id and email are absent", () => {
+		const now = 10_000;
+		const result = resolveRuntimeCurrentAccount(
+			createStorage(),
+			{
+				appHelperStatus: {
+					source: "app-helper",
+					lastAccountIndex: 1,
+					updatedAt: now,
+				},
+			},
+			{ now },
+		);
+
+		expect(result).toEqual({
+			index: 1,
+			source: "app-helper",
+			matchedBy: "index",
+			updatedAt: now,
+		});
+	});
+
+	it("truncates fractional indices and rejects negative or out-of-range ones", () => {
+		const now = 10_000;
+		const select = (lastAccountIndex: number) =>
+			resolveRuntimeCurrentAccount(
+				createStorage(),
+				{
+					appHelperStatus: {
+						source: "app-helper",
+						lastAccountIndex,
+						updatedAt: now,
+					},
+				},
+				{ now },
+			);
+
+		expect(select(1.9)).toMatchObject({ index: 1, matchedBy: "index" });
+		expect(select(-1)).toBeNull();
+		expect(select(2)).toBeNull();
+		expect(select(Number.NaN)).toBeNull();
+	});
+
+	it("rejects an index fallback that contradicts the signal account id or email", () => {
+		const now = 10_000;
+		// Account 0 is acc_selected/selected@example.com; the signal claims an id
+		// and email that exist nowhere in storage, so the index hint must not win.
+		expect(
+			resolveRuntimeCurrentAccount(
+				createStorage(),
+				{
+					appHelperStatus: {
+						source: "app-helper",
+						lastAccountId: "acc_ghost",
+						lastAccountIndex: 0,
+						updatedAt: now,
+					},
+				},
+				{ now },
+			),
+		).toBeNull();
+		expect(
+			resolveRuntimeCurrentAccount(
+				createStorage(),
+				{
+					appHelperStatus: {
+						source: "app-helper",
+						lastAccountEmail: "ghost@example.com",
+						lastAccountIndex: 0,
+						updatedAt: now,
+					},
+				},
+				{ now },
+			),
+		).toBeNull();
+	});
+
+	it("ignores whitespace-only ids and emails when matching by index", () => {
+		const now = 10_000;
+		const result = resolveRuntimeCurrentAccount(
+			createStorage(),
+			{
+				appHelperStatus: {
+					source: "app-helper",
+					lastAccountId: "   ",
+					lastAccountEmail: " ",
+					lastAccountIndex: 0,
+					updatedAt: now,
+				},
+			},
+			{ now },
+		);
+
+		expect(result).toEqual({
+			index: 0,
+			source: "app-helper",
+			matchedBy: "index",
+			updatedAt: now,
+		});
+	});
+
+});
+
+describe("readAppRuntimeHelperStatus", () => {
+	let tempDir: string;
+	let originalDir: string | undefined;
+	const statusFileName = "runtime-rotation-app-helper.json";
+
+	beforeEach(async () => {
+		originalDir = process.env.CODEX_MULTI_AUTH_DIR;
+		tempDir = await fs.mkdtemp(join(tmpdir(), "codex-helper-status-"));
+		process.env.CODEX_MULTI_AUTH_DIR = tempDir;
+	});
+
+	afterEach(async () => {
+		if (originalDir === undefined) {
+			delete process.env.CODEX_MULTI_AUTH_DIR;
+		} else {
+			process.env.CODEX_MULTI_AUTH_DIR = originalDir;
+		}
+		await removeWithRetry(tempDir, { recursive: true, force: true });
+	});
+
+	async function writeStatusFile(contents: string): Promise<void> {
+		await fs.writeFile(join(tempDir, statusFileName), contents, "utf8");
+	}
+
+	it("returns null when the status file is missing", () => {
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+	});
+
+	it("returns null for malformed JSON and non-record payloads", async () => {
+		await writeStatusFile("{nope");
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+
+		await writeStatusFile('"running"');
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+
+		await writeStatusFile("null");
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+	});
+
+	it("refuses status files larger than the 1 MB sanity cap", async () => {
+		const status = {
+			kind: "codex-app-runtime-rotation-helper",
+			state: "running",
+			pid: process.pid,
+			padding: "x".repeat(1024 * 1024),
+		};
+		await writeStatusFile(JSON.stringify(status));
+		expect(readAppRuntimeHelperStatus()).toBeNull();
+	});
+
+	it("normalizes field types, trimming strings and dropping wrong-typed values", async () => {
+		await writeStatusFile(
+			JSON.stringify({
+				kind: "  codex-app-runtime-rotation-helper  ",
+				state: "running",
+				pid: 42,
+				lastAccountIndex: 1,
+				lastAccountLabel: "   ",
+				lastAccountEmail: " user@example.com ",
+				lastAccountId: 7,
+				lastAccountUpdatedAt: "soon",
+				updatedAt: 10_000,
+			}),
+		);
+		expect(readAppRuntimeHelperStatus()).toEqual({
+			kind: "codex-app-runtime-rotation-helper",
+			state: "running",
+			pid: 42,
+			lastAccountIndex: 1,
+			lastAccountLabel: null,
+			lastAccountEmail: "user@example.com",
+			lastAccountId: null,
+			lastAccountUpdatedAt: null,
+			updatedAt: 10_000,
+		});
+	});
+
+	it("treats a JSON array as a record and yields an all-null status", async () => {
+		// Pins current behavior: isRecord() accepts arrays, so `[]` produces a
+		// fully-null status object instead of null. Downstream
+		// appRuntimeHelperStatusToSignal still rejects it via the kind check.
+		await writeStatusFile("[]");
+		const status = readAppRuntimeHelperStatus();
+		expect(status).toEqual({
+			kind: null,
+			state: null,
+			pid: null,
+			lastAccountIndex: null,
+			lastAccountLabel: null,
+			lastAccountEmail: null,
+			lastAccountId: null,
+			lastAccountUpdatedAt: null,
+			updatedAt: null,
+		});
+		expect(appRuntimeHelperStatusToSignal(status)).toBeNull();
 	});
 });

--- a/test/runtime-current-account.test.ts
+++ b/test/runtime-current-account.test.ts
@@ -8,6 +8,7 @@ import {
 	resolveAccountCurrentMarkers,
 	resolveRuntimeCurrentAccount,
 } from "../lib/runtime/runtime-current-account.js";
+import { APP_RUNTIME_HELPER_STATUS_FILE } from "../lib/runtime-constants.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
@@ -460,7 +461,7 @@ describe("resolveRuntimeCurrentAccount", () => {
 describe("readAppRuntimeHelperStatus", () => {
 	let tempDir: string;
 	let originalDir: string | undefined;
-	const statusFileName = "runtime-rotation-app-helper.json";
+	const statusFileName = APP_RUNTIME_HELPER_STATUS_FILE;
 
 	beforeEach(async () => {
 		originalDir = process.env.CODEX_MULTI_AUTH_DIR;

--- a/test/runtime-current-account.test.ts
+++ b/test/runtime-current-account.test.ts
@@ -534,23 +534,10 @@ describe("readAppRuntimeHelperStatus", () => {
 		});
 	});
 
-	it("treats a JSON array as a record and yields an all-null status", async () => {
-		// Pins current behavior: isRecord() accepts arrays, so `[]` produces a
-		// fully-null status object instead of null. Downstream
-		// appRuntimeHelperStatusToSignal still rejects it via the kind check.
+	it("rejects a JSON array status file as not-a-record", async () => {
+		// isRecord() excludes arrays: an `[]` helper-status file is malformed
+		// content, not an all-null status object.
 		await writeStatusFile("[]");
-		const status = readAppRuntimeHelperStatus();
-		expect(status).toEqual({
-			kind: null,
-			state: null,
-			pid: null,
-			lastAccountIndex: null,
-			lastAccountLabel: null,
-			lastAccountEmail: null,
-			lastAccountId: null,
-			lastAccountUpdatedAt: null,
-			updatedAt: null,
-		});
-		expect(appRuntimeHelperStatusToSignal(status)).toBeNull();
+		expect(readAppRuntimeHelperStatus()).toBeNull();
 	});
 });

--- a/test/snapshot-inspectors.test.ts
+++ b/test/snapshot-inspectors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { describeAccountsWalSnapshot } from "../lib/storage/snapshot-inspectors.js";
 import type { SnapshotStats } from "../lib/storage/backup-metadata.js";
+import { isRecord } from "../lib/utils.js";
 
 type WalDeps = Parameters<typeof describeAccountsWalSnapshot>[1];
 
@@ -36,7 +37,7 @@ function createDeps(overrides: Partial<WalDeps> = {}): WalDeps {
 		readFile: vi.fn(async () =>
 			makeJournalEntry(makeInnerStorage()),
 		) as unknown as WalDeps["readFile"],
-		isRecord: (value: unknown) => typeof value === "object" && value !== null,
+		isRecord,
 		computeSha256: fakeSha256,
 		parseAndNormalizeStorage: vi.fn((data: unknown) => ({
 			normalized: { accounts: (data as { accounts: unknown[] }).accounts },

--- a/test/snapshot-inspectors.test.ts
+++ b/test/snapshot-inspectors.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+import { describeAccountsWalSnapshot } from "../lib/storage/snapshot-inspectors.js";
+import type { SnapshotStats } from "../lib/storage/backup-metadata.js";
+
+type WalDeps = Parameters<typeof describeAccountsWalSnapshot>[1];
+
+const STATS: SnapshotStats = { exists: true, bytes: 64, mtimeMs: 1_111 };
+
+function fakeSha256(content: string): string {
+	return `sha:${content.length}:${content.slice(0, 8)}`;
+}
+
+function makeInnerStorage(): string {
+	return JSON.stringify({
+		version: 3,
+		accounts: [
+			{
+				email: "wal@example.com",
+				accountId: "acc_wal",
+				refreshToken: "refresh-wal",
+				addedAt: 1,
+				lastUsed: 1,
+			},
+		],
+		activeIndex: 0,
+	});
+}
+
+function makeJournalEntry(content: string, checksum = fakeSha256(content)): string {
+	return JSON.stringify({ version: 1, createdAt: 5, content, checksum });
+}
+
+function createDeps(overrides: Partial<WalDeps> = {}): WalDeps {
+	return {
+		statSnapshot: vi.fn(async () => STATS),
+		readFile: vi.fn(async () =>
+			makeJournalEntry(makeInnerStorage()),
+		) as unknown as WalDeps["readFile"],
+		isRecord: (value: unknown) => typeof value === "object" && value !== null,
+		computeSha256: fakeSha256,
+		parseAndNormalizeStorage: vi.fn((data: unknown) => ({
+			normalized: { accounts: (data as { accounts: unknown[] }).accounts },
+			storedVersion: (data as { version: unknown }).version,
+			schemaErrors: [] as string[],
+		})),
+		...overrides,
+	};
+}
+
+describe("describeAccountsWalSnapshot", () => {
+	it("returns a non-existing snapshot without touching the file", async () => {
+		const deps = createDeps({
+			statSnapshot: vi.fn(async () => ({ exists: false })),
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: false,
+			valid: false,
+		});
+		expect(deps.readFile).not.toHaveBeenCalled();
+	});
+
+	it("marks malformed journal JSON invalid but keeps the stat metadata", async () => {
+		const deps = createDeps({
+			readFile: vi.fn(async () => "{not json") as unknown as WalDeps["readFile"],
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+		});
+		expect(deps.parseAndNormalizeStorage).not.toHaveBeenCalled();
+	});
+
+	it("rejects journal entries that fail the WAL schema (missing checksum)", async () => {
+		const deps = createDeps({
+			readFile: vi.fn(async () =>
+				JSON.stringify({ version: 1, content: makeInnerStorage() }),
+			) as unknown as WalDeps["readFile"],
+		});
+		const result = await describeAccountsWalSnapshot("wal.json", deps);
+		expect(result.valid).toBe(false);
+		expect(deps.parseAndNormalizeStorage).not.toHaveBeenCalled();
+	});
+
+	it("rejects entries whose checksum does not match the content hash", async () => {
+		const deps = createDeps({
+			readFile: vi.fn(async () =>
+				makeJournalEntry(makeInnerStorage(), "sha:forged"),
+			) as unknown as WalDeps["readFile"],
+		});
+		const result = await describeAccountsWalSnapshot("wal.json", deps);
+		expect(result).toMatchObject({
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+		});
+		expect(deps.parseAndNormalizeStorage).not.toHaveBeenCalled();
+	});
+
+	it("describes a checksum-verified, schema-valid WAL snapshot", async () => {
+		const deps = createDeps();
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: true,
+			bytes: 64,
+			mtimeMs: 1_111,
+			version: 3,
+			accountCount: 1,
+			schemaErrors: undefined,
+		});
+		expect(deps.parseAndNormalizeStorage).toHaveBeenCalledWith(
+			expect.objectContaining({ version: 3, activeIndex: 0 }),
+		);
+	});
+
+	it("falls back to raw JSON for schema-unknown content and surfaces schema errors", async () => {
+		// version 99 fails AnyAccountStorageSchema, so the inspector must hand the
+		// raw JSON.parse result to parseAndNormalizeStorage (legacy-shape path).
+		const legacyContent = JSON.stringify({ version: 99, accounts: [] });
+		const parseAndNormalizeStorage = vi.fn(() => ({
+			normalized: null,
+			storedVersion: "ninety-nine",
+			schemaErrors: ["unsupported version"],
+		}));
+		const deps = createDeps({
+			readFile: vi.fn(async () =>
+				makeJournalEntry(legacyContent),
+			) as unknown as WalDeps["readFile"],
+			parseAndNormalizeStorage,
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+			// non-numeric storedVersion must not leak into the metadata
+			version: undefined,
+			accountCount: undefined,
+			schemaErrors: ["unsupported version"],
+		});
+		expect(parseAndNormalizeStorage).toHaveBeenCalledWith({
+			version: 99,
+			accounts: [],
+		});
+	});
+
+	it("marks entries invalid when the checksummed content is not JSON at all", async () => {
+		const content = "definitely-not-json";
+		const deps = createDeps({
+			readFile: vi.fn(async () =>
+				makeJournalEntry(content),
+			) as unknown as WalDeps["readFile"],
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+		});
+		expect(deps.parseAndNormalizeStorage).not.toHaveBeenCalled();
+	});
+
+	it("treats read failures (EACCES) as an existing-but-invalid snapshot", async () => {
+		const deps = createDeps({
+			readFile: vi.fn(async () => {
+				throw Object.assign(new Error("denied"), { code: "EACCES" });
+			}) as unknown as WalDeps["readFile"],
+		});
+		await expect(
+			describeAccountsWalSnapshot("wal.json", deps),
+		).resolves.toEqual({
+			kind: "accounts-wal",
+			path: "wal.json",
+			exists: true,
+			valid: false,
+			bytes: 64,
+			mtimeMs: 1_111,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the bug surfaced by #543's coverage work: the local `isRecord` copy in `lib/runtime/runtime-current-account.ts` had **drifted from the canonical `lib/utils.ts` guard** and accepted JSON arrays, so an `[]` helper-status file produced an all-null status object instead of `null`. Harmless today only because the downstream `kind` check happened to reject the all-null object — but it's exactly the class of silent drift the canonical guard exists to prevent.

> **Stacked on #543** (which pinned the buggy behavior with a test) — merge that first; this PR then shows only the fix commit.

## Changes

- Deletes the drifted local `isRecord` duplicate; imports the canonical `isRecord` from `lib/utils.js` (which already does `!Array.isArray(value)`). No cycle risk — utils is a leaf.
- Flips #543's behavior-pinning test to the corrected contract: an `[]` helper-status file now reads as `null` (malformed content), not an all-null record.

Note for a future sweep: four more files carry local `isRecord` copies (`commands/rotation.ts`, `codex-cli/writer.ts`, `codex-cli/state.ts`, plus one in recovery) — each needs its own semantics check before deduping, so they're deliberately out of scope here.

## Validation

- [x] `npm run typecheck`; eslint `--max-warnings=0`
- [x] `runtime-current-account` suite 17/17 with the corrected expectation; proxy safe-equal + issue-474 + app-router canaries pass

## Risk / Rollback

One guard tightened to match the canonical implementation; revert the single commit. Behavior change is strictly: malformed array status files are now rejected at read time instead of one step later.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

replaces the drifted local `isRecord` copy in `runtime-current-account.ts` with the canonical import from `lib/utils.ts`, which correctly excludes arrays via `!Array.isArray(value)`. this closes the silent gap where a `[]` status file produced an all-null object instead of `null`.

- **core fix**: one-line import swap in `runtime-current-account.ts` — the local duplicate is deleted and the canonical guard takes over, so array-shaped status files are now rejected at the `isRecord` boundary rather than one step later by the `kind` check.
- **test coverage**: `test/runtime-current-account.test.ts` gets a full `readAppRuntimeHelperStatus` suite including the array-rejection regression case; `test/snapshot-inspectors.test.ts` is a new file that uses the canonical `isRecord` import in `createDeps` (addressing the previous review comment), and two other test files gain additional command-level coverage.
- **windows safety**: all new test cleanup paths use `removeWithRetry`, consistent with the project convention.

<h3>Confidence Score: 5/5</h3>

safe to merge — a one-import swap tightening a guard on an untrusted filesystem read, with a direct regression test covering the corrected behavior

the change is minimal and targeted: the local isRecord copy is deleted, the canonical version (which adds !Array.isArray) is imported, and the new test explicitly asserts that an array status file now returns null. no logic paths beyond the guard change are touched, and downstream consumers of readAppRuntimeHelperStatus are unaffected because the stricter guard only rejects already-malformed input.

no files require special attention — all changed files are straightforward

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime/runtime-current-account.ts | removes drifted local isRecord; imports canonical guard from lib/utils.ts — fix is correct and targeted |
| test/runtime-current-account.test.ts | adds readAppRuntimeHelperStatus suite including the array-rejection regression test; removeWithRetry used correctly for Windows-safe cleanup |
| test/snapshot-inspectors.test.ts | new test file; createDeps now imports canonical isRecord from lib/utils.ts — addresses previous review comment about drifted guard in test helper |
| test/codex-manager-usage-command.test.ts | adds --since parsing, atomic file write, EBUSY retry, and ENOSPC failure tests; all use removeWithRetry for cleanup |
| test/codex-manager-models-command.test.ts | adds --help, --model validation, per-account availability, and quota-cache-failure coverage tests |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[readAppRuntimeHelperStatus] --> B{file exists?}
    B -- no --> Z1[return null]
    B -- yes --> C{size > 1 MB?}
    C -- yes --> Z2[return null]
    C -- no --> D[JSON.parse file]
    D --> E{isRecord check}
    E -- before fix: typeof===object && !==null\naccepts arrays --> F_OLD[array → all-null status object]
    E -- after fix: canonical isRecord\n!Array.isArray added --> F_NEW[array → return null]
    F_OLD --> G[downstream kind check rejects]
    F_NEW --> Z3[return null early]
    E -- plain object --> H[build AppRuntimeHelperAccountStatus]
    H --> I[return normalized status]
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;claude/audit-25-coverage-g..."](https://github.com/ndycode/codex-multi-auth/commit/63f8b75db36c2e25ed84cfcb431f66c230701559) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36683578)</sub>

<!-- /greptile_comment -->