### PR TITLE
test: migrate the deferred small suites to the shared mock factories

### DIFF
--- a/test/accounts-edge.test.ts
+++ b/test/accounts-edge.test.ts
@@ -1,23 +1,40 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OAuthAuthDetails } from "../lib/types.js";
+import {
+  createCodexCliWriterMocks,
+  createStorageMocks,
+  pickMocks,
+} from "./helpers/cli-test-fixtures.js";
 
-const mockLoadAccounts = vi.fn();
-const mockSaveAccounts = vi.fn();
-const mockWithAccountStorageTransaction = vi.fn();
+// Shared mock groups (test/helpers/cli-test-fixtures.ts); the vi.mock
+// factories below resolve the helper lazily so hoisting stays safe (the
+// accounts module is only ever imported dynamically via
+// importAccountsModule). Storage is narrowed to the exact set this suite
+// used to override. The codex-cli state mock stays inline: this suite needs
+// the actual module spread (isCodexCliSyncEnabled and friends must stay
+// real), which diverges from the helper's full-replacement shape.
+const storageMocks = pickMocks(createStorageMocks(), [
+  "loadAccounts",
+  "saveAccounts",
+  "withAccountStorageTransaction",
+]);
+const codexCliWriterMocks = createCodexCliWriterMocks();
+const {
+  loadAccounts: mockLoadAccounts,
+  saveAccounts: mockSaveAccounts,
+  withAccountStorageTransaction: mockWithAccountStorageTransaction,
+} = storageMocks;
+const { setCodexCliActiveSelection: mockSetCodexCliActiveSelection } =
+  codexCliWriterMocks;
 const mockLoadCodexCliState = vi.fn();
 const mockSyncAccountStorageFromCodexCli = vi.fn();
-const mockSetCodexCliActiveSelection = vi.fn();
 const mockSelectHybridAccount = vi.fn();
 
-vi.mock("../lib/storage.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../lib/storage.js")>();
-  return {
-    ...actual,
-    loadAccounts: mockLoadAccounts,
-    saveAccounts: mockSaveAccounts,
-    withAccountStorageTransaction: mockWithAccountStorageTransaction,
-  };
-});
+vi.mock("../lib/storage.js", async () =>
+  (await import("./helpers/cli-test-fixtures.js")).storageModuleMock(
+    storageMocks,
+  ),
+);
 
 vi.mock("../lib/codex-cli/state.js", async (importOriginal) => {
   const actual =
@@ -32,9 +49,11 @@ vi.mock("../lib/codex-cli/sync.js", () => ({
   syncAccountStorageFromCodexCli: mockSyncAccountStorageFromCodexCli,
 }));
 
-vi.mock("../lib/codex-cli/writer.js", () => ({
-  setCodexCliActiveSelection: mockSetCodexCliActiveSelection,
-}));
+vi.mock("../lib/codex-cli/writer.js", async () =>
+  (await import("./helpers/cli-test-fixtures.js")).codexCliWriterModuleMock(
+    codexCliWriterMocks,
+  ),
+);
 
 vi.mock("../lib/rotation.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/rotation.js")>();

--- a/test/accounts-load-from-disk.test.ts
+++ b/test/accounts-load-from-disk.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AccountManager } from "../lib/accounts.js";
 
+// This suite imports the accounts module (and the mocked modules) statically,
+// so the hoisted vi.mock factories run before the test module body evaluates.
+// The mock instances therefore stay in vi.hoisted; the module shapes delegate
+// to the shared factories (test/helpers/cli-test-fixtures.ts), which the
+// factories resolve lazily via dynamic import.
 const {
   mockLoadAccounts,
   mockSaveAccounts,
@@ -11,27 +16,29 @@ const {
   mockWithAccountStorageTransaction: vi.fn(),
 }));
 
-vi.mock("../lib/storage.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../lib/storage.js")>();
-  return {
-    ...actual,
+vi.mock("../lib/storage.js", async () =>
+  (await import("./helpers/cli-test-fixtures.js")).storageModuleMock({
     loadAccounts: mockLoadAccounts,
     saveAccounts: mockSaveAccounts,
     withAccountStorageTransaction: mockWithAccountStorageTransaction,
-  };
-});
+  }),
+);
 
 vi.mock("../lib/codex-cli/sync.js", () => ({
   syncAccountStorageFromCodexCli: vi.fn(),
 }));
 
-vi.mock("../lib/codex-cli/state.js", () => ({
-  loadCodexCliState: vi.fn(),
-}));
+vi.mock("../lib/codex-cli/state.js", async () => {
+  const fixtures = await import("./helpers/cli-test-fixtures.js");
+  return fixtures.codexCliStateModuleMock(fixtures.createCodexCliStateMocks());
+});
 
-vi.mock("../lib/codex-cli/writer.js", () => ({
-  setCodexCliActiveSelection: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("../lib/codex-cli/writer.js", async () => {
+  const fixtures = await import("./helpers/cli-test-fixtures.js");
+  return fixtures.codexCliWriterModuleMock(
+    fixtures.createCodexCliWriterMocks(),
+  );
+});
 
 import { syncAccountStorageFromCodexCli } from "../lib/codex-cli/sync.js";
 import { loadCodexCliState } from "../lib/codex-cli/state.js";

--- a/test/dashboard-display-panel.test.ts
+++ b/test/dashboard-display-panel.test.ts
@@ -4,23 +4,34 @@ import {
 	DEFAULT_DASHBOARD_DISPLAY_SETTINGS,
 } from "../lib/dashboard-settings.js";
 import { UI_COPY } from "../lib/ui/copy.js";
-import {
-	type DashboardDisplayPanelDeps,
-	promptDashboardDisplayPanel,
-} from "../lib/codex-manager/dashboard-display-panel.js";
+import type { DashboardDisplayPanelDeps } from "../lib/codex-manager/dashboard-display-panel.js";
+import { createUiPromptMocks } from "./helpers/cli-test-fixtures.js";
 
-const { selectMock, getUiRuntimeOptionsMock } = vi.hoisted(() => ({
-	selectMock: vi.fn(),
-	getUiRuntimeOptionsMock: vi.fn(() => ({ theme: "test-theme" })),
-}));
+// Shared ui-prompt mock group (test/helpers/cli-test-fixtures.ts). The panel
+// module is only imported lazily inside promptPanel below, so the hoisted
+// vi.mock factories never run before these module-level consts initialize.
+// The ui/runtime mock stays inline: the helper has no factory for it.
+const uiMocks = createUiPromptMocks();
+const { select: selectMock } = uiMocks;
+const getUiRuntimeOptionsMock = vi.fn(() => ({ theme: "test-theme" }));
 
-vi.mock("../lib/ui/select.js", () => ({
-	select: selectMock,
-}));
+vi.mock("../lib/ui/select.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).uiSelectModuleMock(uiMocks),
+);
 
 vi.mock("../lib/ui/runtime.js", () => ({
 	getUiRuntimeOptions: getUiRuntimeOptionsMock,
 }));
+
+/** Lazily import the panel under test so the mocks above are wired first. */
+async function promptPanel(
+	settings: DashboardDisplaySettings,
+): Promise<DashboardDisplaySettings | null> {
+	const { promptDashboardDisplayPanel } = await import(
+		"../lib/codex-manager/dashboard-display-panel.js"
+	);
+	return promptDashboardDisplayPanel(settings, buildDeps());
+}
 
 const stdinIsTTYDescriptor = Object.getOwnPropertyDescriptor(
 	process.stdin,
@@ -146,7 +157,7 @@ describe("promptDashboardDisplayPanel", () => {
 	it("returns null without TTY access", async () => {
 		setInteractiveTTY(false);
 
-		const result = await promptDashboardDisplayPanel(createSettings(), buildDeps());
+		const result = await promptPanel(createSettings());
 
 		expect(result).toBeNull();
 		expect(selectMock).not.toHaveBeenCalled();
@@ -160,7 +171,7 @@ describe("promptDashboardDisplayPanel", () => {
 			})
 			.mockResolvedValueOnce({ type: "save" });
 
-		const result = await promptDashboardDisplayPanel(createSettings(), buildDeps());
+		const result = await promptPanel(createSettings());
 
 		expect(result?.menuShowStatusBadge).toBe(false);
 		expect(selectMock).toHaveBeenCalledTimes(2);
@@ -175,7 +186,7 @@ describe("promptDashboardDisplayPanel", () => {
 			.mockResolvedValueOnce({ type: "reset" })
 			.mockResolvedValueOnce({ type: "save" });
 
-		const result = await promptDashboardDisplayPanel(createSettings(), buildDeps());
+		const result = await promptPanel(createSettings());
 
 		expect(result?.menuShowStatusBadge).toBe(
 			DEFAULT_DASHBOARD_DISPLAY_SETTINGS.menuShowStatusBadge,
@@ -187,12 +198,11 @@ describe("promptDashboardDisplayPanel", () => {
 			.mockResolvedValueOnce({ type: "cycle-sort-mode" })
 			.mockResolvedValueOnce({ type: "save" });
 
-		const result = await promptDashboardDisplayPanel(
+		const result = await promptPanel(
 			createSettings({
 				menuSortMode: "manual",
 				menuSortEnabled: false,
 			}),
-			buildDeps(),
 		);
 
 		expect(result?.menuSortMode).toBe("ready-first");
@@ -204,12 +214,11 @@ describe("promptDashboardDisplayPanel", () => {
 			.mockResolvedValueOnce({ type: "cycle-layout-mode" })
 			.mockResolvedValueOnce({ type: "save" });
 
-		const result = await promptDashboardDisplayPanel(
+		const result = await promptPanel(
 			createSettings({
 				menuLayoutMode: "compact-details",
 				menuShowDetailsForUnselectedRows: false,
 			}),
-			buildDeps(),
 		);
 
 		expect(result?.menuLayoutMode).toBe("expanded-rows");
@@ -219,7 +228,7 @@ describe("promptDashboardDisplayPanel", () => {
 	it("returns null when the panel is cancelled", async () => {
 		selectMock.mockResolvedValueOnce({ type: "cancel" });
 
-		const result = await promptDashboardDisplayPanel(createSettings(), buildDeps());
+		const result = await promptPanel(createSettings());
 
 		expect(result).toBeNull();
 	});

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -378,10 +378,11 @@ vi.mock("../lib/accounts.js", async () => {
 	};
 });
 
-vi.mock("../lib/storage.js", async () => {
-	const actual = await vi.importActual("../lib/storage.js");
-	return {
-		...actual,
+// Shared module shape (test/helpers/cli-test-fixtures.ts): actual storage
+// module spread plus this suite's bespoke stub overrides. The overrides stay
+// inline (plain stubs, not vi.fn instances) because no test asserts on them.
+vi.mock("../lib/storage.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).storageModuleMock({
 		getStoragePath: () => "",
 		loadAccounts: async () => null,
 		saveAccounts: async () => {},
@@ -395,8 +396,8 @@ vi.mock("../lib/storage.js", async () => {
 		setStorageBackupEnabled: () => {},
 		exportAccounts: async () => {},
 		importAccounts: async () => ({ imported: 0, total: 0 }),
-	};
-});
+	}),
+);
 
 vi.mock("../lib/recovery.js", () => ({
 	createSessionRecoveryHook: () => null,

--- a/test/issue-474-pin-end-to-end.test.ts
+++ b/test/issue-474-pin-end-to-end.test.ts
@@ -26,6 +26,11 @@ import {
  * pin contract and affinity invalidation hold across real network requests.
  */
 
+// This suite imports the storage module (and its consumers) statically, so
+// the hoisted vi.mock factory runs before the test module body evaluates.
+// The mock instances therefore stay in vi.hoisted; the module shape delegates
+// to the shared storage factory (test/helpers/cli-test-fixtures.ts), which
+// the factory resolves lazily via dynamic import.
 const {
 	saveAccountsMock,
 	withAccountStorageTransactionMock,
@@ -34,14 +39,12 @@ const {
 	withAccountStorageTransactionMock: vi.fn(),
 }));
 
-vi.mock("../lib/storage.js", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("../lib/storage.js")>();
-	return {
-		...actual,
+vi.mock("../lib/storage.js", async () =>
+	(await import("./helpers/cli-test-fixtures.js")).storageModuleMock({
 		saveAccounts: saveAccountsMock,
 		withAccountStorageTransaction: withAccountStorageTransactionMock,
-	};
-});
+	}),
+);
 
 const CLIENT_API_KEY = "runtime-secret";
 const ACCOUNT_COUNT = 2;


### PR DESCRIPTION
## Summary

The follow-up #537 explicitly deferred: the five small suites it listed migrate onto `test/helpers/cli-test-fixtures.ts`. **Zero test-semantics change** — identical counts and pass/fail lists before/after (274/274 across migrated + canary suites, verified via stash comparison against the unmodified base).

> **Stacked on #537** (`claude/audit-19-cli-test-fixtures`). Merge #537 first; this PR then shows only the migration commit. The giant suites (`index.test.ts`, `runtime-rotation-proxy.test.ts`) remain out of scope, deferred for size.

## Per-suite migration

| Suite | Unified onto the helpers | Deliberately left inline (reason) |
|---|---|---|
| `index-retry.test.ts` | storage `vi.mock` → `storageModuleMock(...)` with bespoke stubs as overrides | `accounts.js`/`config.js` (divergent shapes #537 chose not to force-unify); `fetch-helpers`, `request-transformer`, `wait-utils`, `recovery`, `update-notice`, plugin tool (no helper counterparts) |
| `accounts-edge.test.ts` | storage → `pickMocks(createStorageMocks(), …)` + `storageModuleMock`; writer → `createCodexCliWriterMocks` + module mock | `codex-cli/state.js` (needs the actual-module spread so `isCodexCliSyncEnabled`/`lookupCodexCliTokensByEmail` stay real); `sync.js`/`rotation.js` (no helpers); local storage builders (no `activeIndexByFamily`, past timestamps — diverge from `accountStorageV3Fixture`) |
| `accounts-load-from-disk.test.ts` | storage/state/writer module shapes → helper module mocks | `vi.fn` instances stay in `vi.hoisted` — the suite statically imports `lib/accounts.js`, so hoisted factories must run before module-level consts (documented in-file) |
| `issue-474-pin-end-to-end.test.ts` | storage module shape → `storageModuleMock({saveAccounts, withAccountStorageTransaction})` | same static-import hoisting constraint; the fully-typed local `createStorage` stays (the minimal `as never` fixture would weaken its proper typing) |
| `dashboard-display-panel.test.ts` | select → `createUiPromptMocks()` + `uiSelectModuleMock`; `vi.hoisted` dropped entirely via the canonical lazy dynamic-import pattern (verified no static edge reaches `ui/select`/`ui/runtime`) | `ui/runtime.js` mock (no helper counterpart) |

Also includes the small hygiene commit already on the base branch's review thread: `repair-commands.test.ts` resets the three storage transaction mocks in `beforeEach` (`clearAllMocks` keeps `mockImplementation`s, so inline overrides bled between tests).

Net mechanics: 7 duplicated `vi.fn()` consts, 5 `importOriginal`-spread blocks, and 6 duplicated builder call-sites replaced with one-line helper delegations (+~26 lines are hoisting/divergence rationale comments matching #537's style).

## Validation

- [x] `npm run typecheck`; eslint on all touched files `--max-warnings=0`
- [x] Migrated + canary suites (10 files incl. `codex-manager-cli`, `repair-commands`): **274/274 passed**
- [x] Failure parity via `git stash` against the unmodified base: identical 274/274 with identical per-file counts
- [x] Independently re-verified: typecheck + the five migrated suites, 41/41

## Risk / Rollback

Test-infrastructure only; revert the single migration commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

migrates five small deferred test suites onto the shared `test/helpers/cli-test-fixtures.ts` mock factories introduced in #537, replacing duplicated `vi.fn()` declarations and `importOriginal`-spread blocks with one-line helper delegations. zero test-semantics change — same mock shapes, same counts, same pass/fail behaviour.

- **storage mocks**: all five suites replace inline `importOriginal`/`vi.importActual` spreads with `storageModuleMock(overrides)`, which wraps the identical `vi.importActual("../../lib/storage.js")` call internally; path difference from `test/` vs `test/helpers/` is canonicalized by vitest.
- **hoisting strategy split**: suites that statically import `accounts.js` keep mock instances in `vi.hoisted` and pass them into the shared factory lazily; suites that only import modules dynamically (e.g. `dashboard-display-panel`) drop `vi.hoisted` entirely and use module-level `create*Mocks()` calls.
- **dashboard panel**: replaces the direct `promptDashboardDisplayPanel` call-sites with a `promptPanel` wrapper that lazily imports the module under test, correctly ensuring `vi.mock` factories are wired before the first import.

<h3>Confidence Score: 5/5</h3>

test-infrastructure only migration; no production code touched, no mock shapes changed, no test assertions altered.

every suite correctly handles the hoisting constraint — static-import suites keep `vi.hoisted` and thread refs through as overrides, dynamic-import suites use module-level create calls. mock shapes are additive or identical. `storageModuleMock` path resolution difference is canonicalized by vitest. no token data, no filesystem side-effects, no concurrency changes.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/accounts-edge.test.ts | migrates storage/writer mocks to shared factory helpers; `importOriginal` → `vi.importActual` inside `storageModuleMock` is semantically identical; `pickMocks` correctly narrows the three overrides this suite needs. |
| test/accounts-load-from-disk.test.ts | migrates state/writer mocks to shared factory helpers while keeping `vi.hoisted` for storage instances (required by static import of `accounts.js`); new `codexCliStateModuleMock` exposes two extra exports (`getCodexCliAuthPath`, `getCodexCliConfigPath`) vs the old minimal stub — additive only, not a behavioral regression. |
| test/dashboard-display-panel.test.ts | drops `vi.hoisted` entirely in favour of module-level `createUiPromptMocks()` + lazy `promptPanel` dynamic import; `beforeEach` correctly uses `mockReset()` on `selectMock` and `mockClear()` on `getUiRuntimeOptionsMock`, so mock state doesn't bleed between tests. |
| test/index-retry.test.ts | delegates the `importActual` + bespoke-stub spread to `storageModuleMock`; stubs remain inline plain functions (not `vi.fn`) as no test asserts on them; path resolution difference (`../lib` vs `../../lib`) is canonicalized by Vitest — no behavioural change. |
| test/issue-474-pin-end-to-end.test.ts | replaces `importOriginal` spread with `storageModuleMock`; hoisted `saveAccountsMock`/`withAccountStorageTransactionMock` instances are threaded through as overrides, preserving all existing test assertions unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[vi.mock factory runs lazily] --> B{Static import of\naccounts.js?}
    B -- Yes --> C[Keep vi.fn instances\nin vi.hoisted]
    B -- No --> D[Module-level\ncreate*Mocks call]
    C --> E[Pass hoisted refs\nas overrides into helper]
    D --> F[Capture refs from\nresult at module level]
    E --> G[storageModuleMock / codexCliWriterModuleMock\nvi.importActual spread + overrides]
    F --> G
    G --> H[Vitest module registry\ncaches resolved mock]
    H --> I[Test uses same vi.fn\nrefs across beforeEach resets]
```

<sub>Reviews (1): Last reviewed commit: ["test: migrate the deferred small suites ..."](https://github.com/ndycode/codex-multi-auth/commit/8e280cefa1e39d350a469e80b607eeccbb0dff62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36694509)</sub>

<!-- /greptile_comment -->