### PR TITLE
test: cover login-menu manage actions and prompt fallbacks

### DIFF
--- a/test/login-menu-actions.test.ts
+++ b/test/login-menu-actions.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { promptLoginMode } from "../lib/cli.js";
+import type {
+	AccountMetadataV3,
+	AccountStorageV3,
+	NamedBackupSummary,
+} from "../lib/storage.js";
+
+const {
+	withAccountStorageTransactionMock,
+	runSwitchCommandMock,
+	runOAuthFlowMock,
+	resolveAccountSelectionMock,
+	persistAccountPoolMock,
+	syncSelectionToCodexMock,
+	persistAndSyncSelectedAccountMock,
+} = vi.hoisted(() => ({
+	withAccountStorageTransactionMock: vi.fn(),
+	runSwitchCommandMock: vi.fn(),
+	runOAuthFlowMock: vi.fn(),
+	resolveAccountSelectionMock: vi.fn(),
+	persistAccountPoolMock: vi.fn(),
+	syncSelectionToCodexMock: vi.fn(),
+	persistAndSyncSelectedAccountMock: vi.fn(),
+}));
+
+// Keep the real findMatchingAccountIndex (the identity matching under test)
+// and only fake the transaction wrapper so each test controls the storage
+// the handler reloads and captures what it persists.
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		withAccountStorageTransaction: withAccountStorageTransactionMock,
+	};
+});
+
+vi.mock("../lib/codex-manager/commands/switch.js", () => ({
+	runSwitchCommand: runSwitchCommandMock,
+}));
+
+vi.mock("../lib/codex-manager/login-oauth.js", () => ({
+	runOAuthFlow: runOAuthFlowMock,
+	resolveAccountSelection: resolveAccountSelectionMock,
+	persistAccountPool: persistAccountPoolMock,
+	syncSelectionToCodex: syncSelectionToCodexMock,
+}));
+
+vi.mock("../lib/codex-manager/persist-selected-account.js", () => ({
+	persistAndSyncSelectedAccount: persistAndSyncSelectedAccountMock,
+}));
+
+const {
+	handleManageAction,
+	promptBackupRestoreMode,
+	promptManualBackupSelection,
+	promptOAuthSignInMode,
+} = await import("../lib/codex-manager/login-menu-actions.js");
+
+type MenuResult = Awaited<ReturnType<typeof promptLoginMode>>;
+type TransactionPersist = (storage: AccountStorageV3) => Promise<void>;
+type TransactionHandler = (
+	current: AccountStorageV3 | null,
+	persist: TransactionPersist,
+) => Promise<void>;
+
+const NOW = 1_700_000_000_000;
+
+function account(id: string): AccountMetadataV3 {
+	return {
+		email: `${id}@example.com`,
+		accountId: `acc_${id}`,
+		refreshToken: `refresh-${id}`,
+		accessToken: `access-${id}`,
+		expiresAt: NOW + 3_600_000,
+		addedAt: NOW - 60_000,
+		lastUsed: NOW - 60_000,
+	};
+}
+
+function storageWith(
+	accounts: AccountMetadataV3[],
+	activeIndex = 0,
+	activeIndexByFamily: Record<string, number> = {},
+): AccountStorageV3 {
+	return { version: 3, activeIndex, activeIndexByFamily, accounts };
+}
+
+function backup(fileName: string): NamedBackupSummary {
+	return { path: `/backups/${fileName}`, fileName, accountCount: 2, mtimeMs: NOW };
+}
+
+// Storage the fake transaction hands to the handler as the freshly loaded
+// state, and the storages the handler persisted, in order.
+let loadedStorage: AccountStorageV3 | null = null;
+let persisted: AccountStorageV3[] = [];
+
+const originalStdinIsTTY = process.stdin.isTTY;
+const originalStdoutIsTTY = process.stdout.isTTY;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	loadedStorage = null;
+	persisted = [];
+	withAccountStorageTransactionMock.mockImplementation(
+		async (handler: TransactionHandler) =>
+			handler(loadedStorage, async (storage) => {
+				persisted.push(structuredClone(storage));
+			}),
+	);
+	// Force the non-interactive prompt fallbacks regardless of the runner.
+	process.stdin.isTTY = false;
+	process.stdout.isTTY = false;
+	logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	process.stdin.isTTY = originalStdinIsTTY;
+	process.stdout.isTTY = originalStdoutIsTTY;
+	logSpy.mockRestore();
+	errorSpy.mockRestore();
+});
+
+describe("non-TTY prompt fallbacks", () => {
+	it("defaults sign-in to the browser flow", async () => {
+		expect(await promptOAuthSignInMode(backup("codex-backup-1.json"))).toBe(
+			"browser",
+		);
+	});
+
+	it("restores the latest backup without prompting", async () => {
+		expect(await promptBackupRestoreMode(backup("codex-backup-1.json"))).toBe(
+			"latest",
+		);
+	});
+
+	it("picks the first manual backup, or null when none exist", async () => {
+		const first = backup("codex-backup-1.json");
+		expect(
+			await promptManualBackupSelection([first, backup("codex-backup-2.json")]),
+		).toBe(first);
+		expect(await promptManualBackupSelection([])).toBeNull();
+	});
+});
+
+describe("handleManageAction switch", () => {
+	it("delegates to runSwitchCommand with a 1-based index and storage deps", async () => {
+		const storage = storageWith([account("a"), account("b")]);
+		const menuResult: MenuResult = { mode: "manage", switchAccountIndex: 1 };
+
+		await handleManageAction(storage, menuResult);
+
+		expect(runSwitchCommandMock).toHaveBeenCalledTimes(1);
+		expect(runSwitchCommandMock).toHaveBeenCalledWith(
+			["2"],
+			expect.objectContaining({
+				setStoragePath: expect.any(Function),
+				loadAccounts: expect.any(Function),
+				persistAndSyncSelectedAccount: persistAndSyncSelectedAccountMock,
+			}),
+		);
+		expect(withAccountStorageTransactionMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("handleManageAction delete", () => {
+	it("deletes inside the transaction and rebalances every selection index", async () => {
+		const storage = storageWith(
+			[account("a"), account("b"), account("c")],
+			2,
+			{ "gpt-5-codex": 0, codex: 2 },
+		);
+		loadedStorage = structuredClone(storage);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			deleteAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(persisted).toHaveLength(1);
+		const saved = persisted[0];
+		expect(saved.accounts.map((entry) => entry.accountId)).toEqual([
+			"acc_b",
+			"acc_c",
+		]);
+		// Indexes after the removed row shift left; indexes pointing at the
+		// removed row clamp in place.
+		expect(saved.activeIndex).toBe(1);
+		expect(saved.activeIndexByFamily["gpt-5-codex"]).toBe(0);
+		expect(saved.activeIndexByFamily.codex).toBe(1);
+		// Families without an explicit entry inherit the adjusted activeIndex.
+		expect(saved.activeIndexByFamily["gpt-5.1"]).toBe(1);
+
+		// The in-memory menu storage is synced to what was persisted.
+		expect(storage.accounts.map((entry) => entry.accountId)).toEqual([
+			"acc_b",
+			"acc_c",
+		]);
+		expect(storage.activeIndex).toBe(1);
+		expect(logSpy).toHaveBeenCalledWith("Deleted account 1.");
+	});
+
+	it("re-resolves the account by identity when on-disk storage was reordered", async () => {
+		// The menu showed [a, b] and the user deleted row 1 (account a), but a
+		// concurrent writer reordered storage to [x, a]: account a must be
+		// deleted at its new position, not whatever now sits at index 0.
+		const storage = storageWith([account("a"), account("b")]);
+		loadedStorage = storageWith([account("x"), account("a")]);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			deleteAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0].accounts.map((entry) => entry.accountId)).toEqual([
+			"acc_x",
+		]);
+	});
+
+	it("becomes a no-op when the account vanished from storage", async () => {
+		const storage = storageWith([account("a"), account("b")]);
+		loadedStorage = storageWith([account("x")]);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			deleteAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(persisted).toHaveLength(0);
+		// The menu storage is left untouched and nothing is reported deleted.
+		expect(storage.accounts.map((entry) => entry.accountId)).toEqual([
+			"acc_a",
+			"acc_b",
+		]);
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+
+	it("resets all selection indexes when the last account is deleted", async () => {
+		const storage = storageWith([account("a")], 0, { codex: 0 });
+		loadedStorage = structuredClone(storage);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			deleteAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(persisted).toHaveLength(1);
+		const saved = persisted[0];
+		expect(saved.accounts).toEqual([]);
+		expect(saved.activeIndex).toBe(0);
+		expect(saved.activeIndexByFamily["gpt-5-codex"]).toBe(0);
+		expect(saved.activeIndexByFamily.codex).toBe(0);
+	});
+});
+
+describe("handleManageAction toggle", () => {
+	it("disables an enabled account and reports the new state", async () => {
+		const storage = storageWith([account("a"), account("b")]);
+		loadedStorage = structuredClone(storage);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			toggleAccountIndex: 1,
+		} satisfies MenuResult);
+
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0].accounts[1].enabled).toBe(false);
+		expect(storage.accounts[1].enabled).toBe(false);
+		expect(logSpy).toHaveBeenCalledWith("Disabled account 2.");
+	});
+
+	it("re-enables a disabled account", async () => {
+		const disabled = { ...account("a"), enabled: false };
+		const storage = storageWith([disabled]);
+		loadedStorage = structuredClone(storage);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			toggleAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0].accounts[0].enabled).toBe(true);
+		expect(logSpy).toHaveBeenCalledWith("Enabled account 1.");
+	});
+
+	it("becomes a no-op when the account vanished from storage", async () => {
+		const storage = storageWith([account("a")]);
+		loadedStorage = storageWith([]);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			toggleAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(persisted).toHaveLength(0);
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("handleManageAction refresh", () => {
+	it("runs the OAuth flow and persists the resolved selection on success", async () => {
+		const storage = storageWith([account("a")]);
+		const tokenResult = { type: "success" as const };
+		const resolved = { type: "success" as const, accountIdOverride: "acc_a" };
+		runOAuthFlowMock.mockResolvedValue(tokenResult);
+		resolveAccountSelectionMock.mockReturnValue(resolved);
+		persistAccountPoolMock.mockResolvedValue(undefined);
+		syncSelectionToCodexMock.mockResolvedValue(undefined);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 0,
+		} satisfies MenuResult);
+
+		// Non-TTY sign-in mode resolves to "browser" without prompting.
+		expect(runOAuthFlowMock).toHaveBeenCalledWith(true, "browser");
+		expect(resolveAccountSelectionMock).toHaveBeenCalledWith(tokenResult);
+		expect(persistAccountPoolMock).toHaveBeenCalledWith([resolved], false);
+		expect(syncSelectionToCodexMock).toHaveBeenCalledWith(resolved);
+		expect(logSpy).toHaveBeenCalledWith("Refreshed account 1.");
+	});
+
+	it("reports a failed OAuth flow without persisting anything", async () => {
+		const storage = storageWith([account("a")]);
+		runOAuthFlowMock.mockResolvedValue({
+			type: "failed",
+			message: "browser exploded",
+		});
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(errorSpy).toHaveBeenCalledWith("Refresh failed: browser exploded");
+		expect(persistAccountPoolMock).not.toHaveBeenCalled();
+		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
+	});
+
+	it("ignores a refresh request for an index that no longer exists", async () => {
+		const storage = storageWith([account("a")]);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 5,
+		} satisfies MenuResult);
+
+		expect(runOAuthFlowMock).not.toHaveBeenCalled();
+	});
+});

--- a/test/login-menu-actions.test.ts
+++ b/test/login-menu-actions.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { promptLoginMode } from "../lib/cli.js";
+import { UI_COPY } from "../lib/ui/ui-copy.js";
 import type {
 	AccountMetadataV3,
 	AccountStorageV3,
@@ -14,6 +15,7 @@ const {
 	persistAccountPoolMock,
 	syncSelectionToCodexMock,
 	persistAndSyncSelectedAccountMock,
+	selectMock,
 } = vi.hoisted(() => ({
 	withAccountStorageTransactionMock: vi.fn(),
 	runSwitchCommandMock: vi.fn(),
@@ -22,6 +24,7 @@ const {
 	persistAccountPoolMock: vi.fn(),
 	syncSelectionToCodexMock: vi.fn(),
 	persistAndSyncSelectedAccountMock: vi.fn(),
+	selectMock: vi.fn(),
 }));
 
 // Keep the real findMatchingAccountIndex (the identity matching under test)
@@ -49,6 +52,13 @@ vi.mock("../lib/codex-manager/login-oauth.js", () => ({
 vi.mock("../lib/codex-manager/persist-selected-account.js", () => ({
 	persistAndSyncSelectedAccount: persistAndSyncSelectedAccountMock,
 }));
+
+// The sign-in mode prompt lives in the module under test, so its cancel and
+// manual branches are reached by flipping TTY on and stubbing the UI select.
+vi.mock("../lib/ui/select.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/ui/select.js")>();
+	return { ...actual, select: selectMock };
+});
 
 const {
 	handleManageAction,
@@ -288,6 +298,27 @@ describe("handleManageAction toggle", () => {
 		expect(logSpy).toHaveBeenCalledWith("Enabled account 1.");
 	});
 
+	it("re-resolves the account by identity when on-disk storage was reordered", async () => {
+		// The menu showed [a, b] and the user toggled row 1 (account a), but a
+		// concurrent writer reordered storage to [x, a]: account a must be
+		// toggled at its new position, not whatever now sits at index 0.
+		const storage = storageWith([account("a"), account("b")]);
+		loadedStorage = storageWith([account("x"), account("a")]);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			toggleAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0].accounts[1]).toMatchObject({
+			accountId: "acc_a",
+			enabled: false,
+		});
+		expect(persisted[0].accounts[0].enabled).toBeUndefined();
+		expect(logSpy).toHaveBeenCalledWith("Disabled account 1.");
+	});
+
 	it("becomes a no-op when the account vanished from storage", async () => {
 		const storage = storageWith([account("a")]);
 		loadedStorage = storageWith([]);
@@ -298,6 +329,9 @@ describe("handleManageAction toggle", () => {
 		} satisfies MenuResult);
 
 		expect(persisted).toHaveLength(0);
+		// The in-memory menu storage is left untouched too.
+		expect(storage.accounts.map((entry) => entry.accountId)).toEqual(["acc_a"]);
+		expect(storage.accounts[0].enabled).toBeUndefined();
 		expect(logSpy).not.toHaveBeenCalled();
 	});
 });
@@ -351,5 +385,57 @@ describe("handleManageAction refresh", () => {
 		} satisfies MenuResult);
 
 		expect(runOAuthFlowMock).not.toHaveBeenCalled();
+	});
+
+	it("returns to the menu when the sign-in mode prompt is cancelled", async () => {
+		process.stdin.isTTY = true;
+		process.stdout.isTTY = true;
+		selectMock.mockResolvedValue("cancel");
+		const storage = storageWith([account("a")]);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(runOAuthFlowMock).not.toHaveBeenCalled();
+		expect(String(logSpy.mock.calls[0]?.[0])).toContain(
+			UI_COPY.oauth.cancelledBackToMenu,
+		);
+	});
+
+	it("runs the OAuth flow in manual mode when the prompt selects it", async () => {
+		process.stdin.isTTY = true;
+		process.stdout.isTTY = true;
+		selectMock.mockResolvedValue("manual");
+		const storage = storageWith([account("a")]);
+		const resolved = { type: "success" as const, accountIdOverride: "acc_a" };
+		runOAuthFlowMock.mockResolvedValue({ type: "success" });
+		resolveAccountSelectionMock.mockReturnValue(resolved);
+		persistAccountPoolMock.mockResolvedValue(undefined);
+		syncSelectionToCodexMock.mockResolvedValue(undefined);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(runOAuthFlowMock).toHaveBeenCalledWith(true, "manual");
+		expect(syncSelectionToCodexMock).toHaveBeenCalledWith(resolved);
+	});
+
+	it("bails out silently on a non-transport prompt selection", async () => {
+		process.stdin.isTTY = true;
+		process.stdout.isTTY = true;
+		selectMock.mockResolvedValue("restore-backup");
+		const storage = storageWith([account("a")]);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(runOAuthFlowMock).not.toHaveBeenCalled();
+		expect(logSpy).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Continues the direct-coverage push for the phase-4-extracted login machinery (sibling of #559, independent — based on `main`). `lib/codex-manager/login-menu-actions.ts` previously had only indirect CLI coverage; this adds `test/login-menu-actions.test.ts` (14 tests) for `handleManageAction` and the three prompt fallbacks.

The mocking is deliberately narrow: the **real** `findMatchingAccountIndex` runs (that identity matching is the thing under test), and only `withAccountStorageTransaction` is faked so each test controls the storage the handler reloads and captures exactly what it persists. `runSwitchCommand`, the login-oauth flow functions, and `persistAndSyncSelectedAccount` are mocked at the module boundary. `process.stdin/stdout.isTTY` are forced false (and restored) so the prompt fallbacks are deterministic regardless of the runner.

## What the tests pin

**Delete (the concurrency-safety core):**
- The account is re-resolved **by identity** inside the transaction — when a concurrent writer reordered on-disk storage, the right account is deleted at its new position, not whatever now sits at the menu's stale index.
- `activeIndex` and **every** `activeIndexByFamily` entry rebalance: indexes after the removed row shift left, indexes pointing at the removed row clamp, families without an explicit entry inherit the adjusted `activeIndex`.
- Vanished account → strict no-op: nothing persisted, the in-memory menu storage untouched, no "Deleted" message.
- Deleting the last account resets `activeIndex` and all family indexes to 0.
- On success the in-memory menu storage is synced to the persisted state.

**Toggle:** flips `enabled` both in the persisted storage and the in-memory copy, reports "Enabled"/"Disabled" with the 1-based row, and no-ops when the account vanished.

**Switch:** delegates to `runSwitchCommand` with the 1-based index and the storage deps bundle, without opening a transaction.

**Refresh:** non-TTY sign-in mode resolves to `"browser"` without prompting; success path resolves the selection then `persistAccountPool([resolved], false)` + `syncSelectionToCodex(resolved)`; a failed OAuth flow is reported via `console.error` without persisting; an out-of-range index is ignored entirely.

**Prompt fallbacks (non-TTY):** sign-in → `"browser"`, backup restore → `"latest"`, manual backup → first entry or `null`.

## Validation

- [x] `vitest run test/login-menu-actions.test.ts` — 14/14 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/login-menu-actions.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds `test/login-menu-actions.test.ts` — 14 direct-coverage tests for `handleManageAction` and the three non-tty prompt fallbacks in `lib/codex-manager/login-menu-actions.ts`. the mocking strategy is well-scoped: real `findMatchingAccountIndex` runs so identity-matching is exercised, and only `withAccountStorageTransaction` is faked to control disk state.

- **delete suite** pins concurrency-safety (re-resolve by identity after concurrent reorder), index rebalancing across `activeIndex`/`activeIndexByFamily`, no-op on vanished account, and last-account reset.
- **toggle suite** mirrors the same concurrency/no-op/enable/disable axes, including the reorder scenario that was flagged as missing in the prior review.
- **refresh suite** now covers browser, manual, cancel (tty-mocked), non-transport bail-out, failed oauth, and out-of-range index paths — all gaps called out in the prior round are closed.

<h3>Confidence Score: 5/5</h3>

test-only change adding direct coverage for previously-untested login menu action handlers; no production code touched, no token or filesystem paths modified.

the change is purely additive test code. the mocking boundaries are correct, tty state is saved and restored in afterEach, and all concurrency/no-op/index-rebalance scenarios are explicitly exercised. the two unfilled assertion slots in the manual-refresh and last-account-deleted tests are harmless gaps, not regressions.

no files require special attention; the two minor assertion gaps in the manual-refresh and last-account-deleted tests are worth tightening but do not block merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/login-menu-actions.test.ts | adds 14 direct-coverage tests for handleManageAction and the three prompt fallbacks; mocking strategy is correct and narrow; prior review gaps (toggle concurrent-reorder, no-op storage guard, refresh cancel/manual paths) all addressed; two minor assertion gaps remain in the manual-refresh and last-account-deleted cases |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-42-login-menu-actions-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-42-login-menu-actions-tests%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Flogin-menu-actions.test.ts%3A396-415%0A**manual%20refresh%20test%20under-asserted**%0A%0Athe%20browser-path%20test%20fully%20pins%20%60persistAccountPoolMock%60%2C%20%60syncSelectionToCodexMock%60%2C%20and%20%60logSpy%28%22Refreshed%20account%201.%22%29%60.%20the%20manual-mode%20test%20only%20checks%20%60runOAuthFlowMock%60%20was%20called%20with%20%60%22manual%22%60%20and%20%60syncSelectionToCodexMock%60%20was%20called.%20if%20the%20success%20branch%20were%20accidentally%20gated%20to%20browser-only%20%28missing%20%60persistAccountPool%60%20call%20or%20no%20log%20line%29%2C%20the%20manual%20test%20would%20still%20pass.%20adding%20%60expect%28persistAccountPoolMock%29.toHaveBeenCalledWith%28%5Bresolved%5D%2C%20false%29%60%20and%20%60expect%28logSpy%29.toHaveBeenCalledWith%28%22Refreshed%20account%201.%22%29%60%20closes%20that%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Flogin-menu-actions.test.ts%3A218-236%0A**%22last%20account%20deleted%22%20test%20skips%20in-memory%20sync%20assertions**%0A%0Athe%20first%20delete%20test%20explicitly%20asserts%20%60storage.accounts%60%20and%20%60storage.activeIndex%60%20are%20synced%20to%20the%20persisted%20state%20via%20%60replaceManageActionStorage%60.%20the%20%22last%20account%20deleted%22%20case%20only%20checks%20%60persisted%5B0%5D%60%20%E2%80%94%20it%20never%20verifies%20that%20the%20caller's%20in-memory%20%60storage%60%20object%20was%20mutated%20to%20reflect%20the%20empty%20state.%20adding%20%60expect%28storage.accounts%29.toEqual%28%5B%5D%29%60%20and%20%60expect%28storage.activeIndex%29.toBe%280%29%60%20would%20confirm%20%60replaceManageActionStorage%60%20fired%20on%20this%20code%20path%20too.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/login-menu-actions.test.ts:396-415
**manual refresh test under-asserted**

the browser-path test fully pins `persistAccountPoolMock`, `syncSelectionToCodexMock`, and `logSpy("Refreshed account 1.")`. the manual-mode test only checks `runOAuthFlowMock` was called with `"manual"` and `syncSelectionToCodexMock` was called. if the success branch were accidentally gated to browser-only (missing `persistAccountPool` call or no log line), the manual test would still pass. adding `expect(persistAccountPoolMock).toHaveBeenCalledWith([resolved], false)` and `expect(logSpy).toHaveBeenCalledWith("Refreshed account 1.")` closes that gap.

### Issue 2 of 2
test/login-menu-actions.test.ts:218-236
**"last account deleted" test skips in-memory sync assertions**

the first delete test explicitly asserts `storage.accounts` and `storage.activeIndex` are synced to the persisted state via `replaceManageActionStorage`. the "last account deleted" case only checks `persisted[0]` — it never verifies that the caller's in-memory `storage` object was mutated to reflect the empty state. adding `expect(storage.accounts).toEqual([])` and `expect(storage.activeIndex).toBe(0)` would confirm `replaceManageActionStorage` fired on this code path too.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: strengthen login-menu-actions cove..."](https://github.com/ndycode/codex-multi-auth/commit/0dc92881f451d767b50fbed42dac2d9070b14052) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36769248)</sub>

<!-- /greptile_comment -->