### PR TITLE
test: property-check write-queue serialization and clamp invariants

### DIFF
--- a/test/property/settings-write-queue.property.test.ts
+++ b/test/property/settings-write-queue.property.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import * as fc from "fast-check";
+import { withQueuedRetry } from "../../lib/codex-manager/settings-write-queue.js";
+
+type TaskBehavior = "ok" | "flaky" | "fatal";
+
+const arbSchedule = fc.array(
+	fc.record({
+		key: fc.integer({ min: 0, max: 2 }),
+		behavior: fc.constantFrom<TaskBehavior>("ok", "flaky", "fatal"),
+	}),
+	{ minLength: 1, maxLength: 12 },
+);
+
+function errnoError(code: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(code), { code });
+}
+
+const immediateSleep = { sleep: async () => {} };
+
+// Unique key namespace per run so the module-level queue map never couples
+// property iterations.
+let runCounter = 0;
+
+describe("withQueuedRetry serialization properties", () => {
+	it("keeps every key's tasks contiguous and in submission order, for any schedule", async () => {
+		await fc.assert(
+			fc.asyncProperty(arbSchedule, async (schedule) => {
+				const run = runCounter++;
+				// Invocation log per key: the task index for every task() call,
+				// including retries.
+				const invocationsByKey = new Map<number, number[]>();
+				const flakyFailed = new Set<number>();
+
+				const pending = schedule.map((spec, taskIndex) =>
+					withQueuedRetry(
+						`/settings/prop-${run}-key-${spec.key}.json`,
+						async () => {
+							const log = invocationsByKey.get(spec.key) ?? [];
+							log.push(taskIndex);
+							invocationsByKey.set(spec.key, log);
+							if (spec.behavior === "fatal") {
+								throw errnoError("ENOSPC");
+							}
+							if (spec.behavior === "flaky" && !flakyFailed.has(taskIndex)) {
+								flakyFailed.add(taskIndex);
+								throw errnoError("EBUSY");
+							}
+							return `result-${taskIndex}`;
+						},
+						immediateSleep,
+					).then(
+						(value) => ({ taskIndex, outcome: "ok" as const, value }),
+						() => ({ taskIndex, outcome: "error" as const }),
+					),
+				);
+				const settled = await Promise.all(pending);
+
+				// Outcomes match behaviors: fatal rejects, ok/flaky resolve with
+				// their own result; a failed predecessor never blocks successors.
+				for (const result of settled) {
+					const spec = schedule[result.taskIndex];
+					if (spec.behavior === "fatal") {
+						expect(result.outcome).toBe("error");
+					} else {
+						expect(result).toMatchObject({
+							outcome: "ok",
+							value: `result-${result.taskIndex}`,
+						});
+					}
+				}
+
+				// Per key: invocations form contiguous groups (retries never
+				// interleave with another task) and groups run in submission order.
+				for (const [, invocations] of invocationsByKey) {
+					const groups: number[] = [];
+					for (const taskIndex of invocations) {
+						if (groups[groups.length - 1] !== taskIndex) {
+							groups.push(taskIndex);
+						}
+					}
+					expect(new Set(groups).size).toBe(groups.length);
+					expect([...groups].sort((a, b) => a - b)).toEqual(groups);
+				}
+
+				// Every task ran at least once, on its own key.
+				const totalInvocations = [...invocationsByKey.values()].flat();
+				for (let taskIndex = 0; taskIndex < schedule.length; taskIndex += 1) {
+					expect(totalInvocations).toContain(taskIndex);
+					expect(
+						invocationsByKey.get(schedule[taskIndex].key) ?? [],
+					).toContain(taskIndex);
+				}
+			}),
+		);
+	});
+
+	it("clamps any 429 retry-after hint into the 10ms..30s range", async () => {
+		await fc.assert(
+			fc.asyncProperty(
+				fc.integer({ min: 1, max: 2_000_000_000 }),
+				async (retryAfterMs) => {
+					const run = runCounter++;
+					const delays: number[] = [];
+					let failed = false;
+
+					await withQueuedRetry(
+						`/settings/prop-${run}-clamp.json`,
+						async () => {
+							if (!failed) {
+								failed = true;
+								throw Object.assign(new Error("throttled"), {
+									status: 429,
+									retryAfterMs,
+								});
+							}
+							return "written";
+						},
+						{
+							sleep: async (ms: number) => {
+								delays.push(ms);
+							},
+						},
+					);
+
+					expect(delays).toEqual([
+						Math.max(10, Math.min(30_000, Math.round(retryAfterMs))),
+					]);
+				},
+			),
+		);
+	});
+});

--- a/test/property/settings-write-queue.property.test.ts
+++ b/test/property/settings-write-queue.property.test.ts
@@ -2,12 +2,23 @@ import { describe, expect, it } from "vitest";
 import * as fc from "fast-check";
 import { withQueuedRetry } from "../../lib/codex-manager/settings-write-queue.js";
 
-type TaskBehavior = "ok" | "flaky" | "fatal";
+type TaskBehavior = "ok" | "flaky" | "fatal" | "exhausted";
+
+const RETRYABLE_CODES = [
+	"EBUSY",
+	"EPERM",
+	"EACCES",
+	"EAGAIN",
+	"ENOTEMPTY",
+] as const;
 
 const arbSchedule = fc.array(
 	fc.record({
 		key: fc.integer({ min: 0, max: 2 }),
-		behavior: fc.constantFrom<TaskBehavior>("ok", "flaky", "fatal"),
+		behavior: fc.constantFrom<TaskBehavior>("ok", "flaky", "fatal", "exhausted"),
+		// The transient code a flaky/exhausted task throws: the whole
+		// retryable set matters on Windows, not just EBUSY.
+		retryableCode: fc.constantFrom(...RETRYABLE_CODES),
 	}),
 	{ minLength: 1, maxLength: 12 },
 );
@@ -42,9 +53,13 @@ describe("withQueuedRetry serialization properties", () => {
 							if (spec.behavior === "fatal") {
 								throw errnoError("ENOSPC");
 							}
+							if (spec.behavior === "exhausted") {
+								// Retryable on every attempt: burns the whole budget.
+								throw errnoError(spec.retryableCode);
+							}
 							if (spec.behavior === "flaky" && !flakyFailed.has(taskIndex)) {
 								flakyFailed.add(taskIndex);
-								throw errnoError("EBUSY");
+								throw errnoError(spec.retryableCode);
 							}
 							return `result-${taskIndex}`;
 						},
@@ -60,13 +75,23 @@ describe("withQueuedRetry serialization properties", () => {
 				// their own result; a failed predecessor never blocks successors.
 				for (const result of settled) {
 					const spec = schedule[result.taskIndex];
-					if (spec.behavior === "fatal") {
+					if (spec.behavior === "fatal" || spec.behavior === "exhausted") {
 						expect(result.outcome).toBe("error");
 					} else {
 						expect(result).toMatchObject({
 							outcome: "ok",
 							value: `result-${result.taskIndex}`,
 						});
+					}
+				}
+
+				// An exhausted task burns exactly the full retry budget.
+				const allInvocations = [...invocationsByKey.values()].flat();
+				for (let taskIndex = 0; taskIndex < schedule.length; taskIndex += 1) {
+					if (schedule[taskIndex].behavior === "exhausted") {
+						expect(
+							allInvocations.filter((id) => id === taskIndex),
+						).toHaveLength(4);
 					}
 				}
 


### PR DESCRIPTION
## Summary

Second property suite of this wave (sibling: #574; complements the example-based #567). The settings write queue is the per-path serialization primitive behind every settings write — its Windows-safety claim is precisely a concurrency invariant, which is the kind of thing the repo's `test/property/` tradition exists to pin across the whole input space rather than at hand-picked points. This adds `test/property/settings-write-queue.property.test.ts` (2 fast-check properties).

## Invariants pinned

- **Serialization under any schedule:** for arbitrary schedules of up to 12 tasks spread over three path keys, with each task independently succeeding, failing once retryably (EBUSY) then succeeding, or failing fatally (ENOSPC):
  - every key's invocations form **contiguous groups in submission order** — a task's retries can never interleave with another task on the same path;
  - fatal tasks reject with their own error and never block successors on the same key;
  - every task runs at least once, on its own key.
  Each property iteration uses a unique key namespace so the module-level queue map never couples runs.
- **Retry-after clamping:** any positive 429 `retryAfterMs` hint (up to 2×10⁹) produces exactly one sleep of `max(10, min(30000, round(hint)))` — used verbatim inside the range, clamped at the 10ms floor and the 30s ceiling outside it.

## Validation

- [x] `vitest run test/property/settings-write-queue.property.test.ts` — 2/2 passing (default fast-check run counts)
- [x] `npm run typecheck` — clean
- [x] `npx eslint test/property/settings-write-queue.property.test.ts --max-warnings=0` — clean

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/property/settings-write-queue.property.test.ts` with two fast-check properties pinning the write-queue's concurrency and rate-limit invariants. both previously-flagged gaps — windows-relevant errno codes and retry-budget exhaustion — are addressed.

- **serialization property**: covers all four task behaviors (`ok`, `flaky`, `fatal`, `exhausted`) and all five windows-relevant errno codes (`EBUSY`, `EPERM`, `EACCES`, `EAGAIN`, `ENOTEMPTY`); checks contiguous per-key grouping, correct outcomes, exhausted-task retry count, and "every task ran at least once on its own key."
- **clamp property**: verifies that any positive 429 `retryAfterMs` hint (1..2×10⁹) produces exactly one sleep of `max(10, min(30000, round(hint)))`; uses a unique key per iteration to avoid coupling runs through the module-level queue map.

<h3>Confidence Score: 5/5</h3>

test-only addition with no changes to production code; safe to merge

the new test file exercises all retryable windows errno codes, all four task behaviors including retry-budget exhaustion, per-key serialization contiguity, and the 429 clamp formula — the two previously flagged gaps are both addressed and the implementation logic is sound

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/property/settings-write-queue.property.test.ts | adds two fast-check properties covering queue serialization (all 4 behaviors incl. exhausted, all 5 windows-relevant errno codes) and 429 clamp; logic is sound, minor nits around a magic retry-count and integer-only rounding coverage |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fc.asyncProperty: arbSchedule] --> B[schedule.map: submit tasks]
    B --> C{spec.behavior}
    C -->|ok| D[return result-taskIndex]
    C -->|flaky| E{flakyFailed?}
    E -->|no| F[throw retryableCode\nadd to flakyFailed]
    E -->|yes| D
    C -->|fatal| G[throw ENOSPC\nnon-retryable]
    C -->|exhausted| H[throw retryableCode\nevery attempt]
    F -->|retry| E
    H -->|retry x4| I[budget exhausted\nthrow lastError]
    G --> J[reject immediately\ndon't block successors]
    D --> K[outcome: ok]
    I --> L[outcome: error]
    J --> L
    K --> M[Assert: contiguous groups\nper key in submission order]
    L --> M
    M --> N[Assert: exhausted tasks\ninvoked exactly SETTINGS_WRITE_MAX_ATTEMPTS times]
    N --> O[Assert: every task ran\nat least once on its own key]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-56-write-queue-property%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-56-write-queue-property%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atest%2Fproperty%2Fsettings-write-queue.property.test.ts%3A3%0Athe%20exhausted-invocation%20count%20is%20hardcoded%20to%20%604%60%2C%20but%20the%20source%20exports%20%60SETTINGS_WRITE_MAX_ATTEMPTS%60.%20if%20that%20constant%20is%20bumped%20%28e.g.%20to%205%29%20the%20assertion%20silently%20checks%20the%20wrong%20number%20and%20could%20pass%20or%20fail%20incorrectly%20depending%20on%20the%20new%20value%20%E2%80%94%20import%20the%20constant%20so%20the%20check%20stays%20in%20sync%20automatically.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20withQueuedRetry%2C%20SETTINGS_WRITE_MAX_ATTEMPTS%20%7D%20from%20%22..%2F..%2Flib%2Fcodex-manager%2Fsettings-write-queue.js%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fproperty%2Fsettings-write-queue.property.test.ts%3A88-96%0A**magic%20retry-count%20decoupled%20from%20source%20constant**%20%E2%80%94%20the%20%604%60%20here%20shadows%20%60SETTINGS_WRITE_MAX_ATTEMPTS%20%3D%204%60%20from%20the%20source%20module.%20if%20that%20constant%20is%20bumped%20to%205%20the%20assertion%20would%20still%20check%204%20and%20silently%20pass%20with%20a%20wrong%20expectation.%20import%20and%20use%20%60SETTINGS_WRITE_MAX_ATTEMPTS%60%20directly%20so%20the%20check%20stays%20tied%20to%20the%20real%20budget.%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fproperty%2Fsettings-write-queue.property.test.ts%3A126%0A**rounding%20branch%20never%20exercised**%20%E2%80%94%20%60fc.integer%60%20always%20produces%20whole%20numbers%2C%20so%20%60Math.round%28retryAfterMs%29%60%20is%20a%20no-op%20on%20every%20iteration%20and%20the%20rounding%20code%20in%20%60resolveRetryDelayMs%60%20is%20never%20actually%20tested.%20switching%20to%20%60fc.float%28%7B%20min%3A%201%2C%20max%3A%202_000_000_000%2C%20noNaN%3A%20true%20%7D%29%60%20would%20exercise%20the%20round-up%2Fround-down%20paths%20at%20the%20clamp%20boundaries%20%28e.g.%20%6029999.6%60%20rounds%20to%20%6030000%60%2C%20%6010.4%60%20rounds%20to%20%6010%60%29.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=575&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
test/property/settings-write-queue.property.test.ts:3
the exhausted-invocation count is hardcoded to `4`, but the source exports `SETTINGS_WRITE_MAX_ATTEMPTS`. if that constant is bumped (e.g. to 5) the assertion silently checks the wrong number and could pass or fail incorrectly depending on the new value — import the constant so the check stays in sync automatically.

```suggestion
import { withQueuedRetry, SETTINGS_WRITE_MAX_ATTEMPTS } from "../../lib/codex-manager/settings-write-queue.js";
```

### Issue 2 of 3
test/property/settings-write-queue.property.test.ts:88-96
**magic retry-count decoupled from source constant** — the `4` here shadows `SETTINGS_WRITE_MAX_ATTEMPTS = 4` from the source module. if that constant is bumped to 5 the assertion would still check 4 and silently pass with a wrong expectation. import and use `SETTINGS_WRITE_MAX_ATTEMPTS` directly so the check stays tied to the real budget.

### Issue 3 of 3
test/property/settings-write-queue.property.test.ts:126
**rounding branch never exercised** — `fc.integer` always produces whole numbers, so `Math.round(retryAfterMs)` is a no-op on every iteration and the rounding code in `resolveRetryDelayMs` is never actually tested. switching to `fc.float({ min: 1, max: 2_000_000_000, noNaN: true })` would exercise the round-up/round-down paths at the clamp boundaries (e.g. `29999.6` rounds to `30000`, `10.4` rounds to `10`).

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: draw transient codes from the full..."](https://github.com/ndycode/codex-multi-auth/commit/3e857665b3bfb3200b1fbaf3ba2318418f7129f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36786162)</sub>

<!-- /greptile_comment -->