### PR TITLE
fix: deduplicateAccounts fixpoint loop and identity property tests

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1052,8 +1052,8 @@ export function resolveAccountSelectionIndex<
 	return clampIndex(fallbackIndex, accounts.length);
 }
 
-function deduplicateAccountsByIdentity<T extends AccountLike>(
-	accounts: T[],
+function deduplicateAccountsByIdentityPass<T extends AccountLike>(
+	accounts: readonly T[],
 ): T[] {
 	const deduplicated: T[] = [];
 	for (const account of accounts) {
@@ -1069,6 +1069,23 @@ function deduplicateAccountsByIdentity<T extends AccountLike>(
 		);
 	}
 	return deduplicated;
+}
+
+function deduplicateAccountsByIdentity<T extends AccountLike>(
+	accounts: T[],
+): T[] {
+	// A single pass is not a fixpoint: a newest-wins merge can replace a kept
+	// entry with an account that itself duplicates an earlier survivor through
+	// a different matching tier (e.g. an email-tier merge installs an account
+	// whose accountId + refresh token already match a record that carried no
+	// email). Re-run until stable; every merge strictly shrinks the array, so
+	// this terminates after at most accounts.length passes.
+	let current = deduplicateAccountsByIdentityPass(accounts);
+	for (;;) {
+		const next = deduplicateAccountsByIdentityPass(current);
+		if (next.length === current.length) return next;
+		current = next;
+	}
 }
 
 /**

--- a/test/property/account-identity.property.test.ts
+++ b/test/property/account-identity.property.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import * as fc from "fast-check";
+import {
+	deduplicateAccounts,
+	findMatchingAccountIndex,
+	normalizeEmailKey,
+} from "../../lib/storage.js";
+
+// Small identity alphabets so generated pools actually collide on facets;
+// the matcher's interesting behavior (ambiguity vetoes, newest-wins, tier
+// precedence) only shows up when identities overlap.
+const ACCOUNT_IDS = ["acc-1", "acc-2", "acc-3"];
+const EMAIL_NAMES = ["alice", "bob", "carol"];
+const REFRESH_TOKENS = ["rt-1", "rt-2", "rt-3"];
+
+type TestAccount = {
+	accountId?: string;
+	email?: string;
+	refreshToken?: string;
+	lastUsed?: number;
+	addedAt?: number;
+};
+
+// A spelled variant of an email that must normalize back to the same key:
+// arbitrary casing plus surrounding whitespace.
+const arbSpelledEmail = fc
+	.tuple(
+		fc.constantFrom(...EMAIL_NAMES),
+		fc.boolean(),
+		fc.constantFrom("", " ", "\t", "  "),
+		fc.constantFrom("", " ", "\t"),
+	)
+	.map(([name, upper, pad, trail]) => {
+		const address = `${name}@example.com`;
+		return `${pad}${upper ? address.toUpperCase() : address}${trail}`;
+	});
+
+const arbAccount: fc.Arbitrary<TestAccount> = fc.record(
+	{
+		accountId: fc.option(fc.constantFrom(...ACCOUNT_IDS), { nil: undefined }),
+		email: fc.option(arbSpelledEmail, { nil: undefined }),
+		refreshToken: fc.option(fc.constantFrom(...REFRESH_TOKENS), {
+			nil: undefined,
+		}),
+		addedAt: fc.nat(1_000_000),
+	},
+	{ requiredKeys: [] },
+);
+
+// Pools get strictly distinct lastUsed values so "newest wins" has a unique
+// answer; ties would otherwise be broken by array position, which is exactly
+// the order-dependence the permutation property must not trip over. Each
+// account also carries a random sort key so pools can be re-shuffled into a
+// wide range of permutations.
+const arbPoolWithPermutation = fc
+	.array(fc.tuple(arbAccount, fc.nat(1_000_000)), {
+		minLength: 1,
+		maxLength: 8,
+	})
+	.map((entries) => {
+		const pool = entries.map(([account, permKey], index) => ({
+			account: { ...account, lastUsed: (index + 1) * 1_000 },
+			permKey,
+		}));
+		const permuted = [...pool]
+			.sort((a, b) => a.permKey - b.permKey)
+			.map((entry) => entry.account);
+		return { pool: pool.map((entry) => entry.account), permuted };
+	});
+
+const arbCandidate: fc.Arbitrary<TestAccount> = arbAccount;
+
+describe("normalizeEmailKey properties", () => {
+	it("is idempotent and insensitive to casing and surrounding whitespace", () => {
+		fc.assert(
+			fc.property(arbSpelledEmail, (spelled) => {
+				const key = normalizeEmailKey(spelled);
+				expect(key).toBe(spelled.trim().toLowerCase());
+				expect(normalizeEmailKey(key)).toBe(key);
+				expect(normalizeEmailKey(spelled.toUpperCase())).toBe(key);
+				expect(normalizeEmailKey(` ${spelled} `)).toBe(key);
+			}),
+		);
+	});
+
+	it("returns undefined for missing or blank input", () => {
+		fc.assert(
+			fc.property(fc.constantFrom("", " ", "\t", "  \t "), (blank) => {
+				expect(normalizeEmailKey(blank)).toBeUndefined();
+			}),
+		);
+		expect(normalizeEmailKey(undefined)).toBeUndefined();
+	});
+});
+
+describe("findMatchingAccountIndex properties", () => {
+	it("matches the same account regardless of pool order", () => {
+		fc.assert(
+			fc.property(arbPoolWithPermutation, arbCandidate, ({ pool, permuted }, candidate) => {
+				const originalIndex = findMatchingAccountIndex(pool, candidate);
+				const permutedIndex = findMatchingAccountIndex(permuted, candidate);
+				if (originalIndex === undefined) {
+					expect(permutedIndex).toBeUndefined();
+					return;
+				}
+				expect(permutedIndex).not.toBeUndefined();
+				// Same account object, not just same identity: with distinct
+				// lastUsed values the newest-wins rule has a unique answer.
+				expect(permuted[permutedIndex as number]).toBe(pool[originalIndex]);
+			}),
+		);
+	});
+
+	it("is insensitive to candidate email spelling", () => {
+		fc.assert(
+			fc.property(
+				arbPoolWithPermutation,
+				arbCandidate,
+				fc.boolean(),
+				({ pool }, candidate, upper) => {
+					fc.pre(candidate.email !== undefined);
+					const respelled = {
+						...candidate,
+						email: upper
+							? `  ${(candidate.email as string).toUpperCase()}`
+							: `${(candidate.email as string).toLowerCase()} `,
+					};
+					expect(findMatchingAccountIndex(pool, respelled)).toBe(
+						findMatchingAccountIndex(pool, candidate),
+					);
+				},
+			),
+		);
+	});
+
+	it("only ever matches an account sharing an identity facet with the candidate", () => {
+		fc.assert(
+			fc.property(arbPoolWithPermutation, arbCandidate, ({ pool }, candidate) => {
+				const index = findMatchingAccountIndex(pool, candidate);
+				if (index === undefined) return;
+				const matched = pool[index] as TestAccount;
+				const sharesAccountId =
+					candidate.accountId !== undefined &&
+					matched.accountId === candidate.accountId;
+				const sharesEmail =
+					normalizeEmailKey(candidate.email) !== undefined &&
+					normalizeEmailKey(matched.email) === normalizeEmailKey(candidate.email);
+				const sharesRefreshToken =
+					candidate.refreshToken !== undefined &&
+					matched.refreshToken === candidate.refreshToken;
+				expect(sharesAccountId || sharesEmail || sharesRefreshToken).toBe(true);
+			}),
+		);
+	});
+
+	it("never matches a candidate whose facets are all foreign to the pool", () => {
+		fc.assert(
+			fc.property(arbPoolWithPermutation, ({ pool }) => {
+				const foreign = {
+					accountId: "acc-foreign",
+					email: "nobody@elsewhere.test",
+					refreshToken: "rt-foreign",
+				};
+				expect(findMatchingAccountIndex(pool, foreign)).toBeUndefined();
+			}),
+		);
+	});
+
+	it("refuses email-only matches when the email maps to multiple account ids", () => {
+		fc.assert(
+			fc.property(
+				arbPoolWithPermutation,
+				arbSpelledEmail,
+				fc.boolean(),
+				({ pool }, email, upper) => {
+					const ambiguous: TestAccount[] = [
+						...pool,
+						{ accountId: "acc-1", email, lastUsed: 999_001 },
+						{
+							accountId: "acc-2",
+							email: upper ? email.toUpperCase() : email.toLowerCase(),
+							lastUsed: 999_002,
+						},
+					];
+					expect(
+						findMatchingAccountIndex(ambiguous, { email }),
+					).toBeUndefined();
+				},
+			),
+		);
+	});
+});
+
+describe("deduplicateAccounts properties", () => {
+	// Deterministic replay of the counterexample this suite originally found:
+	// the email tier merges the last record into the carol entry, leaving the
+	// emailless acc-1/rt-1 record as a separate survivor that a second pass
+	// would merge. The fixpoint loop in deduplicateAccountsByIdentity now
+	// converges before returning.
+	it("merges duplicates that only become adjacent after a newest-wins replacement", () => {
+		const emaillessOriginal = {
+			accountId: "acc-1",
+			refreshToken: "rt-1",
+			lastUsed: 1_000,
+		};
+		const carolWithoutId = {
+			email: "carol@example.com",
+			refreshToken: "rt-2",
+			lastUsed: 3_000,
+		};
+		const relogin = {
+			accountId: "acc-1",
+			email: "carol@example.com",
+			refreshToken: "rt-1",
+			lastUsed: 7_000,
+		};
+		const deduplicated = deduplicateAccounts([
+			emaillessOriginal,
+			carolWithoutId,
+			relogin,
+		]);
+		expect(deduplicated).toStrictEqual([relogin]);
+	});
+
+	it("returns a subset of the input accounts and is idempotent", () => {
+		fc.assert(
+			fc.property(arbPoolWithPermutation, ({ pool }) => {
+				const deduplicated = deduplicateAccounts([...pool]);
+				expect(deduplicated.length).toBeLessThanOrEqual(pool.length);
+				for (const account of deduplicated) {
+					// Object identity: dedup picks survivors, it never synthesizes.
+					expect(pool).toContain(account);
+				}
+				expect(deduplicateAccounts([...deduplicated])).toStrictEqual(
+					deduplicated,
+				);
+			}),
+		);
+	});
+});

--- a/test/property/account-identity.property.test.ts
+++ b/test/property/account-identity.property.test.ts
@@ -222,6 +222,35 @@ describe("deduplicateAccounts properties", () => {
 		expect(deduplicated).toStrictEqual([relogin]);
 	});
 
+	// Longer chain needing three shrinking passes, one per matching tier: the
+	// super record first absorbs the email-only record (email tier), the
+	// replacement then matches the refresh-only record (refresh tier), and
+	// that replacement finally matches the emailless accountId record
+	// (unique-id tier). Pins that the fixpoint loop is a real loop, not a
+	// hardcoded second pass.
+	it("converges across chains that need more than two passes", () => {
+		const idOnly = {
+			accountId: "acc-1",
+			refreshToken: "rt-9",
+			lastUsed: 1_000,
+		};
+		const refreshOnly = { refreshToken: "rt-1", lastUsed: 2_000 };
+		const emailOnly = { email: "carol@example.com", lastUsed: 3_000 };
+		const superRecord = {
+			accountId: "acc-1",
+			email: "carol@example.com",
+			refreshToken: "rt-1",
+			lastUsed: 4_000,
+		};
+		const deduplicated = deduplicateAccounts([
+			idOnly,
+			refreshOnly,
+			emailOnly,
+			superRecord,
+		]);
+		expect(deduplicated).toStrictEqual([superRecord]);
+	});
+
 	it("returns a subset of the input accounts and is idempotent", () => {
 		fc.assert(
 			fc.property(arbPoolWithPermutation, ({ pool }) => {


### PR DESCRIPTION
## Summary

- A new fast-check property suite for the account identity-matching layer found a real bug on its 11th generated pool: `deduplicateAccounts` was **not idempotent** — one pass could return a list still containing two records for the same account. This PR fixes the implementation and lands the suite that caught it.

## What Changed

**The bug** (`lib/storage.ts`): `deduplicateAccountsByIdentity` made a single pass, and a newest-wins merge in one matching tier can install an account that duplicates an *earlier* survivor through a *different* tier. Minimal reproduction (now a deterministic test):

1. `{accountId: acc-1, refreshToken: rt-1}` (no email) is kept.
2. `{email: carol@example.com, refreshToken: rt-2}` (no accountId) is kept.
3. `{accountId: acc-1, email: carol@example.com, refreshToken: rt-1}` arrives — the email tier matches record 2 first and replaces that slot.

The result keeps both record 1 and record 3, which are the same account by accountId + refresh token; a second pass would have merged them. **The fix**: re-run the dedup pass until the length stabilizes. Every merge strictly shrinks the array, so the loop terminates after at most `accounts.length` passes; the kept entry is still the most-recently-used one, exactly as the function's contract documents.

**The suite** (`test/property/account-identity.property.test.ts`, 9 tests):
- `normalizeEmailKey`: idempotence, case/whitespace insensitivity, undefined on blank input
- `findMatchingAccountIndex`: the matched account is invariant under pool permutation (pools generated with strictly distinct `lastUsed` so newest-wins has a unique answer); candidate email respelling never changes the result; any match shares at least one identity facet with the candidate; candidates with all-foreign facets never match; email-only candidates are vetoed when the email maps to multiple accountIds
- `deduplicateAccounts`: output is a subset of input (object identity — dedup never synthesizes), idempotence, and a deterministic replay of the discovered counterexample

## Validation

- [x] `npm run typecheck`
- [x] `npx eslint lib/storage.ts test/property/account-identity.property.test.ts --max-warnings=0`
- [x] `npm test -- test/property/account-identity.property.test.ts` — 9/9
- [x] Targeted suites for every consumer of the matching/dedup path (`storage`, `storage-async`, `import-export`, `account-pool`, `account-port`, `rotation-integration`, `refresh-guardian`, `runtime-auth-facade`, `codex-manager-login-workspace-512`): only the 23 known environment failures in `storage.test.ts`, name-diffed exactly against `docs/audits/evidence/test-baseline-2026-06-10.txt`
- [x] Full-suite canary: 60 failures = the 58-name environment baseline + the 2 beta.2 version-drift names that #577 fixes on `main` (this branch is based on `main` without it); zero failures attributable to this change

## Docs and Governance Checklist

- [x] No user-visible command/setting/path surface changed; behavior change is strictly "dedup now actually removes all duplicates", matching the existing doc comment ("Removes duplicate accounts, keeping the most recently used entry")

## Risk and Rollback

- Risk level: low-moderate — `deduplicateAccounts` runs on the storage load path, so the fix can merge account records that previously (incorrectly) survived as duplicates. The kept record is always the most-recently-used of the merged set, which is the documented contract; pools without the multi-tier corner are byte-identical to before (the first pass is unchanged, and a length-stable pass is a pure copy).
- Rollback plan: revert the commit; the property suite's idempotence assertion and the deterministic replay will fail again, flagging the regression.

## Additional Notes

- Companion to the property suites in #574/#575; same conventions (plain `fc.assert`, explicit vitest imports, small identity alphabets so generated pools actually collide on facets).

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes `deduplicateAccountsByIdentity` so it re-runs until the output length stabilises, addressing a real idempotence failure where a newest-wins email-tier merge could leave an earlier survivor still matching a second record through a different tier. the property suite that caught the bug is also landed, including a new deterministic 3-shrinking-pass test that pins the full convergence chain.

- **`lib/storage.ts`**: split the inner loop into `deduplicateAccountsByIdentityPass` (`readonly T[]`), wrapped by a new `deduplicateAccountsByIdentity` that loops until `next.length === current.length`; the length check is a sound fixpoint condition because every merge reduces the count by exactly one, so length-stable ↔ zero merges ↔ content-stable.
- **`test/property/account-identity.property.test.ts`**: 9 fast-check/deterministic tests for `normalizeEmailKey`, `findMatchingAccountIndex`, and `deduplicateAccounts`, including explicit replay of the discovered counterexample and a new 3-pass convergence pin.

<h3>Confidence Score: 5/5</h3>

the change is safe to merge; the fixpoint loop is a pure in-memory operation on small arrays, the termination argument is airtight, and pools without the multi-tier corner case are byte-identical to the previous output.

the fix is narrowly scoped to `deduplicateAccountsByIdentity` and does not touch storage I/O, token handling, or any concurrent path. the length-stable fixpoint condition is provably correct, the property suite fully exercises the affected code paths, and the deterministic regression pins the exact counterexample.

no files require special attention; both changed files are clean.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage.ts | renamed single-pass helper to `deduplicateAccountsByIdentityPass` (now takes `readonly T[]`), then wrapped it in a new `deduplicateAccountsByIdentity` that loops to the length-stable fixpoint — termination is sound because every merge strictly shrinks the array by exactly one entry |
| test/property/account-identity.property.test.ts | new fast-check property suite (9 tests) covering normalizeEmailKey idempotence/blank handling, findMatchingAccountIndex pool-permutation invariance/email-respelling/facet-sharing/foreign-facet/ambiguity-veto, and deduplicateAccounts subset-of-input, idempotence, 2-shrinking-pass regression, and a new 3-shrinking-pass deterministic pin |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["deduplicateAccounts(accounts: T[])"] --> B["deduplicateAccountsByIdentity(accounts)"]
    B --> C["current = deduplicateAccountsByIdentityPass(accounts)"]
    C --> D{"next = deduplicateAccountsByIdentityPass(current)\nnext.length === current.length?"}
    D -- "yes (fixpoint reached)" --> E["return next"]
    D -- "no (merged ≥1 account)" --> F["current = next"]
    F --> D
    G["deduplicateAccountsByIdentityPass(accounts: readonly T[])"] --> H["for each account"]
    H --> I{"findMatchingAccountIndex\nin deduplicated?"}
    I -- "no" --> J["push account"]
    I -- "yes" --> K["deduplicated[i] = selectNewestAccount(existing, account)"]
    J --> H
    K --> H
```

<sub>Reviews (2): Last reviewed commit: ["test: pin three-pass dedup convergence c..."](https://github.com/ndycode/codex-multi-auth/commit/49499e38e8014e3041cfecdc6be8f9bef5f68a5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36797328)</sub>

<!-- /greptile_comment -->