### PR TITLE
test: cover runAuthLogin transports, org threading, and cap handling

### DIFF
--- a/test/login-flow.test.ts
+++ b/test/login-flow.test.ts
@@ -117,6 +117,9 @@ beforeEach(() => {
 	loadAccountsMock.mockImplementation(async () => accountsOnDisk);
 	getNamedBackupsMock.mockResolvedValue([]);
 	isBrowserLaunchSuppressedMock.mockReturnValue(false);
+	// Inert default so a test that forgets to set the sign-in result exits
+	// through the cancellation branch instead of crashing on undefined.
+	runSignInFlowMock.mockResolvedValue(CANCELLED);
 	resolveAccountSelectionMock.mockReturnValue(RESOLVED);
 	persistAccountPoolMock.mockImplementation(async () => {
 		accountsOnDisk = storageWith((accountsOnDisk?.accounts.length ?? 0) + 1);
@@ -262,6 +265,11 @@ describe("runAuthLogin explicit transports", () => {
 	});
 });
 
+// These tests run through the REAL promptOAuthSignInMode in
+// login-menu-actions.ts: with the TTY flags forced false it takes its
+// documented non-interactive fast path and returns "browser" (unless browser
+// launch is suppressed). The runSignInFlow transport assertions below pin
+// exactly that fallback on purpose — do not mock the prompt here.
 describe("runAuthLogin onboarding without explicit flags", () => {
 	it("prefers manual transport when browser launch is suppressed", async () => {
 		isBrowserLaunchSuppressedMock.mockReturnValue(true);

--- a/test/login-flow.test.ts
+++ b/test/login-flow.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ACCOUNT_LIMITS } from "../lib/constants.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../lib/storage.js";
+
+const {
+	loadAccountsMock,
+	getNamedBackupsMock,
+	promptAddAnotherAccountMock,
+	promptLoginModeMock,
+	isBrowserLaunchSuppressedMock,
+	runSignInFlowMock,
+	resolveAccountSelectionMock,
+	persistAccountPoolMock,
+	syncSelectionToCodexMock,
+} = vi.hoisted(() => ({
+	loadAccountsMock: vi.fn(),
+	getNamedBackupsMock: vi.fn(),
+	promptAddAnotherAccountMock: vi.fn(),
+	promptLoginModeMock: vi.fn(),
+	isBrowserLaunchSuppressedMock: vi.fn(),
+	runSignInFlowMock: vi.fn(),
+	resolveAccountSelectionMock: vi.fn(),
+	persistAccountPoolMock: vi.fn(),
+	syncSelectionToCodexMock: vi.fn(),
+}));
+
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		loadAccounts: loadAccountsMock,
+		getNamedBackups: getNamedBackupsMock,
+		setStoragePath: vi.fn(),
+	};
+});
+
+vi.mock("../lib/cli.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/cli.js")>();
+	return {
+		...actual,
+		promptLoginMode: promptLoginModeMock,
+		promptAddAnotherAccount: promptAddAnotherAccountMock,
+	};
+});
+
+vi.mock("../lib/auth/browser.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/auth/browser.js")>();
+	return {
+		...actual,
+		isBrowserLaunchSuppressed: isBrowserLaunchSuppressedMock,
+	};
+});
+
+// Keep the real isOAuthCancellation (the predicate steering the cancel
+// branches under test); fake only the effectful flow functions.
+vi.mock("../lib/codex-manager/login-oauth.js", async (importOriginal) => {
+	const actual = await importOriginal<
+		typeof import("../lib/codex-manager/login-oauth.js")
+	>();
+	return {
+		...actual,
+		runSignInFlow: runSignInFlowMock,
+		resolveAccountSelection: resolveAccountSelectionMock,
+		persistAccountPool: persistAccountPoolMock,
+		syncSelectionToCodex: syncSelectionToCodexMock,
+	};
+});
+
+const { runAuthLogin } = await import("../lib/codex-manager/login-flow.js");
+
+const NOW = 1_700_000_000_000;
+
+function account(id: string): AccountMetadataV3 {
+	return {
+		email: `${id}@example.com`,
+		accountId: `acc_${id}`,
+		refreshToken: `refresh-${id}`,
+		accessToken: `access-${id}`,
+		expiresAt: NOW + 3_600_000,
+		addedAt: NOW - 60_000,
+		lastUsed: NOW - 60_000,
+	};
+}
+
+function storageWith(count: number): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: {},
+		accounts: Array.from({ length: count }, (_, i) => account(`a${i}`)),
+	};
+}
+
+function deps() {
+	return {
+		runForecast: vi.fn(),
+		createRepairCommandDeps: vi.fn(),
+	};
+}
+
+const CANCELLED = { type: "failed" as const, message: "User cancelled login" };
+const TOKEN_SUCCESS = { type: "success" as const };
+const RESOLVED = { type: "success" as const, accountIdOverride: "acc_x" };
+
+// What loadAccounts "sees on disk"; persistAccountPool grows it.
+let accountsOnDisk: AccountStorageV3 | null = null;
+
+const originalStdinIsTTY = process.stdin.isTTY;
+const originalStdoutIsTTY = process.stdout.isTTY;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	accountsOnDisk = null;
+	loadAccountsMock.mockImplementation(async () => accountsOnDisk);
+	getNamedBackupsMock.mockResolvedValue([]);
+	isBrowserLaunchSuppressedMock.mockReturnValue(false);
+	resolveAccountSelectionMock.mockReturnValue(RESOLVED);
+	persistAccountPoolMock.mockImplementation(async () => {
+		accountsOnDisk = storageWith((accountsOnDisk?.accounts.length ?? 0) + 1);
+		return "inserted";
+	});
+	syncSelectionToCodexMock.mockResolvedValue(undefined);
+	promptAddAnotherAccountMock.mockResolvedValue(false);
+	// Keep every prompt on its deterministic non-TTY fallback.
+	process.stdin.isTTY = false;
+	process.stdout.isTTY = false;
+	logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	process.stdin.isTTY = originalStdinIsTTY;
+	process.stdout.isTTY = originalStdoutIsTTY;
+	logSpy.mockRestore();
+	errorSpy.mockRestore();
+	warnSpy.mockRestore();
+});
+
+function loggedLines(spy: ReturnType<typeof vi.spyOn>): string[] {
+	return spy.mock.calls.map((call) => call.map(String).join(" "));
+}
+
+describe("runAuthLogin argument handling", () => {
+	it("rejects --org without a value and prints usage", async () => {
+		expect(await runAuthLogin(["--org"], deps())).toBe(1);
+		expect(loggedLines(errorSpy).join("\n")).toContain(
+			"Missing value for --org",
+		);
+		expect(loadAccountsMock).not.toHaveBeenCalled();
+	});
+
+	it("returns 0 for --help without starting the flow", async () => {
+		expect(await runAuthLogin(["--help"], deps())).toBe(0);
+		expect(loadAccountsMock).not.toHaveBeenCalled();
+		expect(runSignInFlowMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("runAuthLogin explicit transports", () => {
+	it("bypasses the dashboard with --device-auth and exits cleanly on cancel", async () => {
+		// With saved accounts a plain `login` would open the dashboard; an
+		// explicit transport must skip it, and cancelling must NOT fall back to
+		// the dashboard (that would trap scripts in a sign-in loop).
+		accountsOnDisk = storageWith(2);
+		runSignInFlowMock.mockResolvedValue(CANCELLED);
+
+		expect(await runAuthLogin(["--device-auth"], deps())).toBe(0);
+
+		expect(promptLoginModeMock).not.toHaveBeenCalled();
+		expect(runSignInFlowMock).toHaveBeenCalledExactlyOnceWith(true, "device");
+		expect(loggedLines(logSpy)).toContain("Cancelled.");
+	});
+
+	it("exits 1 with the failure message on a non-cancellation failure", async () => {
+		runSignInFlowMock.mockResolvedValue({
+			type: "failed",
+			message: "token exchange exploded",
+		});
+
+		expect(await runAuthLogin(["--manual"], deps())).toBe(1);
+		expect(loggedLines(errorSpy)).toContain(
+			"Login failed: token exchange exploded",
+		);
+		expect(persistAccountPoolMock).not.toHaveBeenCalled();
+	});
+
+	it("threads --org into resolveAccountSelection and persists the account", async () => {
+		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+
+		expect(await runAuthLogin(["--manual", "--org", "org_team"], deps())).toBe(
+			0,
+		);
+
+		// Issue #491: the org binding travels as an explicit argument, not via
+		// process.env mutation.
+		expect(resolveAccountSelectionMock).toHaveBeenCalledExactlyOnceWith(
+			TOKEN_SUCCESS,
+			"org_team",
+		);
+		expect(persistAccountPoolMock).toHaveBeenCalledExactlyOnceWith(
+			[RESOLVED],
+			false,
+		);
+		expect(syncSelectionToCodexMock).toHaveBeenCalledExactlyOnceWith(RESOLVED);
+		// Empty pool at start: this was not a forced re-login.
+		expect(runSignInFlowMock).toHaveBeenCalledExactlyOnceWith(false, "manual");
+		expect(loggedLines(logSpy)).toContain("Added account. Total: 1");
+	});
+
+	it.each([
+		["rebound", "Rebound workspace for existing account. Total: 1"],
+		["updated", "Updated existing account. Total: 1"],
+	] as const)(
+		"reports a %s persist outcome without claiming a new slot",
+		async (outcome, message) => {
+			// Issue #512: same-email logins update or rebind instead of growing
+			// the pool, and the summary line must say so.
+			runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+			persistAccountPoolMock.mockImplementation(async () => {
+				accountsOnDisk = storageWith(1);
+				return outcome;
+			});
+
+			expect(await runAuthLogin(["--manual"], deps())).toBe(0);
+			expect(loggedLines(logSpy)).toContain(message);
+		},
+	);
+
+	it("stops at the account cap without offering another sign-in", async () => {
+		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+		persistAccountPoolMock.mockImplementation(async () => {
+			accountsOnDisk = storageWith(ACCOUNT_LIMITS.MAX_ACCOUNTS);
+			return "inserted";
+		});
+
+		expect(await runAuthLogin(["--manual"], deps())).toBe(0);
+
+		expect(promptAddAnotherAccountMock).not.toHaveBeenCalled();
+		expect(loggedLines(logSpy)).toContain(
+			`Reached maximum account limit (${ACCOUNT_LIMITS.MAX_ACCOUNTS}).`,
+		);
+	});
+
+	it("runs a second sign-in as a forced re-login when adding another account", async () => {
+		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+		promptAddAnotherAccountMock
+			.mockResolvedValueOnce(true)
+			.mockResolvedValueOnce(false);
+
+		expect(await runAuthLogin(["--manual"], deps())).toBe(0);
+
+		expect(runSignInFlowMock).toHaveBeenCalledTimes(2);
+		expect(runSignInFlowMock).toHaveBeenNthCalledWith(1, false, "manual");
+		// The second login must force a fresh browser session so it cannot
+		// silently reuse the first account's cookies.
+		expect(runSignInFlowMock).toHaveBeenNthCalledWith(2, true, "manual");
+		expect(loggedLines(logSpy)).toContain("Added account. Total: 2");
+	});
+});
+
+describe("runAuthLogin onboarding without explicit flags", () => {
+	it("prefers manual transport when browser launch is suppressed", async () => {
+		isBrowserLaunchSuppressedMock.mockReturnValue(true);
+		runSignInFlowMock.mockResolvedValue(CANCELLED);
+
+		expect(await runAuthLogin([], deps())).toBe(0);
+
+		expect(runSignInFlowMock).toHaveBeenCalledExactlyOnceWith(false, "manual");
+		expect(loggedLines(logSpy)).toContain("Cancelled.");
+	});
+
+	it("warns and continues when named-backup discovery fails hard", async () => {
+		getNamedBackupsMock.mockRejectedValue(
+			Object.assign(new Error("permission denied"), { code: "EACCES" }),
+		);
+		runSignInFlowMock.mockResolvedValue(CANCELLED);
+
+		expect(await runAuthLogin([], deps())).toBe(0);
+
+		expect(loggedLines(warnSpy).join("\n")).toContain(
+			"Named backup discovery failed",
+		);
+		// Sign-in still proceeded on the non-TTY default transport.
+		expect(runSignInFlowMock).toHaveBeenCalledExactlyOnceWith(false, "browser");
+	});
+
+	it("treats a missing backup directory as normal, without warning", async () => {
+		getNamedBackupsMock.mockRejectedValue(
+			Object.assign(new Error("no such file"), { code: "ENOENT" }),
+		);
+		runSignInFlowMock.mockResolvedValue(CANCELLED);
+
+		expect(await runAuthLogin([], deps())).toBe(0);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+});

--- a/test/login-flow.test.ts
+++ b/test/login-flow.test.ts
@@ -121,6 +121,9 @@ beforeEach(() => {
 	// through the cancellation branch instead of crashing on undefined.
 	runSignInFlowMock.mockResolvedValue(CANCELLED);
 	resolveAccountSelectionMock.mockReturnValue(RESOLVED);
+	// Default persist simulates the insertion-only path: accountsOnDisk grows
+	// by one and the outcome is "inserted". Tests asserting the same-email
+	// "rebound"/"updated" semantics override this with a non-growing impl.
 	persistAccountPoolMock.mockImplementation(async () => {
 		accountsOnDisk = storageWith((accountsOnDisk?.accounts.length ?? 0) + 1);
 		return "inserted";
@@ -161,6 +164,16 @@ describe("runAuthLogin argument handling", () => {
 		expect(loadAccountsMock).not.toHaveBeenCalled();
 		expect(runSignInFlowMock).not.toHaveBeenCalled();
 	});
+
+	it("rejects combining --device-auth with a manual-mode flag", async () => {
+		expect(await runAuthLogin(["--device-auth", "--no-browser"], deps())).toBe(
+			1,
+		);
+		expect(loggedLines(errorSpy).join("\n")).toContain(
+			"Cannot combine --device-auth with --no-browser",
+		);
+		expect(runSignInFlowMock).not.toHaveBeenCalled();
+	});
 });
 
 describe("runAuthLogin explicit transports", () => {
@@ -193,6 +206,7 @@ describe("runAuthLogin explicit transports", () => {
 
 	it("threads --org into resolveAccountSelection and persists the account", async () => {
 		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+		const envOverrideBefore = process.env.CODEX_AUTH_ACCOUNT_ID;
 
 		expect(await runAuthLogin(["--manual", "--org", "org_team"], deps())).toBe(
 			0,
@@ -200,6 +214,7 @@ describe("runAuthLogin explicit transports", () => {
 
 		// Issue #491: the org binding travels as an explicit argument, not via
 		// process.env mutation.
+		expect(process.env.CODEX_AUTH_ACCOUNT_ID).toBe(envOverrideBefore);
 		expect(resolveAccountSelectionMock).toHaveBeenCalledExactlyOnceWith(
 			TOKEN_SUCCESS,
 			"org_team",


### PR DESCRIPTION
## Summary

Third suite in the direct-coverage push for the phase-4-extracted login machinery (siblings: #559 login-oauth, #560 login-menu-actions; all independent, based on `main`). `lib/codex-manager/login-flow.ts` — the `login` command's control loop — had only indirect CLI coverage. This adds `test/login-flow.test.ts` (12 tests) driving `runAuthLogin` end to end.

The mocking stays at the effectful seams only: storage loads, the sign-in flow, persistence, and the interactive prompts. The **real** `parseAuthLoginArgs` and the **real** `isOAuthCancellation` predicate run, and a small `accountsOnDisk` holder makes `persistAccountPool` actually grow what `loadAccounts` returns, so the post-persist count logic is exercised honestly. TTY flags are forced false (and restored) so prompts hit their deterministic fallbacks.

## What the tests pin

**Argument handling:** `--org` without a value fails with the usage message and exit 1 before touching storage; `--help` exits 0 without starting the flow.

**Explicit transports (the script-safety contracts):**
- `--device-auth` with saved accounts bypasses the dashboard entirely, and a cancellation exits 0 — it must not fall back to the dashboard and trap a script in a sign-in loop.
- A non-cancellation failure exits 1 with `Login failed: <message>` and persists nothing.
- The `MAX_ACCOUNTS` cap exits 0 without offering another sign-in.

**Issue #491/#512 semantics:**
- `--org org_team` is threaded as an explicit argument into `resolveAccountSelection` — no `process.env` mutation.
- `inserted` / `updated` / `rebound` persist outcomes produce their distinct summary lines (same-email logins don't claim a new slot).

**Multi-account flow:** answering "add another" runs the second sign-in with `forceNewLogin: true` so it cannot silently reuse the first account's browser session, and the totals advance.

**Onboarding edges:** browser-launch suppression promotes the manual transport; named-backup discovery failures warn-and-continue on real errors (EACCES) but stay silent on ENOENT.

## Validation

- [x] `vitest run test/login-flow.test.ts` — 12/12 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/login-flow.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/login-flow.test.ts` — 12 vitest tests driving `runAuthLogin` end-to-end as the third suite in the phase-4 direct-coverage push. mocking stays at effectful seams only; the real `parseAuthLoginArgs` and `isOAuthCancellation` run, and a small `accountsOnDisk` holder makes `persistAccountPool` grow what `loadAccounts` returns.

- covers argument validation (`--org` missing value, `--help`, `--device-auth + --no-browser` conflict), explicit transport contracts (`--device-auth` bypass, cancel exit-0, non-cancel exit-1), `--org` threading as an explicit arg (issue #491), `inserted`/`updated`/`rebound` persist outcomes (issue #512), `MAX_ACCOUNTS` cap, forced re-login on \"add another\", and onboarding edges (browser suppression, EACCES warn-and-continue, ENOENT silent skip).
- both previously flagged issues are resolved: `runSignInFlowMock` now has a `CANCELLED` default in `beforeEach` (with an explanatory comment), and the `promptOAuthSignInMode` non-TTY fast-path dependency is documented with an explicit comment block above the onboarding describe.

<h3>Confidence Score: 5/5</h3>

test-only addition with no production code changes; all 12 tests pass, typecheck is clean, and the suite correctly isolates effectful seams.

the change is a new test file only. mocking strategy is sound, the real predicates (parseAuthLoginArgs, isOAuthCancellation) run against proper fixtures, and the accountsOnDisk holder exercises the post-persist count logic honestly. no production paths are modified.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/login-flow.test.ts | new 323-line vitest suite for runAuthLogin; 12 tests covering args, transport routing, org threading, cap handling, and onboarding edges — all passing; previous review concerns (runSignInFlowMock default, promptOAuthSignInMode dependency) are now addressed with a beforeEach default and an explicit comment block |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as test
    participant R as runAuthLogin
    participant P as parseAuthLoginArgs (real)
    participant L as loadAccountsMock
    participant S as runSignInFlowMock
    participant O as isOAuthCancellation (real)
    participant A as resolveAccountSelectionMock
    participant PR as persistAccountPoolMock
    participant SY as syncSelectionToCodexMock

    T->>R: runAuthLogin(args, deps)
    R->>P: parseAuthLoginArgs(args)
    P-->>R: "{ok, options} or {ok:false, reason}"
    alt parse error / --help
        R-->>T: exit 0 or 1 (no storage touched)
    end
    R->>L: loadAccounts() [x3 per loop]
    L-->>R: accountsOnDisk
    R->>S: runSignInFlow(forceNewLogin, mode)
    S-->>R: TokenResult
    R->>O: isOAuthCancellation(result)
    O-->>R: true → exit 0 Cancelled. / false → exit 1 Login failed:
    R->>A: resolveAccountSelection(token, org?)
    A-->>R: RESOLVED
    R->>PR: persistAccountPool([RESOLVED], false)
    PR-->>R: "inserted|updated|rebound"
    R->>SY: syncSelectionToCodex(RESOLVED)
    R-->>T: exit 0 + log outcome message
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-43-login-flow-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-43-login-flow-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Flogin-flow.test.ts%3A87-90%0A**Minimal%20%60TOKEN_SUCCESS%60%20fixture%20silently%20relies%20on%20full%20mock%20coverage**%0A%0A%60TOKEN_SUCCESS%20%3D%20%7B%20type%3A%20%22success%22%20%7D%60%20omits%20every%20token%20field%20%28%60access%60%2C%20%60refresh%60%2C%20%60expires%60%2C%20%60idToken%60%29.%20the%20real%20%60resolveAccountSelection%60%20calls%20%60getAccountIdCandidates%28tokens.access%2C%20tokens.idToken%29%60%20and%20%60extractAccountEmail%28result.access%2C%20result.idToken%29%60%20%E2%80%94%20both%20receive%20%60undefined%60%20if%20the%20mock%20is%20ever%20accidentally%20removed%20or%20replaced.%20since%20%60vi.fn%28%29%60%20doesn't%20enforce%20the%20%60TokenSuccess%60%20type%20at%20the%20call%20site%2C%20typescript%20won't%20catch%20this%20either.%20if%20a%20future%20test%20drops%20the%20%60resolveAccountSelectionMock%60%20or%20%60persistAccountPoolMock%60%20setup%2C%20it%20will%20crash%20at%20a%20confusing%20depth%20rather%20than%20at%20a%20missing-mock%20assertion.%20adding%20the%20minimum%20required%20fields%20%28%60access%3A%20%22%22%60%2C%20%60refresh%3A%20%22%22%60%2C%20%60expires%3A%200%60%29%20or%20exporting%20a%20typed%20constant%20would%20make%20the%20fixture%20self-documenting%20and%20safe%20under%20partial%20de-mocking.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=561&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/login-flow.test.ts:87-90
**Minimal `TOKEN_SUCCESS` fixture silently relies on full mock coverage**

`TOKEN_SUCCESS = { type: "success" }` omits every token field (`access`, `refresh`, `expires`, `idToken`). the real `resolveAccountSelection` calls `getAccountIdCandidates(tokens.access, tokens.idToken)` and `extractAccountEmail(result.access, result.idToken)` — both receive `undefined` if the mock is ever accidentally removed or replaced. since `vi.fn()` doesn't enforce the `TokenSuccess` type at the call site, typescript won't catch this either. if a future test drops the `resolveAccountSelectionMock` or `persistAccountPoolMock` setup, it will crash at a confusing depth rather than at a missing-mock assertion. adding the minimum required fields (`access: ""`, `refresh: ""`, `expires: 0`) or exporting a typed constant would make the fixture self-documenting and safe under partial de-mocking.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: add device-auth conflict case and ..."](https://github.com/ndycode/codex-multi-auth/commit/e088e09c4197807ad7149ca5acc6f0aaa4ae5fc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36769938)</sub>

<!-- /greptile_comment -->