### PR TITLE
test: direct suite for usage-ledger redaction and row normalization

### DIFF
--- a/test/usage-redaction.test.ts
+++ b/test/usage-redaction.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import {
+	createUsageAccountRef,
+	hashUsageIdentifier,
+	normalizeUsageLedgerRow,
+	usageRowToJsonLine,
+} from "../lib/usage/redaction.js";
+import { estimateUsageCostUsd } from "../lib/usage/pricing.js";
+
+const NOW = 1_750_000_000_000;
+
+function sha256(value: string): string {
+	return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+describe("usage ledger redaction and normalization", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("hashUsageIdentifier", () => {
+		it("trims before hashing and prefixes the digest format", () => {
+			expect(hashUsageIdentifier("  acct-123 ")).toBe(sha256("acct-123"));
+			expect(hashUsageIdentifier("acct-123")).toBe(
+				hashUsageIdentifier("\tacct-123  "),
+			);
+		});
+	});
+
+	describe("createUsageAccountRef", () => {
+		it("hashes the account id and lowercased email, never storing raw values", () => {
+			const ref = createUsageAccountRef({
+				accountId: " acct-123 ",
+				email: " Alice@Example.COM ",
+				accountIndex: 2,
+			});
+			expect(ref).toStrictEqual({
+				accountHash: sha256("acct-123"),
+				emailHash: sha256("alice@example.com"),
+				index: 2,
+			});
+		});
+
+		it("returns null when no identifying facet survives normalization", () => {
+			expect(
+				createUsageAccountRef({ accountId: "  ", email: "", accountIndex: null }),
+			).toBeNull();
+			expect(createUsageAccountRef({})).toBeNull();
+		});
+
+		it("rejects negative and fractional indexes but keeps zero", () => {
+			expect(createUsageAccountRef({ accountIndex: 0 })).toStrictEqual({
+				accountHash: undefined,
+				emailHash: undefined,
+				index: 0,
+			});
+			expect(createUsageAccountRef({ accountIndex: -1 })).toBeNull();
+			expect(createUsageAccountRef({ accountIndex: 1.5 })).toBeNull();
+		});
+	});
+
+	describe("normalizeUsageLedgerRow", () => {
+		it("coerces unknown enums to their documented fallbacks", () => {
+			const row = normalizeUsageLedgerRow({
+				source: "smoke-signal",
+				operation: 42 as never,
+				outcome: "exploded",
+			});
+			expect(row.source).toBe("unknown");
+			expect(row.operation).toBe("unknown");
+			// Outcome falls back to "failure", not "unknown": an unclassifiable
+			// outcome must never be counted as a success.
+			expect(row.outcome).toBe("failure");
+		});
+
+		it("keeps valid enums as-is", () => {
+			const row = normalizeUsageLedgerRow({
+				source: "runtime-proxy",
+				operation: "responses",
+				outcome: "blocked",
+			});
+			expect(row.source).toBe("runtime-proxy");
+			expect(row.operation).toBe("responses");
+			expect(row.outcome).toBe("blocked");
+		});
+
+		it("clamps token counts and recomputes the total when none is provided", () => {
+			const row = normalizeUsageLedgerRow({
+				outcome: "success",
+				inputTokens: 100.9,
+				outputTokens: -5,
+				cachedInputTokens: Number.NaN,
+				reasoningTokens: 7,
+			});
+			expect(row.tokens).toStrictEqual({
+				inputTokens: 100,
+				outputTokens: 0,
+				cachedInputTokens: 0,
+				reasoningTokens: 7,
+				// input + output + reasoning; cached input is informational.
+				totalTokens: 107,
+			});
+		});
+
+		it("trusts a provided total but clamps it non-negative", () => {
+			expect(
+				normalizeUsageLedgerRow({ outcome: "success", totalTokens: 42.7 }).tokens
+					.totalTokens,
+			).toBe(42);
+			expect(
+				normalizeUsageLedgerRow({ outcome: "success", totalTokens: -10 }).tokens
+					.totalTokens,
+			).toBe(0);
+		});
+
+		it("accepts only real HTTP status codes", () => {
+			const base = { outcome: "success" } as const;
+			expect(normalizeUsageLedgerRow({ ...base, statusCode: 429 }).statusCode).toBe(429);
+			expect(normalizeUsageLedgerRow({ ...base, statusCode: 99 }).statusCode).toBeNull();
+			expect(normalizeUsageLedgerRow({ ...base, statusCode: 600 }).statusCode).toBeNull();
+			expect(
+				normalizeUsageLedgerRow({ ...base, statusCode: Number.NaN }).statusCode,
+			).toBeNull();
+		});
+
+		it("falls back to the pricing estimate when no explicit cost is given", () => {
+			const row = normalizeUsageLedgerRow({
+				outcome: "success",
+				model: "gpt-5.2",
+				inputTokens: 1_000_000,
+				outputTokens: 1_000_000,
+			});
+			expect(row.costUsd).toBe(
+				estimateUsageCostUsd("gpt-5.2", row.tokens),
+			);
+			expect(
+				normalizeUsageLedgerRow({ outcome: "success", costUsd: -3 }).costUsd,
+			).toBe(0);
+			expect(
+				normalizeUsageLedgerRow({ outcome: "success", costUsd: 1.25 }).costUsd,
+			).toBe(1.25);
+		});
+
+		it("fills id and createdAt defaults deterministically under fake time", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(NOW);
+			const row = normalizeUsageLedgerRow({ outcome: "success" });
+			expect(row.createdAt).toBe(NOW);
+			expect(row.id).toMatch(
+				/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+			);
+			expect(
+				normalizeUsageLedgerRow({ outcome: "success", id: " row-1 ", createdAt: 5 }),
+			).toMatchObject({ id: "row-1", createdAt: 5 });
+		});
+	});
+
+	describe("usageRowToJsonLine", () => {
+		it("serializes one newline-terminated JSON line with no raw identifiers", () => {
+			const line = usageRowToJsonLine(
+				normalizeUsageLedgerRow({
+					outcome: "success",
+					accountId: "acct-123",
+					email: "Alice@Example.com",
+					model: "gpt-5.2",
+				}),
+			);
+			expect(line.endsWith("\n")).toBe(true);
+			expect(line.indexOf("\n")).toBe(line.length - 1);
+			expect(JSON.parse(line)).toBeTruthy();
+			// The redaction guarantee the ledger relies on: raw identifiers must
+			// never reach the serialized row.
+			expect(line).not.toContain("acct-123");
+			expect(line.toLowerCase()).not.toContain("alice@example.com");
+			expect(line).toContain(sha256("acct-123"));
+			expect(line).toContain(sha256("alice@example.com"));
+		});
+	});
+});

--- a/test/usage-redaction.test.ts
+++ b/test/usage-redaction.test.ts
@@ -131,15 +131,38 @@ describe("usage ledger redaction and normalization", () => {
 				inputTokens: 1_000_000,
 				outputTokens: 1_000_000,
 			});
-			expect(row.costUsd).toBe(
-				estimateUsageCostUsd("gpt-5.2", row.tokens),
-			);
+			// Literal pin of the gpt-5.2 price card ($1.25/M input + $10/M
+			// output), not just delegation: a wrong table entry must fail here.
+			expect(row.costUsd).toBe(11.25);
+			expect(row.costUsd).toBe(estimateUsageCostUsd("gpt-5.2", row.tokens));
 			expect(
 				normalizeUsageLedgerRow({ outcome: "success", costUsd: -3 }).costUsd,
 			).toBe(0);
 			expect(
 				normalizeUsageLedgerRow({ outcome: "success", costUsd: 1.25 }).costUsd,
 			).toBe(1.25);
+		});
+
+		it("records a null cost for models without a price card", () => {
+			// null (not 0) so the summary aggregator can distinguish "free" from
+			// "unpriceable".
+			expect(
+				normalizeUsageLedgerRow({
+					outcome: "success",
+					model: "mystery-model",
+					inputTokens: 1_000,
+				}).costUsd,
+			).toBeNull();
+		});
+
+		it("clamps and truncates durationMs, dropping non-finite values", () => {
+			const base = { outcome: "success" } as const;
+			expect(normalizeUsageLedgerRow({ ...base, durationMs: 1234.9 }).durationMs).toBe(1234);
+			expect(normalizeUsageLedgerRow({ ...base, durationMs: -50 }).durationMs).toBe(0);
+			expect(
+				normalizeUsageLedgerRow({ ...base, durationMs: Number.NaN }).durationMs,
+			).toBeNull();
+			expect(normalizeUsageLedgerRow(base).durationMs).toBeNull();
 		});
 
 		it("fills id and createdAt defaults deterministically under fake time", () => {


### PR DESCRIPTION
## Summary

- Adds `test/usage-redaction.test.ts` (12 mock-free cases) for `lib/usage/redaction.ts`. The existing `test/usage-ledger.test.ts` covers append/rotation/locks through the `usage/index.js` facade, but the normalization and redaction contracts themselves had no direct pinning — and redaction is the security property the whole usage ledger relies on.

## What Changed

One new test file pinning:

- **`hashUsageIdentifier`**: trims before hashing, `sha256:`-prefixed hex digest, whitespace-spelled inputs collapse to the same hash.
- **`createUsageAccountRef`**: account id and *lowercased* email are stored only as hashes; returns `null` when no identifying facet survives normalization; the index gate keeps `0` but rejects negative and fractional indexes.
- **`normalizeUsageLedgerRow`** enum fallbacks: unknown `source`/`operation` → `"unknown"`, but unknown `outcome` → `"failure"` — an unclassifiable outcome must never be counted as a success.
- Token clamping: fractional floors, negatives/NaN to zero, total recomputed as input + output + reasoning (cached input excluded); a provided total is trusted but truncated and clamped non-negative.
- Status codes accepted only in the real HTTP window (100..599); 99, 600, NaN → `null`.
- Cost: falls back to `estimateUsageCostUsd` when absent, explicit cost clamped non-negative.
- `id`/`createdAt` defaults (UUID shape, `Date.now()` under fake timers), trimmed explicit values kept.
- **`usageRowToJsonLine`**: exactly one newline-terminated parseable JSON line that contains the hashes but **never** the raw account id or email — the redaction guarantee asserted end-to-end on the serialized output.

Time-dependent cases use `vi.useFakeTimers()`/`vi.setSystemTime` with real timers restored in `afterEach`.

## Validation

- [x] `npm run typecheck` (also runs in the pre-commit hook)
- [x] `npx eslint test/usage-redaction.test.ts --max-warnings=0`
- [x] `npm test -- test/usage-redaction.test.ts` — 12/12

## Docs and Governance Checklist

- [x] Test-only; no user-visible behavior, commands, settings, or paths changed

## Risk and Rollback

- Risk level: minimal — one new test file, no source changes.
- Rollback plan: delete the test file.

## Additional Notes

- Independent of every other open branch; based on `main`. Complements `test/usage-ledger.test.ts`, which keeps owning the filesystem/locking behavior.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/usage-redaction.test.ts` — a 14-case direct suite for `lib/usage/redaction.ts` covering hashing, normalization, and the end-to-end redaction guarantee on serialized output. all previously flagged gaps (durationMs clamping, null cost for unknown models, literal price-card pin) are resolved in this revision.

- **redaction contract**: `usageRowToJsonLine` test verifies raw `accountId`/`email` never appear in the JSON line while both sha256 hashes are present — the core security property of the usage ledger.
- **normalization coverage**: enum fallbacks (`source`/`operation` → `"unknown"`, `outcome` → `"failure"`), token clamping, status code window (100–599), `durationMs` floor+clamp, explicit vs. estimated cost, and `id`/`createdAt` defaults under fake timers are all exercised.
- **no source changes**: test-only addition; no production code is modified.

<h3>Confidence Score: 5/5</h3>

test-only addition with no source changes; safe to merge

one new test file, no production code touched, all normalization and redaction paths verified against the real implementation without mocks — the literal price pin and null-cost case close the last meaningful gaps from previous review rounds

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/usage-redaction.test.ts | New test file (14 cases) pinning redaction, normalization, and serialization contracts for lib/usage/redaction.ts — all three previously flagged gaps (durationMs, null cost, literal price pin) are now addressed; no P0/P1 issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UsageLedgerAppendInput] --> B[normalizeUsageLedgerRow]
    B --> C[normalizeSource\nunknown fallback]
    B --> D[normalizeOperation\nunknown fallback]
    B --> E[normalizeOutcome\nfailure fallback]
    B --> F[normalizeTokens\nfloor + clamp, recompute total]
    B --> G[normalizeStatusCode\n100..599 only]
    B --> H[normalizeDurationMs\nfloor + clamp, null if NaN]
    B --> I[createUsageAccountRef\nhash accountId + email]
    B --> J{explicit costUsd?}
    J -- yes --> K[clamp ≥ 0]
    J -- no --> L[estimateUsageCostUsd\nnull if model unknown]
    B --> M[UsageLedgerRow]
    M --> N[usageRowToJsonLine\nJSON + newline\nraw ids never written]

    style I fill:#f96,color:#000
    style N fill:#f96,color:#000
```

<sub>Reviews (2): Last reviewed commit: ["test: pin literal gpt-5.2 price, null co..."](https://github.com/ndycode/codex-multi-auth/commit/c713871d3bcc3ff43c838333cf82e4bc3d189b9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36800963)</sub>

<!-- /greptile_comment -->