### PR TITLE
fix: sync plugin manifest and docs portal to v2.3.0-beta.2

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.3.0-beta.1",
+  "version": "2.3.0-beta.2",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Generated: 2026-04-25
 Commit: a87e005
 Validated: 2026-06-10 against commit 98d9819 (repo audit; claims re-checked against the tree, content not regenerated)
 Branch: main
-Package version: 2.3.0-beta.1
+Package version: 2.3.0-beta.2
 
 ## OVERVIEW
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,8 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.3.0-beta.1.md](releases/v2.3.0-beta.1.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
-| [releases/v2.3.0-beta.0.md](releases/v2.3.0-beta.0.md) | Prior prerelease notes |
+| [releases/v2.3.0-beta.2.md](releases/v2.3.0-beta.2.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
+| [releases/v2.3.0-beta.1.md](releases/v2.3.0-beta.1.md) | Prior prerelease notes |
 | [releases/v2.2.2.md](releases/v2.2.2.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
 | [releases/v2.2.1.md](releases/v2.2.1.md) | Prior stable release notes |
 | [releases/v2.2.0.md](releases/v2.2.0.md) | Prior stable release notes |

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -205,6 +205,13 @@ describe("Documentation Integrity", () => {
 		expect(beta).toContain("superseded by [v0.1.0]");
 	});
 
+	it("keeps the AGENTS.md package-version claim in sync with package.json", () => {
+		// This header drifted on two version bumps (2.2.0 in the audit's M6,
+		// then 2.3.0-beta.1 after the beta.2 bump); pin it to the manifest.
+		const agents = read("AGENTS.md");
+		expect(agents).toContain(`Package version: ${packageVersion}`);
+	});
+
 	it("uses codex-multi-auth as canonical package name", () => {
 		const canonicalPackageDocs = [
 			"README.md",


### PR DESCRIPTION
## Summary

**Fixes two test failures currently live on `main`, plus a third stale version reference the suite didn't guard.** A full-suite canary run against clean `main` came back at 60 failures instead of the documented 58-failure environment baseline; the byte-level diff against `docs/audits/evidence/test-baseline-2026-06-10.txt` isolated two genuinely new, non-environmental failures, both fallout from the `2.3.0-beta.2` version bump:

- `test/plugin-manifest.test.ts` — `.codex-plugin/plugin.json` still declared `2.3.0-beta.1` while `package.json` says `2.3.0-beta.2`.
- `test/documentation.test.ts` — `docs/README.md`'s release-history table still listed `v2.3.0-beta.1` as the current prerelease, so the `releases/v${packageVersion}.md` link assertion failed. (The root README and `docs/releases/v2.3.0-beta.2.md` were already updated.)

A follow-up sweep for other stale `2.3.0-beta.1` references found one more: the root `AGENTS.md` "Package version" header — the **second** time that header has drifted on a version bump (the audit's M6 caught it at 2.2.0), because nothing guards it.

## Changes

- `.codex-plugin/plugin.json`: version → `2.3.0-beta.2`.
- `docs/README.md`: prerelease rows shifted — `v2.3.0-beta.2` becomes the current prerelease, `v2.3.0-beta.1` becomes the prior, preserving the table's established one-prior-beta window.
- `AGENTS.md`: "Package version" header → `2.3.0-beta.2`.
- `test/documentation.test.ts`: new assertion pinning the `AGENTS.md` version header to `package.json`, so the third bump cannot drift silently.

## Validation

- [x] `vitest run test/documentation.test.ts test/plugin-manifest.test.ts` — 28/28 passing (both previously failing tests now green, new guard included)
- [x] With this fix the failure set on `main` returns exactly to the 58 environment-only baseline names.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

syncs three version-string locations — `.codex-plugin/plugin.json`, `AGENTS.md`, and `docs/README.md` — to `2.3.0-beta.2` after a prior bump left them stale against `package.json`, fixing two failing tests. a new vitest guard in `test/documentation.test.ts` pins `AGENTS.md`'s version header to `package.json` so the drift can't silently recur.

- **`.codex-plugin/plugin.json` + `AGENTS.md`**: mechanical version-string updates from `2.3.0-beta.1` → `2.3.0-beta.2`, no logic change.
- **`docs/README.md`**: release-history table rolled forward — `beta.2` becomes current prerelease, `beta.1` becomes prior, honoring the one-prior-beta window policy; `beta.0` is retired from the table.
- **`test/documentation.test.ts`**: new `it` block reads `AGENTS.md` and asserts `Package version: ${packageVersion}` is present, using the `packageVersion` already populated by `beforeAll`.

<h3>Confidence Score: 5/5</h3>

all four changed files are version-string updates or a new regression-guard test — no logic, auth, or filesystem paths touched.

changes are purely mechanical: three files update a single version string from beta.1 to beta.2, and the test file adds one assertion that reads a static file and compares a string. no runtime paths, token handling, concurrency, or windows filesystem code is touched. the new test correctly relies on the pre-existing beforeAll hook for packageVersion and adds meaningful coverage against future drift.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .codex-plugin/plugin.json | version bumped from 2.3.0-beta.1 to 2.3.0-beta.2 to match package.json; single-field mechanical change. |
| AGENTS.md | package-version header updated to 2.3.0-beta.2; minimal header-only change with no logic impact. |
| docs/README.md | release-history table shifted: beta.2 becomes current prerelease row, beta.1 becomes the prior-beta row; beta.0 dropped per the one-prior-beta window policy. |
| test/documentation.test.ts | adds regression guard that asserts AGENTS.md package-version header matches package.json; uses already-populated packageVersion from beforeAll so the assertion is live. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PJ[package.json\nversion: 2.3.0-beta.2]
    PJ -->|read by beforeAll| TV[packageVersion variable]
    TV -->|assertion| AT[test: AGENTS.md header sync]
    TV -->|assertion| PM[test: plugin-manifest version]
    TV -->|assertion| DR[test: docs/README.md release link]

    PJ -.->|must match| CPJ[.codex-plugin/plugin.json\nversion: 2.3.0-beta.2 ✓]
    PJ -.->|must match| AM[AGENTS.md\nPackage version: 2.3.0-beta.2 ✓]
    PJ -.->|link must exist| RM[docs/README.md\nreleases/v2.3.0-beta.2.md ✓]
```

<sub>Reviews (2): Last reviewed commit: ["fix: sync the AGENTS.md version claim an..."](https://github.com/ndycode/codex-multi-auth/commit/9e7f87e97e938dda30c1caeee2169b177cccbf78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36789582)</sub>

<!-- /greptile_comment -->