### PR TITLE
test: cover the auth menu view-model formatting helpers

### DIFF
--- a/test/auth-menu-builder.test.ts
+++ b/test/auth-menu-builder.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	accountRowColor,
+	accountSearchText,
+	accountTitle,
+	authMenuFocusKey,
+	currentMarkerLabel,
+	formatAccountHint,
+	formatRelativeTime,
+	mainMenuTitleWithVersion,
+	statusBadge,
+	type AccountInfo,
+	type AuthMenuAction,
+} from "../lib/ui/auth-menu-builder.js";
+import { getUiRuntimeOptions } from "../lib/ui/runtime.js";
+import { UI_COPY } from "../lib/ui/ui-copy.js";
+
+const NOW = Date.now();
+const DAY_MS = 86_400_000;
+
+// All formatting helpers may paint with ANSI in either UI mode; the contract
+// under test is the text content, not the palette.
+function stripAnsi(value: string): string {
+	 
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function account(overrides: Partial<AccountInfo> = {}): AccountInfo {
+	return { index: 0, ...overrides };
+}
+
+const originalVersionEnv = process.env.CODEX_MULTI_AUTH_CLI_VERSION;
+
+beforeEach(() => {
+	delete process.env.CODEX_MULTI_AUTH_CLI_VERSION;
+});
+
+afterEach(() => {
+	if (originalVersionEnv === undefined) {
+		delete process.env.CODEX_MULTI_AUTH_CLI_VERSION;
+	} else {
+		process.env.CODEX_MULTI_AUTH_CLI_VERSION = originalVersionEnv;
+	}
+});
+
+describe("mainMenuTitleWithVersion", () => {
+	it("returns the bare title when no CLI version is exported", () => {
+		expect(mainMenuTitleWithVersion()).toBe(UI_COPY.mainMenu.title);
+	});
+
+	it("appends the version, prefixing a v only when missing", () => {
+		process.env.CODEX_MULTI_AUTH_CLI_VERSION = "1.2.3";
+		expect(mainMenuTitleWithVersion()).toBe(
+			`${UI_COPY.mainMenu.title} (v1.2.3)`,
+		);
+
+		process.env.CODEX_MULTI_AUTH_CLI_VERSION = "v2.0.0";
+		expect(mainMenuTitleWithVersion()).toBe(
+			`${UI_COPY.mainMenu.title} (v2.0.0)`,
+		);
+	});
+});
+
+describe("formatRelativeTime", () => {
+	it.each([
+		["never", undefined],
+		["today", NOW - 1_000],
+		["yesterday", NOW - DAY_MS - 1_000],
+		["3d ago", NOW - 3 * DAY_MS - 1_000],
+		["2w ago", NOW - 15 * DAY_MS],
+	] as const)("renders %s", (expected, timestamp) => {
+		expect(formatRelativeTime(timestamp)).toBe(expected);
+	});
+
+	it("falls back to a locale date beyond a month", () => {
+		const old = NOW - 60 * DAY_MS;
+		expect(formatRelativeTime(old)).toBe(new Date(old).toLocaleDateString());
+	});
+});
+
+describe("accountTitle", () => {
+	it("prefers email, then label, then id, then a generic name", () => {
+		expect(accountTitle(account({ email: "a@example.com" }))).toBe(
+			"1. a@example.com",
+		);
+		expect(accountTitle(account({ accountLabel: "Team A" }))).toBe(
+			"1. Team A",
+		);
+		expect(accountTitle(account({ accountId: "acc_1" }))).toBe("1. acc_1");
+		expect(accountTitle(account())).toBe("1. Account 1");
+	});
+
+	it("numbers rows by quickSwitchNumber when present", () => {
+		expect(
+			accountTitle(account({ index: 4, quickSwitchNumber: 2, email: "a@b.c" })),
+		).toBe("2. a@b.c");
+	});
+
+	it("strips ANSI escapes and control characters from identity fields", () => {
+		// A hostile accountLabel must not be able to repaint the menu row.
+		const title = accountTitle(
+			account({ accountLabel: "\x1b[31mEvil\x1b[0m Label" }),
+		);
+		expect(title).toBe("1. Evil Label");
+	});
+});
+
+describe("accountSearchText", () => {
+	it("joins the lowercased identity fields and the row number", () => {
+		expect(
+			accountSearchText(
+				account({
+					index: 1,
+					email: "User@Example.com",
+					accountLabel: "Team A",
+					accountId: "ACC_9",
+				}),
+			),
+		).toBe("user@example.com team a acc_9 2");
+	});
+});
+
+describe("accountRowColor", () => {
+	it("highlights the current row green unless highlighting is disabled", () => {
+		expect(
+			accountRowColor(account({ isCurrentAccount: true, status: "disabled" })),
+		).toBe("green");
+		expect(
+			accountRowColor(
+				account({
+					isCurrentAccount: true,
+					highlightCurrentRow: false,
+					status: "disabled",
+				}),
+			),
+		).toBe("red");
+	});
+
+	it.each([
+		["green", "ok"],
+		["yellow", "rate-limited"],
+		["yellow", "cooldown"],
+		["red", "flagged"],
+		["yellow", undefined],
+	] as const)("maps to %s for status %s", (expected, status) => {
+		expect(accountRowColor(account({ status }))).toBe(expected);
+	});
+});
+
+describe("statusBadge", () => {
+	it.each([
+		"active",
+		"ok",
+		"quota-exhausted",
+		"rate-limited",
+		"cooldown",
+		"flagged",
+		"disabled",
+		"error",
+	] as const)("labels the %s badge with its status", (status) => {
+		expect(stripAnsi(statusBadge(status))).toContain(status);
+	});
+
+	it("labels missing statuses unknown", () => {
+		expect(stripAnsi(statusBadge(undefined))).toContain("unknown");
+	});
+});
+
+describe("currentMarkerLabel", () => {
+	it("humanizes in-use and passes other markers through", () => {
+		expect(currentMarkerLabel("in-use")).toBe("in use");
+		expect(currentMarkerLabel("current")).toBe("current");
+		expect(currentMarkerLabel("selected")).toBe("selected");
+	});
+});
+
+describe("formatAccountHint", () => {
+	const ui = getUiRuntimeOptions();
+
+	it("renders last-used and quota limits in the default field order", () => {
+		const hint = stripAnsi(
+			formatAccountHint(
+				account({
+					lastUsed: NOW - 1_000,
+					quota5hLeftPercent: 50,
+					quota5hResetAtMs: NOW + 30_000,
+				}),
+				ui,
+			),
+		);
+
+		expect(hint).toMatch(/^Last used: today \| Limits: 5h /);
+		expect(hint).toContain("50%");
+		expect(hint).toContain("reset ");
+	});
+
+	it("includes the status text only when the badge column is hidden", () => {
+		const visibleBadge = stripAnsi(
+			formatAccountHint(account({ status: "ok", lastUsed: NOW }), ui),
+		);
+		expect(visibleBadge).not.toContain("Status:");
+
+		const hiddenBadge = stripAnsi(
+			formatAccountHint(
+				account({ status: "ok", lastUsed: NOW, showStatusBadge: false }),
+				ui,
+			),
+		);
+		expect(hiddenBadge).toContain("Status: ok");
+	});
+
+	it("orders the parts by the configured statusline fields", () => {
+		const hint = stripAnsi(
+			formatAccountHint(
+				account({
+					status: "ok",
+					lastUsed: NOW,
+					showStatusBadge: false,
+					statuslineFields: ["status", "last-used"],
+				}),
+				ui,
+			),
+		);
+
+		expect(hint.indexOf("Status:")).toBeLessThan(hint.indexOf("Last used:"));
+	});
+
+	it("flags rate-limited and exhausted accounts in the limits segment", () => {
+		const hint = stripAnsi(
+			formatAccountHint(
+				account({
+					lastUsed: NOW,
+					quotaRateLimited: true,
+					quotaExhausted: true,
+				}),
+				ui,
+			),
+		);
+
+		expect(hint).toContain("rate-limited");
+		expect(hint).toContain("quota-exhausted");
+	});
+
+	it("returns an empty string when every field is hidden", () => {
+		expect(
+			formatAccountHint(account({ showLastUsed: false }), ui),
+		).toBe("");
+	});
+});
+
+describe("authMenuFocusKey", () => {
+	it("keys account actions by their storage position", () => {
+		const row = account({ index: 2, sourceIndex: 5 });
+		const action: AuthMenuAction = { type: "select-account", account: row };
+		expect(authMenuFocusKey(action)).toBe("account:5");
+		// Without a sourceIndex the display index is the identity.
+		expect(
+			authMenuFocusKey({
+				type: "delete-account",
+				account: account({ index: 2 }),
+			}),
+		).toBe("account:2");
+	});
+
+	it("keys static actions by their type", () => {
+		expect(authMenuFocusKey({ type: "add" })).toBe("action:add");
+		expect(authMenuFocusKey({ type: "cancel" })).toBe("action:cancel");
+	});
+});

--- a/test/auth-menu-builder.test.ts
+++ b/test/auth-menu-builder.test.ts
@@ -6,13 +6,18 @@ import {
 	authMenuFocusKey,
 	currentMarkerLabel,
 	formatAccountHint,
+	formatDate,
 	formatRelativeTime,
 	mainMenuTitleWithVersion,
 	statusBadge,
 	type AccountInfo,
 	type AuthMenuAction,
 } from "../lib/ui/auth-menu-builder.js";
-import { getUiRuntimeOptions } from "../lib/ui/runtime.js";
+import {
+	getUiRuntimeOptions,
+	resetUiRuntimeOptions,
+	setUiRuntimeOptions,
+} from "../lib/ui/runtime.js";
 import { UI_COPY } from "../lib/ui/ui-copy.js";
 
 const NOW = Date.now();
@@ -96,12 +101,18 @@ describe("accountTitle", () => {
 		).toBe("2. a@b.c");
 	});
 
-	it("strips ANSI escapes and control characters from identity fields", () => {
-		// A hostile accountLabel must not be able to repaint the menu row.
-		const title = accountTitle(
-			account({ accountLabel: "\x1b[31mEvil\x1b[0m Label" }),
+	it("strips ANSI escapes and control characters from every identity field", () => {
+		// Hostile identity values must not be able to repaint the menu row,
+		// regardless of which field carries them.
+		expect(
+			accountTitle(account({ accountLabel: "\x1b[31mEvil\x1b[0m Label" })),
+		).toBe("1. Evil Label");
+		expect(
+			accountTitle(account({ email: "\x1b[2Jevil@example.com" })),
+		).toBe("1. evil@example.com");
+		expect(accountTitle(account({ accountId: "acc\x1b[31m_red" }))).toBe(
+			"1. acc_red",
 		);
-		expect(title).toBe("1. Evil Label");
 	});
 });
 
@@ -163,6 +174,14 @@ describe("statusBadge", () => {
 
 	it("labels missing statuses unknown", () => {
 		expect(stripAnsi(statusBadge(undefined))).toContain("unknown");
+	});
+});
+
+describe("formatDate", () => {
+	it("renders unknown for missing timestamps and a locale date otherwise", () => {
+		expect(formatDate(undefined)).toBe("unknown");
+		const ts = NOW - 10 * DAY_MS;
+		expect(formatDate(ts)).toBe(new Date(ts).toLocaleDateString());
 	});
 });
 
@@ -245,6 +264,33 @@ describe("formatAccountHint", () => {
 		expect(
 			formatAccountHint(account({ showLastUsed: false }), ui),
 		).toBe("");
+	});
+});
+
+describe("legacy (v1) palette rendering", () => {
+	it("renders badges and hints with the same text content when v2 is off", () => {
+		setUiRuntimeOptions({ v2Enabled: false });
+		try {
+			expect(stripAnsi(statusBadge("rate-limited"))).toContain(
+				"rate-limited",
+			);
+			expect(stripAnsi(statusBadge(undefined))).toContain("unknown");
+
+			const hint = stripAnsi(
+				formatAccountHint(
+					account({
+						lastUsed: NOW - 1_000,
+						quota5hLeftPercent: 50,
+						quota5hResetAtMs: NOW + 30_000,
+					}),
+					getUiRuntimeOptions(),
+				),
+			);
+			expect(hint).toMatch(/^Last used: today \| Limits: 5h /);
+			expect(hint).toContain("50%");
+		} finally {
+			resetUiRuntimeOptions();
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary

Thirteenth suite in the direct-coverage wave (siblings: #559–#561, #563–#567, #569–#572; all independent, based on `main`). `lib/ui/auth-menu-builder.ts` (445 lines) builds the auth dashboard's row titles, badges, colors, hints, and focus keys — it was the last substantive untested module in `lib/`. This adds `test/auth-menu-builder.test.ts` (35 tests).

The suite asserts **text content with ANSI stripped**, so the contracts hold in both the legacy and v2 UI palettes, and the version env var is saved/restored.

## What the tests pin

- **`mainMenuTitleWithVersion`:** bare title without the env var; the version suffix gets a `v` prefix only when missing.
- **`formatRelativeTime`:** the never/today/yesterday/`Nd ago`/`Nw ago` buckets and the locale-date fallback beyond a month.
- **`accountTitle` (the injection guard):** identity precedence email > label > id > generic, numbering by `quickSwitchNumber` over the display index, and — the security-relevant bit — ANSI escapes and control characters are stripped from identity fields so a hostile account label cannot repaint the menu row.
- **`accountSearchText`:** lowercased identity fields joined with the row number.
- **`accountRowColor`:** the current row highlights green unless `highlightCurrentRow` is disabled (then the status color wins); the ok/limited/flagged tone mapping with the unknown fallback.
- **`statusBadge`:** every status renders its own label; missing statuses render `unknown`.
- **`formatAccountHint`:** default field order (`Last used | Limits`), `Status:` appears only when the badge column is hidden, configured `statuslineFields` ordering is respected, rate-limited/quota-exhausted flags surface in the limits segment (with the quota bar and reset countdown), and hiding every field yields an empty string.
- **`authMenuFocusKey`:** account actions key on the **storage** position (`sourceIndex` over display index — focus survives re-sorting), static actions key on their type.

## Validation

- [x] `vitest run test/auth-menu-builder.test.ts` — 35/35 passing
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/auth-menu-builder.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/auth-menu-builder.test.ts` — 35 tests that pin the text-content contracts for every exported formatting helper in `lib/ui/auth-menu-builder.ts`, the last substantive untested module in `lib/`. all assertions strip ansi before comparing, so they hold across both the v2 and legacy v1 palettes.

- **security coverage**: `accountTitle` injection guard now tests all three identity fields (`email`, `accountLabel`, `accountId`) with hostile CSI sequences, closing the gap noted in the previous review round.
- **v1 palette path**: a `legacy (v1) palette rendering` suite wraps `setUiRuntimeOptions({ v2Enabled: false })` in a `try/finally` to guarantee state restoration, covering `statusBadge` and `formatAccountHint` branches that were dead code under the default v2 mode.
- **remaining gap**: the `accountTitle` precedence test exercises each identity field in isolation; it does not verify that `email` wins when `email`, `accountLabel`, and `accountId` are all simultaneously non-empty — a multi-field assertion would make the declared priority enforceable by the test.

<h3>Confidence Score: 5/5</h3>

test-only addition with no production code changes; all 35 tests pass, typecheck is clean, and the suite correctly isolates shared state (env var and ui runtime options) via beforeEach/afterEach and try/finally.

the change is a pure test file. it touches no auth logic, no storage paths, no token handling, and no windows filesystem code. state isolation is handled correctly: the env var is saved/restored at the top level and the v1 runtime option override is wrapped in try/finally. the only notable gap is the identity-priority test not exercising multi-field conflict, which does not affect production correctness.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/auth-menu-builder.test.ts | new 35-test suite for auth-menu-builder.ts: covers title/version, relative time, identity sanitization on all three fields, search text, row color, status badges, account hints (field order, badge visibility, rate-limit/quota flags, empty output), legacy v1 palette path, and focus key routing — formatDate and currentMarkerLabel gaps from prior review threads are now closed |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[auth-menu-builder.test.ts] --> B[mainMenuTitleWithVersion]
    A --> C[formatRelativeTime]
    A --> D[accountTitle]
    A --> E[accountSearchText]
    A --> F[accountRowColor]
    A --> G[statusBadge]
    A --> H[formatDate]
    A --> I[currentMarkerLabel]
    A --> J[formatAccountHint]
    A --> K[legacy v1 palette]
    A --> L[authMenuFocusKey]
    B --> B1[bare title / v prefix]
    C --> C1[never/today/yesterday/Nd/Nw/locale]
    D --> D1[email > label > id > generic]
    D --> D2[quickSwitchNumber numbering]
    D --> D3[ANSI injection guard all 3 fields]
    E --> E1[lowercased join + row number]
    F --> F1[isCurrentAccount + highlightCurrentRow]
    F --> F2[status tone mapping]
    G --> G1[all 8 statuses + unknown]
    J --> J1[default field order]
    J --> J2[badge visibility toggle]
    J --> J3[statuslineFields ordering]
    J --> J4[rate-limited / quota-exhausted flags]
    J --> J5[empty string when all hidden]
    K --> K1[statusBadge v1 labels]
    K --> K2[formatAccountHint v1 text]
    L --> L1[account actions keyed by sourceIndex]
    L --> L2[static actions keyed by type]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-54-auth-menu-builder-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-54-auth-menu-builder-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fauth-menu-builder.test.ts%3A87-95%0A**identity%20priority%20not%20tested%20under%20conflict**%0A%0Athe%20test%20name%20says%20%22prefers%20email%2C%20then%20label%2C%20then%20id%22%20but%20every%20assertion%20uses%20only%20one%20field%20at%20a%20time.%20if%20the%20%60%7C%7C%60%20chain%20in%20%60accountTitle%60%20were%20accidentally%20reordered%20%28e.g.%20%60accountLabel%60%20before%20%60email%60%29%2C%20all%20four%20assertions%20would%20still%20pass.%20adding%20a%20case%20where%20%60email%60%2C%20%60accountLabel%60%2C%20and%20%60accountId%60%20are%20all%20non-empty%20would%20actually%20exercise%20the%20declared%20priority%20%E2%80%94%20and%20would%20also%20benefit%20%60accountSearchText%60%20implicitly.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=573&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/auth-menu-builder.test.ts:87-95
**identity priority not tested under conflict**

the test name says "prefers email, then label, then id" but every assertion uses only one field at a time. if the `||` chain in `accountTitle` were accidentally reordered (e.g. `accountLabel` before `email`), all four assertions would still pass. adding a case where `email`, `accountLabel`, and `accountId` are all non-empty would actually exercise the declared priority — and would also benefit `accountSearchText` implicitly.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: extend the injection guard and cov..."](https://github.com/ndycode/codex-multi-auth/commit/a9c60c0a93c971af2b3bc32a18250ee56d2107e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36782797)</sub>

<!-- /greptile_comment -->