### PR TITLE
test: strengthen the quota-refresh regression suite per #549 review

### DIFF
--- a/test/codex-manager-login-menu-refresh.test.ts
+++ b/test/codex-manager-login-menu-refresh.test.ts
@@ -146,6 +146,33 @@ describe("refreshQuotaCacheForMenu", () => {
 		}
 	});
 
+	it("still resolves and warns when both the reload and the save fail", async () => {
+		// Windows can hold the cache file locked across the whole refresh cycle:
+		// the reload falls back to the snapshot clone AND the save then rejects.
+		// The refresh must resolve with the clone and surface the same warning.
+		loadQuotaCacheMock.mockRejectedValue(new Error("EBUSY"));
+		saveQuotaCacheMock.mockRejectedValue(new Error("EBUSY: locked"));
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		try {
+			const result = await refreshQuotaCacheForMenu(
+				createStorage(Date.now()),
+				emptyCache(),
+				60_000,
+			);
+
+			expect(loadQuotaCacheMock).toHaveBeenCalledTimes(1);
+			expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+			expect(result.byAccountId.acc_a).toMatchObject({ status: 200 });
+			expect(result.byAccountId.acc_b).toMatchObject({ status: 200 });
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("Quota cache save failed: EBUSY: locked"),
+			);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
 	it("does not reload or save when every probe fails", async () => {
 		fetchCodexQuotaSnapshotMock.mockRejectedValue(new Error("network"));
 

--- a/test/codex-manager-login-menu-refresh.test.ts
+++ b/test/codex-manager-login-menu-refresh.test.ts
@@ -96,6 +96,7 @@ describe("refreshQuotaCacheForMenu", () => {
 			60_000,
 		);
 
+		expect(loadQuotaCacheMock).toHaveBeenCalledTimes(1);
 		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
 		const saved = saveQuotaCacheMock.mock.calls[0][0] as QuotaCacheData;
 		expect(saved.byAccountId.acc_concurrent).toMatchObject({ status: 429 });
@@ -113,11 +114,36 @@ describe("refreshQuotaCacheForMenu", () => {
 			60_000,
 		);
 
+		expect(loadQuotaCacheMock).toHaveBeenCalledTimes(1);
 		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
 		const saved = saveQuotaCacheMock.mock.calls[0][0] as QuotaCacheData;
 		expect(saved.byAccountId.acc_a).toMatchObject({ status: 200 });
 		expect(saved.byAccountId.acc_b).toMatchObject({ status: 200 });
 		expect(result).toBe(saved);
+	});
+
+	it("resolves and surfaces a warning when the save itself fails", async () => {
+		// The save is best-effort (Windows EBUSY/EPERM must not fail the menu
+		// refresh), but the failure must reach console.warn, not vanish into the
+		// caller's background .catch.
+		loadQuotaCacheMock.mockResolvedValue(emptyCache());
+		saveQuotaCacheMock.mockRejectedValue(new Error("EBUSY: locked"));
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		try {
+			const result = await refreshQuotaCacheForMenu(
+				createStorage(Date.now()),
+				emptyCache(),
+				60_000,
+			);
+
+			expect(result.byAccountId.acc_a).toMatchObject({ status: 200 });
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("Quota cache save failed: EBUSY: locked"),
+			);
+		} finally {
+			warnSpy.mockRestore();
+		}
 	});
 
 	it("does not reload or save when every probe fails", async () => {
@@ -133,6 +159,8 @@ describe("refreshQuotaCacheForMenu", () => {
 		expect(loadQuotaCacheMock).not.toHaveBeenCalled();
 		expect(saveQuotaCacheMock).not.toHaveBeenCalled();
 		expect(result).toEqual(cache);
+		// The function works on a clone; the caller's snapshot is never mutated.
+		expect(result).not.toBe(cache);
 	});
 
 	it("returns the input cache untouched when there are no accounts", async () => {


### PR DESCRIPTION
## Summary

CodeRabbit's review of #549 landed minutes after the merge wave took it into `main`, so its three suggestions arrive here as a small follow-up, plus the edge case its walkthrough correctly flagged as untested.

## Changes (test-only, one file)

- The **rebase** and **reload-fallback** tests now assert `loadQuotaCache` was called exactly once, pinning the reload code path explicitly instead of inferring it from the merged result.
- The **no-change** test additionally asserts `result !== cache` — the function works on a clone and must never mutate the caller's snapshot in place.
- New test for the previously uncovered **save-failure path**: a rejecting `saveQuotaCache` (Windows `EBUSY`) must resolve the refresh and surface `console.warn`, not vanish into the caller's background `.catch`.

## Validation

- [x] `npm run typecheck`; eslint `--max-warnings=0`
- [x] `npx vitest run test/codex-manager-login-menu-refresh.test.ts` — 5/5 (4 existing + 1 new)

## Risk / Rollback

Test-only; revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

follow-up to #549 strengthening the quota-refresh regression suite: pins `loadQuotaCache` call counts in the rebase and reload-fallback tests, adds a `result !== cache` identity check to the no-change test, and introduces two new tests for previously uncovered windows filesystem failure paths.

- `loadQuotaCacheMock.toHaveBeenCalledTimes(1)` added to the rebase and reload-fallback tests, making the reload code path explicit rather than inferred from merged results.
- new `loadOk + saveFail` and `loadFail + saveFail` tests verify that a rejecting `saveQuotaCache` (windows `EBUSY`) still resolves the refresh and surfaces `console.warn`, covering both reload-ok and reload-fail branches of the save-failure path.
- `result !== cache` assertion added to the no-change test to document that the function always returns a clone, never the caller's original snapshot reference.

<h3>Confidence Score: 5/5</h3>

test-only change; no production code is touched. all new assertions match the implementation's actual behavior.

the implementation correctly handles every path the tests cover — load-ok+save-fail and load-fail+save-fail both fall through to console.warn and resolve with the available cache data. the result !== cache identity check accurately reflects the cloneQuotaCacheData call that always runs before probing.

no files require special attention; a minor call-count assertion is missing in the new save-fail test but does not affect correctness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/codex-manager-login-menu-refresh.test.ts | adds loadQuotaCacheMock call-count assertions to existing tests, new loadOk+saveFail test, new loadFail+saveFail test, and result!==cache identity check — all assertions align with the implementation |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant refreshQuotaCacheForMenu
    participant loadQuotaCache
    participant fetchCodexQuotaSnapshot
    participant saveQuotaCache

    Test->>refreshQuotaCacheForMenu: call(storage, cache, maxAgeMs)
    refreshQuotaCacheForMenu->>fetchCodexQuotaSnapshot: probe acc_a, acc_b
    fetchCodexQuotaSnapshot-->>refreshQuotaCacheForMenu: snapshot (status 200)

    alt "changed=true reload path"
        refreshQuotaCacheForMenu->>loadQuotaCache: reload persisted cache
        alt loadOk
            loadQuotaCache-->>refreshQuotaCacheForMenu: persisted cache
            Note over refreshQuotaCacheForMenu: apply snapshots onto persisted
        else loadFail (EBUSY)
            loadQuotaCache-->>refreshQuotaCacheForMenu: throw EBUSY
            Note over refreshQuotaCacheForMenu: fall back to nextCache clone
        end
        refreshQuotaCacheForMenu->>saveQuotaCache: save cacheToSave
        alt saveOk
            saveQuotaCache-->>refreshQuotaCacheForMenu: resolved
        else saveFail (EBUSY)
            saveQuotaCache-->>refreshQuotaCacheForMenu: throw EBUSY locked
            Note over refreshQuotaCacheForMenu: console.warn still return cacheToSave
        end
    end
    refreshQuotaCacheForMenu-->>Test: cacheToSave or nextCache if no change
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-35-refresh-test-assertions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-35-refresh-test-assertions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fcodex-manager-login-menu-refresh.test.ts%3A133-146%0Athe%20save-fail%20test%20covers%20the%20%60loadOk%20%2B%20saveFail%60%20path%20but%20doesn't%20assert%20that%20%60loadQuotaCacheMock%60%20was%20called%20exactly%20once.%20every%20other%20test%20in%20this%20pr%20that%20goes%20through%20the%20reload%20branch%20now%20pins%20the%20call%20count%20%E2%80%94%20this%20one%20is%20the%20odd%20one%20out%2C%20and%20a%20regression%20where%20%60loadQuotaCache%60%20is%20skipped%20entirely%20in%20the%20save-fail%20path%20would%20slip%20through%20undetected.%0A%0A%60%60%60suggestion%0A%09%09try%20%7B%0A%09%09%09const%20result%20%3D%20await%20refreshQuotaCacheForMenu%28%0A%09%09%09%09createStorage%28Date.now%28%29%29%2C%0A%09%09%09%09emptyCache%28%29%2C%0A%09%09%09%0960_000%2C%0A%09%09%09%29%3B%0A%0A%09%09%09expect%28loadQuotaCacheMock%29.toHaveBeenCalledTimes%281%29%3B%0A%09%09%09expect%28saveQuotaCacheMock%29.toHaveBeenCalledTimes%281%29%3B%0A%09%09%09expect%28result.byAccountId.acc_a%29.toMatchObject%28%7B%20status%3A%20200%20%7D%29%3B%0A%09%09%09expect%28result.byAccountId.acc_b%29.toMatchObject%28%7B%20status%3A%20200%20%7D%29%3B%0A%09%09%09expect%28warnSpy%29.toHaveBeenCalledWith%28%0A%09%09%09%09expect.stringContaining%28%22Quota%20cache%20save%20failed%3A%20EBUSY%3A%20locked%22%29%2C%0A%09%09%09%29%3B%0A%09%09%7D%20finally%20%7B%0A%09%09%09warnSpy.mockRestore%28%29%3B%0A%09%09%7D%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=552&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/codex-manager-login-menu-refresh.test.ts:133-146
the save-fail test covers the `loadOk + saveFail` path but doesn't assert that `loadQuotaCacheMock` was called exactly once. every other test in this pr that goes through the reload branch now pins the call count — this one is the odd one out, and a regression where `loadQuotaCache` is skipped entirely in the save-fail path would slip through undetected.

```suggestion
		try {
			const result = await refreshQuotaCacheForMenu(
				createStorage(Date.now()),
				emptyCache(),
				60_000,
			);

			expect(loadQuotaCacheMock).toHaveBeenCalledTimes(1);
			expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
			expect(result.byAccountId.acc_a).toMatchObject({ status: 200 });
			expect(result.byAccountId.acc_b).toMatchObject({ status: 200 });
			expect(warnSpy).toHaveBeenCalledWith(
				expect.stringContaining("Quota cache save failed: EBUSY: locked"),
			);
		} finally {
			warnSpy.mockRestore();
		}
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover the combined reload+save fai..."](https://github.com/ndycode/codex-multi-auth/commit/c101a3cebd1f7c2734f3bb7bba8b55819ed91b22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36755216)</sub>

<!-- /greptile_comment -->