### PR TITLE
chore: add a tuned knip config and drop the unused @fast-check/vitest

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/knip@latest/schema.json",
+	"$schema": "https://unpkg.com/knip@6.16.1/schema.json",
 	"entry": [
 		"index.ts",
 		"lib/index.ts",

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://unpkg.com/knip@latest/schema.json",
+	"entry": [
+		"index.ts",
+		"lib/index.ts",
+		"lib/auth/index.ts",
+		"lib/request/index.ts",
+		"lib/codex-cli/index.ts",
+		"lib/ui/index.ts",
+		"scripts/*.{js,mjs}",
+		"test/**/*.test.ts",
+		"test/helpers/**/*.ts"
+	],
+	"project": [
+		"lib/**/*.ts",
+		"scripts/**/*.{js,mjs}",
+		"index.ts",
+		"test/**/*.ts"
+	],
+	"ignore": [
+		"bench/**",
+		"vendor/**",
+		"dist/**",
+		"docs/**"
+	],
+	"ignoreBinaries": [
+		"powershell.exe",
+		"pbcopy",
+		"where"
+	],
+	"ignoreDependencies": [
+		"typescript-language-server",
+		"@openai/codex"
+	],
+	"rules": {
+		"exports": "warn",
+		"types": "warn",
+		"nsExports": "warn",
+		"nsTypes": "warn",
+		"duplicates": "warn",
+		"enumMembers": "warn"
+	}
+}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -29,9 +29,17 @@
 		"where"
 	],
 	"ignoreDependencies": [
+		// Editor-only LSP tooling; never imported.
 		"typescript-language-server",
+		// The official Codex CLI this package wraps: resolved from the HOST
+		// install at runtime (scripts/codex-bin-resolver.js), deliberately not
+		// a package.json dependency.
 		"@openai/codex"
 	],
+	// Export/type-level findings are warn-only on purpose: the blocking signal
+	// is unused FILES and DEPENDENCIES. The export backlog was cleared
+	// incrementally (PRs #556/#557, down to two documented keepers); escalate a
+	// rule to "error" once its warning count is intentionally pinned at zero.
 	"rules": {
 		"exports": "warn",
 		"types": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
 				"mcodex": "scripts/mcodex.js"
 			},
 			"devDependencies": {
-				"@fast-check/vitest": "^0.2.4",
 				"@types/node": "^20.19.42",
 				"@typescript-eslint/eslint-plugin": "^8.56.0",
 				"@typescript-eslint/parser": "^8.56.0",
@@ -684,29 +683,6 @@
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
-			}
-		},
-		"node_modules/@fast-check/vitest": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@fast-check/vitest/-/vitest-0.2.4.tgz",
-			"integrity": "sha512-Ilcr+JAIPhb1s6FRm4qoglQYSGXXrS+zAupZeNuWAA3qHVGDA1d1Gb84Hb/+otL3GzVZjFJESg5/1SfIvrgssA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/dubzzz"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fast-check"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"fast-check": "^3.0.0 || ^4.0.0"
-			},
-			"peerDependencies": {
-				"vitest": "^1 || ^2 || ^3 || ^4"
 			}
 		},
 		"node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
 		"node": ">=18.17.0"
 	},
 	"devDependencies": {
-		"@fast-check/vitest": "^0.2.4",
 		"@types/node": "^20.19.42",
 		"@typescript-eslint/eslint-plugin": "^8.56.0",
 		"@typescript-eslint/parser": "^8.56.0",


### PR DESCRIPTION
## Summary

Follow-up to #554: makes dead-code detection repeatable instead of a one-off manual audit. Raw `knip` output on this repo was untrustworthy — it flagged `lib/index.ts` itself as unused because nothing declared the entry points — which is exactly why #554 needed every finding hand-verified.

> **Stacked on #554** (`claude/audit-37-dead-code`). Merge #554 first; this PR then shows only the config commit. (The `runtime/session-affinity.ts` orphan this config surfaced was added to #554, where it belongs thematically.)

## Changes

- **`knip.json`** (new): declares the real entry points — the plugin-host `index.ts`, the `lib/index.ts` facade, the `auth/`, `request/`, `codex-cli/`, `ui/` subpath index files that back `package.json` `exports`, the `scripts/` bins, and the test suites; ignores `bench/`, `vendor/`, `dist/`, `docs/`; ignores the host-resolved `@openai/codex` peer, the editor-only `typescript-language-server`, and the platform clipboard/locator binaries; downgrades export-level findings to **warnings**, so the blocking signal is unused *files* and *dependencies* only. With this config, knip exits clean on the current tree (94 unused-export warnings remain as an explicit pruning backlog rather than noise).
- **`@fast-check/vitest` removed** from devDependencies: zero imports anywhere — the property/chaos suites import `fast-check` directly, which stays. Both `package.json` and the tab-indented `package-lock.json` were edited surgically; the lockfile diff is exactly the one removed entry (24 lines), no formatting churn.

Deliberately **no npm script**: `knip` is not a devDependency, and whether to add and pin it (this repo SHA-pins its CI actions) is a maintainer decision. Until then it runs via `npx knip` and picks the config up automatically.

## Validation

- [x] `npx knip` exits 0 with zero error-level findings on this tree
- [x] `npm ci --dry-run` validates the hand-edited lockfile
- [x] `npm run typecheck`; the fast-check property suite still passes (4/4)

## Risk / Rollback

Tooling config + one unused devDependency; revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds a `knip.jsonc` config that declares entry points and demotes export-level findings to warnings, and removes the `@fast-check/vitest` devDependency which has zero imports across the repo (property tests use `fast-check` directly).

- **`knip.jsonc`**: pins entry points for the plugin-host, lib facade, subpath exports, scripts, and test suites; ignores `bench/`, `vendor/`, `dist/`, `docs/`; lists platform-specific binaries (`powershell.exe`, `pbcopy`, `where`) and runtime-resolved deps (`@openai/codex`, `typescript-language-server`) explicitly; keeps `files`/`dependencies` at error severity.
- **`@fast-check/vitest` removal**: confirmed unused — all property and chaos test files import from `fast-check` directly; both `package.json` and `package-lock.json` are updated surgically with no collateral formatting churn.

<h3>Confidence Score: 5/5</h3>

safe to merge — tooling config and one unused devDependency removal, no runtime code touched

the change is entirely in tooling config and lockfile; all declared entry points were verified to exist on disk; @fast-check/vitest has zero imports across the codebase; the lockfile diff is surgical with no collateral churn

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| knip.jsonc | new knip config — entry points verified against repo structure; ignoreBinaries covers windows/mac platform binaries; schema pinned to 6.16.1; no issues found |
| package.json | removes @fast-check/vitest from devDependencies — confirmed no imports anywhere in the codebase |
| package-lock.json | removes the single @fast-check/vitest lockfile entry (24 lines); no formatting churn; lockfile remains consistent |

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: convert the knip config to jsonc ..."](https://github.com/ndycode/codex-multi-auth/commit/4bbb78b0300edcf3b58f888ef2fe53b6469f705c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36761381)</sub>

<!-- /greptile_comment -->