### PR TITLE
test: cover login-oauth account selection and cancellation predicates

### DIFF
--- a/test/login-oauth-selection.test.ts
+++ b/test/login-oauth-selection.test.ts
@@ -49,6 +49,10 @@ describe("isOAuthCancellation", () => {
 		expect(
 			isOAuthCancellation({ type: "failed", message: "flow was CANCELED" }),
 		).toBe(true);
+		// The reason field is only consulted when message is absent.
+		expect(
+			isOAuthCancellation({ type: "failed", reason: "Login Cancelled" }),
+		).toBe(true);
 		expect(isOAuthCancellation({ type: "failed", reason: "unknown" })).toBe(false);
 		expect(isOAuthCancellation({ type: "failed" })).toBe(false);
 	});
@@ -106,6 +110,7 @@ describe("resolveAccountSelection", () => {
 		const result = resolveAccountSelection(BASE_TOKENS);
 
 		expect(result.accountIdOverride).toBe("org_team");
+		expect(result.accountIdSource).toBe("org");
 		expect(result.accountLabel).toContain("Acme Team");
 		// Issue #491/#512: every workspace exposed by the token must persist so
 		// `workspace <account>` can switch between them later.

--- a/test/login-oauth-selection.test.ts
+++ b/test/login-oauth-selection.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { JWT_CLAIM_PATH } from "../lib/constants.js";
+
+// Maps fake token strings to decoded JWT payloads so the real candidate
+// extraction in lib/auth/token-utils.ts runs against controlled claims.
+const { jwtPayloads } = vi.hoisted(() => ({
+	jwtPayloads: new Map<string, unknown>(),
+}));
+
+vi.mock("../lib/auth/auth.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/auth/auth.js")>();
+	return {
+		...actual,
+		decodeJWT: (token: string) => jwtPayloads.get(token) ?? null,
+	};
+});
+
+const { isAbortError, isOAuthCancellation, resolveAccountSelection } =
+	await import("../lib/codex-manager/login-oauth.js");
+
+const BASE_TOKENS = {
+	type: "success" as const,
+	access: "access-token",
+	refresh: "refresh-token",
+	expires: 9_999_999_999_999,
+	idToken: "id-token",
+};
+
+const originalEnvOverride = process.env.CODEX_AUTH_ACCOUNT_ID;
+
+beforeEach(() => {
+	jwtPayloads.clear();
+	delete process.env.CODEX_AUTH_ACCOUNT_ID;
+});
+
+afterEach(() => {
+	if (originalEnvOverride === undefined) {
+		delete process.env.CODEX_AUTH_ACCOUNT_ID;
+	} else {
+		process.env.CODEX_AUTH_ACCOUNT_ID = originalEnvOverride;
+	}
+});
+
+describe("isOAuthCancellation", () => {
+	it("matches cancelled/canceled in message or reason, case-insensitively", () => {
+		expect(
+			isOAuthCancellation({ type: "failed", message: "Login Cancelled by user" }),
+		).toBe(true);
+		expect(
+			isOAuthCancellation({ type: "failed", message: "flow was CANCELED" }),
+		).toBe(true);
+		expect(isOAuthCancellation({ type: "failed", reason: "unknown" })).toBe(false);
+		expect(isOAuthCancellation({ type: "failed" })).toBe(false);
+	});
+});
+
+describe("isAbortError", () => {
+	it("recognizes AbortError names and ABORT_ERR codes on real Errors only", () => {
+		const named = new Error("aborted");
+		named.name = "AbortError";
+		expect(isAbortError(named)).toBe(true);
+
+		const coded = new Error("aborted") as Error & { code?: string };
+		coded.code = "ABORT_ERR";
+		expect(isAbortError(coded)).toBe(true);
+
+		expect(isAbortError(new Error("plain"))).toBe(false);
+		expect(isAbortError({ name: "AbortError" })).toBe(false);
+		expect(isAbortError("AbortError")).toBe(false);
+	});
+});
+
+describe("resolveAccountSelection", () => {
+	it("returns the tokens unchanged when no candidates exist", () => {
+		const result = resolveAccountSelection(BASE_TOKENS);
+		expect(result).toEqual(BASE_TOKENS);
+		expect(result.workspaces).toBeUndefined();
+	});
+
+	it("adopts a single token candidate and surfaces it as a workspace", () => {
+		jwtPayloads.set("access-token", {
+			[JWT_CLAIM_PATH]: { chatgpt_account_id: "acc_solo" },
+		});
+
+		const result = resolveAccountSelection(BASE_TOKENS);
+
+		expect(result.accountIdOverride).toBe("acc_solo");
+		expect(result.accountIdSource).toBe("token");
+		expect(result.workspaces).toHaveLength(1);
+		expect(result.workspaces?.[0]).toMatchObject({
+			id: "acc_solo",
+			enabled: true,
+			isDefault: true,
+		});
+	});
+
+	it("prefers the default non-personal org among multiple candidates and keeps every workspace", () => {
+		jwtPayloads.set("access-token", {
+			[JWT_CLAIM_PATH]: { chatgpt_account_id: "acc_personal" },
+			organizations: [
+				{ id: "org_personal", name: "Personal", is_default: false, is_personal: true },
+				{ id: "org_team", name: "Acme Team", is_default: true },
+			],
+		});
+
+		const result = resolveAccountSelection(BASE_TOKENS);
+
+		expect(result.accountIdOverride).toBe("org_team");
+		expect(result.accountLabel).toContain("Acme Team");
+		// Issue #491/#512: every workspace exposed by the token must persist so
+		// `workspace <account>` can switch between them later.
+		expect(result.workspaces?.map((workspace) => workspace.id)).toEqual([
+			"acc_personal",
+			"org_personal",
+			"org_team",
+		]);
+	});
+
+	it("binds an explicit --org override as manual and reuses the candidate label", () => {
+		jwtPayloads.set("access-token", {
+			organizations: [
+				{ id: "org_a", name: "Alpha", is_default: true },
+				{ id: "org_b", name: "Beta" },
+			],
+		});
+
+		const result = resolveAccountSelection(BASE_TOKENS, "org_b");
+
+		expect(result.accountIdOverride).toBe("org_b");
+		expect(result.accountIdSource).toBe("manual");
+		expect(result.accountLabel).toContain("Beta");
+		// Issue #512: the explicit-binding flow must persist workspaces too.
+		expect(result.workspaces?.map((workspace) => workspace.id)).toEqual([
+			"org_a",
+			"org_b",
+		]);
+	});
+
+	it("binds an unknown --org override bare, without a fabricated label", () => {
+		jwtPayloads.set("access-token", {
+			organizations: [{ id: "org_a", name: "Alpha", is_default: true }],
+		});
+
+		const result = resolveAccountSelection(BASE_TOKENS, "org_elsewhere");
+
+		expect(result.accountIdOverride).toBe("org_elsewhere");
+		expect(result.accountIdSource).toBe("manual");
+		expect(result.accountLabel).toBeUndefined();
+		expect(result.workspaces?.map((workspace) => workspace.id)).toEqual(["org_a"]);
+	});
+
+	it("falls back to the CODEX_AUTH_ACCOUNT_ID env override when no --org is given", () => {
+		process.env.CODEX_AUTH_ACCOUNT_ID = "org_env";
+		jwtPayloads.set("access-token", {
+			organizations: [{ id: "org_env", name: "EnvOrg" }],
+		});
+
+		const result = resolveAccountSelection(BASE_TOKENS);
+
+		expect(result.accountIdOverride).toBe("org_env");
+		expect(result.accountIdSource).toBe("manual");
+		expect(result.accountLabel).toContain("EnvOrg");
+	});
+
+	it("lets an explicit --org win over the ambient env override", () => {
+		process.env.CODEX_AUTH_ACCOUNT_ID = "org_env";
+		jwtPayloads.set("access-token", {
+			organizations: [
+				{ id: "org_env", name: "EnvOrg" },
+				{ id: "org_cli", name: "CliOrg" },
+			],
+		});
+
+		const result = resolveAccountSelection(BASE_TOKENS, "org_cli");
+
+		expect(result.accountIdOverride).toBe("org_cli");
+		expect(result.accountLabel).toContain("CliOrg");
+	});
+
+	it("treats a whitespace-only --org as absent so the env fallback still applies", () => {
+		process.env.CODEX_AUTH_ACCOUNT_ID = "org_env";
+		jwtPayloads.set("access-token", {
+			organizations: [{ id: "org_env", name: "EnvOrg" }],
+		});
+
+		const result = resolveAccountSelection(BASE_TOKENS, "   ");
+
+		expect(result.accountIdOverride).toBe("org_env");
+	});
+});


### PR DESCRIPTION
## Summary

The phase-4-extracted login machinery (`lib/codex-manager/login-oauth.ts`) previously had only indirect coverage through the CLI suites. This adds a direct suite (`test/login-oauth-selection.test.ts`, 10 tests) for its three exported building blocks: `resolveAccountSelection`, `isOAuthCancellation`, and `isAbortError`.

Note: this `resolveAccountSelection` is **distinct** from the deps-injected one in `lib/runtime/account-selection.ts` (already covered by `test/account-selection.test.ts`). The login-oauth variant runs the *real* candidate extraction (`getAccountIdCandidates` / `resolveOrgOverride` / `selectBestAccountCandidate`) — only `decodeJWT` is mocked, via a `vi.hoisted` token→payload map with an `importOriginal` spread so the rest of `lib/auth/auth.js` stays live.

## What the tests pin

**`resolveAccountSelection`:**
- No candidates → tokens returned unchanged, no `workspaces` field.
- Single token candidate adopted with `accountIdSource: "token"` and surfaced as a default-enabled workspace.
- Multi-candidate selection prefers the default non-personal org, and **every** workspace from the token persists (the issue #491/#512 contract that lets `workspace <account>` switch later).
- Explicit `--org` matching a candidate → `accountIdSource: "manual"`, candidate label reused, and workspaces still built on the explicit-binding path (#512).
- Unknown `--org` → bare manual binding, no fabricated label.
- `CODEX_AUTH_ACCOUNT_ID` env fallback applies when no `--org` is given; an explicit `--org` wins over it; a whitespace-only `--org` falls through to the env override.

**Predicates:**
- `isOAuthCancellation` matches cancelled/canceled case-insensitively in either `message` or `reason`, and rejects everything else.
- `isAbortError` accepts `AbortError` names and `ABORT_ERR` codes on real `Error` instances only — plain objects and strings are rejected.

The env override is saved/restored around every test so the suite can't leak `CODEX_AUTH_ACCOUNT_ID` into other suites.

## Validation

- [x] `vitest run test/login-oauth-selection.test.ts` — 10/10 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/login-oauth-selection.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds a direct 10-test vitest suite (`test/login-oauth-selection.test.ts`) for the three exported building blocks in `lib/codex-manager/login-oauth.ts` — `resolveAccountSelection`, `isOAuthCancellation`, and `isAbortError` — which previously only had indirect CLI-level coverage.

- `resolveAccountSelection` tests span the zero-candidate, single-candidate, multi-candidate, explicit `--org`, unknown `--org`, env-fallback, and whitespace-override paths, with `decodeJWT` stubbed via a `vi.hoisted` token→payload map while the rest of `lib/auth/auth.js` stays live through `importOriginal`.
- `isOAuthCancellation` and `isAbortError` predicate tests cover positive and negative branches including the `reason` fallback field, case-insensitive matching, and the `instanceof Error` guard.
- env isolation uses a module-load-time snapshot of `CODEX_AUTH_ACCOUNT_ID` with `beforeEach`/`afterEach` save-restore; note that this still mutates `process.env` directly, so running with widened vitest worker parallelism carries the concurrency risk flagged in the existing review thread.

<h3>Confidence Score: 5/5</h3>

test-only addition; no production code touched, safe to merge.

the change is a new test file with no production code modifications. the happy-path and error-path assertions for all three exported functions are present and correct; the two thin env-override tests are coverage gaps rather than incorrect assertions. no risk of regression to the auth machinery itself.

test/login-oauth-selection.test.ts — the two env-override tests (lines 156-169 and 183-192) could be strengthened, but they do not cause any test to mis-pass.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/login-oauth-selection.test.ts | New 10-test suite for resolveAccountSelection, isOAuthCancellation, and isAbortError; most paths well-covered, but two env-override tests have thin assertion sets that leave accountIdSource and workspaces un-validated. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveAccountSelection] --> B{getAccountIdCandidates}
    B -->|length == 0| C[return tokens unchanged]
    B -->|length > 0| D{resolveOrgOverride}
    D -->|override present| E[find matched candidate]
    E --> F[return manual binding + workspaces]
    D -->|no override| G{length == 1?}
    G -->|yes| H[return single candidate + workspaces]
    G -->|no| I[selectBestAccountCandidate]
    I -->|best found| J[return best + workspaces]
    I -->|no best| C

    subgraph ENV["env-override priority"]
        K["explicit --org arg"] -->|wins| D
        L["CODEX_AUTH_ACCOUNT_ID env"] -->|fallback| D
        M["whitespace-only --org"] -->|treated as absent| D
    end
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-41-login-oauth-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-41-login-oauth-tests%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Flogin-oauth-selection.test.ts%3A183-192%0A**thin%20assertions%20on%20the%20whitespace-fallback%20path**%0A%0Athe%20test%20verifies%20that%20%60accountIdOverride%60%20resolves%20to%20the%20env%20value%2C%20but%20omits%20%60accountIdSource%60%2C%20%60accountLabel%60%2C%20and%20%60workspaces%60.%20the%20whitespace-only%20%60--org%60%20goes%20through%20the%20same%20%60override%60%20branch%20as%20every%20other%20explicit-binding%20path%20%28source%20lines%20111-125%29%2C%20so%20the%20%23512%20workspace-persistence%20contract%20and%20the%20%60%22manual%22%60%20source%20type%20are%20equally%20in-scope%20here.%20a%20regression%20that%20dropped%20%60workspaces%60%20on%20this%20path%20or%20mis-labelled%20the%20source%20would%20pass%20this%20test%20unnoticed.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Flogin-oauth-selection.test.ts%3A156-169%0A**missing%20%60accountIdSource%60%20and%20%60workspaces%60%20in%20the%20priority%20test**%0A%0Athe%20test%20confirms%20the%20winning%20%60accountIdOverride%60%20and%20%60accountLabel%60%2C%20but%20neither%20%60accountIdSource%60%20%28should%20be%20%60%22manual%22%60%29%20nor%20%60workspaces%60%20%28both%20%60org_env%60%20and%20%60org_cli%60%20should%20be%20present%29%20are%20asserted.%20since%20the%20PR%20description%20calls%20out%20the%20%23512%20contract%20on%20the%20explicit-binding%20path%2C%20and%20the%20parallel%20%22binds%20explicit%20--org%22%20test%20at%20line%20110%20does%20check%20%60workspaces%60%2C%20omitting%20it%20here%20leaves%20the%20priority%20path%20partially%20unverified.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=559&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/login-oauth-selection.test.ts:183-192
**thin assertions on the whitespace-fallback path**

the test verifies that `accountIdOverride` resolves to the env value, but omits `accountIdSource`, `accountLabel`, and `workspaces`. the whitespace-only `--org` goes through the same `override` branch as every other explicit-binding path (source lines 111-125), so the #512 workspace-persistence contract and the `"manual"` source type are equally in-scope here. a regression that dropped `workspaces` on this path or mis-labelled the source would pass this test unnoticed.

### Issue 2 of 2
test/login-oauth-selection.test.ts:156-169
**missing `accountIdSource` and `workspaces` in the priority test**

the test confirms the winning `accountIdOverride` and `accountLabel`, but neither `accountIdSource` (should be `"manual"`) nor `workspaces` (both `org_env` and `org_cli` should be present) are asserted. since the PR description calls out the #512 contract on the explicit-binding path, and the parallel "binds explicit --org" test at line 110 does check `workspaces`, omitting it here leaves the priority path partially unverified.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: strengthen login-oauth assertions ..."](https://github.com/ndycode/codex-multi-auth/commit/eefe8b62ddaa68bab6b61023fca16217f5ff93d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36767804)</sub>

<!-- /greptile_comment -->