### PR TITLE
chore: drop unused @fast-check/vitest devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
 				"mcodex": "scripts/mcodex.js"
 			},
 			"devDependencies": {
-				"@fast-check/vitest": "^0.2.4",
 				"@types/node": "^20.19.42",
 				"@typescript-eslint/eslint-plugin": "^8.56.0",
 				"@typescript-eslint/parser": "^8.56.0",
@@ -686,29 +685,6 @@
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
-		"node_modules/@fast-check/vitest": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@fast-check/vitest/-/vitest-0.2.4.tgz",
-			"integrity": "sha512-Ilcr+JAIPhb1s6FRm4qoglQYSGXXrS+zAupZeNuWAA3qHVGDA1d1Gb84Hb/+otL3GzVZjFJESg5/1SfIvrgssA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/dubzzz"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fast-check"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"fast-check": "^3.0.0 || ^4.0.0"
-			},
-			"peerDependencies": {
-				"vitest": "^1 || ^2 || ^3 || ^4"
-			}
-		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -980,9 +956,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -997,9 +970,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1014,9 +984,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1031,9 +998,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1048,9 +1012,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1065,9 +1026,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1082,9 +1040,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1099,9 +1054,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1116,9 +1068,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1133,9 +1082,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1150,9 +1096,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1167,9 +1110,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1184,9 +1124,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
 		"node": ">=18.17.0"
 	},
 	"devDependencies": {
-		"@fast-check/vitest": "^0.2.4",
 		"@types/node": "^20.19.42",
 		"@typescript-eslint/eslint-plugin": "^8.56.0",
 		"@typescript-eslint/parser": "^8.56.0",


### PR DESCRIPTION
## Summary

- Removes the `@fast-check/vitest` devDependency. Nothing in the repository imports it — the only references anywhere are the `package.json` entry, its lockfile subtree, and a line in the historical audit evidence snapshot.

## What Changed

- `npm uninstall @fast-check/vitest`: one line out of `devDependencies`, 63 lines out of `package-lock.json`.
- Plain `fast-check` stays: the property suites (#574, #575, #579) deliberately use `fc.assert`/`fc.asyncProperty` with explicit vitest imports per repo convention, so the `test.prop` wrapper this package provides has no consumers.
- `typescript-language-server` (the other knip-flagged devDependency) was deliberately left alone — editor/LSP tooling usage is invisible to import scans, so that removal is a maintainer call.

## Validation

- [x] `npm run typecheck` after the uninstall
- [x] Spot-check test run (`test/settings-panels.test.ts`) confirms the install is healthy
- [x] `grep -r "@fast-check/vitest"` across the repo (excluding `node_modules`/`dist`): only `package.json`/lockfile and the frozen audit evidence file

## Docs and Governance Checklist

- [x] No user-visible behavior, commands, settings, or docs affected (devDependency only; not part of the shipped tarball)

## Risk and Rollback

- Risk level: minimal — unused devDependency; cannot affect runtime or the published package.
- Rollback plan: `npm install -D @fast-check/vitest` restores it.

## Additional Notes

- If property tests ever migrate to the `test.prop` API, reinstalling is a one-liner; until then the dependency is pure surface.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

removes the unused `@fast-check/vitest` devdependency from `package.json` and its lockfile subtree. plain `fast-check` is retained since the property test suites use `fc.assert`/`fc.asyncProperty` directly with explicit vitest imports.

- `package.json`: one-line removal of `@fast-check/vitest: ^0.2.4` from devdependencies; `fast-check` stays.
- `package-lock.json`: `@fast-check/vitest` block removed cleanly; a side effect strips the `libc` field from ~12 `@rollup/rollup-linux-*` optional platform packages, likely due to npm version differences during lockfile regeneration.

<h3>Confidence Score: 4/5</h3>

safe to merge — removing an unused devdependency with no runtime or published-package impact.

the `@fast-check/vitest` removal is clean and well-validated. the only notable artifact is the collateral stripping of `libc` fields from rollup's linux platform packages, an unintended lockfile diff from npm version drift; those packages are optional so the install won't break, but musl-based ci runners could silently fall back to the wasm rollup.

package-lock.json deserves a quick look for the rollup libc field removals beyond the intended @fast-check/vitest subtree.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| package.json | removes `@fast-check/vitest` from devDependencies — clean, no consumers in the codebase |
| package-lock.json | removes `@fast-check/vitest` lockfile subtree cleanly; also strips `libc` field from rollup linux platform packages as an unintended side effect of npm version differences |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm uninstall @fast-check/vitest] --> B[package.json: remove entry]
    A --> C[package-lock.json: remove @fast-check/vitest block]
    C --> D[expected: fast-check peer dep subtree removed]
    C --> E[unexpected side effect: libc field stripped from @rollup/rollup-linux-* optionals]
    E --> F{impact?}
    F -->|glibc linux / macOS / windows| G[no impact - libc not used]
    F -->|musl linux / Alpine CI| H[npm falls back to wasm rollup - slower builds only]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `package-lock.json`, line 951-1124 ([link](https://github.com/ndycode/codex-multi-auth/blob/025dc132142f5fa7868a6b649320b062ff63dd93/package-lock.json#L951-L1124)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **unexpected `libc` field removals from rollup platform packages**

   the uninstall also stripped the `libc` field from ~12 `@rollup/rollup-linux-*` entries (both `glibc` and `musl` variants for arm, arm64, loong64, ppc64, riscv64, s390x, x64). this suggests the lockfile was regenerated with a different npm version than the one that originally wrote it — the `libc` field is used by npm to select the correct native binary on linux. since these packages are `optional: true` and their names already encode the variant (`-gnu` vs `-musl`), practical impact is low. on an alpine/musl ci runner the wrong binary could theoretically be selected, falling back to the wasm rollup, which just makes builds slower. worth noting the npm version in use if this diff looks unexpected.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: package-lock.json
   Line: 951-1124

   Comment:
   **unexpected `libc` field removals from rollup platform packages**

   the uninstall also stripped the `libc` field from ~12 `@rollup/rollup-linux-*` entries (both `glibc` and `musl` variants for arm, arm64, loong64, ppc64, riscv64, s390x, x64). this suggests the lockfile was regenerated with a different npm version than the one that originally wrote it — the `libc` field is used by npm to select the correct native binary on linux. since these packages are `optional: true` and their names already encode the variant (`-gnu` vs `-musl`), practical impact is low. on an alpine/musl ci runner the wrong binary could theoretically be selected, falling back to the wasm rollup, which just makes builds slower. worth noting the npm version in use if this diff looks unexpected.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-62-drop-unused-fastcheck-vitest%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-62-drop-unused-fastcheck-vitest%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20package-lock.json%0ALine%3A%20951-1124%0A%0AComment%3A%0A**unexpected%20%60libc%60%20field%20removals%20from%20rollup%20platform%20packages**%0A%0Athe%20uninstall%20also%20stripped%20the%20%60libc%60%20field%20from%20~12%20%60%40rollup%2Frollup-linux-*%60%20entries%20%28both%20%60glibc%60%20and%20%60musl%60%20variants%20for%20arm%2C%20arm64%2C%20loong64%2C%20ppc64%2C%20riscv64%2C%20s390x%2C%20x64%29.%20this%20suggests%20the%20lockfile%20was%20regenerated%20with%20a%20different%20npm%20version%20than%20the%20one%20that%20originally%20wrote%20it%20%E2%80%94%20the%20%60libc%60%20field%20is%20used%20by%20npm%20to%20select%20the%20correct%20native%20binary%20on%20linux.%20since%20these%20packages%20are%20%60optional%3A%20true%60%20and%20their%20names%20already%20encode%20the%20variant%20%28%60-gnu%60%20vs%20%60-musl%60%29%2C%20practical%20impact%20is%20low.%20on%20an%20alpine%2Fmusl%20ci%20runner%20the%20wrong%20binary%20could%20theoretically%20be%20selected%2C%20falling%20back%20to%20the%20wasm%20rollup%2C%20which%20just%20makes%20builds%20slower.%20worth%20noting%20the%20npm%20version%20in%20use%20if%20this%20diff%20looks%20unexpected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth&pr=581&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-62-drop-unused-fastcheck-vitest%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-62-drop-unused-fastcheck-vitest%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackage-lock.json%3A951-1124%0A**unexpected%20%60libc%60%20field%20removals%20from%20rollup%20platform%20packages**%0A%0Athe%20uninstall%20also%20stripped%20the%20%60libc%60%20field%20from%20~12%20%60%40rollup%2Frollup-linux-*%60%20entries%20%28both%20%60glibc%60%20and%20%60musl%60%20variants%20for%20arm%2C%20arm64%2C%20loong64%2C%20ppc64%2C%20riscv64%2C%20s390x%2C%20x64%29.%20this%20suggests%20the%20lockfile%20was%20regenerated%20with%20a%20different%20npm%20version%20than%20the%20one%20that%20originally%20wrote%20it%20%E2%80%94%20the%20%60libc%60%20field%20is%20used%20by%20npm%20to%20select%20the%20correct%20native%20binary%20on%20linux.%20since%20these%20packages%20are%20%60optional%3A%20true%60%20and%20their%20names%20already%20encode%20the%20variant%20%28%60-gnu%60%20vs%20%60-musl%60%29%2C%20practical%20impact%20is%20low.%20on%20an%20alpine%2Fmusl%20ci%20runner%20the%20wrong%20binary%20could%20theoretically%20be%20selected%2C%20falling%20back%20to%20the%20wasm%20rollup%2C%20which%20just%20makes%20builds%20slower.%20worth%20noting%20the%20npm%20version%20in%20use%20if%20this%20diff%20looks%20unexpected.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=581&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package-lock.json:951-1124
**unexpected `libc` field removals from rollup platform packages**

the uninstall also stripped the `libc` field from ~12 `@rollup/rollup-linux-*` entries (both `glibc` and `musl` variants for arm, arm64, loong64, ppc64, riscv64, s390x, x64). this suggests the lockfile was regenerated with a different npm version than the one that originally wrote it — the `libc` field is used by npm to select the correct native binary on linux. since these packages are `optional: true` and their names already encode the variant (`-gnu` vs `-musl`), practical impact is low. on an alpine/musl ci runner the wrong binary could theoretically be selected, falling back to the wasm rollup, which just makes builds slower. worth noting the npm version in use if this diff looks unexpected.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: drop unused @fast-check/vitest de..."](https://github.com/ndycode/codex-multi-auth/commit/025dc132142f5fa7868a6b649320b062ff63dd93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36798411)</sub>

<!-- /greptile_comment -->