### PR TITLE
test: cover chooseAccount selection tiers and cursor discipline

### DIFF
--- a/test/rotation-account-selection.test.ts
+++ b/test/rotation-account-selection.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AccountManager } from "../lib/accounts.js";
+import type { RuntimePolicyDecision } from "../lib/policy/runtime-policy.js";
+import { chooseAccount } from "../lib/runtime/rotation-account-selection.js";
+import { SessionAffinityStore } from "../lib/session-affinity.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../lib/storage.js";
+
+const NOW = Date.now();
+const FAMILY = "gpt-5-codex" as const;
+
+function storageWith(
+	count: number,
+	overridesByIndex: Record<number, Partial<AccountMetadataV3>> = {},
+): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { [FAMILY]: 0 },
+		accounts: Array.from({ length: count }, (_unused, index) => ({
+			email: `account-${index + 1}@example.com`,
+			accountId: `acc_${index + 1}`,
+			refreshToken: `refresh-${index + 1}`,
+			accessToken: `access-${index + 1}`,
+			expiresAt: NOW + 3_600_000,
+			addedAt: NOW - 60_000,
+			lastUsed: NOW - (count - index) * 60_000,
+			enabled: true,
+			...overridesByIndex[index],
+		})),
+	};
+}
+
+function manager(
+	count = 3,
+	overridesByIndex: Record<number, Partial<AccountMetadataV3>> = {},
+): AccountManager {
+	return new AccountManager(undefined, storageWith(count, overridesByIndex));
+}
+
+function policyWith(blocked: number[] = []): RuntimePolicyDecision {
+	return {
+		allowed: true,
+		statusCode: 200,
+		errorCode: null,
+		reasons: [],
+		projectKey: null,
+		blockedAccountIndexes: new Set(blocked),
+		scoreBoostByAccount: {},
+		budgetEvaluations: [],
+	};
+}
+
+function baseParams(accountManager: AccountManager) {
+	return {
+		accountManager,
+		sessionAffinityStore: null,
+		sessionKey: null,
+		family: FAMILY,
+		model: null,
+		attemptedIndexes: new Set<number>(),
+		now: NOW,
+		policy: null,
+		pinnedIndex: null,
+	};
+}
+
+beforeEach(() => {
+	// Circuit breakers and rate-limit trackers are module-level state.
+	AccountManager.resetVolatileRuntimeState();
+});
+
+describe("chooseAccount pinned selection (issue #474)", () => {
+	it("returns the pinned account without advancing any cursor", () => {
+		const accountManager = manager();
+		const markSwitched = vi.spyOn(accountManager, "markSwitched");
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			pinnedIndex: 1,
+		});
+
+		expect(selected?.index).toBe(1);
+		// The proxy must not clobber the pin set by the CLI.
+		expect(markSwitched).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		[
+			"already-attempted",
+			{ pinnedIndex: 1, attemptedIndexes: new Set([1]) },
+		],
+		["missing", { pinnedIndex: 7 }],
+		["policy-blocked", { pinnedIndex: 1, policy: policyWith([1]) }],
+	] as const)(
+		"refuses the pin with reason %s instead of falling back",
+		(reason, overrides) => {
+			const accountManager = manager();
+			const skipReasons = new Map<number, string>();
+
+			const selected = chooseAccount({
+				...baseParams(accountManager),
+				...overrides,
+				skipReasons,
+			});
+
+			// A pin never falls back to another account; the request fails over
+			// to the caller with the reason recorded.
+			expect(selected).toBeNull();
+			expect(skipReasons.get(overrides.pinnedIndex)).toBe(reason);
+		},
+	);
+
+	it("refuses a disabled pinned account", () => {
+		const accountManager = manager(3, { 1: { enabled: false } });
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			pinnedIndex: 1,
+			skipReasons,
+		});
+
+		expect(selected).toBeNull();
+		expect(skipReasons.get(1)).toBe("disabled");
+	});
+
+	it("refuses a rate-limited pinned account with the runtime reason", () => {
+		const accountManager = manager(3, {
+			1: { rateLimitResetTimes: { [FAMILY]: NOW + 600_000 } },
+		});
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			pinnedIndex: 1,
+			skipReasons,
+		});
+
+		expect(selected).toBeNull();
+		expect(skipReasons.get(1)).toBe("rate-limited");
+	});
+});
+
+describe("chooseAccount session affinity tier", () => {
+	it("prefers the remembered account and commits the cursor", () => {
+		const accountManager = manager();
+		const markSwitched = vi.spyOn(accountManager, "markSwitched");
+		const store = new SessionAffinityStore();
+		store.remember("sess-1", 2, NOW);
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			sessionAffinityStore: store,
+			sessionKey: "sess-1",
+		});
+
+		expect(selected?.index).toBe(2);
+		expect(markSwitched).toHaveBeenCalledExactlyOnceWith(
+			selected,
+			"rotation",
+			FAMILY,
+		);
+	});
+
+	it("records the skip reason and falls through when the sticky account is unusable", () => {
+		const accountManager = manager(3, {
+			2: { rateLimitResetTimes: { [FAMILY]: NOW + 600_000 } },
+		});
+		vi.spyOn(
+			accountManager,
+			"getCurrentOrNextForFamilyHybrid",
+		).mockReturnValue(accountManager.getAccountByIndex(0));
+		const store = new SessionAffinityStore();
+		store.remember("sess-1", 2, NOW);
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			sessionAffinityStore: store,
+			sessionKey: "sess-1",
+			skipReasons,
+		});
+
+		expect(skipReasons.get(2)).toBe("rate-limited");
+		expect(selected?.index).toBe(0);
+	});
+});
+
+describe("chooseAccount hybrid tier and linear fallback", () => {
+	it("returns the hybrid selector's pick without an extra cursor commit", () => {
+		const accountManager = manager();
+		vi.spyOn(
+			accountManager,
+			"getCurrentOrNextForFamilyHybrid",
+		).mockReturnValue(accountManager.getAccountByIndex(1));
+		const markSwitched = vi.spyOn(accountManager, "markSwitched");
+
+		const selected = chooseAccount(baseParams(accountManager));
+
+		expect(selected?.index).toBe(1);
+		// The hybrid selector advances its own cursor internally.
+		expect(markSwitched).not.toHaveBeenCalled();
+	});
+
+	it("falls back to a linear scan that commits the cursor when the hybrid pick was attempted", () => {
+		const accountManager = manager();
+		vi.spyOn(
+			accountManager,
+			"getCurrentOrNextForFamilyHybrid",
+		).mockReturnValue(accountManager.getAccountByIndex(0));
+		const markSwitched = vi.spyOn(accountManager, "markSwitched");
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			attemptedIndexes: new Set([0]),
+			policy: policyWith([1]),
+			skipReasons,
+		});
+
+		// 0 was attempted, 1 is policy-blocked, 2 wins and becomes the cursor.
+		expect(selected?.index).toBe(2);
+		expect(skipReasons.get(0)).toBe("already-attempted");
+		expect(skipReasons.get(1)).toBe("policy-blocked");
+		expect(markSwitched).toHaveBeenCalledExactlyOnceWith(
+			selected,
+			"rotation",
+			FAMILY,
+		);
+	});
+
+	it("returns null with a reason per account when the pool is exhausted", () => {
+		const accountManager = manager();
+		vi.spyOn(
+			accountManager,
+			"getCurrentOrNextForFamilyHybrid",
+		).mockReturnValue(accountManager.getAccountByIndex(0));
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			attemptedIndexes: new Set([0, 1, 2]),
+			skipReasons,
+		});
+
+		expect(selected).toBeNull();
+		expect([...skipReasons.entries()]).toEqual([
+			[0, "already-attempted"],
+			[1, "already-attempted"],
+			[2, "already-attempted"],
+		]);
+	});
+});
+
+describe("chooseAccount sequential mode (issue #509)", () => {
+	it("follows the drain-first selector and skips the affinity tier", () => {
+		const accountManager = manager();
+		const sequential = vi
+			.spyOn(accountManager, "getCurrentOrNextForFamilySequential")
+			.mockReturnValue(accountManager.getAccountByIndex(0));
+		const store = new SessionAffinityStore();
+		store.remember("sess-1", 2, NOW);
+		const affinity = vi.spyOn(store, "getPreferredAccountIndex");
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			sessionAffinityStore: store,
+			sessionKey: "sess-1",
+			schedulingStrategy: "sequential",
+		});
+
+		// Every request follows the single active account: no per-chat
+		// stickiness consulted.
+		expect(selected?.index).toBe(0);
+		expect(sequential).toHaveBeenCalledTimes(1);
+		expect(affinity).not.toHaveBeenCalled();
+	});
+
+	it("retries another account without moving the drain-first primary", () => {
+		const accountManager = manager();
+		vi.spyOn(
+			accountManager,
+			"getCurrentOrNextForFamilySequential",
+		).mockReturnValue(accountManager.getAccountByIndex(0));
+		const markSwitched = vi.spyOn(accountManager, "markSwitched");
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			attemptedIndexes: new Set([0]),
+			schedulingStrategy: "sequential",
+			skipReasons,
+		});
+
+		// The transiently failed active account stays primary: the fallback
+		// only finds an account to TRY, it must not commit the cursor.
+		expect(selected?.index).toBe(1);
+		expect(markSwitched).not.toHaveBeenCalled();
+		expect(skipReasons.get(0)).toBe("already-attempted");
+	});
+});

--- a/test/rotation-account-selection.test.ts
+++ b/test/rotation-account-selection.test.ts
@@ -139,6 +139,43 @@ describe("chooseAccount pinned selection (issue #474)", () => {
 		expect(selected).toBeNull();
 		expect(skipReasons.get(1)).toBe("rate-limited");
 	});
+
+	it("refuses a cooling-down pinned account with the tagged reason", () => {
+		const accountManager = manager();
+		const pinned = accountManager.getAccountByIndex(1);
+		if (!pinned) throw new Error("fixture account missing");
+		accountManager.markAccountCoolingDown(pinned, 60_000, "auth-failure");
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			pinnedIndex: 1,
+			skipReasons,
+		});
+
+		expect(selected).toBeNull();
+		expect(skipReasons.get(1)).toBe("cooling-down:auth-failure");
+	});
+
+	it("refuses a pinned account whose circuit breaker is open", () => {
+		const accountManager = manager();
+		const pinned = accountManager.getAccountByIndex(1);
+		if (!pinned) throw new Error("fixture account missing");
+		// Trip the breaker (threshold is 3 failures).
+		for (let i = 0; i < 3; i += 1) {
+			accountManager.recordFailure(pinned, FAMILY, null);
+		}
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			pinnedIndex: 1,
+			skipReasons,
+		});
+
+		expect(selected).toBeNull();
+		expect(skipReasons.get(1)).toBe("circuit-open");
+	});
 });
 
 describe("chooseAccount session affinity tier", () => {
@@ -274,6 +311,34 @@ describe("chooseAccount sequential mode (issue #509)", () => {
 		expect(selected?.index).toBe(0);
 		expect(sequential).toHaveBeenCalledTimes(1);
 		expect(affinity).not.toHaveBeenCalled();
+	});
+
+	it("routes around a policy-blocked primary without moving it", () => {
+		const accountManager = manager();
+		const sequential = vi
+			.spyOn(accountManager, "getCurrentOrNextForFamilySequential")
+			.mockReturnValue(accountManager.getAccountByIndex(0));
+		const markSwitched = vi.spyOn(accountManager, "markSwitched");
+		const policy = policyWith([0]);
+		const skipReasons = new Map<number, string>();
+
+		const selected = chooseAccount({
+			...baseParams(accountManager),
+			policy,
+			schedulingStrategy: "sequential",
+			skipReasons,
+		});
+
+		// The blocked set is threaded into the drain-first selector, the linear
+		// fallback records the block, and the primary pointer stays put.
+		expect(sequential).toHaveBeenCalledExactlyOnceWith(
+			FAMILY,
+			null,
+			policy.blockedAccountIndexes,
+		);
+		expect(selected?.index).toBe(1);
+		expect(skipReasons.get(0)).toBe("policy-blocked");
+		expect(markSwitched).not.toHaveBeenCalled();
 	});
 
 	it("retries another account without moving the drain-first primary", () => {


### PR DESCRIPTION
## Summary

Tenth suite in the direct-coverage wave (siblings: #559–#561, #563–#567, #569; all independent, based on `main`). `lib/runtime/rotation-account-selection.ts` is the phase-2-extracted rotation selector at the heart of the proxy hot path. The proxy giant suite exercises it indirectly; this adds `test/rotation-account-selection.test.ts` (13 tests) pinning its documented selection contracts directly.

The suite drives a **real `AccountManager`** built from V3 storage fixtures — `markSwitched`, the skip-reason taxonomy, and the cursor bookkeeping are all live. Only the hybrid/sequential selector methods are stubbed per test (via `vi.spyOn` on the real instance) for deterministic path control, and module-level circuit/rate trackers are reset per test.

## What the tests pin

**Pinned selection (issue #474):**
- The pin wins without **any** cursor commit — the proxy must not clobber the pin set by the CLI.
- A pin never falls back to another account: already-attempted, missing, policy-blocked, disabled, and rate-limited pins each return null with the precise skip reason recorded.

**Session affinity tier:**
- The remembered account wins and commits the cursor with `markSwitched(account, "rotation", family)`.
- An unusable sticky account records its runtime skip reason and falls through to the hybrid tier.

**Hybrid tier and linear fallback:**
- The hybrid selector's pick is returned **without** an extra cursor commit (it advances its own cursor internally).
- An attempted/blocked hybrid pick falls back to the linear scan, which records a reason per rejected candidate (`already-attempted`, `policy-blocked`) and commits the winner as the new cursor.
- An exhausted pool returns null with a reason recorded for every account.

**Sequential / drain-first mode (issue #509):**
- The drain-first selector governs and the per-session affinity tier is **never consulted**.
- A transient failure on the active account retries another account **without** moving the drain-first primary — `markSwitched` is not called on the within-request fallback, so only true exhaustion advances the pointer.

## Validation

- [x] `vitest run test/rotation-account-selection.test.ts` — 13/13 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/rotation-account-selection.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/rotation-account-selection.test.ts` — 13 direct-coverage tests for `chooseAccount` in `lib/runtime/rotation-account-selection.ts`, driving a live `AccountManager` built from v3 fixtures with per-test volatile state resets. both issues flagged in previous review threads (missing `cooling-down`/`circuit-open` pin coverage and the sequential policy-blocked primary path) are addressed.

- **pin tier** now covers all six skip reasons (`already-attempted`, `missing`, `policy-blocked`, `disabled`, `rate-limited`, `cooling-down:*`, `circuit-open`) and asserts cursor is not committed.
- **affinity tier** verifies cursor commit on hit and reason recording on fallthrough; **hybrid tier** asserts no extra cursor commit; **sequential tier** pins drain-first stickiness, policy-blocked routing, and within-request retry without moving the active pointer.

<h3>Confidence Score: 5/5</h3>

test-only addition with no production code changes; the live AccountManager and module-level state reset in beforeEach are correct and all 13 contracts align with the implementation.

the suite correctly drives the real AccountManager, resets volatile circuit/rate state per test, and properly stubs only the hybrid/sequential selector methods — the selection contracts asserted match the chooseAccount implementation exactly. all findings are coverage gaps, not defects in the tests or the code they exercise.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/rotation-account-selection.test.ts | new 13-test suite directly pinning chooseAccount contracts across pin, affinity, hybrid, and sequential tiers using a live AccountManager; addresses all previously flagged coverage gaps except workspace-disabled |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[chooseAccount] --> B{pinnedIndex?}
    B -- yes --> C{attempted / missing / blocked?}
    C -- yes --> D[record skip reason]
    C -- no --> E{enabled? runtime skip?}
    E -- no --> D
    E -- yes --> F[return pinned no markSwitched]
    B -- no --> G{schedulingStrategy = sequential?}
    G -- yes --> H[getCurrentOrNextForFamilySequential]
    H --> I{usable and not attempted/blocked?}
    I -- yes --> J[return selected no markSwitched]
    I -- no --> K[chooseLinearScanFallback advancePtr=false]
    K --> L[return winner no markSwitched]
    G -- no --> M{session affinity hit?}
    M -- yes --> N{usable?}
    N -- yes --> O[markSwitched then return preferred]
    N -- no --> P[record skip reason then fall through]
    M -- no --> Q[getCurrentOrNextForFamilyHybrid]
    P --> Q
    Q --> R{usable and not attempted/blocked?}
    R -- yes --> S[return hybrid pick no markSwitched]
    R -- no --> T[chooseLinearScanFallback advancePtr=true]
    T --> U[markSwitched then return winner]
    T -- exhausted --> V[null]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-51-rotation-selection-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-51-rotation-selection-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Frotation-account-selection.test.ts%3A87-101%0A**%60workspace-disabled%60%20skip%20reason%20not%20covered%20in%20any%20tier**%0A%0A%60getAccountRuntimeSkipReason%60%20can%20return%20%60%22workspace-disabled%22%60%20when%20%60hasEnabledWorkspaces%60%20is%20false.%20this%20PR%20closed%20the%20%60cooling-down%60%20and%20%60circuit-open%60%20gaps%2C%20but%20%60workspace-disabled%60%20is%20the%20last%20untested%20branch%20in%20the%20same%20function.%20a%20pin%2C%20affinity%20sticky%20hit%2C%20or%20sequential%20primary%20that%20has%20all%20workspaces%20disabled%20would%20silently%20return%20%60null%60%20without%20the%20skip%20reason%20contract%20being%20pinned.%20to%20exercise%20it%2C%20add%20workspace%20metadata%20to%20a%20fixture%20account%20via%20the%20existing%20%60overridesByIndex%60%20mechanism%20%28e.g.%20%60workspaces%3A%20%5B%7B%20enabled%3A%20false%20%7D%5D%60%29%20and%20assert%20the%20recorded%20reason%20is%20%60%22workspace-disabled%22%60%20%E2%80%94%20at%20minimum%20in%20the%20pin%20tier%2C%20which%20already%20has%20dedicated%20cases%20for%20every%20other%20reason.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/rotation-account-selection.test.ts:87-101
**`workspace-disabled` skip reason not covered in any tier**

`getAccountRuntimeSkipReason` can return `"workspace-disabled"` when `hasEnabledWorkspaces` is false. this PR closed the `cooling-down` and `circuit-open` gaps, but `workspace-disabled` is the last untested branch in the same function. a pin, affinity sticky hit, or sequential primary that has all workspaces disabled would silently return `null` without the skip reason contract being pinned. to exercise it, add workspace metadata to a fixture account via the existing `overridesByIndex` mechanism (e.g. `workspaces: [{ enabled: false }]`) and assert the recorded reason is `"workspace-disabled"` — at minimum in the pin tier, which already has dedicated cases for every other reason.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover cooling-down and circuit-ope..."](https://github.com/ndycode/codex-multi-auth/commit/7d946f9250fdf309d2faa1d6dac73216e5c98237) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36778651)</sub>

<!-- /greptile_comment -->