### PR TITLE
test: cover runHealthCheck quick and live probe paths

### DIFF
--- a/test/health-check.test.ts
+++ b/test/health-check.test.ts
@@ -250,6 +250,36 @@ describe("runHealthCheck live probe", () => {
 		expect(logged()).toContain("0 signed in only");
 	});
 
+	it("probes with the refreshed token after a stale session is renewed", async () => {
+		// The refresh-then-probe branch must use the rotated access token, not
+		// the stale pre-refresh one.
+		const storage = storageWith([
+			account("a", { expiresAt: STALE_EXPIRES_AT }),
+		]);
+		loadAccountsMock.mockResolvedValue(storage);
+		queuedRefreshMock.mockResolvedValue({
+			type: "success",
+			access: "access-new",
+			refresh: "refresh-new-long-enough-to-look-real",
+			expires: REAL_NOW + 7_200_000,
+			idToken: "id-new",
+		});
+		fetchCodexQuotaSnapshotMock.mockResolvedValue(snapshot());
+
+		await runHealthCheck({ liveProbe: true });
+
+		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({
+				accountId: "acc_a",
+				accessToken: "access-new",
+			}),
+		);
+		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		const saved = saveQuotaCacheMock.mock.calls[0][0] as QuotaCacheData;
+		expect(saved.byAccountId.acc_a).toMatchObject({ status: 200 });
+		expect(logged()).toContain("1 Codex available");
+	});
+
 	it("treats a probe failure as signed-in-only without touching the cache", async () => {
 		const storage = storageWith([account("a")]);
 		loadAccountsMock.mockResolvedValue(storage);

--- a/test/health-check.test.ts
+++ b/test/health-check.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { QuotaCacheData } from "../lib/quota-cache.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../lib/storage.js";
+
+const {
+	loadAccountsMock,
+	saveAccountsMock,
+	queuedRefreshMock,
+	setCodexCliActiveSelectionMock,
+	loadQuotaCacheMock,
+	saveQuotaCacheMock,
+	fetchCodexQuotaSnapshotMock,
+} = vi.hoisted(() => ({
+	loadAccountsMock: vi.fn(),
+	saveAccountsMock: vi.fn(),
+	queuedRefreshMock: vi.fn(),
+	setCodexCliActiveSelectionMock: vi.fn(),
+	loadQuotaCacheMock: vi.fn(),
+	saveQuotaCacheMock: vi.fn(),
+	fetchCodexQuotaSnapshotMock: vi.fn(),
+}));
+
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		loadAccounts: loadAccountsMock,
+		saveAccounts: saveAccountsMock,
+		setStoragePath: vi.fn(),
+	};
+});
+
+vi.mock("../lib/refresh-queue.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/refresh-queue.js")>();
+	return { ...actual, queuedRefresh: queuedRefreshMock };
+});
+
+vi.mock("../lib/codex-cli/writer.js", () => ({
+	setCodexCliActiveSelection: setCodexCliActiveSelectionMock,
+}));
+
+vi.mock("../lib/quota-cache.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/quota-cache.js")>();
+	return {
+		...actual,
+		loadQuotaCache: loadQuotaCacheMock,
+		saveQuotaCache: saveQuotaCacheMock,
+	};
+});
+
+vi.mock("../lib/quota-probe.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/quota-probe.js")>();
+	return { ...actual, fetchCodexQuotaSnapshot: fetchCodexQuotaSnapshotMock };
+});
+
+const { runHealthCheck } = await import(
+	"../lib/codex-manager/health-check.js"
+);
+const { inspectRequestedModel } = await import(
+	"../lib/codex-manager/formatters/index.js"
+);
+const { DEFAULT_LIVE_PROBE_MODEL } = await import(
+	"../lib/codex-manager/quota-cache-helpers.js"
+);
+
+// Token freshness is decided against the real clock inside runHealthCheck.
+const REAL_NOW = Date.now();
+const STALE_EXPIRES_AT = REAL_NOW + 60_000;
+
+function account(
+	id: string,
+	overrides: Partial<AccountMetadataV3> = {},
+): AccountMetadataV3 {
+	return {
+		email: `${id}@example.com`,
+		accountId: `acc_${id}`,
+		refreshToken: `refresh-${id}-long-enough-to-look-real`,
+		accessToken: `access-${id}`,
+		expiresAt: REAL_NOW + 3_600_000,
+		addedAt: REAL_NOW - 60_000,
+		lastUsed: REAL_NOW - 60_000,
+		...overrides,
+	};
+}
+
+function storageWith(
+	accounts: AccountMetadataV3[],
+	activeIndex = 0,
+): AccountStorageV3 {
+	return { version: 3, activeIndex, activeIndexByFamily: {}, accounts };
+}
+
+function emptyCache(): QuotaCacheData {
+	return { byAccountId: {}, byEmail: {} };
+}
+
+function snapshot() {
+	return {
+		status: 200,
+		model: "gpt-5-codex",
+		primary: { usedPercent: 10, windowMinutes: 300, resetAtMs: REAL_NOW + 1 },
+		secondary: {
+			usedPercent: 5,
+			windowMinutes: 10_080,
+			resetAtMs: REAL_NOW + 2,
+		},
+	};
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+function logged(): string {
+	return logSpy.mock.calls.map((call) => call.map(String).join(" ")).join("\n");
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	saveAccountsMock.mockResolvedValue(undefined);
+	setCodexCliActiveSelectionMock.mockResolvedValue(true);
+	loadQuotaCacheMock.mockResolvedValue(emptyCache());
+	saveQuotaCacheMock.mockResolvedValue(undefined);
+	logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	logSpy.mockRestore();
+	warnSpy.mockRestore();
+});
+
+describe("runHealthCheck quick check", () => {
+	it("reports when no accounts are configured", async () => {
+		loadAccountsMock.mockResolvedValue(null);
+
+		await runHealthCheck();
+
+		expect(logged()).toContain("No accounts configured.");
+		expect(queuedRefreshMock).not.toHaveBeenCalled();
+	});
+
+	it("trusts fresh sessions without refreshing and syncs the active account", async () => {
+		const storage = storageWith([account("a"), account("b")]);
+		loadAccountsMock.mockResolvedValue(storage);
+
+		await runHealthCheck();
+
+		expect(queuedRefreshMock).not.toHaveBeenCalled();
+		expect(logged()).toContain("2 working");
+		expect(logged()).toContain("0 need re-login");
+		// The active account's session was validated, so the CLI state is synced.
+		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ accountId: "acc_a" }),
+		);
+		// Nothing changed, so no storage write.
+		expect(saveAccountsMock).not.toHaveBeenCalled();
+	});
+
+	it("re-enables a disabled-but-healthy account and persists the change", async () => {
+		const storage = storageWith([account("a", { enabled: false })]);
+		loadAccountsMock.mockResolvedValue(storage);
+
+		await runHealthCheck();
+
+		expect(storage.accounts[0].enabled).toBe(true);
+		expect(saveAccountsMock).toHaveBeenCalledExactlyOnceWith(storage);
+	});
+
+	it("refreshes stale sessions and writes back rotated credentials", async () => {
+		const storage = storageWith([
+			account("a", { expiresAt: STALE_EXPIRES_AT }),
+		]);
+		loadAccountsMock.mockResolvedValue(storage);
+		queuedRefreshMock.mockResolvedValue({
+			type: "success",
+			access: "access-new",
+			refresh: "refresh-new-long-enough-to-look-real",
+			expires: REAL_NOW + 7_200_000,
+			idToken: "id-new",
+		});
+
+		await runHealthCheck();
+
+		expect(queuedRefreshMock).toHaveBeenCalledExactlyOnceWith(
+			"refresh-a-long-enough-to-look-real",
+		);
+		expect(storage.accounts[0]).toMatchObject({
+			accessToken: "access-new",
+			refreshToken: "refresh-new-long-enough-to-look-real",
+			expiresAt: REAL_NOW + 7_200_000,
+		});
+		expect(saveAccountsMock).toHaveBeenCalledTimes(1);
+		expect(logged()).toContain("1 working");
+		// The refreshed account is active, so its new tokens reach the CLI state.
+		expect(setCodexCliActiveSelectionMock).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ accessToken: "access-new" }),
+		);
+	});
+
+	it("counts an expired account with a failed refresh as needing re-login", async () => {
+		const storage = storageWith([
+			account("a", { expiresAt: STALE_EXPIRES_AT }),
+		]);
+		loadAccountsMock.mockResolvedValue(storage);
+		queuedRefreshMock.mockResolvedValue({
+			type: "failed",
+			message: "invalid_grant",
+		});
+
+		await runHealthCheck();
+
+		expect(logged()).toContain("1 need re-login");
+		expect(saveAccountsMock).not.toHaveBeenCalled();
+		expect(setCodexCliActiveSelectionMock).not.toHaveBeenCalled();
+	});
+
+	it("downgrades a failed forced refresh to a warning while the session still works", async () => {
+		const storage = storageWith([account("a")]);
+		loadAccountsMock.mockResolvedValue(storage);
+		queuedRefreshMock.mockResolvedValue({
+			type: "failed",
+			message: "invalid_grant",
+		});
+
+		await runHealthCheck({ forceRefresh: true });
+
+		expect(logged()).toContain("still works right now");
+		expect(logged()).toContain("0 need re-login");
+		expect(logged()).toContain("1 warning");
+	});
+});
+
+describe("runHealthCheck live probe", () => {
+	it("probes quota, updates the cache, and reports Codex availability", async () => {
+		const storage = storageWith([account("a")]);
+		loadAccountsMock.mockResolvedValue(storage);
+		fetchCodexQuotaSnapshotMock.mockResolvedValue(snapshot());
+
+		await runHealthCheck({ liveProbe: true });
+
+		expect(fetchCodexQuotaSnapshotMock).toHaveBeenCalledExactlyOnceWith({
+			accountId: "acc_a",
+			accessToken: "access-a",
+			model: inspectRequestedModel(DEFAULT_LIVE_PROBE_MODEL).normalized,
+		});
+		expect(saveQuotaCacheMock).toHaveBeenCalledTimes(1);
+		const saved = saveQuotaCacheMock.mock.calls[0][0] as QuotaCacheData;
+		expect(saved.byAccountId.acc_a).toMatchObject({ status: 200 });
+		expect(logged()).toContain("1 Codex available");
+		expect(logged()).toContain("0 signed in only");
+	});
+
+	it("treats a probe failure as signed-in-only without touching the cache", async () => {
+		const storage = storageWith([account("a")]);
+		loadAccountsMock.mockResolvedValue(storage);
+		fetchCodexQuotaSnapshotMock.mockRejectedValue(new Error("probe boom"));
+
+		await runHealthCheck({ liveProbe: true });
+
+		expect(saveQuotaCacheMock).not.toHaveBeenCalled();
+		expect(logged()).toContain("1 signed in only");
+		expect(logged()).toContain("live check failed");
+	});
+
+	it("skips the live probe when the account has no resolvable id", async () => {
+		const storage = storageWith([account("a", { accountId: undefined })]);
+		loadAccountsMock.mockResolvedValue(storage);
+
+		await runHealthCheck({ liveProbe: true });
+
+		// "access-a" is not a decodable JWT, so no account id can be extracted.
+		expect(fetchCodexQuotaSnapshotMock).not.toHaveBeenCalled();
+		expect(logged()).toContain("live check skipped: missing account ID");
+		expect(logged()).toContain("1 signed in only");
+	});
+
+	it("survives a quota cache save failure with a warning", async () => {
+		const storage = storageWith([account("a")]);
+		loadAccountsMock.mockResolvedValue(storage);
+		fetchCodexQuotaSnapshotMock.mockResolvedValue(snapshot());
+		saveQuotaCacheMock.mockRejectedValue(new Error("EBUSY"));
+
+		await expect(runHealthCheck({ liveProbe: true })).resolves.toBeUndefined();
+
+		expect(String(warnSpy.mock.calls[0]?.[0])).toContain(
+			"Quota cache save failed: EBUSY",
+		);
+		// The check still completed and reported availability.
+		expect(logged()).toContain("1 Codex available");
+	});
+});


### PR DESCRIPTION
## Summary

Sixth suite in the direct-coverage push (siblings: #559, #560, #561, #563, #564; all independent, based on `main`). `lib/codex-manager/health-check.ts` is the body of the `check` command and the dashboard's quick/deep check actions — 375 lines of refresh, probe, and persistence logic with no direct tests. This adds `test/health-check.test.ts` (10 tests).

Mocked seams: `loadAccounts`/`saveAccounts`, `queuedRefresh`, the Codex CLI writer, the quota cache loader/saver, and `fetchCodexQuotaSnapshot`. The real freshness check, the real quota-cache update/attribution helpers, and the real summary formatting all run. Fixtures are clock-relative because the check decides token freshness against `Date.now()`.

## What the tests pin

**Quick check:**
- Empty pool short-circuits with `No accounts configured.` and never touches the refresh queue.
- Fresh sessions are trusted without a refresh, the summary reports them working, the **active** account is synced to the Codex CLI, and an unchanged pool is **not** re-saved.
- A disabled-but-healthy account is re-enabled and that change is persisted.
- Stale sessions refresh through the queue; rotated credentials are written back to storage and carried into the CLI sync.
- An expired account whose refresh fails counts as `need re-login`, with no save and no CLI sync.
- `forceRefresh` with a failed refresh on a still-valid session downgrades to a warning (`still works right now`) instead of a failure — the account is not falsely flagged for re-login.

**Live probe:**
- Quota snapshots are fetched with the account id/token and the normalized default probe model, applied to the cache, persisted, and counted as `Codex available`.
- A probe failure counts as `signed in only` and leaves the cache untouched.
- An account with no resolvable id skips the probe with `live check skipped: missing account ID`.
- A quota-cache save failure (Windows EBUSY class) warns but never aborts the check — account fixes still commit and the summary still prints.

## Validation

- [x] `vitest run test/health-check.test.ts` — 10/10 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/health-check.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/health-check.test.ts` — the first direct coverage for `lib/codex-manager/health-check.ts`, which was previously untested. all mock seams (storage, refresh queue, codex-cli writer, quota cache, quota probe) are correctly hoisted; the real freshness, cache-update, and summary helpers run unmodified.

- **quick-check paths (6 tests):** empty pool short-circuit, fresh-session trust + cli sync, disabled-but-healthy re-enable, stale refresh success, stale refresh failure, and forceRefresh downgrade to warning — all covered with precise counter and save/sync assertions.
- **live-probe paths (4 tests):** fresh account + successful probe (cache persisted), stale-then-refresh-then-probe using rotated token (addresses the gap flagged in the previous review thread), probe failure as signed-in-only, missing account id skip, and EBUSY cache-save resilience.
- clock-relative fixtures (`REAL_NOW + 60_000` for stale, `REAL_NOW + 3_600_000` for fresh) are correct given the 5-minute `ACCESS_TOKEN_FRESH_WINDOW_MS` threshold in `account-credentials.ts`.

<h3>Confidence Score: 5/5</h3>

test-only change adding coverage for a previously untested 375-line module; no production logic is modified

mock seams are correct, the stale+liveProbe path previously flagged is now covered, and clock-relative fixtures are sound against the real 5-minute freshness threshold; remaining gaps are minor branches with no production risk

no files require special attention; the three uncovered branches are low-risk gaps worth a follow-up but not blocking

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/health-check.test.ts | new 10-test suite covering quick-check and live-probe paths with correct mock seams; stale+liveProbe combined path (previously flagged) is now covered; three minor branch gaps remain (isCodexUnavailableError, forceRefresh+liveProbe+failed, accountIdentityChanged pruning) |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runHealthCheck] --> B{storage empty?}
    B -- yes --> C[log No accounts configured. / return]
    B -- no --> D[for each account]
    D --> E{forceRefresh=false AND sessionLikelyValid?}
    E -- yes --> F[re-enable if disabled]
    F --> G{liveProbe?}
    G -- no --> H[ok++]
    G -- yes --> I{probeAccountId resolved?}
    I -- no --> J[signedInOnly++ / warnings++]
    I -- yes --> K[fetchCodexQuotaSnapshot]
    K -- success --> L[updateQuotaCache / codexAvailable++]
    K -- failure --> M{isCodexUnavailableError?}
    M -- yes --> N[CODEX_UNAVAILABLE_PROBE_NOTE untested]
    M -- no --> O[signedInOnly++ / warnings++]
    E -- no --> P[queuedRefresh]
    P -- success --> Q{liveProbe?}
    Q -- yes --> R[fetchCodexQuotaSnapshot with rotated token]
    Q -- no --> S[ok++]
    P -- failure --> T{sessionLikelyValid?}
    T -- yes --> U[warnings++ signedInOnly if liveProbe untested combo]
    T -- no --> V[failed++]
    R -- success --> W[updateQuotaCache / codexAvailable++]
    P -- success --> X{accountIdentityChanged AND liveProbe?}
    X -- yes --> Y[pruneUnsafeQuotaEmailCacheEntry untested]
    D --> Z[save quota cache if changed]
    Z --> AA[saveAccountsWithRetry if changed]
    AA --> AB[setCodexCliActiveSelection if active refreshed]
    AB --> AC[formatResultSummary]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-46-health-check-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-46-health-check-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fhealth-check.test.ts%3A157-190%0A**three%20untested%20branches%20in%20health-check.ts**%0A%0Athe%20live%20probe%20tests%20cover%20generic%20errors%20but%20miss%20the%20%60isCodexUnavailableError%60%20branch%20%28health-check.ts%20lines%20153%E2%80%93155%20and%20261%E2%80%93263%29%2C%20which%20produces%20a%20distinct%20%60CODEX_UNAVAILABLE_PROBE_NOTE%60%20message.%20a%20regression%20there%20%28e.g.%20wrong%20import%20or%20message%20change%29%20would%20go%20undetected.%20two%20other%20gaps%3A%20%281%29%20%60forceRefresh%3A%20true%60%20%2B%20%60liveProbe%3A%20true%60%20%2B%20failed%20refresh%20on%20a%20still-valid%20session%20%E2%80%94%20the%20%60signedInOnly%20%2B%3D%201%60%20at%20line%20285%20is%20never%20exercised%3B%20%282%29%20the%20%60accountIdentityChanged%20%26%26%20liveProbe%60%20branch%20%28lines%20211%E2%80%93221%29%20that%20calls%20%60pruneUnsafeQuotaEmailCacheEntry%60%20is%20never%20reached%20because%20the%20fake%20tokens%20don't%20produce%20a%20real%20JWT%2C%20so%20%60extractAccountId%60%20always%20returns%20%60undefined%60%20and%20%60applyTokenAccountIdentity%60%20never%20signals%20a%20change.%20none%20of%20these%20are%20blocking%2C%20but%20the%20pruning%20path%20in%20particular%20hides%20a%20windows-relevant%20cache-file%20mutation%20that's%20worth%20at%20least%20a%20smoke%20test.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=565&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/health-check.test.ts:157-190
**three untested branches in health-check.ts**

the live probe tests cover generic errors but miss the `isCodexUnavailableError` branch (health-check.ts lines 153–155 and 261–263), which produces a distinct `CODEX_UNAVAILABLE_PROBE_NOTE` message. a regression there (e.g. wrong import or message change) would go undetected. two other gaps: (1) `forceRefresh: true` + `liveProbe: true` + failed refresh on a still-valid session — the `signedInOnly += 1` at line 285 is never exercised; (2) the `accountIdentityChanged && liveProbe` branch (lines 211–221) that calls `pruneUnsafeQuotaEmailCacheEntry` is never reached because the fake tokens don't produce a real JWT, so `extractAccountId` always returns `undefined` and `applyTokenAccountIdentity` never signals a change. none of these are blocking, but the pruning path in particular hides a windows-relevant cache-file mutation that's worth at least a smoke test.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover the refresh-then-probe live ..."](https://github.com/ndycode/codex-multi-auth/commit/92825bc9d7df5f927a2b15b47b1efb157588a65d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36773800)</sub>

<!-- /greptile_comment -->