### PR TITLE
fix(request): stream-stall failover, private-header prefix block, pinned-index message

### DIFF
--- a/lib/request/rate-limit-decision.ts
+++ b/lib/request/rate-limit-decision.ts
@@ -195,9 +195,14 @@ export function buildPinnedUnavailableErrorBody(
 			? accountSkipReasons.get(normalizedPinnedIndex) ?? null
 			: null;
 	const reasonSuffix = skipReason ? ` (${skipReason})` : "";
-	const displayIndex = (normalizedPinnedIndex ?? 0) + 1;
+	// On the desync path the pin index is unknown (null); claiming "account 1"
+	// there would contradict the machine-readable pinnedAccountIndex: null.
+	const accountPhrase =
+		normalizedPinnedIndex === null
+			? "The pinned account"
+			: `Pinned account ${normalizedPinnedIndex + 1}`;
 	return {
-		message: `Pinned account ${displayIndex} is currently unavailable${reasonSuffix}; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
+		message: `${accountPhrase} is currently unavailable${reasonSuffix}; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
 		code: "codex_pinned_account_unavailable",
 		pinnedAccountIndex: normalizedPinnedIndex,
 		reason: skipReason,

--- a/lib/request/stream-failover-runtime.ts
+++ b/lib/request/stream-failover-runtime.ts
@@ -48,8 +48,12 @@ export async function withTimeout<T>(
 			promise,
 			new Promise<T>((_resolve, reject) => {
 				timeout = setTimeout(() => {
-					onTimeout();
+					// Reject BEFORE onTimeout: onTimeout side effects (e.g. cancelling a
+					// stream reader) can settle `promise` with a clean value, and a
+					// settlement enqueued ahead of this rejection would win the race —
+					// turning a stall into a silent success.
 					reject(new Error(message));
+					onTimeout();
 				}, Math.max(1, timeoutMs));
 			}),
 		]);

--- a/lib/request/stream-failover-runtime.ts
+++ b/lib/request/stream-failover-runtime.ts
@@ -13,12 +13,11 @@ export const HOP_BY_HOP_HEADERS = new Set([
 	"transfer-encoding",
 	"upgrade",
 ]);
-const PRIVATE_CLIENT_RESPONSE_HEADERS = new Set([
-	"x-codex-multi-auth-account-index",
-	"x-codex-multi-auth-account-label",
-	"x-codex-multi-auth-account-email",
-	"x-codex-multi-auth-account-id",
-]);
+// Any header under this prefix carries account-identifying rotation metadata
+// (index/label/email/id today) and must never reach the client; matching by
+// prefix means a future header added under it is blocked by default instead
+// of leaking until someone remembers to extend an allowlist.
+const PRIVATE_CLIENT_RESPONSE_HEADER_PREFIX = "x-codex-multi-auth-account-";
 const DECODED_UPSTREAM_RESPONSE_HEADERS = new Set([
 	// Node fetch returns decoded bytes while preserving the upstream encoding header.
 	"content-encoding",
@@ -29,7 +28,7 @@ export function responseHeadersForClient(upstreamHeaders: Headers): Record<strin
 	for (const [key, value] of upstreamHeaders.entries()) {
 		const normalizedKey = key.toLowerCase();
 		if (HOP_BY_HOP_HEADERS.has(normalizedKey)) continue;
-		if (PRIVATE_CLIENT_RESPONSE_HEADERS.has(normalizedKey)) continue;
+		if (normalizedKey.startsWith(PRIVATE_CLIENT_RESPONSE_HEADER_PREFIX)) continue;
 		if (DECODED_UPSTREAM_RESPONSE_HEADERS.has(normalizedKey)) continue;
 		headers[key] = value;
 	}

--- a/test/issue-474-pin-honored.test.ts
+++ b/test/issue-474-pin-honored.test.ts
@@ -719,7 +719,10 @@ describe("issue #474 — manual pin honored by runtime proxy", () => {
 			);
 			expect(body.pinnedAccountIndex).toBeNull();
 			expect(body.reason).toBeNull();
-			expect(body.message).toContain("Pinned account 1");
+			// The desync path must not fabricate an index that contradicts the
+			// machine-readable pinnedAccountIndex: null.
+			expect(body.message).toContain("The pinned account is currently unavailable;");
+			expect(body.message).not.toContain("Pinned account 1");
 		});
 
 		it("mirrors the full accountSkipReasons map even when the pinned entry is unknown", () => {

--- a/test/rate-limit-decision.test.ts
+++ b/test/rate-limit-decision.test.ts
@@ -275,11 +275,14 @@ describe("buildPinnedUnavailableErrorBody", () => {
 		expect(body.account_skip_reasons).toEqual({ "0": "rate-limited", "1": "disabled" });
 	});
 
-	it("omits the parenthetical and reason on the null-index desync path", () => {
+	it("omits the index, parenthetical, and reason on the null-index desync path", () => {
+		// Regression: the message used to render the null index as "Pinned
+		// account 1", contradicting the machine-readable pinnedAccountIndex.
 		const body = buildPinnedUnavailableErrorBody(null, new Map());
 		expect(body.pinnedAccountIndex).toBeNull();
 		expect(body.reason).toBeNull();
-		expect(body.message).toContain("Pinned account 1 is currently unavailable;");
+		expect(body.message).toContain("The pinned account is currently unavailable;");
+		expect(body.message).not.toContain("Pinned account 1");
 		expect(body.message).not.toContain("(");
 		expect(body.account_skip_reasons).toEqual({});
 	});

--- a/test/stream-failover-runtime.test.ts
+++ b/test/stream-failover-runtime.test.ts
@@ -232,14 +232,12 @@ describe("forwardStreamingResponse", () => {
 		expect(res.chunks).toEqual([]);
 	});
 
-	it("currently ends a stalled stream cleanly instead of failing it", async () => {
-		// Pins a BUG (not the intended design): on a stall, withTimeout's
-		// onTimeout cancels the reader, which settles the pending read() with
-		// {done: true} BEFORE the rejection lands, so Promise.race resolves.
-		// The stall is reported as a clean end: truncated body, res.end(), no
-		// lastError, and onStreamError (the failover hook) never fires. The
-		// stall branch of the catch block is unreachable today. Fixed in the
-		// stacked follow-up PR, which flips these expectations.
+	it("records the stall error, destroys the response, and reports failure on timeout", async () => {
+		// Regression: withTimeout used to invoke onTimeout (which cancels the
+		// reader and thereby settles the pending read() with {done: true})
+		// before rejecting, so the race resolved and a stalled upstream was
+		// forwarded as a clean end-of-stream — truncated body, res.end(), no
+		// lastError, and onStreamError (the failover hook) never fired.
 		const res = new FakeServerResponse();
 		const status = createStatus();
 		const upstream = new Response(streamOf(
@@ -250,13 +248,14 @@ describe("forwardStreamingResponse", () => {
 		const onStreamError = vi.fn();
 		await expect(
 			forwardStreamingResponse(upstream, res.asServerResponse(), status, onStreamError, 25),
-		).resolves.toBe(true);
+		).resolves.toBe(false);
 
-		expect(onStreamError).not.toHaveBeenCalled();
-		expect(status.lastError).toBeNull();
-		expect(res.destroyed).toBe(false);
+		expect(onStreamError).toHaveBeenCalledTimes(1);
+		expect(status.lastError).toBe("upstream stream stalled after 25ms");
+		expect(res.destroyed).toBe(true);
+		expect(res.destroyError).toBeInstanceOf(Error);
 		expect(Buffer.concat(res.chunks).toString("utf8")).toBe("data: a\n\n");
-		expect(res.ended).toBe(true);
+		expect(res.ended).toBe(false);
 	});
 
 	it("fails the stream when the upstream read rejects mid-stream", async () => {

--- a/test/stream-failover-runtime.test.ts
+++ b/test/stream-failover-runtime.test.ts
@@ -96,6 +96,19 @@ describe("responseHeadersForClient", () => {
 		});
 	});
 
+	it("blocks any header under the private account prefix, not just known names", () => {
+		// Regression: the filter used to be an exact-name allowlist, so a future
+		// x-codex-multi-auth-account-* header would have leaked by default.
+		const upstream = new Headers({
+			"content-type": "application/json",
+			"x-codex-multi-auth-account-plan": "pro",
+			"X-Codex-Multi-Auth-Account-Future-Field": "secret",
+		});
+		expect(responseHeadersForClient(upstream)).toEqual({
+			"content-type": "application/json",
+		});
+	});
+
 	it("covers every hop-by-hop header in the exported set", () => {
 		const upstream = new Headers();
 		for (const name of HOP_BY_HOP_HEADERS) {


### PR DESCRIPTION
## Summary

Fixes three latent issues in the modules #532 extracted — all pre-existing behavior moved verbatim by the carve (same code on `main` inside `runtime-rotation-proxy.ts`), fixed here so #532 stays zero-behavior-change. The first was found by writing #532's unit suites; the other two are CodeRabbit review findings on #532.

> **Stacked on #532** (`claude/audit-15-rotation-proxy-carve`). Merge #532 first; this PR then shows only the two fix commits.

## Fix 1 — stream stall forwarded as clean success (`withTimeout` ordering)

`withTimeout` invoked `onTimeout` before rejecting. `forwardStreamingResponse`'s `onTimeout` cancels the stream reader, and cancelling a reader settles the pending `read()` with `{done: true}` ahead of the rejection in the microtask queue — so `Promise.race` **resolved**. A stalled upstream stream was forwarded to the client as a clean end-of-stream: truncated body with a normal `end()`, no `status.lastError`, and the `onStreamError` failover hook never fired; the stall branch of the catch block was unreachable. Fix: reject first, then run `onTimeout`. `readErrorBody` (the only other caller) passes a no-op `onTimeout` and is unaffected.

## Fix 2 — private account headers blocked by prefix (CodeRabbit, security guideline)

`responseHeadersForClient` filtered account metadata with an exact-name allowlist (`x-codex-multi-auth-account-{index,label,email,id}`); a future header under the same prefix would have leaked to clients by default. The filter now blocks the entire `x-codex-multi-auth-account-` prefix.

## Fix 3 — null pinned index rendered as "Pinned account 1" (CodeRabbit)

On the pin-desync path `buildPinnedUnavailableErrorBody` reported `pinnedAccountIndex: null` but the human-readable message claimed "Pinned account 1", contradicting the payload. The message now says "The pinned account is currently unavailable…" when the index is unknown; the machine-readable fields are unchanged.

## Changes

- `lib/request/stream-failover-runtime.ts`: timer-callback ordering swap (with the ordering constraint documented); prefix-based private-header filter replacing the exact-name set.
- `lib/request/rate-limit-decision.ts`: null-index message branch.
- `test/stream-failover-runtime.test.ts`: stall test flipped from pinned-bug to intended behavior; new prefix-coverage case (`x-codex-multi-auth-account-plan` / mixed-case future field blocked).
- `test/rate-limit-decision.test.ts` + `test/issue-474-pin-honored.test.ts`: null-index expectations updated to the corrected message (the issue-474 test previously pinned the contradictory message).

## Validation

- [x] `npm run typecheck`; eslint on all touched files `--max-warnings=0`
- [x] `npx vitest run` rate-limit-decision + stream-failover-runtime + issue-474-pin-honored + runtime-rotation-proxy: **147 passed, 2 failed** — the 2 are the known IPv6 `::1` bind environment failures from the documented baseline

## Risk / Rollback

Three small, isolated fixes; the only client-visible deltas are that stalled streams now take the (previously dead) error path, unknown future account headers are stripped, and the desync message no longer fabricates an index. Revert the two commits to roll back.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes a latent race condition in `withTimeout` where `onTimeout` was called before `reject`, allowing `reader.cancel()` to settle the pending `read()` with `{done: true}` ahead of the rejection — causing `Promise.race` to resolve a stalled stream as a clean end-of-stream. also fixes a null-index desync message bug and upgrades the private header filter from an exact-name set to a prefix check.

- **`withTimeout` ordering fix**: `reject()` now fires before `onTimeout()`, ensuring the race rejection is enqueued first; stalled streams now correctly destroy the response, set `lastError`, and fire `onStreamError`
- **prefix-based header filter**: `PRIVATE_CLIENT_RESPONSE_HEADERS` set replaced with `startsWith(\"x-codex-multi-auth-account-\")` — any future account-identifying header is blocked by default instead of leaking until added to an allowlist
- **null-index message fix**: `buildPinnedUnavailableErrorBody` no longer fabricates \"Pinned account 1\" when `pinnedIndex` is null, keeping the human-readable message consistent with `pinnedAccountIndex: null`

<h3>Confidence Score: 5/5</h3>

safe to merge — the change is a two-line swap in a single timer callback, isolated to withTimeout, and the stall error path it restores was already fully implemented; the only behavioral delta is that stalled streams now take the intended error path

the ordering fix is mechanically correct: reject() enqueues the rejection synchronously before any reader.cancel() microtask can settle the read() promise, so Promise.race cannot resolve ahead of it. the forwardStreamingResponse stall test proves the end-to-end behavior and is a reliable regression pin. the two companion fixes (null-index message, prefix header filter) are small and independently verified by their own test updates.

test/stream-failover-runtime.test.ts — the withTimeout ordering guarantee is only covered end-to-end via the forwardStreamingResponse stall test; a direct withTimeout unit test that lets onTimeout settle the inner promise would make the regression harder to miss in a future refactor

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/stream-failover-runtime.ts | core fix: swaps reject/onTimeout order in withTimeout so race rejection is enqueued before reader.cancel() can settle the read promise; also upgrades private header filter from exact Set to prefix match |
| test/stream-failover-runtime.test.ts | stall test flipped from bug-pinning to correct expectations; new prefix regression test added; withTimeout ordering not directly unit-tested at the function boundary |
| lib/request/rate-limit-decision.ts | null-index desync path now emits "The pinned account" instead of fabricating "Pinned account 1", keeping human-readable message consistent with machine-readable pinnedAccountIndex: null |
| test/rate-limit-decision.test.ts | test description and assertion updated to match fixed null-index message; regression note added |
| test/issue-474-pin-honored.test.ts | integration assertion updated to expect "The pinned account" and explicitly rejects "Pinned account 1" on the desync path |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Timer as setTimeout callback
    participant Race as Promise.race
    participant Read as reader.read()
    participant Cancel as reader.cancel()

    note over Timer,Cancel: BEFORE fix (buggy)
    Timer->>Cancel: onTimeout() → reader.cancel()
    Cancel-->>Read: "settles {done:true} (microtask)"
    Timer->>Race: reject(Error)
    Read-->>Race: "resolves {done:true} wins race ❌"
    note over Race: resolves — stall silently ends stream

    note over Timer,Cancel: AFTER fix (correct)
    Timer->>Race: reject(Error)
    note over Race: rejection enqueued in microtask queue
    Timer->>Cancel: onTimeout() → reader.cancel()
    Cancel-->>Read: "settles {done:true} (later microtask)"
    Race-->>Race: rejection wins — caught by forwardStreamingResponse ✅
    note over Race: rejects — lastError set, res.destroy(), onStreamError fires
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-30-stream-stall-fix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-30-stream-stall-fix%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fstream-failover-runtime.test.ts%3A135-152%0A**missing%20ordering-specific%20unit%20test%20for%20%60withTimeout%60**%0A%0Athe%20existing%20%60withTimeout%60%20stall%20test%20covers%20the%20rejection%20path%20but%20passes%20a%20promise%20that%20can%20never%20settle%20on%20its%20own%20%28%60new%20Promise%3Cnever%3E%28%28%29%20%3D%3E%20undefined%29%60%29%2C%20so%20it%20doesn't%20exercise%20the%20exact%20failure%20mode%20this%20PR%20fixes%20%E2%80%94%20where%20%60onTimeout%60's%20side%20effects%20*do*%20settle%20%60promise%60%20before%20the%20rejection%20wins%20the%20race.%20the%20regression%20is%20proven%20end-to-end%20via%20the%20%60forwardStreamingResponse%60%20stall%20test%2C%20but%20a%20targeted%20%60withTimeout%60%20unit%20test%20%28one%20where%20%60onTimeout%60%20triggers%20settlement%20of%20the%20inner%20promise%2C%20e.g.%20by%20cancelling%20a%20real%20stream%20reader%29%20would%20pin%20the%20ordering%20guarantee%20closer%20to%20the%20function%20itself%20and%20survive%20a%20refactor%20of%20%60forwardStreamingResponse%60.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=546&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/stream-failover-runtime.test.ts:135-152
**missing ordering-specific unit test for `withTimeout`**

the existing `withTimeout` stall test covers the rejection path but passes a promise that can never settle on its own (`new Promise<never>(() => undefined)`), so it doesn't exercise the exact failure mode this PR fixes — where `onTimeout`'s side effects *do* settle `promise` before the rejection wins the race. the regression is proven end-to-end via the `forwardStreamingResponse` stall test, but a targeted `withTimeout` unit test (one where `onTimeout` triggers settlement of the inner promise, e.g. by cancelling a real stream reader) would pin the ordering guarantee closer to the function itself and survive a refactor of `forwardStreamingResponse`.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(request): block private account head..."](https://github.com/ndycode/codex-multi-auth/commit/3d08e3545d86bed47b1d13858006e3e7bc32ce52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36686432)</sub>

<!-- /greptile_comment -->