### PR TITLE
test: cover rotation proxy state init and stale-state recovery

### DIFF
--- a/test/rotation-proxy-state.test.ts
+++ b/test/rotation-proxy-state.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AccountManager } from "../lib/accounts.js";
+import type { RotationProxyStateInit } from "../lib/runtime/rotation-proxy-state.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+const { recordRuntimeResetMock, recordRuntimeReloadMock } = vi.hoisted(() => ({
+	recordRuntimeResetMock: vi.fn(),
+	recordRuntimeReloadMock: vi.fn(),
+}));
+
+vi.mock("../lib/runtime/runtime-observability.js", async (importOriginal) => {
+	const actual = await importOriginal<
+		typeof import("../lib/runtime/runtime-observability.js")
+	>();
+	return {
+		...actual,
+		recordRuntimeReset: recordRuntimeResetMock,
+		recordRuntimeReload: recordRuntimeReloadMock,
+	};
+});
+
+const { createRotationProxyState, recoverStaleRuntimeState } = await import(
+	"../lib/runtime/rotation-proxy-state.js"
+);
+
+const NOW = Date.now();
+
+function storageWith(count: number): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: {},
+		accounts: Array.from({ length: count }, (_unused, index) => ({
+			email: `account-${index + 1}@example.com`,
+			accountId: `acc_${index + 1}`,
+			refreshToken: `refresh-${index + 1}`,
+			accessToken: `access-${index + 1}`,
+			expiresAt: NOW + 3_600_000,
+			addedAt: NOW - 60_000,
+			lastUsed: NOW - 60_000,
+			enabled: true,
+		})),
+	};
+}
+
+function stateInit(): RotationProxyStateInit {
+	return {
+		activeAccountManager: new AccountManager(undefined, storageWith(1)),
+		routingMutexMode: "enabled",
+		schedulingStrategy: "hybrid",
+		fetchImpl: fetch,
+		upstreamBaseUrl: "https://upstream.example",
+		clientApiKey: "key",
+		now: () => NOW,
+		tokenRefreshSkewMs: 30_000,
+		networkErrorCooldownMs: 10_000,
+		serverErrorCooldownMs: 10_000,
+		tokenInvalidationCooldownMs: 300_000,
+		minRotationIntervalMs: 0,
+		pidOffsetEnabled: false,
+		fetchTimeoutMs: 30_000,
+		streamStallTimeoutMs: 30_000,
+		maxRuntimeAccountAttempts: 3,
+		maxRequestBodyBytes: 1024,
+		quotaRemainingPercentThreshold: 0,
+		sessionAffinityStore: null,
+		lastObservedAffinityGeneration: 0,
+	};
+}
+
+let loadFromDisk: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	loadFromDisk = vi.spyOn(AccountManager, "loadFromDisk");
+});
+
+afterEach(() => {
+	loadFromDisk.mockRestore();
+});
+
+describe("createRotationProxyState", () => {
+	it("seeds the known-manager set and a zeroed status from the injected clock", () => {
+		const init = stateInit();
+
+		const state = createRotationProxyState(init);
+
+		expect([...state.knownAccountManagers]).toEqual([
+			init.activeAccountManager,
+		]);
+		expect(state.status).toMatchObject({
+			startedAt: NOW,
+			totalRequests: 0,
+			upstreamRequests: 0,
+			retries: 0,
+			rotations: 0,
+			streamsStarted: 0,
+			lastError: null,
+			lastAccountIndex: null,
+		});
+		expect(state.lastGlobalAccountIndex).toBeNull();
+		expect(state.lastStaleRuntimeReloadAt).toBe(0);
+	});
+});
+
+describe("recoverStaleRuntimeState", () => {
+	it("reloads from disk, swaps the active manager, and records observability", async () => {
+		const state = createRotationProxyState(stateInit());
+		const previousManager = state.activeAccountManager;
+		const reloaded = new AccountManager(undefined, storageWith(2));
+		loadFromDisk.mockResolvedValue(reloaded);
+
+		const result = await recoverStaleRuntimeState(state);
+
+		expect(result).toBe(reloaded);
+		expect(state.activeAccountManager).toBe(reloaded);
+		// The previous manager stays known so in-flight requests can finish.
+		expect(state.knownAccountManagers.has(previousManager)).toBe(true);
+		expect(state.knownAccountManagers.has(reloaded)).toBe(true);
+		// The configured mutex mode carries over to the reloaded pool.
+		expect(reloaded.getRoutingMutexMode()).toBe("enabled");
+		expect(state.lastStaleRuntimeReloadAt).toBeGreaterThan(0);
+		expect(recordRuntimeResetMock).toHaveBeenCalledExactlyOnceWith(
+			"pool-exhausted-no-account",
+		);
+		expect(recordRuntimeReloadMock).toHaveBeenCalledExactlyOnceWith(
+			"pool-exhausted-no-account",
+		);
+	});
+
+	it("returns the current manager inside the dedupe window without reloading", async () => {
+		const state = createRotationProxyState(stateInit());
+		const reloaded = new AccountManager(undefined, storageWith(2));
+		loadFromDisk.mockResolvedValue(reloaded);
+
+		await recoverStaleRuntimeState(state);
+		const second = await recoverStaleRuntimeState(state);
+
+		// The second call lands inside the 1s dedupe window: no second reload.
+		expect(second).toBe(reloaded);
+		expect(loadFromDisk).toHaveBeenCalledTimes(1);
+	});
+
+	it("shares one in-flight reload between concurrent callers", async () => {
+		const state = createRotationProxyState(stateInit());
+		const reloaded = new AccountManager(undefined, storageWith(2));
+		let releaseReload!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			releaseReload = resolve;
+		});
+		loadFromDisk.mockImplementation(async () => {
+			await gate;
+			return reloaded;
+		});
+
+		const firstPending = recoverStaleRuntimeState(state);
+		const secondPending = recoverStaleRuntimeState(state);
+		releaseReload();
+		const [first, second] = await Promise.all([firstPending, secondPending]);
+
+		expect(first).toBe(reloaded);
+		expect(second).toBe(reloaded);
+		expect(loadFromDisk).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports a failed reload and allows the next attempt to retry", async () => {
+		const state = createRotationProxyState(stateInit());
+		loadFromDisk.mockRejectedValueOnce(new Error("disk exploded"));
+
+		const failed = await recoverStaleRuntimeState(state);
+
+		expect(failed).toBeNull();
+		expect(state.status.lastError).toBe("disk exploded");
+		// The failure does not arm the dedupe window or leak a stale promise:
+		// the next call retries the reload.
+		const reloaded = new AccountManager(undefined, storageWith(2));
+		loadFromDisk.mockResolvedValue(reloaded);
+		await expect(recoverStaleRuntimeState(state)).resolves.toBe(reloaded);
+		expect(loadFromDisk).toHaveBeenCalledTimes(2);
+	});
+});

--- a/test/rotation-proxy-state.test.ts
+++ b/test/rotation-proxy-state.test.ts
@@ -88,7 +88,7 @@ describe("createRotationProxyState", () => {
 		expect([...state.knownAccountManagers]).toEqual([
 			init.activeAccountManager,
 		]);
-		expect(state.status).toMatchObject({
+		expect(state.status).toStrictEqual({
 			startedAt: NOW,
 			totalRequests: 0,
 			upstreamRequests: 0,
@@ -97,6 +97,9 @@ describe("createRotationProxyState", () => {
 			streamsStarted: 0,
 			lastError: null,
 			lastAccountIndex: null,
+			lastAccountLabel: null,
+			lastAccountId: null,
+			lastAccountUpdatedAt: null,
 		});
 		expect(state.lastGlobalAccountIndex).toBeNull();
 		expect(state.lastStaleRuntimeReloadAt).toBe(0);

--- a/test/rotation-proxy-state.test.ts
+++ b/test/rotation-proxy-state.test.ts
@@ -128,17 +128,31 @@ describe("recoverStaleRuntimeState", () => {
 		);
 	});
 
-	it("returns the current manager inside the dedupe window without reloading", async () => {
-		const state = createRotationProxyState(stateInit());
-		const reloaded = new AccountManager(undefined, storageWith(2));
-		loadFromDisk.mockResolvedValue(reloaded);
+	it("dedupes within the 1s window and reloads again once it expires", async () => {
+		// The dedupe guard runs on the real wall clock (deliberately not the
+		// injected now()), so fake timers make the window deterministic.
+		vi.useFakeTimers();
+		try {
+			const state = createRotationProxyState(stateInit());
+			const reloaded = new AccountManager(undefined, storageWith(2));
+			loadFromDisk.mockResolvedValue(reloaded);
 
-		await recoverStaleRuntimeState(state);
-		const second = await recoverStaleRuntimeState(state);
+			await recoverStaleRuntimeState(state);
+			const second = await recoverStaleRuntimeState(state);
 
-		// The second call lands inside the 1s dedupe window: no second reload.
-		expect(second).toBe(reloaded);
-		expect(loadFromDisk).toHaveBeenCalledTimes(1);
+			// The second call lands inside the 1s dedupe window: no second reload.
+			expect(second).toBe(reloaded);
+			expect(loadFromDisk).toHaveBeenCalledTimes(1);
+
+			// Once the window expires, the next call reloads from disk again.
+			vi.advanceTimersByTime(1_001);
+			const freshest = new AccountManager(undefined, storageWith(3));
+			loadFromDisk.mockResolvedValue(freshest);
+			await expect(recoverStaleRuntimeState(state)).resolves.toBe(freshest);
+			expect(loadFromDisk).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("shares one in-flight reload between concurrent callers", async () => {
@@ -171,6 +185,8 @@ describe("recoverStaleRuntimeState", () => {
 
 		expect(failed).toBeNull();
 		expect(state.status.lastError).toBe("disk exploded");
+		// The failure must not arm the dedupe window.
+		expect(state.lastStaleRuntimeReloadAt).toBe(0);
 		// The failure does not arm the dedupe window or leak a stale promise:
 		// the next call retries the reload.
 		const reloaded = new AccountManager(undefined, storageWith(2));


### PR DESCRIPTION
## Summary

Twelfth suite in the direct-coverage wave (siblings: #559–#561, #563–#567, #569–#571; all independent, based on `main`). `lib/runtime/rotation-proxy-state.ts` holds the proxy's per-instance state container and the pool-exhausted stale-state recovery. This adds `test/rotation-proxy-state.test.ts` (5 tests).

A real `AccountManager` backs the state; `AccountManager.loadFromDisk` is the one stubbed seam (static spy), and the observability reset/reload recorders are mocked so nothing touches disk.

## What the tests pin

- **`createRotationProxyState`:** the known-manager set is seeded with the active manager and the status block starts zeroed with `startedAt` from the **injected** clock.
- **Recovery happy path:** `recoverStaleRuntimeState` reloads from disk, swaps `activeAccountManager`, keeps the previous manager in the known set (so in-flight requests can still finish against it), carries the configured routing-mutex mode onto the reloaded pool, stamps `lastStaleRuntimeReloadAt`, and records both observability markers with `pool-exhausted-no-account`.
- **Dedupe:** a second call inside the 1s window returns the freshly reloaded manager without a second disk read, and two concurrent callers share one in-flight reload (gated `loadFromDisk` so the window is genuinely open).
- **Failure:** a failed reload returns null, surfaces the message in `status.lastError`, and neither arms the dedupe window nor leaks a stale promise — the very next call retries the reload.

## Validation

- [x] `vitest run test/rotation-proxy-state.test.ts` — 5/5 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/rotation-proxy-state.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/rotation-proxy-state.test.ts` — 5 tests covering the init shape, happy-path stale-state recovery, 1-second dedupe window (with `vi.useFakeTimers()` for determinism), concurrent-caller deduplication via a gated `loadFromDisk`, and failure-path behaviour.

- **init test** uses `toStrictEqual` to pin the full `status` object (all 11 fields), `knownAccountManagers` seeding, `lastGlobalAccountIndex`, and `lastStaleRuntimeReloadAt` zero-value.
- **recovery tests** verify mutex-mode carry-over, `knownAccountManagers` accumulation, observability call counts, dedupe window expiry after `vi.advanceTimersByTime(1_001)`, and that a failed reload surfaces `status.lastError`, leaves `lastStaleRuntimeReloadAt` at 0, and allows an immediate retry.

<h3>Confidence Score: 5/5</h3>

test-only change; adds no production code and does not touch disk, tokens, or any live state.

the suite correctly exercises every branch of recoverStaleRuntimeState — happy path, concurrent deduplication, dedupe-window expiry, and failure recovery — using fake timers and a gate promise to keep assertions deterministic. no issues were found that would affect correctness or safety of the production module.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/rotation-proxy-state.test.ts | new 5-test suite; correctly uses vi.useFakeTimers() for dedupe-window determinism, toStrictEqual for full status shape, and a gate promise to hold the in-flight reload open for the concurrency test — all major contract points are pinned. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2
    participant R as recoverStaleRuntimeState
    participant S as RotationProxyState
    participant AM as AccountManager

    Note over R,S: dedupe check — Date.now() - lastStaleRuntimeReloadAt <= 1000?
    C1->>R: call
    R->>S: read lastStaleRuntimeReloadAt (0)
    R->>S: read staleRuntimeReloadPromise (null)
    R->>AM: resetVolatileRuntimeState()
    R->>AM: loadFromDisk() [async, gated]
    R->>S: set staleRuntimeReloadPromise

    C2->>R: call (concurrent)
    R->>S: read lastStaleRuntimeReloadAt (still 0)
    R->>S: read staleRuntimeReloadPromise (non-null)
    R-->>C2: return existing promise

    AM-->>R: reloaded AccountManager
    R->>S: "activeAccountManager = reloaded"
    R->>S: knownAccountManagers.add(reloaded)
    R->>S: "lastStaleRuntimeReloadAt = Date.now()"
    R->>S: "staleRuntimeReloadPromise = null (finally)"
    R-->>C1: reloaded
    R-->>C2: reloaded (same promise)

    Note over R,S: within 1s dedupe window
    C1->>R: call again
    R->>S: "read lastStaleRuntimeReloadAt (> 0, within window)"
    R-->>C1: return activeAccountManager (no disk read)
```

<sub>Reviews (2): Last reviewed commit: ["test: pin the full initial status shape ..."](https://github.com/ndycode/codex-multi-auth/commit/a032a288e4cf7dcadc684cbef1371195537ddcc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36780637)</sub>

<!-- /greptile_comment -->