### PR TITLE
test: cover the settings write queue retry and serialization contract

### DIFF
--- a/test/settings-write-queue.test.ts
+++ b/test/settings-write-queue.test.ts
@@ -57,6 +57,25 @@ describe("withQueuedRetry retries", () => {
 		expect(delays).toEqual([50, 100]);
 	});
 
+	it.each(["EPERM", "EAGAIN", "ENOTEMPTY"])(
+		"treats %s as a retryable Windows lock code",
+		async (code) => {
+			// Windows file locks most often surface as EPERM, so the whole
+			// retryable set is pinned, not just EBUSY/EACCES.
+			const { sleep, delays } = recordingSleep();
+			const task = vi
+				.fn()
+				.mockRejectedValueOnce(errnoError(code))
+				.mockResolvedValueOnce("written");
+
+			await expect(
+				withQueuedRetry(uniqueKey(), task, { sleep }),
+			).resolves.toBe("written");
+			expect(task).toHaveBeenCalledTimes(2);
+			expect(delays).toEqual([50]);
+		},
+	);
+
 	it("honors a 429 retry-after hint, clamped into the sane range", async () => {
 		const { sleep, delays } = recordingSleep();
 		const task = vi

--- a/test/settings-write-queue.test.ts
+++ b/test/settings-write-queue.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from "vitest";
+// Everything is driven through withQueuedRetry on purpose: it is the one
+// entry point external callers use, and the module's helper exports are
+// internal surface that may be pruned.
+import { withQueuedRetry } from "../lib/codex-manager/settings-write-queue.js";
+
+function errnoError(code: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(code), { code });
+}
+
+// Records requested delays and resolves immediately: the retry schedule is
+// asserted, not waited for.
+function recordingSleep(): {
+	sleep: (ms: number) => Promise<void>;
+	delays: number[];
+} {
+	const delays: number[] = [];
+	return {
+		delays,
+		sleep: async (ms: number) => {
+			delays.push(ms);
+		},
+	};
+}
+
+// Unique key per test so the module-level queue map never couples tests.
+let keyCounter = 0;
+function uniqueKey(): string {
+	keyCounter += 1;
+	return `/settings/test-${keyCounter}.json`;
+}
+
+describe("withQueuedRetry retries", () => {
+	it("returns the task result without sleeping on first-try success", async () => {
+		const { sleep, delays } = recordingSleep();
+		const task = vi.fn().mockResolvedValue("written");
+
+		await expect(withQueuedRetry(uniqueKey(), task, { sleep })).resolves.toBe(
+			"written",
+		);
+		expect(task).toHaveBeenCalledTimes(1);
+		expect(delays).toEqual([]);
+	});
+
+	it("retries Windows sharing violations with exponential backoff", async () => {
+		const { sleep, delays } = recordingSleep();
+		const task = vi
+			.fn()
+			.mockRejectedValueOnce(errnoError("EBUSY"))
+			.mockRejectedValueOnce(errnoError("EACCES"))
+			.mockResolvedValueOnce("written");
+
+		await expect(withQueuedRetry(uniqueKey(), task, { sleep })).resolves.toBe(
+			"written",
+		);
+		expect(task).toHaveBeenCalledTimes(3);
+		expect(delays).toEqual([50, 100]);
+	});
+
+	it("honors a 429 retry-after hint, clamped into the sane range", async () => {
+		const { sleep, delays } = recordingSleep();
+		const task = vi
+			.fn()
+			.mockRejectedValueOnce(
+				Object.assign(new Error("throttled"), {
+					status: 429,
+					retryAfterMs: 12_345,
+				}),
+			)
+			.mockRejectedValueOnce(
+				Object.assign(new Error("throttled"), {
+					statusCode: 429,
+					retryAfterMs: 2, // below the 10ms floor
+				}),
+			)
+			.mockRejectedValueOnce(
+				Object.assign(new Error("throttled"), {
+					status: 429,
+					retryAfterMs: 999_999_999, // above the 30s ceiling
+				}),
+			)
+			.mockResolvedValueOnce("written");
+
+		await expect(withQueuedRetry(uniqueKey(), task, { sleep })).resolves.toBe(
+			"written",
+		);
+		expect(delays).toEqual([12_345, 10, 30_000]);
+	});
+
+	it("rethrows non-retryable errors immediately", async () => {
+		const { sleep, delays } = recordingSleep();
+		const task = vi.fn().mockRejectedValue(errnoError("ENOSPC"));
+
+		await expect(
+			withQueuedRetry(uniqueKey(), task, { sleep }),
+		).rejects.toThrow("ENOSPC");
+		expect(task).toHaveBeenCalledTimes(1);
+		expect(delays).toEqual([]);
+	});
+
+	it("gives up with the last error after four retryable attempts", async () => {
+		const { sleep, delays } = recordingSleep();
+		const task = vi.fn().mockRejectedValue(errnoError("EBUSY"));
+
+		await expect(
+			withQueuedRetry(uniqueKey(), task, { sleep }),
+		).rejects.toThrow("EBUSY");
+		expect(task).toHaveBeenCalledTimes(4);
+		// No sleep after the final attempt.
+		expect(delays).toEqual([50, 100, 200]);
+	});
+});
+
+describe("withQueuedRetry serialization", () => {
+	it("runs tasks for the same path strictly in submission order", async () => {
+		const { sleep } = recordingSleep();
+		const key = uniqueKey();
+		const order: string[] = [];
+		let releaseFirst!: () => void;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+
+		const first = withQueuedRetry(
+			key,
+			async () => {
+				order.push("first:start");
+				await firstGate;
+				order.push("first:end");
+				return 1;
+			},
+			{ sleep },
+		);
+		const second = withQueuedRetry(
+			key,
+			async () => {
+				order.push("second:start");
+				return 2;
+			},
+			{ sleep },
+		);
+
+		// Give the second task every chance to start early if the queue leaked.
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(order).toEqual(["first:start"]);
+
+		releaseFirst();
+		await expect(first).resolves.toBe(1);
+		await expect(second).resolves.toBe(2);
+		expect(order).toEqual([
+			"first:start",
+			"first:end",
+			"second:start",
+		]);
+	});
+
+	it("does not let a failed predecessor block the next write", async () => {
+		const { sleep } = recordingSleep();
+		const key = uniqueKey();
+
+		const failed = withQueuedRetry(
+			key,
+			async () => {
+				throw errnoError("ENOSPC");
+			},
+			{ sleep },
+		);
+		const next = withQueuedRetry(key, async () => "recovered", { sleep });
+
+		await expect(failed).rejects.toThrow("ENOSPC");
+		await expect(next).resolves.toBe("recovered");
+	});
+
+	it("lets different paths proceed independently", async () => {
+		const { sleep } = recordingSleep();
+		const order: string[] = [];
+		let releaseBlocked!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseBlocked = resolve;
+		});
+
+		const blocked = withQueuedRetry(
+			uniqueKey(),
+			async () => {
+				await gate;
+				order.push("blocked");
+			},
+			{ sleep },
+		);
+		const independent = withQueuedRetry(
+			uniqueKey(),
+			async () => {
+				order.push("independent");
+			},
+			{ sleep },
+		);
+
+		await independent;
+		expect(order).toEqual(["independent"]);
+		releaseBlocked();
+		await blocked;
+		expect(order).toEqual(["independent", "blocked"]);
+	});
+
+	it("keeps every retry of a task ahead of the next queued task", async () => {
+		const { sleep } = recordingSleep();
+		const key = uniqueKey();
+		const order: string[] = [];
+		const flaky = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				order.push("flaky:1");
+				throw errnoError("EBUSY");
+			})
+			.mockImplementationOnce(async () => {
+				order.push("flaky:2");
+				return "ok";
+			});
+
+		const first = withQueuedRetry(key, flaky, { sleep });
+		const second = withQueuedRetry(
+			key,
+			async () => {
+				order.push("second");
+				return "done";
+			},
+			{ sleep },
+		);
+
+		await expect(first).resolves.toBe("ok");
+		await expect(second).resolves.toBe("done");
+		// The retry happened inside the queue slot, before the second task.
+		expect(order).toEqual(["flaky:1", "flaky:2", "second"]);
+	});
+});


### PR DESCRIPTION
## Summary

Eighth suite in the direct-coverage push (siblings: #559, #560, #561, #563, #564, #565, #566; all independent, based on `main`). `lib/codex-manager/settings-write-queue.ts` is the per-path serialization + retry primitive behind every settings write, with no direct tests. This adds `test/settings-write-queue.test.ts` (9 tests).

Two deliberate design choices:
- Everything is driven through **`withQueuedRetry` only** — it is the one entry point external callers use; the helper exports (`readErrorNumber`, `getRetryAfterMs`, …) are internal surface that #556 prunes, so the suite stays valid either way.
- `sleep` is injected as a recording stub, so the retry **schedule** is asserted exactly (no real waiting, fully deterministic).

Each test uses a unique path key so the module-level queue map never couples tests.

## What the tests pin

**Retry policy:**
- First-try success returns the task result without sleeping.
- `EBUSY`/`EACCES` retry with the 50ms exponential backoff (`[50, 100]`).
- A 429 `retryAfterMs` hint wins over backoff and clamps into the 10ms..30s range (`[12345, 10, 30000]` for hint values 12345 / 2 / 999999999).
- Non-retryable errors rethrow after exactly one attempt.
- Persistent retryable failures give up after four attempts with the last error, and there is no sleep after the final attempt (`[50, 100, 200]`).

**Per-path serialization (the Windows-safety core):**
- Tasks for the same path run strictly in submission order — the second task does not start while the first is in flight (verified with a gate plus a macrotask turn that would expose a leak).
- A failed predecessor does not block the next write on the same path.
- Different paths proceed independently.
- Every retry of a task happens **inside its queue slot**, ahead of the next queued task — a concurrent write can never interleave between a failure and its retry.

## Validation

- [x] `vitest run test/settings-write-queue.test.ts` — 9/9 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/settings-write-queue.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/settings-write-queue.test.ts` — 9 deterministic vitest tests for `withQueuedRetry`, the per-path serialization and retry primitive behind all settings writes.

- **retry policy**: covers first-try success, exponential backoff (EBUSY/EACCES), `it.each` for EPERM/EAGAIN/ENOTEMPTY, 429 `retryAfterMs` clamping, non-retryable immediate rethrow, and four-attempt exhaustion without a trailing sleep — addressing the gap flagged in a prior review comment.
- **serialization contract**: gate-based proofs that same-path tasks run in submission order, a failed predecessor doesn't block the successor, different paths are fully independent, and retries stay inside their queue slot before the next queued task starts.
- **test infra**: `recordingSleep` injects sleep as a recording stub (no real waiting); `uniqueKey()` prevents cross-test queue coupling via the module-level map.

<h3>Confidence Score: 5/5</h3>

test-only addition with no production code changes; all 9 tests pass and the suite correctly models the windows-filesystem serialization contract.

the change is a new test file only. retry arithmetic, clamping logic, ordering assertions, and gate-based concurrency proofs all match the source implementation exactly. the previously flagged eperm/eagain gap is closed by the it.each block. no production paths are touched.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/settings-write-queue.test.ts | adds 9 vitest tests covering retry policy and per-path serialization for withQueuedRetry; sleep-injection keeps tests fully deterministic; previously flagged EPERM/EAGAIN gap is addressed via it.each; no logic bugs found |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[withQueuedRetry called] --> B[enqueueSettingsWrite\nchains task onto per-path queue tail]
    B --> C[retry wrapper starts]
    C --> D{attempt < 4?}
    D -- no --> E[throw lastError]
    D -- yes --> F[call task]
    F -- success --> G[return result]
    F -- error --> H{isRetryable?}
    H -- no --> I[rethrow immediately]
    H -- yes --> J{last attempt?}
    J -- yes --> E
    J -- no --> K{has retryAfterMs?}
    K -- yes --> L[clamp 10ms..30s\nawait sleep]
    K -- no --> M[exponential backoff\n50ms * 2^attempt\nawait sleep]
    L --> D
    M --> D
    B --> N[queueTail always resolves\nnext path slot unblocked]
```

<sub>Reviews (2): Last reviewed commit: ["test: pin the full retryable Windows loc..."](https://github.com/ndycode/codex-multi-auth/commit/c68b3b4cf51b980dba5ba76ed2d6616e9177cb7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36775245)</sub>

<!-- /greptile_comment -->