### PR TITLE
test: cover dashboard settings clone defaults and equality semantics

### DIFF
--- a/test/dashboard-settings-data.test.ts
+++ b/test/dashboard-settings-data.test.ts
@@ -55,7 +55,11 @@ describe("cloneDashboardSettingsData", () => {
 			menuSortQuickSwitchVisibleRow: true,
 			uiThemePreset: "green",
 			uiAccentColor: "green",
+			menuShowStatusBadge: true,
+			menuShowCurrentBadge: true,
+			menuShowLastUsed: true,
 			menuShowQuotaSummary: true,
+			menuShowQuotaCooldown: true,
 			menuShowFetchStatus: true,
 			menuQuotaTtlMs: 5 * 60_000,
 			menuFocusStyle: "row-invert",
@@ -122,27 +126,33 @@ describe("dashboardSettingsDataEqual", () => {
 		).toBe(true);
 	});
 
-	it("detects a difference in any single field", () => {
+	it.each([
+		["menuQuotaTtlMs", { menuQuotaTtlMs: 60_000 }],
+		["uiThemePreset", { uiThemePreset: "mono" }],
+		["uiAccentColor", { uiAccentColor: "cyan" }],
+		["showQuotaDetails", { showQuotaDetails: false }],
+		["showPerAccountRows", { showPerAccountRows: false }],
+		["actionAutoReturnMs", { actionAutoReturnMs: 500 }],
+		["actionPauseOnKey", { actionPauseOnKey: false }],
+		["menuAutoFetchLimits", { menuAutoFetchLimits: false }],
+		["menuSortEnabled", { menuSortEnabled: false }],
+		["menuSortPinCurrent", { menuSortPinCurrent: true }],
+		[
+			"menuSortQuickSwitchVisibleRow",
+			{ menuSortQuickSwitchVisibleRow: false },
+		],
+		["menuShowStatusBadge", { menuShowStatusBadge: false }],
+		["menuShowCurrentBadge", { menuShowCurrentBadge: false }],
+		["menuShowLastUsed", { menuShowLastUsed: false }],
+		["menuShowQuotaSummary", { menuShowQuotaSummary: false }],
+		["menuShowQuotaCooldown", { menuShowQuotaCooldown: false }],
+		["menuShowFetchStatus", { menuShowFetchStatus: false }],
+		["menuHighlightCurrentRow", { menuHighlightCurrentRow: false }],
+	] as const satisfies ReadonlyArray<
+		readonly [string, Partial<DashboardDisplaySettings>]
+	>)("detects a difference in %s alone", (_field, override) => {
 		expect(
-			dashboardSettingsDataEqual(
-				settings(),
-				settings({ menuQuotaTtlMs: 60_000 }),
-				deps,
-			),
-		).toBe(false);
-		expect(
-			dashboardSettingsDataEqual(
-				settings(),
-				settings({ uiThemePreset: "mono" }),
-				deps,
-			),
-		).toBe(false);
-		expect(
-			dashboardSettingsDataEqual(
-				settings(),
-				settings({ showQuotaDetails: false }),
-				deps,
-			),
+			dashboardSettingsDataEqual(settings(), settings(override), deps),
 		).toBe(false);
 	});
 

--- a/test/dashboard-settings-data.test.ts
+++ b/test/dashboard-settings-data.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+	cloneDashboardSettingsData,
+	dashboardSettingsDataEqual,
+} from "../lib/codex-manager/dashboard-settings-data.js";
+import {
+	DEFAULT_DASHBOARD_DISPLAY_SETTINGS,
+	type DashboardDisplaySettings,
+	type DashboardStatuslineField,
+} from "../lib/dashboard-settings.js";
+import { resolveMenuLayoutMode } from "../lib/codex-manager/settings-hub.js";
+
+const DEFAULT_FIELDS: DashboardStatuslineField[] = [
+	"last-used",
+	"limits",
+	"status",
+];
+
+// The real production deps: the actual layout-mode resolver, and a
+// normalizer matching dashboard-settings semantics (default on absence).
+const deps = {
+	resolveMenuLayoutMode,
+	normalizeStatuslineFields: (
+		fields: DashboardDisplaySettings["menuStatuslineFields"],
+	) => fields ?? DEFAULT_FIELDS,
+};
+
+function settings(
+	overrides: Partial<DashboardDisplaySettings> = {},
+): DashboardDisplaySettings {
+	return { ...DEFAULT_DASHBOARD_DISPLAY_SETTINGS, ...overrides };
+}
+
+// A sparse settings object as it comes from an older settings.json that
+// predates most optional fields.
+const SPARSE: DashboardDisplaySettings = {
+	showPerAccountRows: true,
+	showQuotaDetails: false,
+	showForecastReasons: true,
+	showRecommendations: false,
+	showLiveProbeNotes: true,
+};
+
+describe("cloneDashboardSettingsData", () => {
+	it("fills every optional field with its documented default", () => {
+		const clone = cloneDashboardSettingsData(SPARSE, deps);
+
+		expect(clone).toMatchObject({
+			actionAutoReturnMs: 2_000,
+			actionPauseOnKey: true,
+			menuAutoFetchLimits: true,
+			menuSortEnabled: true,
+			menuSortMode: "ready-first",
+			menuSortPinCurrent: false,
+			menuSortQuickSwitchVisibleRow: true,
+			uiThemePreset: "green",
+			uiAccentColor: "green",
+			menuShowQuotaSummary: true,
+			menuShowFetchStatus: true,
+			menuQuotaTtlMs: 5 * 60_000,
+			menuFocusStyle: "row-invert",
+			menuHighlightCurrentRow: true,
+			menuLayoutMode: "compact-details",
+			menuShowDetailsForUnselectedRows: false,
+			menuStatuslineFields: DEFAULT_FIELDS,
+		});
+		// The required flags pass through unchanged.
+		expect(clone.showQuotaDetails).toBe(false);
+		expect(clone.showRecommendations).toBe(false);
+	});
+
+	it("derives layout mode and the unselected-rows flag together", () => {
+		const expanded = cloneDashboardSettingsData(
+			{ ...SPARSE, menuShowDetailsForUnselectedRows: true },
+			deps,
+		);
+		expect(expanded.menuLayoutMode).toBe("expanded-rows");
+		expect(expanded.menuShowDetailsForUnselectedRows).toBe(true);
+
+		// An explicit layout mode wins over the legacy boolean.
+		const compact = cloneDashboardSettingsData(
+			{
+				...SPARSE,
+				menuLayoutMode: "compact-details",
+				menuShowDetailsForUnselectedRows: true,
+			},
+			deps,
+		);
+		expect(compact.menuLayoutMode).toBe("compact-details");
+		expect(compact.menuShowDetailsForUnselectedRows).toBe(false);
+	});
+
+	it("copies the statusline fields instead of aliasing the input array", () => {
+		const fields: DashboardStatuslineField[] = ["limits"];
+		const clone = cloneDashboardSettingsData(
+			{ ...SPARSE, menuStatuslineFields: fields },
+			deps,
+		);
+
+		expect(clone.menuStatuslineFields).toEqual(["limits"]);
+		expect(clone.menuStatuslineFields).not.toBe(fields);
+	});
+});
+
+describe("dashboardSettingsDataEqual", () => {
+	it("treats absent optional fields as equal to their defaults", () => {
+		expect(
+			dashboardSettingsDataEqual(
+				SPARSE,
+				cloneDashboardSettingsData(SPARSE, deps),
+				deps,
+			),
+		).toBe(true);
+		// A fully-defaulted object equals the sparse one when the required
+		// flags agree.
+		expect(
+			dashboardSettingsDataEqual(
+				settings({ showQuotaDetails: false, showRecommendations: false }),
+				SPARSE,
+				deps,
+			),
+		).toBe(true);
+	});
+
+	it("detects a difference in any single field", () => {
+		expect(
+			dashboardSettingsDataEqual(
+				settings(),
+				settings({ menuQuotaTtlMs: 60_000 }),
+				deps,
+			),
+		).toBe(false);
+		expect(
+			dashboardSettingsDataEqual(
+				settings(),
+				settings({ uiThemePreset: "mono" }),
+				deps,
+			),
+		).toBe(false);
+		expect(
+			dashboardSettingsDataEqual(
+				settings(),
+				settings({ showQuotaDetails: false }),
+				deps,
+			),
+		).toBe(false);
+	});
+
+	it("compares layout through the resolver, not the raw fields", () => {
+		// expanded-rows expressed via the legacy boolean equals the explicit
+		// layout-mode spelling (no explicit menuLayoutMode on the left, since
+		// an explicit mode would win over the boolean).
+		expect(
+			dashboardSettingsDataEqual(
+				{ ...SPARSE, menuShowDetailsForUnselectedRows: true },
+				{ ...SPARSE, menuLayoutMode: "expanded-rows" },
+				deps,
+			),
+		).toBe(true);
+		expect(
+			dashboardSettingsDataEqual(
+				settings({ menuLayoutMode: "expanded-rows" }),
+				settings({ menuLayoutMode: "compact-details" }),
+				deps,
+			),
+		).toBe(false);
+	});
+
+	it("compares statusline fields through the normalizer", () => {
+		// Absent fields equal the normalized default list...
+		expect(
+			dashboardSettingsDataEqual(
+				settings({ menuStatuslineFields: undefined }),
+				settings({ menuStatuslineFields: DEFAULT_FIELDS }),
+				deps,
+			),
+		).toBe(true);
+		// ...but a different order is a real difference.
+		expect(
+			dashboardSettingsDataEqual(
+				settings({ menuStatuslineFields: ["limits", "status", "last-used"] }),
+				settings({ menuStatuslineFields: DEFAULT_FIELDS }),
+				deps,
+			),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Ninth suite in the direct-coverage wave (siblings: #559–#561, #563–#567; all independent, based on `main`). `lib/codex-manager/dashboard-settings-data.ts` is the clone/equality contract the settings hub uses to decide whether a settings edit is dirty and what to persist — wrong defaults here silently rewrite user settings. It had no direct tests. This adds `test/dashboard-settings-data.test.ts` (7 tests).

The deps are the real `resolveMenuLayoutMode` plus a normalizer matching the dashboard-settings default semantics, so the layout-derivation behavior under test is the production one.

## What the tests pin

**`cloneDashboardSettingsData`:**
- A sparse legacy settings object (an old `settings.json` predating the optional fields) clones with **every** optional field at its documented default, while the required flags pass through unchanged.
- The layout mode and `menuShowDetailsForUnselectedRows` are derived together, and an explicit `menuLayoutMode` wins over the legacy boolean.
- The statusline fields are copied, not aliased — mutating the input array cannot leak into the clone.

**`dashboardSettingsDataEqual`:**
- Absent optional fields compare equal to their defaults (a sparse object equals its own clone, and equals a fully-defaulted object when the required flags agree).
- Any single-field difference (TTL, theme, a required flag) flips the result.
- Layout is compared **through the resolver**: the legacy boolean spelling of expanded-rows equals the explicit mode spelling.
- Statusline fields are compared through the normalizer: absent equals the default list, but a different field order is a real difference.

## Validation

- [x] `vitest run test/dashboard-settings-data.test.ts` — 7/7 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/dashboard-settings-data.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/dashboard-settings-data.test.ts` — the first direct test suite for `cloneDashboardSettingsData` and `dashboardSettingsDataEqual`, covering sparse-input defaults, layout/unselected-rows co-derivation, statusline array copy semantics, and 18 single-field equality cases using the real `resolveMenuLayoutMode` dep.

- **clone defaults**: pins all 21 optional fields via `toMatchObject`, verifies required flags pass through, and confirms the statusline array is copied (not aliased).
- **equality coverage**: 18 `it.each` entries exercise most comparison branches; layout resolution is tested through the resolver; statusline normalizer injection is validated for both absent-equals-default and order-sensitive cases.
- **type issue**: one entry uses `uiThemePreset: "mono"`, which is outside `DashboardThemePreset = "green" | "blue"` and would fail `tsc` if test files are included in the typecheck config; `"blue"` is the correct in-union alternative.

<h3>Confidence Score: 5/5</h3>

test-only addition with no changes to production code; safe to merge.

the change is a new test file that exercises pure, side-effect-free functions against their real deps — no production logic, no i/o, no concurrency. the one out-of-union value (`"mono"`) is a test-quality nit that does not affect production behavior or ci correctness on the current typecheck config.

test/dashboard-settings-data.test.ts — the out-of-union `uiThemePreset: "mono"` entry is worth fixing before any typecheck config change widens coverage to include test files.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/dashboard-settings-data.test.ts | new 7-test suite for cloneDashboardSettingsData and dashboardSettingsDataEqual; uses real resolveMenuLayoutMode dep; one out-of-type value in the equality it.each ("mono" not in DashboardThemePreset = "green" | "blue") |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SPARSE / settings helper] --> B[cloneDashboardSettingsData]
    A --> C[dashboardSettingsDataEqual]

    B --> D{resolveMenuLayoutMode}
    D -->|expanded-rows| E[menuLayoutMode + menuShowDetailsForUnselectedRows=true]
    D -->|compact-details| F[menuLayoutMode + menuShowDetailsForUnselectedRows=false]
    B --> G[normalizeStatuslineFields → spread copy]
    B --> H[optional fields ?? documented defaults]

    C --> I{resolveMenuLayoutMode left == right?}
    I -->|yes| J[compare 22 other fields with ?? defaults]
    I -->|no| K[return false]
    C --> L{normalizeStatuslineFields JSON.stringify ==?}
    L -->|yes| M[fields equal]
    L -->|no| N[return false]

    subgraph Tests
        T1[fills every optional field with its default]
        T2[derives layout mode and unselected-rows flag together]
        T3[copies statusline array not alias]
        T4[absent fields equal their defaults]
        T5[18 x it.each single-field difference]
        T6[compares layout through resolver]
        T7[compares statusline through normalizer]
    end
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-50-dashboard-settings-data-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-50-dashboard-settings-data-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fdashboard-settings-data.test.ts%3A131%0A%60%22mono%22%60%20is%20not%20a%20member%20of%20%60DashboardThemePreset%20%3D%20%22green%22%20%7C%20%22blue%22%60%2C%20so%20this%20entry%20violates%20the%20%60satisfies%20Partial%3CDashboardDisplaySettings%3E%60%20constraint%20and%20would%20fail%20any%20%60tsc%60%20invocation%20that%20covers%20test%20files.%20Using%20%60%22blue%22%60%20is%20an%20in-union%20value%20that%20still%20detects%20a%20genuine%20difference%20from%20the%20default%20%60%22green%22%60%20and%20keeps%20the%20test%20type-safe.%0A%0A%60%60%60suggestion%0A%09%09%5B%22uiThemePreset%22%2C%20%7B%20uiThemePreset%3A%20%22blue%22%20%7D%5D%2C%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=569&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/dashboard-settings-data.test.ts:131
`"mono"` is not a member of `DashboardThemePreset = "green" | "blue"`, so this entry violates the `satisfies Partial<DashboardDisplaySettings>` constraint and would fail any `tsc` invocation that covers test files. Using `"blue"` is an in-union value that still detects a genuine difference from the default `"green"` and keeps the test type-safe.

```suggestion
		["uiThemePreset", { uiThemePreset: "blue" }],
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: pin the badge defaults and sweep e..."](https://github.com/ndycode/codex-multi-auth/commit/730d6aa0c568306128ca7d254423b6f8455ee637) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36777200)</sub>

<!-- /greptile_comment -->