### PR TITLE
test: direct suite for the extracted account rate-limit helpers

### DIFF
--- a/test/account-rate-limits.test.ts
+++ b/test/account-rate-limits.test.ts
@@ -61,6 +61,9 @@ describe("account rate-limit helpers", () => {
 			["undefined", undefined, 7, 7],
 			["NaN", Number.NaN, 7, 7],
 			["Infinity", Number.POSITIVE_INFINITY, 7, 7],
+			// Non-finite short-circuits to the fallback before the negative
+			// clamp, so -Infinity yields the fallback rather than 0.
+			["-Infinity", Number.NEGATIVE_INFINITY, 7, 7],
 			["negative", -3, 7, 0],
 			["fractional", 3.9, 7, 3],
 			["zero", 0, 7, 0],
@@ -103,6 +106,19 @@ describe("account rate-limit helpers", () => {
 	});
 
 	describe("isRateLimitedForFamily", () => {
+		it("treats a null model the same as no model (family key only)", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(NOW);
+			const entity = entityWith({ "gpt-5.2": NOW + 60_000 });
+			expect(isRateLimitedForFamily(entity, "gpt-5.2", null)).toBe(true);
+			const modelScopedOnly = entityWith({
+				"gpt-5.2:gpt-5.2-codex": NOW + 60_000,
+			});
+			expect(isRateLimitedForFamily(modelScopedOnly, "gpt-5.2", null)).toBe(
+				false,
+			);
+		});
+
 		it("honors a model-scoped limit even when the family is clear", () => {
 			vi.useFakeTimers();
 			vi.setSystemTime(NOW);

--- a/test/account-rate-limits.test.ts
+++ b/test/account-rate-limits.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	clampNonNegativeInt,
+	clearExpiredRateLimits,
+	formatWaitTime,
+	getQuotaKey,
+	isRateLimitedForFamily,
+	isRateLimitedForQuotaKey,
+	parseRateLimitReason,
+	type RateLimitedEntity,
+} from "../lib/accounts/rate-limits.js";
+
+const NOW = 1_750_000_000_000;
+
+function entityWith(resetTimes: Record<string, number | undefined>): RateLimitedEntity {
+	return { rateLimitResetTimes: { ...resetTimes } };
+}
+
+describe("account rate-limit helpers", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("parseRateLimitReason", () => {
+		it.each([
+			[undefined, "unknown"],
+			["", "unknown"],
+			["insufficient_quota", "quota"],
+			["usage_limit_reached", "quota"],
+			["QUOTA_EXCEEDED", "quota"],
+			["tokens_exhausted", "tokens"],
+			["tpm_limit_exceeded", "tokens"],
+			["rpm_limit_exceeded", "tokens"],
+			["concurrent_request_limit", "concurrent"],
+			["parallel_requests", "concurrent"],
+			// No quota/token/concurrent keyword: generic 429 codes stay unknown.
+			["rate_limit_exceeded", "unknown"],
+			["slow_down", "unknown"],
+		] as const)("maps %j to %j", (code, expected) => {
+			expect(parseRateLimitReason(code)).toBe(expected);
+		});
+	});
+
+	describe("getQuotaKey", () => {
+		it("returns the bare family when no model is given", () => {
+			expect(getQuotaKey("gpt-5.2")).toBe("gpt-5.2");
+			expect(getQuotaKey("gpt-5.2", null)).toBe("gpt-5.2");
+			expect(getQuotaKey("gpt-5.2", undefined)).toBe("gpt-5.2");
+		});
+
+		it("scopes the key to the model when one is given", () => {
+			expect(getQuotaKey("gpt-5.2", "gpt-5.2-codex")).toBe(
+				"gpt-5.2:gpt-5.2-codex",
+			);
+		});
+	});
+
+	describe("clampNonNegativeInt", () => {
+		it.each([
+			["non-number string", "12", 7, 7],
+			["undefined", undefined, 7, 7],
+			["NaN", Number.NaN, 7, 7],
+			["Infinity", Number.POSITIVE_INFINITY, 7, 7],
+			["negative", -3, 7, 0],
+			["fractional", 3.9, 7, 3],
+			["zero", 0, 7, 0],
+			["plain integer", 42, 7, 42],
+		])("%s -> clamped", (_label, value, fallback, expected) => {
+			expect(clampNonNegativeInt(value, fallback)).toBe(expected);
+		});
+	});
+
+	describe("clearExpiredRateLimits", () => {
+		it("removes entries at or past their reset time and keeps future ones", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(NOW);
+			const entity = entityWith({
+				expired: NOW - 1,
+				boundary: NOW,
+				future: NOW + 60_000,
+				dangling: undefined,
+			});
+			clearExpiredRateLimits(entity);
+			expect(entity.rateLimitResetTimes).toStrictEqual({
+				future: NOW + 60_000,
+				dangling: undefined,
+			});
+		});
+	});
+
+	describe("isRateLimitedForQuotaKey", () => {
+		it("is limited only while the reset time lies in the future", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(NOW);
+			const entity = entityWith({
+				"gpt-5.2": NOW + 1,
+				"gpt-5.3": NOW,
+			});
+			expect(isRateLimitedForQuotaKey(entity, "gpt-5.2")).toBe(true);
+			expect(isRateLimitedForQuotaKey(entity, "gpt-5.3")).toBe(false);
+			expect(isRateLimitedForQuotaKey(entity, "gpt-5.1")).toBe(false);
+		});
+	});
+
+	describe("isRateLimitedForFamily", () => {
+		it("honors a model-scoped limit even when the family is clear", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(NOW);
+			const entity = entityWith({ "gpt-5.2:gpt-5.2-codex": NOW + 60_000 });
+			expect(isRateLimitedForFamily(entity, "gpt-5.2", "gpt-5.2-codex")).toBe(
+				true,
+			);
+			expect(isRateLimitedForFamily(entity, "gpt-5.2")).toBe(false);
+			expect(isRateLimitedForFamily(entity, "gpt-5.2", "other-model")).toBe(
+				false,
+			);
+		});
+
+		it("applies a family-wide limit to every model in the family", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(NOW);
+			const entity = entityWith({ "gpt-5.2": NOW + 60_000 });
+			expect(isRateLimitedForFamily(entity, "gpt-5.2")).toBe(true);
+			expect(isRateLimitedForFamily(entity, "gpt-5.2", "gpt-5.2-codex")).toBe(
+				true,
+			);
+		});
+
+		it("prunes expired entries as a side effect before answering", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(NOW);
+			const entity = entityWith({
+				"gpt-5.2": NOW - 1,
+				"gpt-5.3": NOW + 60_000,
+			});
+			expect(isRateLimitedForFamily(entity, "gpt-5.2")).toBe(false);
+			expect(entity.rateLimitResetTimes).toStrictEqual({
+				"gpt-5.3": NOW + 60_000,
+			});
+		});
+	});
+
+	describe("formatWaitTime", () => {
+		it.each([
+			[0, "0s"],
+			[-5_000, "0s"],
+			[999, "0s"],
+			[1_000, "1s"],
+			[59_999, "59s"],
+			[60_000, "1m 0s"],
+			[90_500, "1m 30s"],
+			// No hours unit: long waits stay in minutes.
+			[3_725_000, "62m 5s"],
+		])("formats %dms as %j", (ms, expected) => {
+			expect(formatWaitTime(ms)).toBe(expected);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `test/account-rate-limits.test.ts` (35 cases) for `lib/accounts/rate-limits.ts`, which was previously reachable only through the `accounts.ts` facade — the same extracted-module gap the #559–#575 wave closed elsewhere.

## What Changed

One new mock-free test file pinning the module's contracts directly:

- **`parseRateLimitReason`** keyword taxonomy: quota (`quota`/`usage_limit`), tokens (`token`/`tpm`/`rpm`), concurrent (`concurrent`/`parallel`), case-insensitivity, and the deliberate `unknown` bucket for generic 429 codes like `rate_limit_exceeded` that carry none of the keywords.
- **`getQuotaKey`**: bare family key vs `family:model` scoping (null/undefined model falls back to the family key).
- **`clampNonNegativeInt`**: fallback on non-numbers/NaN/Infinity, clamp-to-zero on negatives, floor on fractionals.
- **`clearExpiredRateLimits`** boundary semantics: `now >= reset` deletes (an entry expiring exactly now is cleared), future entries and dangling `undefined` values survive.
- **`isRateLimitedForQuotaKey`** strict-future check (a reset time of exactly now is not limited).
- **`isRateLimitedForFamily`**: a model-scoped limit blocks only that model, a family-wide limit blocks every model in the family, and expired entries are pruned from the entity as a side effect before answering.
- **`formatWaitTime`**: sub-second floors to `0s`, negative clamps to `0s`, the `1m 0s` boundary, and minutes-only formatting for long waits (no hours unit).

Time-dependent cases use `vi.useFakeTimers()` + `vi.setSystemTime` with real timers restored in `afterEach` (`nowMs()` is a direct `Date.now()` wrapper).

## Validation

- [x] `npm run typecheck` (also runs in the pre-commit hook)
- [x] `npx eslint test/account-rate-limits.test.ts --max-warnings=0`
- [x] `npm test -- test/account-rate-limits.test.ts` — 35/35

## Docs and Governance Checklist

- [x] Test-only; no user-visible behavior, commands, settings, or paths changed

## Risk and Rollback

- Risk level: minimal — one new test file, no source changes.
- Rollback plan: delete the test file.

## Additional Notes

- Independent of every other open branch; based on `main`.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/account-rate-limits.test.ts`, a 35-case mock-free suite that pins the full public contract of `lib/accounts/rate-limits.ts` directly rather than through the `accounts.ts` facade. both gaps flagged in the previous review round (`Number.NEGATIVE_INFINITY` in `clampNonNegativeInt` and the `null` model path in `isRateLimitedForFamily`) are addressed in this revision.

- **`parseRateLimitReason`**: covers all four buckets (quota, tokens, concurrent, unknown) plus case-insensitivity and the deliberate unknown bucket for generic 429 codes.
- **`clearExpiredRateLimits` / `isRateLimitedForQuotaKey` / `isRateLimitedForFamily`**: fake-timer isolation via a top-level `afterEach(() => vi.useRealTimers())` is correct; boundary semantics (reset-exactly-now is not limited, pruning as a side effect) are all asserted.
- **`formatWaitTime`**: sub-second floor, negative clamp, minute boundary, and large-minute (no hours) formatting are all verified.

<h3>Confidence Score: 5/5</h3>

test-only change with no source modifications — safe to merge.

single new test file, no production code touched. fake-timer setup and teardown are correct, all behavioral contracts for the module are pinned, and the two gaps from the previous review round are resolved. no token handling, no filesystem operations, no concurrency surface introduced.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/account-rate-limits.test.ts | new direct test suite (35 cases) for lib/accounts/rate-limits.ts — all behavioral contracts verified, fake-timer usage correct, previous review gaps (-Infinity and null model) addressed |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["isRateLimitedForFamily(entity, family, model?)"] --> B["clearExpiredRateLimits(entity)\nnow >= reset → delete key"]
    B --> C{model truthy?}
    C -- yes --> D["getQuotaKey(family, model)\n→ family:model"]
    D --> E["isRateLimitedForQuotaKey\nnow < reset?"]
    E -- true --> F["return true"]
    E -- false --> G["getQuotaKey(family)\n→ family"]
    C -- no/null --> G
    G --> H["isRateLimitedForQuotaKey\nnow < reset?"]
    H -- true --> I["return true"]
    H -- false --> J["return false"]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-61-rate-limits-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-61-rate-limits-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Faccount-rate-limits.test.ts%3A56-68%0A**%60clampNonNegativeInt%60%20%E2%80%94%20%60null%60%20input%20not%20covered**%0A%0A%60value%3A%20unknown%60%20means%20%60null%60%20is%20a%20valid%20caller%20input%3A%20%60typeof%20null%20!%3D%3D%20%22number%22%60%20short-circuits%20to%20the%20fallback%2C%20the%20same%20as%20%60undefined%60.%20it's%20a%20separate%20falsy%20type%20though%2C%20and%20the%20existing%20row%20labelled%20%60%22undefined%22%60%20doesn't%20pin%20this%20branch.%20adding%20%60%5B%22null%22%2C%20null%2C%207%2C%207%5D%60%20would%20explicitly%20document%20that%20%60null%60%20is%20treated%20identically%20to%20%60undefined%60%20and%20guard%20against%20a%20future%20tightening%20of%20the%20type%20guard.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=580&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/account-rate-limits.test.ts:56-68
**`clampNonNegativeInt` — `null` input not covered**

`value: unknown` means `null` is a valid caller input: `typeof null !== "number"` short-circuits to the fallback, the same as `undefined`. it's a separate falsy type though, and the existing row labelled `"undefined"` doesn't pin this branch. adding `["null", null, 7, 7]` would explicitly document that `null` is treated identically to `undefined` and guard against a future tightening of the type guard.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: pin -Infinity fallback and null-mo..."](https://github.com/ndycode/codex-multi-auth/commit/ea81528239110e3649e0a2943fbc9bd0ede40914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36798164)</sub>

<!-- /greptile_comment -->