### PR TITLE
test: cover persistAndSyncSelectedAccount switching contract

### DIFF
--- a/test/persist-selected-account.test.ts
+++ b/test/persist-selected-account.test.ts
@@ -75,6 +75,9 @@ beforeEach(() => {
 	saveAccountsMock.mockResolvedValue(undefined);
 	setCodexCliActiveSelectionMock.mockResolvedValue(true);
 	readAffinityGenerationFromDiskMock.mockReturnValue(0);
+	// Loud default: only the stale-token tests may reach the refresh queue,
+	// and they install their own result. Anything else is a test bug.
+	queuedRefreshMock.mockRejectedValue(new Error("unexpected refresh call"));
 	warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
@@ -284,6 +287,46 @@ describe("persistAndSyncSelectedAccount", () => {
 		expect(readAffinityGenerationFromDiskMock).toHaveBeenCalledWith(
 			"/tmp/accounts.json",
 		);
+	});
+
+	it("keeps the in-memory generation when it is ahead of the disk", async () => {
+		// The normal case after several in-process switches: memory leads disk,
+		// and a swapped Math.max argument order would regress this silently.
+		const storage = {
+			...storageWith([account("a")]),
+			affinityGeneration: 7,
+		};
+		readAffinityGenerationFromDiskMock.mockReturnValue(3);
+
+		await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+			bumpAffinityGeneration: true,
+		});
+
+		expect(storage.affinityGeneration).toBe(8);
+	});
+
+	it("retries the storage write through a transient EBUSY before succeeding", async () => {
+		const storage = storageWith([account("a")]);
+		saveAccountsMock
+			.mockRejectedValueOnce(
+				Object.assign(new Error("locked"), { code: "EBUSY" }),
+			)
+			.mockResolvedValueOnce(undefined);
+
+		const result = await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+		});
+
+		// The Windows sharing violation is absorbed by the retry wrapper.
+		expect(result.synced).toBe(true);
+		expect(saveAccountsMock).toHaveBeenCalledTimes(2);
 	});
 
 	it("does not touch the affinity generation without the bump flag", async () => {

--- a/test/persist-selected-account.test.ts
+++ b/test/persist-selected-account.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MODEL_FAMILIES } from "../lib/prompts/codex.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../lib/storage.js";
+
+const {
+	queuedRefreshMock,
+	setCodexCliActiveSelectionMock,
+	saveAccountsMock,
+	readAffinityGenerationFromDiskMock,
+} = vi.hoisted(() => ({
+	queuedRefreshMock: vi.fn(),
+	setCodexCliActiveSelectionMock: vi.fn(),
+	saveAccountsMock: vi.fn(),
+	readAffinityGenerationFromDiskMock: vi.fn(),
+}));
+
+vi.mock("../lib/refresh-queue.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/refresh-queue.js")>();
+	return { ...actual, queuedRefresh: queuedRefreshMock };
+});
+
+vi.mock("../lib/codex-cli/writer.js", () => ({
+	setCodexCliActiveSelection: setCodexCliActiveSelectionMock,
+}));
+
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		saveAccounts: saveAccountsMock,
+		getStoragePath: () => "/tmp/accounts.json",
+		readAffinityGenerationFromDisk: readAffinityGenerationFromDiskMock,
+	};
+});
+
+const { persistAndSyncSelectedAccount } = await import(
+	"../lib/codex-manager/persist-selected-account.js"
+);
+
+// Fixtures must be relative to the real clock: the function calls Date.now()
+// internally to decide token freshness.
+const REAL_NOW = Date.now();
+
+function account(
+	id: string,
+	overrides: Partial<AccountMetadataV3> = {},
+): AccountMetadataV3 {
+	return {
+		email: `${id}@example.com`,
+		accountId: `acc_${id}`,
+		refreshToken: `refresh-${id}`,
+		accessToken: `access-${id}`,
+		expiresAt: REAL_NOW + 3_600_000,
+		addedAt: REAL_NOW - 60_000,
+		lastUsed: REAL_NOW - 60_000,
+		...overrides,
+	};
+}
+
+function storageWith(
+	accounts: AccountMetadataV3[],
+	activeIndex = 0,
+	activeIndexByFamily: Record<string, number> = {},
+): AccountStorageV3 {
+	return { version: 3, activeIndex, activeIndexByFamily, accounts };
+}
+
+// Token inside the 5-minute freshness window forces the validation refresh.
+const STALE_EXPIRES_AT = REAL_NOW + 60_000;
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	saveAccountsMock.mockResolvedValue(undefined);
+	setCodexCliActiveSelectionMock.mockResolvedValue(true);
+	readAffinityGenerationFromDiskMock.mockReturnValue(0);
+	warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	warnSpy.mockRestore();
+});
+
+describe("persistAndSyncSelectedAccount", () => {
+	it("throws for an out-of-range selection", async () => {
+		await expect(
+			persistAndSyncSelectedAccount({
+				storage: storageWith([account("a")]),
+				targetIndex: 3,
+				parsed: 4,
+				switchReason: "manual",
+			}),
+		).rejects.toThrow("Account 4 not found.");
+		expect(saveAccountsMock).not.toHaveBeenCalled();
+	});
+
+	it("persists the selection across every family and syncs fresh tokens as-is", async () => {
+		const storage = storageWith([account("a"), account("b")], 0, { codex: 0 });
+
+		const result = await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 1,
+			parsed: 2,
+			switchReason: "manual",
+		});
+
+		expect(result).toEqual({ synced: true, wasDisabled: false });
+		// A fresh token must not trigger a validation refresh.
+		expect(queuedRefreshMock).not.toHaveBeenCalled();
+		expect(storage.activeIndex).toBe(1);
+		for (const family of MODEL_FAMILIES) {
+			expect(storage.activeIndexByFamily[family]).toBe(1);
+		}
+		expect(storage.accounts[1].lastSwitchReason).toBe("manual");
+		expect(storage.accounts[1].lastUsed).toBeGreaterThanOrEqual(REAL_NOW);
+		expect(saveAccountsMock).toHaveBeenCalledExactlyOnceWith(storage);
+		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledExactlyOnceWith({
+			accountId: "acc_b",
+			email: "b@example.com",
+			accessToken: "access-b",
+			refreshToken: "refresh-b",
+			expiresAt: storage.accounts[1].expiresAt,
+		});
+	});
+
+	it("re-enables a disabled account and reports it", async () => {
+		const storage = storageWith([account("a", { enabled: false })]);
+
+		const result = await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+		});
+
+		expect(result.wasDisabled).toBe(true);
+		expect(storage.accounts[0].enabled).toBe(true);
+	});
+
+	it("refreshes a stale token and syncs the refreshed credentials", async () => {
+		const storage = storageWith([
+			account("a", { expiresAt: STALE_EXPIRES_AT }),
+		]);
+		queuedRefreshMock.mockResolvedValue({
+			type: "success",
+			access: "access-new",
+			refresh: "refresh-new",
+			expires: REAL_NOW + 7_200_000,
+			idToken: "id-new",
+		});
+
+		const result = await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "rotation",
+		});
+
+		expect(result.synced).toBe(true);
+		expect(queuedRefreshMock).toHaveBeenCalledExactlyOnceWith("refresh-a");
+		// The stored account is updated in place before saving...
+		expect(storage.accounts[0]).toMatchObject({
+			refreshToken: "refresh-new",
+			accessToken: "access-new",
+			expiresAt: REAL_NOW + 7_200_000,
+		});
+		// ...and the CLI sync carries the refreshed tokens, including the id token.
+		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledExactlyOnceWith({
+			accountId: "acc_a",
+			email: "a@example.com",
+			accessToken: "access-new",
+			refreshToken: "refresh-new",
+			expiresAt: REAL_NOW + 7_200_000,
+			idToken: "id-new",
+		});
+	});
+
+	it("warns and syncs the old tokens when the validation refresh fails", async () => {
+		const storage = storageWith([
+			account("a", { expiresAt: STALE_EXPIRES_AT }),
+		]);
+		queuedRefreshMock.mockResolvedValue({
+			type: "failed",
+			message: "invalid_grant",
+		});
+
+		const result = await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+		});
+
+		// A failed validation refresh degrades gracefully: warn, keep the old
+		// credentials, still persist and sync.
+		expect(result.synced).toBe(true);
+		expect(String(warnSpy.mock.calls[0]?.[0])).toContain(
+			"Switch validation refresh failed for account 1",
+		);
+		expect(storage.accounts[0].refreshToken).toBe("refresh-a");
+		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ accessToken: "access-a" }),
+		);
+	});
+
+	it("preserves per-family selections when re-selecting the active account", async () => {
+		const storage = storageWith([account("a"), account("b")], 1, {
+			codex: 0,
+			"gpt-5-codex": 9, // stale out-of-range entry must clamp
+		});
+
+		await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 1,
+			parsed: 2,
+			switchReason: "restore",
+			preserveActiveIndexByFamily: true,
+		});
+
+		expect(storage.activeIndex).toBe(1);
+		expect(storage.activeIndexByFamily.codex).toBe(0);
+		expect(storage.activeIndexByFamily["gpt-5-codex"]).toBe(1);
+		// Families without an entry fall back to the target index.
+		expect(storage.activeIndexByFamily["gpt-5.1"]).toBe(1);
+	});
+
+	it("ignores the preserve flag when switching to a different account", async () => {
+		const storage = storageWith([account("a"), account("b")], 0, { codex: 0 });
+
+		await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 1,
+			parsed: 2,
+			switchReason: "manual",
+			preserveActiveIndexByFamily: true,
+		});
+
+		expect(storage.activeIndexByFamily.codex).toBe(1);
+	});
+
+	it("sets and clears the pinned account index", async () => {
+		const storage = storageWith([account("a"), account("b")]);
+
+		await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 1,
+			parsed: 2,
+			switchReason: "manual",
+			setPin: true,
+		});
+		expect(storage.pinnedAccountIndex).toBe(1);
+
+		await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+			clearPin: true,
+		});
+		expect(storage.pinnedAccountIndex).toBeUndefined();
+	});
+
+	it("bumps the affinity generation past the freshest on-disk value", async () => {
+		// Issue #474: a concurrent CLI process may have incremented the on-disk
+		// generation since this storage snapshot was loaded; the bump must build
+		// on max(disk, memory) so no invalidation is lost.
+		const storage = {
+			...storageWith([account("a")]),
+			affinityGeneration: 3,
+		};
+		readAffinityGenerationFromDiskMock.mockReturnValue(7);
+
+		await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+			bumpAffinityGeneration: true,
+		});
+
+		expect(storage.affinityGeneration).toBe(8);
+		expect(readAffinityGenerationFromDiskMock).toHaveBeenCalledWith(
+			"/tmp/accounts.json",
+		);
+	});
+
+	it("does not touch the affinity generation without the bump flag", async () => {
+		const storage = {
+			...storageWith([account("a")]),
+			affinityGeneration: 3,
+		};
+
+		await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+		});
+
+		expect(storage.affinityGeneration).toBe(3);
+		expect(readAffinityGenerationFromDiskMock).not.toHaveBeenCalled();
+	});
+
+	it("passes an explicit initial id token through to the CLI sync", async () => {
+		const storage = storageWith([account("a")]);
+
+		await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+			initialSyncIdToken: "id-initial",
+		});
+
+		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ idToken: "id-initial" }),
+		);
+	});
+
+	it("reports synced=false when the CLI write is skipped", async () => {
+		setCodexCliActiveSelectionMock.mockResolvedValue(false);
+		const storage = storageWith([account("a")]);
+
+		const result = await persistAndSyncSelectedAccount({
+			storage,
+			targetIndex: 0,
+			parsed: 1,
+			switchReason: "manual",
+		});
+
+		expect(result.synced).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Fifth suite in the direct-coverage push (siblings: #559, #560, #561, #563; all independent, based on `main`). `lib/codex-manager/persist-selected-account.ts` is the persistence helper shared by `switch`, `best`, and the dashboard's backup-restore flow — every explicit account selection funnels through it — yet it had no direct tests. This adds `test/persist-selected-account.test.ts` (12 tests).

Mocked seams: `queuedRefresh`, the Codex CLI writer, `saveAccounts`, and `readAffinityGenerationFromDisk`. The real `hasUsableAccessToken` freshness check, the real `saveAccountsWithRetry` wrapper, and the real family-index bookkeeping all run. Fixtures are built relative to the real clock because the function calls `Date.now()` internally to decide token freshness.

## What the tests pin

- **Selection bookkeeping:** `activeIndex` and **every** `activeIndexByFamily` entry move to the target; `lastUsed`/`lastSwitchReason` are stamped; out-of-range selections throw `Account N not found.` without saving.
- **Token freshness:** a fresh token syncs to the Codex CLI as-is with **no** validation refresh; a token inside the 5-minute window triggers `queuedRefresh`, and the refreshed credentials are written into the stored account **and** carried into the CLI sync (including the id token).
- **Graceful degradation:** a failed validation refresh warns (`Switch validation refresh failed for account N`), keeps the old credentials, and still persists and syncs — switching never hard-fails on a refresh hiccup.
- **`preserveActiveIndexByFamily`:** per-family selections survive only when re-selecting the already-active row, stale out-of-range entries clamp, missing families fall back to the target; the flag is ignored on a real switch.
- **Pinning:** `setPin` sets `pinnedAccountIndex`, `clearPin` removes it.
- **Affinity generation (issue #474):** the bump re-reads the on-disk generation and builds on `max(disk, memory) + 1` so concurrent CLI increments are never lost; without the flag the counter is untouched and the disk read never happens.
- **Pass-throughs:** `initialSyncIdToken` reaches the CLI writer; `wasDisabled` reports re-enabling; `synced=false` propagates from a skipped CLI write.

## Validation

- [x] `vitest run test/persist-selected-account.test.ts` — 12/12 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/persist-selected-account.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds 12 tests for `persistAndSyncSelectedAccount`, the shared selection-persistence helper used by `switch`, `best`, and the backup-restore flow. all three previous review comments have been addressed: the memory-ahead-of-disk affinity branch is now covered, `queuedRefreshMock` has a loud reject-by-default in `beforeEach`, and the EBUSY retry path is exercised.

- selection bookkeeping, token freshness, graceful refresh degradation, `preserveActiveIndexByFamily`, pinning, affinity generation, and `synced`/`wasDisabled` pass-throughs are all pinned by dedicated tests.
- the real `saveAccountsWithRetry` wrapper runs against the mocked `saveAccounts`, letting the retry logic execute without mocking the wrapper itself.

<h3>Confidence Score: 5/5</h3>

test-only addition with no production code changes; all 12 tests are self-contained and the real saveAccountsWithRetry wrapper runs against the mocked saveAccounts

no production code is changed; the test suite is well-structured with defensive defaults, all three previously flagged gaps are closed, and the new tests correctly model the real clock and real retry wrapper behavior

no files require special attention; the single test file is straightforward and the one remaining gap is EPERM retry coverage

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/persist-selected-account.test.ts | 12 new tests covering all major paths through persistAndSyncSelectedAccount; all three previous review issues addressed; EPERM retry path not covered alongside EBUSY |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[persistAndSyncSelectedAccount] --> B{targetIndex in range?}
    B -- no --> C[throw Account N not found.
✅ test: out-of-range throws]
    B -- yes --> D[update activeIndex + activeIndexByFamily]
    D --> E{preserveActiveIndexByFamily and same account?}
    E -- yes --> F[clamp per-family entries
✅ test: preserve flag]
    E -- no --> G[set all families = targetIndex
✅ test: ignore preserve on switch]
    F --> H{account.enabled === false?}
    G --> H
    H -- yes --> I[re-enable + wasDisabled=true
✅ test: re-enables disabled]
    H -- no --> J
    I --> J{hasUsableAccessToken?}
    J -- yes --> K[skip refresh
✅ test: fresh token no refresh]
    J -- no --> L[queuedRefresh]
    L --> M{type === success?}
    M -- yes --> N[update tokens in-place
✅ test: stale token refresh]
    M -- no --> O[console.warn keep old tokens
✅ test: failed refresh degrades]
    K --> P[stamp lastUsed + lastSwitchReason]
    N --> P
    O --> P
    P --> Q{setPin or clearPin?}
    Q --> R[update pinnedAccountIndex
✅ test: set + clear pin]
    R --> S{bumpAffinityGeneration?}
    S -- yes --> T[max disk memory gen + 1
✅ test: disk>mem mem>disk]
    S -- no --> U[skip disk read
✅ test: no-bump guard]
    T --> V[saveAccountsWithRetry]
    U --> V
    V -- EBUSY/EPERM --> W[retry up to 3x
✅ EBUSY ⚠️ EPERM untested]
    V -- success --> X[setCodexCliActiveSelection
✅ test: synced=false idToken pass-through]
    W --> X
    X --> Y[return synced + wasDisabled]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-45-persist-selected-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-45-persist-selected-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fpersist-selected-account.test.ts%3A312-330%0A%60save-retry.ts%60%20retries%20on%20both%20%60EBUSY%60%20and%20%60EPERM%60%20%28they%20share%20%60RETRYABLE_STORAGE_WRITE_CODES%60%29%2C%20and%20%60AGENTS.md%60%20calls%20them%20out%20together%3A%20%22retry%20transient%20EBUSY%2FEPERM%2FENOTEMPTY%20write%20failures%20where%20tests%20cover%20Windows%20locks.%22%20only%20EBUSY%20is%20exercised%20here%3B%20an%20EPERM%20variant%20would%20close%20the%20gap%20and%20guard%20against%20any%20future%20divergence%20in%20retry%20logic%20between%20the%20two%20codes.%0A%0A%60%60%60suggestion%0A%09it%28%22retries%20the%20storage%20write%20through%20a%20transient%20EBUSY%20before%20succeeding%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%09%09const%20storage%20%3D%20storageWith%28%5Baccount%28%22a%22%29%5D%29%3B%0A%09%09saveAccountsMock%0A%09%09%09.mockRejectedValueOnce%28%0A%09%09%09%09Object.assign%28new%20Error%28%22locked%22%29%2C%20%7B%20code%3A%20%22EBUSY%22%20%7D%29%2C%0A%09%09%09%29%0A%09%09%09.mockResolvedValueOnce%28undefined%29%3B%0A%0A%09%09const%20result%20%3D%20await%20persistAndSyncSelectedAccount%28%7B%0A%09%09%09storage%2C%0A%09%09%09targetIndex%3A%200%2C%0A%09%09%09parsed%3A%201%2C%0A%09%09%09switchReason%3A%20%22manual%22%2C%0A%09%09%7D%29%3B%0A%0A%09%09%2F%2F%20The%20Windows%20sharing%20violation%20is%20absorbed%20by%20the%20retry%20wrapper.%0A%09%09expect%28result.synced%29.toBe%28true%29%3B%0A%09%09expect%28saveAccountsMock%29.toHaveBeenCalledTimes%282%29%3B%0A%09%7D%29%3B%0A%0A%09it%28%22retries%20the%20storage%20write%20through%20a%20transient%20EPERM%20before%20succeeding%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%09%09const%20storage%20%3D%20storageWith%28%5Baccount%28%22a%22%29%5D%29%3B%0A%09%09saveAccountsMock%0A%09%09%09.mockRejectedValueOnce%28%0A%09%09%09%09Object.assign%28new%20Error%28%22operation%20not%20permitted%22%29%2C%20%7B%20code%3A%20%22EPERM%22%20%7D%29%2C%0A%09%09%09%29%0A%09%09%09.mockResolvedValueOnce%28undefined%29%3B%0A%0A%09%09const%20result%20%3D%20await%20persistAndSyncSelectedAccount%28%7B%0A%09%09%09storage%2C%0A%09%09%09targetIndex%3A%200%2C%0A%09%09%09parsed%3A%201%2C%0A%09%09%09switchReason%3A%20%22manual%22%2C%0A%09%09%7D%29%3B%0A%0A%09%09expect%28result.synced%29.toBe%28true%29%3B%0A%09%09expect%28saveAccountsMock%29.toHaveBeenCalledTimes%282%29%3B%0A%09%7D%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=564&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/persist-selected-account.test.ts:312-330
`save-retry.ts` retries on both `EBUSY` and `EPERM` (they share `RETRYABLE_STORAGE_WRITE_CODES`), and `AGENTS.md` calls them out together: "retry transient EBUSY/EPERM/ENOTEMPTY write failures where tests cover Windows locks." only EBUSY is exercised here; an EPERM variant would close the gap and guard against any future divergence in retry logic between the two codes.

```suggestion
	it("retries the storage write through a transient EBUSY before succeeding", async () => {
		const storage = storageWith([account("a")]);
		saveAccountsMock
			.mockRejectedValueOnce(
				Object.assign(new Error("locked"), { code: "EBUSY" }),
			)
			.mockResolvedValueOnce(undefined);

		const result = await persistAndSyncSelectedAccount({
			storage,
			targetIndex: 0,
			parsed: 1,
			switchReason: "manual",
		});

		// The Windows sharing violation is absorbed by the retry wrapper.
		expect(result.synced).toBe(true);
		expect(saveAccountsMock).toHaveBeenCalledTimes(2);
	});

	it("retries the storage write through a transient EPERM before succeeding", async () => {
		const storage = storageWith([account("a")]);
		saveAccountsMock
			.mockRejectedValueOnce(
				Object.assign(new Error("operation not permitted"), { code: "EPERM" }),
			)
			.mockResolvedValueOnce(undefined);

		const result = await persistAndSyncSelectedAccount({
			storage,
			targetIndex: 0,
			parsed: 1,
			switchReason: "manual",
		});

		expect(result.synced).toBe(true);
		expect(saveAccountsMock).toHaveBeenCalledTimes(2);
	});
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: harden persist-selected-account su..."](https://github.com/ndycode/codex-multi-auth/commit/fd06ced3fb9feb0cb5dc885f9481ce17b99275f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36772629)</sub>

<!-- /greptile_comment -->