### PR TITLE
test: cover forecast-report-shared patch persistence and save retry

### DIFF
--- a/test/forecast-report-shared.test.ts
+++ b/test/forecast-report-shared.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ForecastAccountResult } from "../lib/forecast.js";
+import type { CodexQuotaSnapshot } from "../lib/quota-probe.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../lib/storage.js";
+import type { TokenFailure } from "../lib/types.js";
+
+// persistRefreshedAccountPatch is fully deps-injected and the rest of the
+// module is pure, so this suite runs without any module mocks: the real
+// findMatchingAccountIndex identity matching and the real retry wrapper run.
+import {
+	applyRefreshedAccountPatch,
+	persistRefreshedAccountPatch,
+	serializeForecastResults,
+} from "../lib/codex-manager/forecast-report-shared.js";
+import {
+	isRetryableStorageWriteError,
+	saveAccountsWithRetry,
+} from "../lib/storage/save-retry.js";
+
+const NOW = 1_700_000_000_000;
+
+function account(
+	id: string,
+	overrides: Partial<AccountMetadataV3> = {},
+): AccountMetadataV3 {
+	return {
+		email: `${id}@example.com`,
+		accountId: `acc_${id}`,
+		refreshToken: `refresh-${id}`,
+		accessToken: `access-${id}`,
+		expiresAt: NOW + 3_600_000,
+		addedAt: NOW - 60_000,
+		lastUsed: NOW - 60_000,
+		...overrides,
+	};
+}
+
+function storageWith(accounts: AccountMetadataV3[]): AccountStorageV3 {
+	return { version: 3, activeIndex: 0, activeIndexByFamily: {}, accounts };
+}
+
+function errnoError(code: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(code), { code });
+}
+
+const PATCH = {
+	refreshToken: "refresh-rotated",
+	accessToken: "access-rotated",
+	expiresAt: NOW + 7_200_000,
+};
+
+describe("isRetryableStorageWriteError", () => {
+	it("retries only on the Windows sharing-violation codes", () => {
+		expect(isRetryableStorageWriteError(errnoError("EBUSY"))).toBe(true);
+		expect(isRetryableStorageWriteError(errnoError("EPERM"))).toBe(true);
+		expect(isRetryableStorageWriteError(errnoError("ENOENT"))).toBe(false);
+		expect(isRetryableStorageWriteError(new Error("plain"))).toBe(false);
+		expect(isRetryableStorageWriteError("EBUSY")).toBe(false);
+		expect(isRetryableStorageWriteError(undefined)).toBe(false);
+	});
+});
+
+describe("saveAccountsWithRetry", () => {
+	it("retries transient EBUSY failures and eventually succeeds", async () => {
+		const storage = storageWith([account("a")]);
+		const save = vi
+			.fn()
+			.mockRejectedValueOnce(errnoError("EBUSY"))
+			.mockRejectedValueOnce(errnoError("EPERM"))
+			.mockResolvedValueOnce(undefined);
+
+		await saveAccountsWithRetry(storage, save);
+
+		expect(save).toHaveBeenCalledTimes(3);
+		expect(save).toHaveBeenLastCalledWith(storage);
+	});
+
+	it("rethrows non-retryable errors immediately", async () => {
+		const save = vi.fn().mockRejectedValue(errnoError("ENOSPC"));
+
+		await expect(
+			saveAccountsWithRetry(storageWith([account("a")]), save),
+		).rejects.toThrow("ENOSPC");
+		expect(save).toHaveBeenCalledTimes(1);
+	});
+
+	it("gives up after four attempts of retryable failures", async () => {
+		const save = vi.fn().mockRejectedValue(errnoError("EBUSY"));
+
+		await expect(
+			saveAccountsWithRetry(storageWith([account("a")]), save),
+		).rejects.toThrow("EBUSY");
+		expect(save).toHaveBeenCalledTimes(4);
+	});
+});
+
+describe("applyRefreshedAccountPatch", () => {
+	it("always rotates the credential triple and only conditionally identity", () => {
+		const target = account("a");
+
+		applyRefreshedAccountPatch(target, PATCH);
+
+		expect(target).toMatchObject({
+			refreshToken: "refresh-rotated",
+			accessToken: "access-rotated",
+			expiresAt: NOW + 7_200_000,
+			// No email/accountId in the patch: identity is untouched.
+			email: "a@example.com",
+			accountId: "acc_a",
+		});
+		expect(target.accountIdSource).toBeUndefined();
+	});
+
+	it("adopts a new identity when the patch carries one", () => {
+		const target = account("a");
+
+		applyRefreshedAccountPatch(target, {
+			...PATCH,
+			email: "new@example.com",
+			accountId: "acc_new",
+			accountIdSource: "token",
+		});
+
+		expect(target.email).toBe("new@example.com");
+		expect(target.accountId).toBe("acc_new");
+		expect(target.accountIdSource).toBe("token");
+	});
+});
+
+describe("persistRefreshedAccountPatch", () => {
+	const match = {
+		accountId: "acc_a",
+		email: "a@example.com",
+		refreshToken: "refresh-a",
+	};
+
+	it("re-resolves the account in the freshly loaded storage and saves a patched clone", async () => {
+		const inMemory = storageWith([account("a")]);
+		// On disk the account moved to index 1 — identity matching must find it.
+		const onDisk = storageWith([account("x"), account("a")]);
+		const saved: AccountStorageV3[] = [];
+
+		await persistRefreshedAccountPatch(
+			inMemory,
+			match,
+			PATCH,
+			async () => onDisk,
+			async (storage) => {
+				saved.push(storage);
+			},
+		);
+
+		expect(saved).toHaveLength(1);
+		expect(saved[0].accounts[1]).toMatchObject({
+			accountId: "acc_a",
+			refreshToken: "refresh-rotated",
+		});
+		// The loaded storage is cloned before mutation; neither input changes.
+		expect(onDisk.accounts[1].refreshToken).toBe("refresh-a");
+		expect(inMemory.accounts[0].refreshToken).toBe("refresh-a");
+	});
+
+	it("falls back to the caller's storage when the reload returns nothing", async () => {
+		const inMemory = storageWith([account("a")]);
+		const saved: AccountStorageV3[] = [];
+
+		await persistRefreshedAccountPatch(
+			inMemory,
+			match,
+			PATCH,
+			async () => null,
+			async (storage) => {
+				saved.push(storage);
+			},
+		);
+
+		expect(saved[0].accounts[0].refreshToken).toBe("refresh-rotated");
+		expect(inMemory.accounts[0].refreshToken).toBe("refresh-a");
+	});
+
+	it("matches by the patched credentials when the on-disk copy already rotated", async () => {
+		// A concurrent writer already persisted the rotated refresh token, so
+		// the pre-rotation identity no longer matches; the patch identity does.
+		const rotated = account("a", {
+			refreshToken: "refresh-rotated",
+			accountId: undefined,
+			email: undefined,
+		});
+		const onDisk = storageWith([rotated]);
+		const saved: AccountStorageV3[] = [];
+
+		await persistRefreshedAccountPatch(
+			storageWith([account("a")]),
+			{ accountId: undefined, email: undefined, refreshToken: "refresh-old" },
+			PATCH,
+			async () => onDisk,
+			async (storage) => {
+				saved.push(storage);
+			},
+		);
+
+		expect(saved).toHaveLength(1);
+		expect(saved[0].accounts[0].accessToken).toBe("access-rotated");
+	});
+
+	it("throws when the account cannot be resolved in the latest storage", async () => {
+		const onDisk = storageWith([account("x")]);
+		const save = vi.fn();
+
+		await expect(
+			persistRefreshedAccountPatch(
+				storageWith([account("a")]),
+				match,
+				PATCH,
+				async () => onDisk,
+				save,
+			),
+		).rejects.toThrow("Unable to resolve refreshed account for persistence");
+		expect(save).not.toHaveBeenCalled();
+	});
+});
+
+describe("serializeForecastResults", () => {
+	function result(
+		index: number,
+		overrides: Partial<ForecastAccountResult> = {},
+	): ForecastAccountResult {
+		return {
+			index,
+			label: `Account ${index + 1}`,
+			isCurrent: index === 0,
+			availability: "ready",
+			riskScore: 10,
+			riskLevel: "low",
+			waitMs: 0,
+			reasons: ["plenty of quota", "recently refreshed"],
+			hardFailure: false,
+			disabled: false,
+			exhausted: false,
+			...overrides,
+		};
+	}
+
+	it("joins forecast rows with live quota and refresh failures by index", () => {
+		const snapshot: CodexQuotaSnapshot = {
+			status: 200,
+			model: "gpt-5-codex",
+			planType: "plus",
+			activeLimit: 100,
+			primary: { usedPercent: 10, windowMinutes: 300, resetAtMs: NOW + 1 },
+			secondary: { usedPercent: 5, windowMinutes: 10_080, resetAtMs: NOW + 2 },
+		};
+		const failure: TokenFailure = { type: "failed", message: "invalid_grant" };
+
+		const rows = serializeForecastResults(
+			[result(0), result(1, { availability: "delayed", waitMs: 9_000 })],
+			new Map([[0, snapshot]]),
+			new Map([[1, failure]]),
+			(entry) => `summary:${entry.model}`,
+		);
+
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toMatchObject({
+			index: 0,
+			label: "Account 1",
+			isCurrent: true,
+			selected: false,
+			primaryReason: "plenty of quota",
+			liveQuota: {
+				status: 200,
+				planType: "plus",
+				activeLimit: 100,
+				model: "gpt-5-codex",
+				summary: "summary:gpt-5-codex",
+			},
+		});
+		expect(rows[0].refreshFailure).toBeUndefined();
+		expect(rows[1]).toMatchObject({
+			index: 1,
+			availability: "delayed",
+			waitMs: 9_000,
+			refreshFailure: failure,
+		});
+		expect(rows[1].liveQuota).toBeUndefined();
+	});
+
+	it("leaves primaryReason undefined when a row has no reasons", () => {
+		const rows = serializeForecastResults(
+			[result(0, { reasons: [] })],
+			new Map(),
+			new Map(),
+			() => "unused",
+		);
+
+		expect(rows[0].primaryReason).toBeUndefined();
+		expect(rows[0].reasons).toEqual([]);
+	});
+});

--- a/test/forecast-report-shared.test.ts
+++ b/test/forecast-report-shared.test.ts
@@ -125,6 +125,18 @@ describe("applyRefreshedAccountPatch", () => {
 		expect(target.accountId).toBe("acc_new");
 		expect(target.accountIdSource).toBe("token");
 	});
+
+	it("clears accountIdSource when a patch rebinds the id without a source", () => {
+		// Deliberate behavior pin: accountIdSource follows patch.accountId, so a
+		// patch that rebinds the id without declaring a source strips the old
+		// one rather than leaving a stale "token"/"manual" attribution behind.
+		const target = account("a", { accountIdSource: "token" });
+
+		applyRefreshedAccountPatch(target, { ...PATCH, accountId: "acc_new" });
+
+		expect(target.accountId).toBe("acc_new");
+		expect(target.accountIdSource).toBeUndefined();
+	});
 });
 
 describe("persistRefreshedAccountPatch", () => {
@@ -176,6 +188,33 @@ describe("persistRefreshedAccountPatch", () => {
 
 		expect(saved[0].accounts[0].refreshToken).toBe("refresh-rotated");
 		expect(inMemory.accounts[0].refreshToken).toBe("refresh-a");
+	});
+
+	it("matches on the first pass when identity survives a concurrent rotation", async () => {
+		// The common case: a concurrent writer rotated the tokens but the
+		// account kept its accountId/email, so the first identity pass matches
+		// without falling back to the patch credentials.
+		const onDisk = storageWith([
+			account("a", { refreshToken: "refresh-already-rotated" }),
+		]);
+		const saved: AccountStorageV3[] = [];
+
+		await persistRefreshedAccountPatch(
+			storageWith([account("a")]),
+			match,
+			PATCH,
+			async () => onDisk,
+			async (storage) => {
+				saved.push(storage);
+			},
+		);
+
+		expect(saved).toHaveLength(1);
+		expect(saved[0].accounts[0]).toMatchObject({
+			accountId: "acc_a",
+			refreshToken: "refresh-rotated",
+			accessToken: "access-rotated",
+		});
 	});
 
 	it("matches by the patched credentials when the on-disk copy already rotated", async () => {


### PR DESCRIPTION
## Summary

Seventh suite in the direct-coverage push (siblings: #559, #560, #561, #563, #564, #565; all independent, based on `main`). Covers `lib/codex-manager/forecast-report-shared.ts` and the `lib/storage/save-retry.ts` wrapper it re-exports — the refreshed-credential persistence path used by the forecast/report/best commands. This adds `test/forecast-report-shared.test.ts` (12 tests).

The suite is **mock-free**: `persistRefreshedAccountPatch` is fully deps-injected (`loadAccounts`/`saveAccounts` are parameters) and the rest of the module is pure, so the real `findMatchingAccountIndex` identity matching and the real retry wrapper run end to end.

## What the tests pin

**`saveAccountsWithRetry` / `isRetryableStorageWriteError`:**
- Only `EBUSY`/`EPERM` errno errors are retryable; ENOENT, plain Errors, strings, and undefined are not.
- Transient sharing violations are retried until success; non-retryable errors rethrow immediately after one attempt; persistent retryable failures give up after four attempts.

**`applyRefreshedAccountPatch`:** always rotates the credential triple (refresh/access/expiresAt); email and accountId+accountIdSource are adopted only when the patch carries them.

**`persistRefreshedAccountPatch` (the concurrency-safety core):**
- Re-resolves the account **by identity** in the freshly loaded storage — when the on-disk pool was reordered, the patch lands on the right account at its new position.
- Mutates a clone: neither the caller's storage nor the loaded storage is touched.
- Falls back to the caller's storage when the reload returns nothing.
- Falls back to matching by the **patched** credentials when a concurrent writer already rotated them (the second `findMatchingAccountIndex` pass).
- Throws `Unable to resolve refreshed account for persistence` without saving when neither identity matches.

**`serializeForecastResults`:** joins forecast rows with live quota snapshots and refresh failures by index, applies the injected summary formatter, marks `selected: false`, takes `primaryReason` from the first reason and leaves it undefined for empty reason lists.

## Validation

- [x] `vitest run test/forecast-report-shared.test.ts` — 12/12 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/forecast-report-shared.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/forecast-report-shared.test.ts`, a 12-test mock-free suite covering the credential-persistence path (`persistRefreshedAccountPatch`, `applyRefreshedAccountPatch`) and the windows-safe write retry wrapper (`saveAccountsWithRetry`, `isRetryableStorageWriteError`), plus `serializeForecastResults`. it also addresses both items flagged in the previous review round (accountIdSource strip behavior and concurrent-rotation first-pass identity coverage).

- **save-retry**: pins `EBUSY`/`EPERM`-only retryability, 4-attempt ceiling, and immediate rethrow on non-retryable errors; real `sleep()` runs during these tests (not fake-timered).
- **persistRefreshedAccountPatch**: covers index-shift re-resolution, structural clone isolation, null-reload fallback, both concurrent-rotation match passes, and the unresolvable-account throw path.
- **serializeForecastResults**: validates quota/failure join by index, `primaryReason` from first reason, and `selected: false` invariant.

<h3>Confidence Score: 5/5</h3>

this is a test-only addition with no production code changes; the new suite is mock-free, structurally sound, and directly exercises the real identity-matching and retry logic end-to-end.

the change is a pure test file that adds meaningful coverage to a previously untested module. the two gaps called out (real sleep in retry tests, no coverage for loadAccounts() throwing) do not break anything and do not affect production behaviour. no production code is touched.

no files require special attention; the single changed file is test/forecast-report-shared.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/forecast-report-shared.test.ts | new 12-test suite covering save-retry, applyRefreshedAccountPatch, persistRefreshedAccountPatch, and serializeForecastResults; mock-free, deps-injected, addresses both previous review comments (accountIdSource strip, concurrent-rotation first-pass); two minor gaps: real sleep in retry tests and no coverage for loadAccounts() throwing |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant caller
    participant persistRefreshedAccountPatch
    participant loadAccounts
    participant findMatchingAccountIndex
    participant applyRefreshedAccountPatch
    participant saveAccountsWithRetry

    caller->>persistRefreshedAccountPatch: storage, accountMatch, patch
    persistRefreshedAccountPatch->>loadAccounts: ()
    loadAccounts-->>persistRefreshedAccountPatch: "latestStorage | null"
    note over persistRefreshedAccountPatch: latestStorage ?? storage (null fallback)
    persistRefreshedAccountPatch->>persistRefreshedAccountPatch: structuredClone(latestStorage)
    persistRefreshedAccountPatch->>findMatchingAccountIndex: accounts, accountMatch (1st pass by identity)
    findMatchingAccountIndex-->>persistRefreshedAccountPatch: "index | undefined"
    alt identity not found
        persistRefreshedAccountPatch->>findMatchingAccountIndex: accounts, patch (2nd pass by rotated tokens)
        findMatchingAccountIndex-->>persistRefreshedAccountPatch: "index | undefined"
    end
    alt index still undefined
        persistRefreshedAccountPatch-->>caller: throws Unable to resolve
    else index found
        persistRefreshedAccountPatch->>applyRefreshedAccountPatch: cloned account, patch
        persistRefreshedAccountPatch->>saveAccountsWithRetry: clonedStorage, saveAccounts
        loop EBUSY/EPERM up to 4 attempts
            saveAccountsWithRetry->>saveAccountsWithRetry: attempt + sleep
        end
        saveAccountsWithRetry-->>persistRefreshedAccountPatch: "void | throws"
        persistRefreshedAccountPatch-->>caller: void
    end
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-47-forecast-shared-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-47-forecast-shared-tests%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fforecast-report-shared.test.ts%3A64-95%0A**real%20%60sleep%28%29%60%20runs%20during%20retry%20tests**%0A%0A%60saveAccountsWithRetry%60%20calls%20%60sleep%2810%20*%202%20**%20attempt%29%60%20between%20retries%2C%20and%20it%20isn't%20mocked%20here.%20the%20%22retries%20transient%20EBUSY%22%20case%20sleeps%20~30%20ms%20of%20real%20wall-clock%20time%3B%20the%20%22gives%20up%20after%20four%20attempts%22%20case%20sleeps%20~70%20ms.%20the%20codebase%20convention%20%28see%20test%2FAGENTS.md%20and%20%60stream-failover.test.ts%60%29%20is%20to%20use%20%60vi.useFakeTimers%28%29%60%20for%20timing-dependent%20tests%20so%20they%20are%20deterministic%20and%20instant.%20wrapping%20each%20retry%20%60it%60%20in%20%60vi.useFakeTimers%28%29%60%20%2F%20%60vi.useRealTimers%28%29%60%20would%20eliminate%20the%20real%20delays%20without%20changing%20what%20is%20asserted.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fforecast-report-shared.test.ts%3A131-215%0A**%60loadAccounts%28%29%60%20throwing%20is%20not%20covered**%0A%0Athe%20suite%20covers%20%60loadAccounts%28%29%60%20returning%20%60null%60%20%28falls%20back%20to%20caller's%20storage%29%20and%20returning%20an%20on-disk%20pool%2C%20but%20not%20the%20case%20where%20%60loadAccounts%28%29%60%20itself%20rejects.%20in%20%60persistRefreshedAccountPatch%60%20there%20is%20no%20try%2Fcatch%20around%20%60await%20loadAccounts%28%29%60%2C%20so%20a%20transient%20read%20error%20%28e.g.%20%60ENOENT%60%20on%20first-access%20race%2C%20Windows%20%60EBUSY%60%29%20will%20propagate%20unhandled%20and%20skip%20the%20save%20entirely.%20a%20single%20%60it%28%22propagates%20loadAccounts%20rejection%20without%20saving%22%2C%20...%29%60%20pinning%20that%20behaviour%20would%20prevent%20a%20future%20refactor%20from%20silently%20swallowing%20those%20errors.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/forecast-report-shared.test.ts:64-95
**real `sleep()` runs during retry tests**

`saveAccountsWithRetry` calls `sleep(10 * 2 ** attempt)` between retries, and it isn't mocked here. the "retries transient EBUSY" case sleeps ~30 ms of real wall-clock time; the "gives up after four attempts" case sleeps ~70 ms. the codebase convention (see test/AGENTS.md and `stream-failover.test.ts`) is to use `vi.useFakeTimers()` for timing-dependent tests so they are deterministic and instant. wrapping each retry `it` in `vi.useFakeTimers()` / `vi.useRealTimers()` would eliminate the real delays without changing what is asserted.

### Issue 2 of 2
test/forecast-report-shared.test.ts:131-215
**`loadAccounts()` throwing is not covered**

the suite covers `loadAccounts()` returning `null` (falls back to caller's storage) and returning an on-disk pool, but not the case where `loadAccounts()` itself rejects. in `persistRefreshedAccountPatch` there is no try/catch around `await loadAccounts()`, so a transient read error (e.g. `ENOENT` on first-access race, Windows `EBUSY`) will propagate unhandled and skip the save entirely. a single `it("propagates loadAccounts rejection without saving", ...)` pinning that behaviour would prevent a future refactor from silently swallowing those errors.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: pin identity-source strip and firs..."](https://github.com/ndycode/codex-multi-auth/commit/a942ded76450ba8d20b76ff6fa4033cb94fc8ba7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36774562)</sub>

<!-- /greptile_comment -->