### PR TITLE
fix(codex-manager): close the menu quota-refresh write races

### DIFF
--- a/lib/codex-manager/login-flow.ts
+++ b/lib/codex-manager/login-flow.ts
@@ -86,6 +86,20 @@ function clearMenuQuotaAutoRefreshSkip(state: MenuQuotaRefreshState): void {
 	state.menuQuotaRefreshGeneration += 1;
 }
 
+// The menu quota refresh runs fire-and-forget behind the dashboard. On the
+// paths that leave the loop (add-account's storage write, process exit) an
+// in-flight refresh must finish first so its cache save cannot race the
+// account-pool write (Windows EBUSY/EPERM on sibling files) or be orphaned
+// mid-write. The chain never rejects (it ends in .catch/.finally), and the
+// wait is bounded by the per-probe HTTP timeouts.
+async function drainPendingMenuQuotaRefresh(
+	state: MenuQuotaRefreshState,
+): Promise<void> {
+	if (state.pendingMenuQuotaRefresh) {
+		await state.pendingMenuQuotaRefresh;
+	}
+}
+
 const log = createLogger("codex-manager");
 
 async function clearAccountsAndReset(): Promise<void> {
@@ -126,6 +140,7 @@ async function runLoginDashboardLoop(
 	while (true) {
 		const existingStorage = await loadAccounts();
 		if (!existingStorage || existingStorage.accounts.length === 0) {
+			await drainPendingMenuQuotaRefresh(menuState);
 			return "add-account";
 		}
 		const currentStorage = existingStorage;
@@ -203,6 +218,7 @@ async function runLoginDashboardLoop(
 
 		if (menuResult.mode === "cancel") {
 			console.log("Cancelled.");
+			await drainPendingMenuQuotaRefresh(menuState);
 			return "exit";
 		}
 		if (menuResult.mode === "check") {
@@ -304,6 +320,7 @@ async function runLoginDashboardLoop(
 			continue;
 		}
 		if (menuResult.mode === "add") {
+			await drainPendingMenuQuotaRefresh(menuState);
 			return "add-account";
 		}
 	}

--- a/lib/codex-manager/login-menu-data.ts
+++ b/lib/codex-manager/login-menu-data.ts
@@ -8,11 +8,15 @@ import {
 	DEFAULT_DASHBOARD_DISPLAY_SETTINGS,
 } from "../dashboard-settings.js";
 import {
+	loadQuotaCache,
 	type QuotaCacheData,
 	type QuotaCacheEntry,
 	saveQuotaCache,
 } from "../quota-cache.js";
-import { fetchCodexQuotaSnapshot } from "../quota-probe.js";
+import {
+	type CodexQuotaSnapshot,
+	fetchCodexQuotaSnapshot,
+} from "../quota-probe.js";
 import {
 	buildQuotaEmailFallbackState,
 	hasSafeQuotaEmailFallback,
@@ -181,6 +185,10 @@ export async function refreshQuotaCacheForMenu(
 	let processed = 0;
 	onProgress?.(processed, total);
 	let changed = false;
+	const appliedSnapshots: {
+		account: AccountMetadataV3;
+		snapshot: CodexQuotaSnapshot;
+	}[] = [];
 	for (const target of targets) {
 		processed += 1;
 		onProgress?.(processed, total);
@@ -191,22 +199,45 @@ export async function refreshQuotaCacheForMenu(
 				accessToken: target.accessToken,
 				model: MENU_QUOTA_REFRESH_MODEL,
 			});
-			changed =
-				updateQuotaCacheForAccount(
-					nextCache,
-					target.account,
-					snapshot,
-					storage.accounts,
-					emailFallbackState,
-				) || changed;
+			const applied = updateQuotaCacheForAccount(
+				nextCache,
+				target.account,
+				snapshot,
+				storage.accounts,
+				emailFallbackState,
+			);
+			if (applied) appliedSnapshots.push({ account: target.account, snapshot });
+			changed = applied || changed;
 		} catch {
 			// Keep existing cached values if probing fails.
 		}
 	}
 
 	if (changed) {
+		// The probes above ran against a snapshot clone of the cache the menu
+		// loaded; another writer (a deep check, a second session) may have saved
+		// entries meanwhile, and writing the stale clone back whole-file would
+		// silently discard them (last write wins). Re-apply this run's results
+		// onto the freshest persisted cache instead.
+		let cacheToSave = nextCache;
 		try {
-			await saveQuotaCache(nextCache);
+			const persisted = await loadQuotaCache();
+			for (const { account, snapshot } of appliedSnapshots) {
+				updateQuotaCacheForAccount(
+					persisted,
+					account,
+					snapshot,
+					storage.accounts,
+					emailFallbackState,
+				);
+			}
+			cacheToSave = persisted;
+		} catch {
+			// Fall back to the snapshot clone; saving slightly stale data beats
+			// dropping this run's probe results.
+		}
+		try {
+			await saveQuotaCache(cacheToSave);
 		} catch (error) {
 			// Quota cache is a derived artifact; a transient Windows EBUSY/EPERM
 			// here must not fail the menu refresh, but it should not vanish into
@@ -216,6 +247,7 @@ export async function refreshQuotaCacheForMenu(
 				`Quota cache save failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}
+		return cacheToSave;
 	}
 
 	return nextCache;

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -750,10 +750,14 @@ describe("codex manager cli commands", () => {
 			primary: {},
 			secondary: {},
 		});
-		loadQuotaCacheMock.mockResolvedValue({
+		// Fresh object per call, like the real loadQuotaCache (a fresh disk read
+		// each time): refreshQuotaCacheForMenu rebases onto and mutates the
+		// loaded cache before saving, and a shared singleton here would leak
+		// that mutation into every later load in the same test.
+		loadQuotaCacheMock.mockImplementation(async () => ({
 			byAccountId: {},
 			byEmail: {},
-		});
+		}));
 		loadFlaggedAccountsMock.mockResolvedValue({
 			version: 1,
 			accounts: [],
@@ -9073,7 +9077,7 @@ describe("codex manager cli commands", () => {
 
 		let promptCallCount = 0;
 		promptLoginModeMock
-			.mockImplementationOnce(async (accounts) => {
+			.mockImplementationOnce(async (accounts, options) => {
 				promptCallCount += 1;
 				expect(promptCallCount).toBe(1);
 				expect(
@@ -9085,6 +9089,14 @@ describe("codex manager cli commands", () => {
 
 				queueMicrotask(() => {
 					releaseFirstRefresh.resolve();
+				});
+				// Wait for the first refresh to fully settle (statusMessage clears in
+				// the same .finally that releases the pending slot) so the second
+				// menu pass deterministically starts its own refresh; the refresh
+				// chain gained an await (the save-time cache rebase), so returning
+				// immediately could reach the pass-2 guard while pass 1 is pending.
+				await vi.waitFor(() => {
+					expect(options?.statusMessage?.()).toBeUndefined();
 				});
 				return { mode: "manage", deleteAccountIndex: 99 };
 			})
@@ -9258,12 +9270,17 @@ describe("codex manager cli commands", () => {
 
 		let promptCallCount = 0;
 		promptLoginModeMock
-			.mockImplementationOnce(async () => {
+			.mockImplementationOnce(async (_accounts, options) => {
 				promptCallCount += 1;
 				expect(promptCallCount).toBe(1);
 
 				queueMicrotask(() => {
 					releaseFirstRefresh.resolve();
+				});
+				// See the stale-refresh test above: settle pass 1's refresh before
+				// returning so pass 2's auto-fetch guard sees a free slot.
+				await vi.waitFor(() => {
+					expect(options?.statusMessage?.()).toBeUndefined();
 				});
 				return { mode: "manage", deleteAccountIndex: 99 };
 			})

--- a/test/codex-manager-login-menu-refresh.test.ts
+++ b/test/codex-manager-login-menu-refresh.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { QuotaCacheData } from "../lib/quota-cache.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+const { loadQuotaCacheMock, saveQuotaCacheMock, fetchCodexQuotaSnapshotMock } =
+	vi.hoisted(() => ({
+		loadQuotaCacheMock: vi.fn(),
+		saveQuotaCacheMock: vi.fn(),
+		fetchCodexQuotaSnapshotMock: vi.fn(),
+	}));
+
+vi.mock("../lib/quota-cache.js", () => ({
+	loadQuotaCache: loadQuotaCacheMock,
+	saveQuotaCache: saveQuotaCacheMock,
+}));
+
+vi.mock("../lib/quota-probe.js", () => ({
+	fetchCodexQuotaSnapshot: fetchCodexQuotaSnapshotMock,
+}));
+
+const { refreshQuotaCacheForMenu } = await import(
+	"../lib/codex-manager/login-menu-data.js"
+);
+
+function createStorage(now: number): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { codex: 0 },
+		accounts: [
+			{
+				email: "a@example.com",
+				accountId: "acc_a",
+				refreshToken: "refresh-a",
+				accessToken: "access-a",
+				expiresAt: now + 3_600_000,
+				addedAt: now - 60_000,
+				lastUsed: now - 60_000,
+			},
+			{
+				email: "b@example.com",
+				accountId: "acc_b",
+				refreshToken: "refresh-b",
+				accessToken: "access-b",
+				expiresAt: now + 3_600_000,
+				addedAt: now - 60_000,
+				lastUsed: now - 60_000,
+			},
+		],
+	};
+}
+
+function emptyCache(): QuotaCacheData {
+	return { byAccountId: {}, byEmail: {} };
+}
+
+function snapshotFor(model: string) {
+	return {
+		status: 200,
+		model,
+		primary: { usedPercent: 10, windowMinutes: 300, resetAtMs: 1 },
+		secondary: { usedPercent: 5, windowMinutes: 10080, resetAtMs: 2 },
+	};
+}
+
+const CONCURRENT_ENTRY = {
+	updatedAt: 1,
+	status: 429,
+	model: "gpt-5-codex",
+	primary: { usedPercent: 100, windowMinutes: 300, resetAtMs: 99 },
+	secondary: {},
+};
+
+beforeEach(() => {
+	loadQuotaCacheMock.mockReset();
+	saveQuotaCacheMock.mockReset();
+	fetchCodexQuotaSnapshotMock.mockReset();
+	saveQuotaCacheMock.mockResolvedValue(undefined);
+	fetchCodexQuotaSnapshotMock.mockResolvedValue(snapshotFor("gpt-5-codex"));
+});
+
+describe("refreshQuotaCacheForMenu", () => {
+	it("rebases its results onto the freshest persisted cache before saving", async () => {
+		// Regression for the last-write-wins clobber: a concurrent writer (deep
+		// check, second session) saved acc_concurrent while the menu refresh was
+		// probing against its stale snapshot clone. The whole-file save must keep
+		// that entry, not silently discard it.
+		loadQuotaCacheMock.mockResolvedValue({
+			byAccountId: { acc_concurrent: { ...CONCURRENT_ENTRY } },
+			byEmail: {},
+		});
+
+		const result = await refreshQuotaCacheForMenu(
+			createStorage(Date.now()),
+			emptyCache(),
+			60_000,
+		);
+
+		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		const saved = saveQuotaCacheMock.mock.calls[0][0] as QuotaCacheData;
+		expect(saved.byAccountId.acc_concurrent).toMatchObject({ status: 429 });
+		expect(saved.byAccountId.acc_a).toMatchObject({ status: 200 });
+		expect(saved.byAccountId.acc_b).toMatchObject({ status: 200 });
+		expect(result).toBe(saved);
+	});
+
+	it("falls back to saving its own snapshot clone when the reload fails", async () => {
+		loadQuotaCacheMock.mockRejectedValue(new Error("EBUSY"));
+
+		const result = await refreshQuotaCacheForMenu(
+			createStorage(Date.now()),
+			emptyCache(),
+			60_000,
+		);
+
+		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		const saved = saveQuotaCacheMock.mock.calls[0][0] as QuotaCacheData;
+		expect(saved.byAccountId.acc_a).toMatchObject({ status: 200 });
+		expect(saved.byAccountId.acc_b).toMatchObject({ status: 200 });
+		expect(result).toBe(saved);
+	});
+
+	it("does not reload or save when every probe fails", async () => {
+		fetchCodexQuotaSnapshotMock.mockRejectedValue(new Error("network"));
+
+		const cache = emptyCache();
+		const result = await refreshQuotaCacheForMenu(
+			createStorage(Date.now()),
+			cache,
+			60_000,
+		);
+
+		expect(loadQuotaCacheMock).not.toHaveBeenCalled();
+		expect(saveQuotaCacheMock).not.toHaveBeenCalled();
+		expect(result).toEqual(cache);
+	});
+
+	it("returns the input cache untouched when there are no accounts", async () => {
+		const cache = emptyCache();
+		const result = await refreshQuotaCacheForMenu(
+			{ version: 3, activeIndex: 0, activeIndexByFamily: {}, accounts: [] },
+			cache,
+			60_000,
+		);
+		expect(result).toBe(cache);
+		expect(fetchCodexQuotaSnapshotMock).not.toHaveBeenCalled();
+		expect(saveQuotaCacheMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

The focused follow-up promised on the #540 and #547 review threads: both quota-cache write races are pre-existing (they predate the login-machinery extraction; #547 moved them verbatim), fixed together here so the extraction stack stays zero-behavior-change.

> **Stacked on #547** (`claude/audit-29-login-machinery`), i.e. five deep: #525 → #535 → #540 → #547 → this. Merge in order; this PR then shows only the one fix commit.

## Fix 1 — last-write-wins clobber (flagged on #540)

`refreshQuotaCacheForMenu` probed against a snapshot **clone** of the cache the menu had loaded, then saved that clone whole-file. Any entries a concurrent writer persisted while the probes ran — a user-triggered deep check, a second session — were silently discarded. The save now reloads the freshest persisted cache and **re-applies this run's successful probe results onto it** (using the same `updateQuotaCacheForAccount` logic, so unsafe-email pruning behaves identically), falling back to the clone if the reload fails. No blocking, no UX change — concurrent writers' entries simply survive.

## Fix 2 — orphaned in-flight refresh (flagged on #547)

Leaving the dashboard (add-account, cancel, and the empty-storage onboarding path) abandoned a running background refresh whose cache save could land mid-flight against the subsequent `persistAccountPool` storage write (Windows `EBUSY`/`EPERM` on sibling files). The three exit paths now drain the pending refresh first. The wait is bounded by the per-probe HTTP timeouts, the chain never rejects, and menu **actions are deliberately not drained** — they stay instant; fix 1 makes their concurrent saves safe instead.

## Changes

- `lib/codex-manager/login-menu-data.ts`: save-time rebase in `refreshQuotaCacheForMenu` (tracks applied `(account, snapshot)` pairs, re-applies onto a fresh `loadQuotaCache()` result).
- `lib/codex-manager/login-flow.ts`: `drainPendingMenuQuotaRefresh` helper called at the three dashboard exit points.
- `test/codex-manager-login-menu-refresh.test.ts` (new): pins the rebase (a concurrent `acc_concurrent` entry survives the save), the reload-failure fallback, no-save-when-unchanged, and the empty-storage no-op.
- `test/codex-manager-cli.test.ts`: the suite's `loadQuotaCache` mock now returns a **fresh object per call**, matching the real implementation's fresh disk read (the old shared singleton would leak the rebase mutation across loads); the two refresh-orchestration tests settle pass 1 via the `statusMessage()` observable (cleared in the same `.finally` that frees the pending slot) instead of relying on exact microtask counts, which the added rebase `await` shifted.

## Validation

- [x] `npm run typecheck`; eslint on all 4 touched files `--max-warnings=0`
- [x] All 29 codex-manager suites: **484/484 passed** (480 pre-existing + 4 new)

## Risk / Rollback

The rebase only changes *which base* the whole-file save starts from; same-account results still take latest-wins (correct). The drain adds a bounded wait only on dashboard exit. Revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes two pre-existing quota-cache write races introduced during the login-machinery extraction: a last-write-wins clobber in `refreshQuotaCacheForMenu` (now rebases probe results onto a fresh disk load before saving) and an orphaned in-flight refresh on dashboard exit (now drained at all three loop-exit paths before returning to the oauth flow).

- `login-menu-data.ts`: tracks successful `(account, snapshot)` pairs, reloads the freshest persisted cache after all probes complete, re-applies the pairs onto it, and saves — concurrent writers' entries survive. the surrounding catch block is dead code because `loadQuotaCache` never rejects; on a real EBUSY reload it resolves to `{}`, silently losing non-probed entries instead of falling back to the snapshot clone as the comment promises.
- `login-flow.ts`: `drainPendingMenuQuotaRefresh` called at empty-storage, cancel, and add-account exits — prevents windows EBUSY/EPERM on the subsequent `persistAccountPool` write.
- `test/codex-manager-login-menu-refresh.test.ts` (new): four rebase scenarios; the reload-failure case mocks `loadQuotaCache` to reject, which the real implementation never does, so the fallback path tested here is unreachable in production.
- `test/codex-manager-cli.test.ts`: mock changed to fresh-object-per-call to prevent rebase mutation leak; refresh-settle guard switched to `vi.waitFor` on `statusMessage()` clearing for determinism.

<h3>Confidence Score: 3/5</h3>

the drain fix in login-flow.ts is safe and correct; the rebase logic in login-menu-data.ts has a silent failure mode when the disk reload encounters windows filesystem errors

the catch block surrounding loadQuotaCache() in the rebase path is unreachable — the real implementation swallows all errors and returns empty. on windows EBUSY during reload, cacheToSave becomes an empty base with only the fresh probes applied, silently discarding every pre-existing non-probed entry rather than falling back to the snapshot clone as documented. the test exercising this fallback passes only because it mocks a rejection that never fires in production.

lib/codex-manager/login-menu-data.ts (rebase catch block) and test/codex-manager-login-menu-refresh.test.ts (reload-failure test case)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/login-menu-data.ts | adds save-time rebase via loadQuotaCache + re-apply logic; the surrounding catch block is dead code because loadQuotaCache never rejects, causing silent empty-object fallback instead of the documented snapshot-clone fallback on EBUSY reload |
| lib/codex-manager/login-flow.ts | adds drainPendingMenuQuotaRefresh helper and calls it at all three loop-exit paths; logic is correct and bounded; no issues found |
| test/codex-manager-login-menu-refresh.test.ts | new suite covering 4 rebase scenarios; the reload-failure test mocks a rejection that the real loadQuotaCache never emits, so the fallback path it claims to cover is unreachable in production |
| test/codex-manager-cli.test.ts | mock switched to fresh-object-per-call to prevent mutation leak; refresh-settle guard changed to vi.waitFor on statusMessage clearing; both changes are correct and necessary |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dashboard as DashboardLoop
    participant Refresh as refreshQuotaCache
    participant Disk as quota-cache.json
    participant Pool as persistAccountPool

    Dashboard->>Disk: loadQuotaCache initial
    Dashboard->>Refresh: fire-and-forget
    activate Refresh
    Refresh->>Refresh: probe accounts via HTTP
    Refresh->>Disk: loadQuotaCache rebase reload
    Disk-->>Refresh: fresh persisted state
    Refresh->>Refresh: re-apply snapshots onto persisted
    Refresh->>Disk: saveQuotaCache cacheToSave
    deactivate Refresh
    Dashboard->>Refresh: drain await pendingMenuQuotaRefresh
    Refresh-->>Dashboard: settled
    Dashboard-->>Pool: return add-account
    Pool->>Disk: persistAccountPool write no EBUSY race
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-32-quota-cache-races%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-32-quota-cache-races%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fcodex-manager%2Flogin-menu-data.ts%3A235-238%0A**dead%20catch%20%E2%80%94%20%60loadQuotaCache%60%20never%20rejects**%0A%0A%60loadQuotaCache%60%20wraps%20every%20code%20path%20in%20a%20try%2Fcatch%20and%20returns%20%60%7B%20byAccountId%3A%20%7B%7D%2C%20byEmail%3A%20%7B%7D%20%7D%60%20on%20any%20failure%20%E2%80%94%20it%20is%20documented%20never%20to%20throw.%20so%20this%20catch%20block%20is%20unreachable%20in%20production.%0A%0Athe%20real-world%20EBUSY-during-reload%20path%20is%3A%20%60readCacheFileWithRetry%60%20exhausts%205%20attempts%20and%20throws%20%E2%86%92%20%60loadQuotaCache%60's%20own%20catch%20swallows%20it%20and%20resolves%20to%20an%20empty%20object%20%E2%86%92%20%60persisted%20%3D%20%7B%7D%60%20%E2%86%92%20the%20rebase%20applies%20only%20this%20run's%20probes%20onto%20an%20empty%20base%20%E2%86%92%20%60cacheToSave%60%20silently%20drops%20every%20pre-existing%20entry%20in%20%60nextCache%60%20that%20wasn't%20re-probed%20this%20pass.%20that%20is%20the%20opposite%20of%20what%20the%20fallback%20comment%20intends%20%28%22saving%20slightly%20stale%20data%20beats%20dropping%20this%20run's%20probe%20results%22%29.%0A%0Athe%20corresponding%20test%20%28%60%22falls%20back%20to%20saving%20its%20own%20snapshot%20clone%20when%20the%20reload%20fails%22%60%29%20confirms%20this%20gap%3A%20it%20uses%20%60mockRejectedValue%28new%20Error%28%22EBUSY%22%29%29%60%2C%20which%20exercises%20the%20dead%20catch%2C%20but%20the%20production%20%60loadQuotaCache%60%20would%20resolve%20instead%20of%20reject.%20the%20passing%20test%20gives%20false%20safety%20on%20a%20code%20path%20that%20is%20never%20reached.%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fcodex-manager-login-menu-refresh.test.ts%3A107-121%0A**test%20exercises%20dead%20catch%20branch**%0A%0A%60loadQuotaCacheMock.mockRejectedValue%28new%20Error%28%22EBUSY%22%29%29%60%20is%20the%20only%20way%20to%20reach%20the%20catch%20in%20the%20rebase%20block%2C%20but%20the%20real%20%60loadQuotaCache%60%20in%20%60lib%2Fquota-cache.ts%60%20never%20rejects%20%E2%80%94%20it%20catches%20internally%20and%20returns%20%60%7B%7D%60.%20this%20test%20passes%20but%20verifies%20a%20code%20path%20that%20never%20fires%20in%20production%2C%20so%20the%20actual%20EBUSY%20behavior%20%28silent%20empty-object%20reload%20%E2%86%92%20partial%20save%29%20has%20no%20coverage.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fcodex-manager%2Flogin-flow.ts%3A95-101%0A**no%20test%20pins%20the%20drain-before-exit%20contract**%0A%0Athe%20three%20%60drainPendingMenuQuotaRefresh%60%20call-sites%20cover%20the%20stated%20exit%20paths%2C%20but%20no%20vitest%20case%20asserts%20that%20a%20drain%20actually%20happens%20before%20%60persistAccountPool%60%20is%20reached.%20the%20%60codex-manager-cli.test.ts%60%20changes%20verify%20refresh%20settling%20within%20a%20menu%20pass%2C%20which%20is%20a%20different%20assertion.%20a%20test%20that%20starts%20a%20slow%20in-flight%20refresh%20and%20verifies%20%60persistAccountPool%60%20is%20only%20called%20after%20the%20drain%20resolves%20would%20lock%20in%20the%20windows%20EBUSY%20fix%20and%20prevent%20regression%20on%20this%20path.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=549&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
lib/codex-manager/login-menu-data.ts:235-238
**dead catch — `loadQuotaCache` never rejects**

`loadQuotaCache` wraps every code path in a try/catch and returns `{ byAccountId: {}, byEmail: {} }` on any failure — it is documented never to throw. so this catch block is unreachable in production.

the real-world EBUSY-during-reload path is: `readCacheFileWithRetry` exhausts 5 attempts and throws → `loadQuotaCache`'s own catch swallows it and resolves to an empty object → `persisted = {}` → the rebase applies only this run's probes onto an empty base → `cacheToSave` silently drops every pre-existing entry in `nextCache` that wasn't re-probed this pass. that is the opposite of what the fallback comment intends ("saving slightly stale data beats dropping this run's probe results").

the corresponding test (`"falls back to saving its own snapshot clone when the reload fails"`) confirms this gap: it uses `mockRejectedValue(new Error("EBUSY"))`, which exercises the dead catch, but the production `loadQuotaCache` would resolve instead of reject. the passing test gives false safety on a code path that is never reached.

### Issue 2 of 3
test/codex-manager-login-menu-refresh.test.ts:107-121
**test exercises dead catch branch**

`loadQuotaCacheMock.mockRejectedValue(new Error("EBUSY"))` is the only way to reach the catch in the rebase block, but the real `loadQuotaCache` in `lib/quota-cache.ts` never rejects — it catches internally and returns `{}`. this test passes but verifies a code path that never fires in production, so the actual EBUSY behavior (silent empty-object reload → partial save) has no coverage.

### Issue 3 of 3
lib/codex-manager/login-flow.ts:95-101
**no test pins the drain-before-exit contract**

the three `drainPendingMenuQuotaRefresh` call-sites cover the stated exit paths, but no vitest case asserts that a drain actually happens before `persistAccountPool` is reached. the `codex-manager-cli.test.ts` changes verify refresh settling within a menu pass, which is a different assertion. a test that starts a slow in-flight refresh and verifies `persistAccountPool` is only called after the drain resolves would lock in the windows EBUSY fix and prevent regression on this path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(codex-manager): close the menu quota..."](https://github.com/ndycode/codex-multi-auth/commit/37548ef683f90d42c4f36142bc9099f1dcfe7053) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36694374)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->