### PR TITLE
test: cover ensureFreshAccessToken refresh, cooldown, and dedup paths

### DIFF
--- a/test/rotation-token-refresh.test.ts
+++ b/test/rotation-token-refresh.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AccountManager } from "../lib/accounts.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+const { queuedRefreshMock, saveAccountsMock, withAccountStorageTransactionMock } =
+	vi.hoisted(() => ({
+		queuedRefreshMock: vi.fn(),
+		saveAccountsMock: vi.fn(),
+		withAccountStorageTransactionMock: vi.fn(),
+	}));
+
+vi.mock("../lib/refresh-queue.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/refresh-queue.js")>();
+	return { ...actual, queuedRefresh: queuedRefreshMock };
+});
+
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		saveAccounts: saveAccountsMock,
+		withAccountStorageTransaction: withAccountStorageTransactionMock,
+	};
+});
+
+vi.mock("../lib/codex-cli/writer.js", () => ({
+	setCodexCliActiveSelection: vi.fn().mockResolvedValue(true),
+}));
+
+const {
+	applyMonotonicAuthCooldown,
+	DEFAULT_AUTH_FAILURE_COOLDOWN_MS,
+	ensureFreshAccessToken,
+} = await import("../lib/runtime/rotation-token-refresh.js");
+
+const NOW = Date.now();
+const FAMILY = "gpt-5-codex" as const;
+const SKEW_MS = 30_000;
+const INVALIDATION_COOLDOWN_MS = 300_000;
+
+function storageWith(expiresAt: number): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { [FAMILY]: 0 },
+		accounts: [
+			{
+				email: "account-1@example.com",
+				accountId: "acc_1",
+				refreshToken: "refresh-1",
+				accessToken: "access-1",
+				expiresAt,
+				addedAt: NOW - 60_000,
+				lastUsed: NOW - 60_000,
+				enabled: true,
+			},
+		],
+	};
+}
+
+const FRESH_EXPIRES = NOW + 3_600_000;
+// Inside the refresh skew window: the proxy must refresh before using it.
+const STALE_EXPIRES = NOW + 10_000;
+
+const openManagers: AccountManager[] = [];
+
+function managerWith(expiresAt: number): AccountManager {
+	const accountManager = new AccountManager(undefined, storageWith(expiresAt));
+	openManagers.push(accountManager);
+	return accountManager;
+}
+
+function refreshParams(accountManager: AccountManager) {
+	const account = accountManager.getAccountByIndex(0);
+	if (!account) throw new Error("fixture account missing");
+	return {
+		accountManager,
+		account,
+		family: FAMILY,
+		model: null,
+		now: NOW,
+		tokenRefreshSkewMs: SKEW_MS,
+		tokenInvalidationCooldownMs: INVALIDATION_COOLDOWN_MS,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	AccountManager.resetVolatileRuntimeState();
+	saveAccountsMock.mockResolvedValue(undefined);
+	withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+		handler(null, async () => undefined),
+	);
+});
+
+afterEach(async () => {
+	for (const accountManager of openManagers.splice(0, openManagers.length)) {
+		await accountManager.flushPendingSave();
+	}
+});
+
+describe("ensureFreshAccessToken", () => {
+	it("uses a fresh token as-is without touching the refresh queue", async () => {
+		const accountManager = managerWith(FRESH_EXPIRES);
+
+		const result = await ensureFreshAccessToken(refreshParams(accountManager));
+
+		expect(result).toMatchObject({ ok: true, accessToken: "access-1" });
+		expect(queuedRefreshMock).not.toHaveBeenCalled();
+	});
+
+	it("refreshes a stale token and commits the rotated credentials", async () => {
+		const accountManager = managerWith(STALE_EXPIRES);
+		queuedRefreshMock.mockResolvedValue({
+			type: "success",
+			access: "access-new",
+			refresh: "refresh-new",
+			expires: NOW + 7_200_000,
+		});
+
+		const result = await ensureFreshAccessToken(refreshParams(accountManager));
+
+		expect(queuedRefreshMock).toHaveBeenCalledExactlyOnceWith("refresh-1");
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.accessToken).toBe("access-new");
+			expect(result.account.access).toBe("access-new");
+		}
+		// The in-memory pool now carries the rotated credentials.
+		expect(accountManager.getAccountByIndex(0)).toMatchObject({
+			access: "access-new",
+			refreshToken: "refresh-new",
+		});
+	});
+
+	it("deduplicates concurrent commits for the same refreshed account", async () => {
+		const accountManager = managerWith(STALE_EXPIRES);
+		const commit = vi.spyOn(accountManager, "commitRefreshedAuth");
+		queuedRefreshMock.mockResolvedValue({
+			type: "success",
+			access: "access-new",
+			refresh: "refresh-new",
+			expires: NOW + 7_200_000,
+		});
+		// Hold the first commit open so the second caller arrives while it is
+		// still in flight — that is the window the dedup queue exists for.
+		let releaseCommit!: () => void;
+		const commitGate = new Promise<void>((resolve) => {
+			releaseCommit = resolve;
+		});
+		withAccountStorageTransactionMock.mockImplementation(async (handler) => {
+			await commitGate;
+			return handler(null, async () => undefined);
+		});
+		const params = refreshParams(accountManager);
+
+		const firstPending = ensureFreshAccessToken(params);
+		const secondPending = ensureFreshAccessToken({ ...params });
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		releaseCommit();
+		const [first, second] = await Promise.all([firstPending, secondPending]);
+
+		// Both callers share the single in-flight commit and the same token.
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(first).toMatchObject({ ok: true, accessToken: "access-new" });
+		expect(second).toMatchObject({ ok: true, accessToken: "access-new" });
+	});
+
+	it("applies the short cooldown on a non-retryable auth failure", async () => {
+		const accountManager = managerWith(STALE_EXPIRES);
+		queuedRefreshMock.mockResolvedValue({
+			type: "failed",
+			reason: "http_error",
+			statusCode: 401,
+			message: "token expired",
+		});
+
+		const result = await ensureFreshAccessToken(refreshParams(accountManager));
+
+		expect(result).toMatchObject({
+			ok: false,
+			retryable: false,
+			invalidated: false,
+		});
+		const coolingDownUntil =
+			accountManager.getAccountByIndex(0)?.coolingDownUntil ?? 0;
+		expect(coolingDownUntil).toBeGreaterThan(NOW);
+		expect(coolingDownUntil).toBeLessThanOrEqual(
+			Date.now() + DEFAULT_AUTH_FAILURE_COOLDOWN_MS,
+		);
+	});
+
+	it("marks transient refresh failures retryable", async () => {
+		const accountManager = managerWith(STALE_EXPIRES);
+		queuedRefreshMock.mockResolvedValue({
+			type: "failed",
+			reason: "network_error",
+			message: "fetch failed",
+		});
+
+		const result = await ensureFreshAccessToken(refreshParams(accountManager));
+
+		expect(result).toMatchObject({ ok: false, retryable: true });
+	});
+
+	it("applies the long cooldown and signals invalidation on a revoked token", async () => {
+		const accountManager = managerWith(STALE_EXPIRES);
+		queuedRefreshMock.mockResolvedValue({
+			type: "failed",
+			reason: "http_error",
+			statusCode: 401,
+			message: "OAuth token has been invalidated",
+		});
+
+		const result = await ensureFreshAccessToken(refreshParams(accountManager));
+
+		expect(result).toMatchObject({ ok: false, invalidated: true });
+		const coolingDownUntil =
+			accountManager.getAccountByIndex(0)?.coolingDownUntil ?? 0;
+		// The invalidation cooldown is the long one, far beyond the 30s default.
+		expect(coolingDownUntil).toBeGreaterThan(
+			NOW + INVALIDATION_COOLDOWN_MS - 10_000,
+		);
+	});
+
+	it("never lets a later generic failure truncate an invalidation cooldown", async () => {
+		const accountManager = managerWith(STALE_EXPIRES);
+		const account = accountManager.getAccountByIndex(0);
+		if (!account) throw new Error("fixture account missing");
+		accountManager.markAccountCoolingDown(
+			account,
+			INVALIDATION_COOLDOWN_MS,
+			"auth-failure",
+		);
+		const longDeadline =
+			accountManager.getAccountByIndex(0)?.coolingDownUntil ?? 0;
+		queuedRefreshMock.mockResolvedValue({
+			type: "failed",
+			reason: "http_error",
+			statusCode: 401,
+			message: "token expired",
+		});
+
+		await ensureFreshAccessToken(refreshParams(accountManager));
+
+		// Monotonic guard: the 30s generic cooldown must not shorten the
+		// 5-minute invalidation cooldown set by a concurrent request.
+		expect(accountManager.getAccountByIndex(0)?.coolingDownUntil).toBe(
+			longDeadline,
+		);
+	});
+
+	it("cools down and stays retryable when the commit itself fails", async () => {
+		const accountManager = managerWith(STALE_EXPIRES);
+		queuedRefreshMock.mockResolvedValue({
+			type: "success",
+			access: "access-new",
+			refresh: "refresh-new",
+			expires: NOW + 7_200_000,
+		});
+		// Once: the post-test debounced-save flush must still see the working
+		// transaction implementation from beforeEach.
+		withAccountStorageTransactionMock.mockRejectedValueOnce(
+			Object.assign(new Error("locked"), { code: "EBUSY" }),
+		);
+
+		const result = await ensureFreshAccessToken(refreshParams(accountManager));
+
+		expect(result).toMatchObject({ ok: false, retryable: true });
+		expect(
+			accountManager.getAccountByIndex(0)?.coolingDownUntil ?? 0,
+		).toBeGreaterThan(NOW);
+	});
+});
+
+describe("applyMonotonicAuthCooldown", () => {
+	it("extends an absent cooldown but never shortens an existing one", () => {
+		const accountManager = managerWith(FRESH_EXPIRES);
+		const account = accountManager.getAccountByIndex(0);
+		if (!account) throw new Error("fixture account missing");
+
+		applyMonotonicAuthCooldown(accountManager, account, 60_000);
+		const firstDeadline =
+			accountManager.getAccountByIndex(0)?.coolingDownUntil ?? 0;
+		expect(firstDeadline).toBeGreaterThan(NOW);
+
+		applyMonotonicAuthCooldown(accountManager, account, 1_000);
+		expect(accountManager.getAccountByIndex(0)?.coolingDownUntil).toBe(
+			firstDeadline,
+		);
+
+		applyMonotonicAuthCooldown(accountManager, account, 600_000);
+		expect(
+			accountManager.getAccountByIndex(0)?.coolingDownUntil ?? 0,
+		).toBeGreaterThan(firstDeadline);
+	});
+});

--- a/test/rotation-token-refresh.test.ts
+++ b/test/rotation-token-refresh.test.ts
@@ -133,6 +133,30 @@ describe("ensureFreshAccessToken", () => {
 		});
 	});
 
+	it("falls back to the refresh result's token when the commit cannot resolve the account", async () => {
+		const accountManager = managerWith(STALE_EXPIRES);
+		const original = accountManager.getAccountByIndex(0);
+		if (!original) throw new Error("fixture account missing");
+		queuedRefreshMock.mockResolvedValue({
+			type: "success",
+			access: "access-new",
+			refresh: "refresh-new",
+			expires: NOW + 7_200_000,
+		});
+		// The account vanished from storage between refresh and persist: the
+		// commit reports null and the caller must use the freshly refreshed
+		// token, never the stale one on the original account object.
+		vi.spyOn(accountManager, "commitRefreshedAuth").mockResolvedValue(null);
+
+		const result = await ensureFreshAccessToken(refreshParams(accountManager));
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.accessToken).toBe("access-new");
+			expect(result.account).toBe(original);
+		}
+	});
+
 	it("deduplicates concurrent commits for the same refreshed account", async () => {
 		const accountManager = managerWith(STALE_EXPIRES);
 		const commit = vi.spyOn(accountManager, "commitRefreshedAuth");


### PR DESCRIPTION
## Summary

Eleventh suite in the direct-coverage wave (siblings: #559–#561, #563–#567, #569, #570; all independent, based on `main`). `lib/runtime/rotation-token-refresh.ts` decides on the proxy hot path whether an account's token is usable, refreshes it through the queue, and applies the auth-failure cooldowns — including the issue #495 invalidation handling. This adds `test/rotation-token-refresh.test.ts` (9 tests).

Like #570, the suite drives a **real `AccountManager`** — the cooldown bookkeeping, `commitRefreshedAuth`'s snapshot/rollback machinery, and the live in-memory pool all run. Only `queuedRefresh` and the storage-transaction seam are mocked, and the real `isTokenInvalidationError`/`isTokenRefreshRetryable` predicates classify the failures.

## What the tests pin

- **Fresh-token short-circuit:** a token outside the skew window is used as-is, with no refresh-queue call.
- **Rotate-and-commit:** a stale token refreshes and the rotated credentials land in both the result and the in-memory pool.
- **Concurrent-commit dedup:** two callers refreshing the same account share **one** in-flight `commitRefreshedAuth` and both receive the committed token (the transaction is gated open so the dedup window genuinely exists during the test).
- **Failure taxonomy:** a 401 with a generic message → 30s auth-failure cooldown, `retryable: false`, `invalidated: false`; a network error → `retryable: true`; an explicit "OAuth token has been invalidated" body → the long invalidation cooldown plus `invalidated: true`, telling the caller to stop rotating instead of parading other accounts' tokens from the same IP (issue #495).
- **Monotonic cooldown guard:** a later generic 30s failure must never truncate a concurrent 5-minute invalidation cooldown; `applyMonotonicAuthCooldown` only ever extends deadlines.
- **Commit failure:** a failed persistence cools the account down and reports `retryable: true` with the rollback machinery exercised.

## Validation

- [x] `vitest run test/rotation-token-refresh.test.ts` — 9/9 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/rotation-token-refresh.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/rotation-token-refresh.test.ts` with 9 tests for `ensureFreshAccessToken` and `applyMonotonicAuthCooldown`, driving a real `AccountManager` with only `queuedRefresh` and the storage-transaction seam mocked.

- **fresh-token short-circuit, rotate-and-commit, concurrent dedup, commit-null fallback** — all four success-path branches are now pinned, including the previously-flagged `null`-return fallback added in this PR.
- **failure taxonomy** — non-retryable 401, retryable network error, invalidation cooldown with `invalidated: true`, monotonic guard, and commit-exception paths are all covered with real `isTokenInvalidationError`/`isTokenRefreshRetryable` predicates classifying the failures.
- the dedup test correctly gates `withAccountStorageTransaction` so both concurrent callers genuinely overlap in the in-flight window before the gate opens.

<h3>Confidence Score: 5/5</h3>

test-only PR adding 9 vitest tests with no production code changes; safe to merge

the change is purely additive test code. all 9 tests drive the real AccountManager and pass according to the author's validation run. the two notes above are minor gaps in assertion coverage that leave some production behaviors under-pinned but do not introduce regressions.

no files require special attention; all changes are in the test file

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/rotation-token-refresh.test.ts | new test suite covering 9 paths through ensureFreshAccessToken and applyMonotonicAuthCooldown; well-structured with real AccountManager; minor coverage gaps in side-effect assertions for failure paths |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test
    participant E as ensureFreshAccessToken
    participant Q as queuedRefresh (mock)
    participant D as commitRefreshedAuthOnce
    participant C as AccountManager.commitRefreshedAuth
    participant S as withAccountStorageTransaction (mock)

    T->>E: params (stale token)
    E->>E: hasUsableAccessToken → false
    E->>Q: queuedRefresh(refreshToken)
    Q-->>E: "{type:success, access:access-new}"
    E->>D: commitRefreshedAuthOnce(manager, account, auth)
    D->>C: accountManager.commitRefreshedAuth(account, auth)
    C->>S: withAccountStorageTransaction(handler)
    S-->>C: handler(null, persist)
    C-->>D: liveAccount (updated in-memory)
    D-->>E: liveAccount
    E-->>T: "{ok:true, accessToken:access-new, account}"

    Note over D: dedup: 2nd concurrent caller returns same in-flight promise
    Note over E: on failure: applyMonotonicAuthCooldown only extends, never shortens
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-52-rotation-token-refresh-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-52-rotation-token-refresh-tests%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Frotation-token-refresh.test.ts%3A183-211%0A**failure%20side-effects%20not%20asserted%20in%20three%20failure%20tests**%0A%0Athe%20three%20refresh-failure%20tests%20%28%60non-retryable%20auth%20failure%60%2C%20%60marks%20transient%20failures%20retryable%60%2C%20%60revoked%20token%60%29%20assert%20on%20the%20%60result%60%20shape%20and%20%60coolingDownUntil%60%2C%20but%20none%20assert%20that%20%60accountManager.recordFailure%60%20and%20%60accountManager.incrementAuthFailures%60%20were%20called.%20if%20either%20call%20is%20accidentally%20removed%20from%20the%20%60refreshResult.type%20%3D%3D%3D%20%22failed%22%60%20branch%20in%20%60rotation-token-refresh.ts%60%2C%20the%20suite%20stays%20green%20while%20health-tracking%20and%20auth-failure%20counters%20stop%20updating%20silently.%20spying%20on%20both%20methods%20in%20these%20tests%20would%20pin%20the%20full%20side-effect%20contract.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Frotation-token-refresh.test.ts%3A156-181%0A**dedup%20test%20does%20not%20assert%20queuedRefresh%20is%20called%20twice**%0A%0Aby%20design%2C%20%60queuedRefresh%60%20is%20not%20deduplicated%20here%20%E2%80%94%20only%20the%20commit%20step%20is.%20two%20independent%20callers%20each%20issue%20their%20own%20%60queuedRefresh%60%2C%20and%20the%20dedup%20queue%20merges%20only%20the%20%60commitRefreshedAuth%60%20leg.%20the%20test%20correctly%20checks%20%60commit%60%20called%20once%2C%20but%20adding%20%60expect%28queuedRefreshMock%29.toHaveBeenCalledTimes%282%29%60%20would%20document%20and%20lock%20down%20that%20intentional%20difference%20so%20future%20refactors%20don't%20accidentally%20merge%20the%20refresh%20calls%20too.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=571&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/rotation-token-refresh.test.ts:183-211
**failure side-effects not asserted in three failure tests**

the three refresh-failure tests (`non-retryable auth failure`, `marks transient failures retryable`, `revoked token`) assert on the `result` shape and `coolingDownUntil`, but none assert that `accountManager.recordFailure` and `accountManager.incrementAuthFailures` were called. if either call is accidentally removed from the `refreshResult.type === "failed"` branch in `rotation-token-refresh.ts`, the suite stays green while health-tracking and auth-failure counters stop updating silently. spying on both methods in these tests would pin the full side-effect contract.

### Issue 2 of 2
test/rotation-token-refresh.test.ts:156-181
**dedup test does not assert queuedRefresh is called twice**

by design, `queuedRefresh` is not deduplicated here — only the commit step is. two independent callers each issue their own `queuedRefresh`, and the dedup queue merges only the `commitRefreshedAuth` leg. the test correctly checks `commit` called once, but adding `expect(queuedRefreshMock).toHaveBeenCalledTimes(2)` would document and lock down that intentional difference so future refactors don't accidentally merge the refresh calls too.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover the commit-null token fallba..."](https://github.com/ndycode/codex-multi-auth/commit/9480f3f95df6b498c65f82afaa0765949d0ecf74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36779689)</sub>

<!-- /greptile_comment -->