### PR TITLE
test: direct suite for the settings preview builders

### DIFF
--- a/test/settings-preview.test.ts
+++ b/test/settings-preview.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildAccountListPreview,
+	buildSummaryPreviewText,
+	DEFAULT_STATUSLINE_FIELDS,
+	highlightPreviewToken,
+	normalizeStatuslineFields,
+} from "../lib/codex-manager/settings-preview.js";
+import { resolveMenuLayoutMode } from "../lib/codex-manager/settings-hub/shared.js";
+import { getUiRuntimeOptions } from "../lib/ui/runtime.js";
+import type { DashboardDisplaySettings } from "../lib/codex-manager/dashboard-settings.js";
+
+const UI = getUiRuntimeOptions();
+
+function summary(
+	settings: DashboardDisplaySettings,
+	focus: Parameters<typeof buildSummaryPreviewText>[3] = null,
+): string {
+	return buildSummaryPreviewText(settings, UI, resolveMenuLayoutMode, focus);
+}
+
+function setStdoutTty(value: boolean | undefined): () => void {
+	const original = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	Object.defineProperty(process.stdout, "isTTY", {
+		value,
+		configurable: true,
+	});
+	return () => {
+		if (original) {
+			Object.defineProperty(process.stdout, "isTTY", original);
+		} else {
+			delete (process.stdout as { isTTY?: boolean }).isTTY;
+		}
+	};
+}
+
+describe("settings preview builders", () => {
+	describe("normalizeStatuslineFields", () => {
+		it("falls back to the documented defaults for undefined and empty input", () => {
+			expect(normalizeStatuslineFields(undefined)).toStrictEqual(
+				DEFAULT_STATUSLINE_FIELDS,
+			);
+			const fromEmpty = normalizeStatuslineFields([]);
+			expect(fromEmpty).toStrictEqual(DEFAULT_STATUSLINE_FIELDS);
+			// Defensive copy: mutating the result must not corrupt the defaults.
+			expect(fromEmpty).not.toBe(DEFAULT_STATUSLINE_FIELDS);
+		});
+
+		it("deduplicates while preserving first-occurrence order", () => {
+			expect(
+				normalizeStatuslineFields([
+					"status",
+					"last-used",
+					"status",
+					"limits",
+					"last-used",
+				]),
+			).toStrictEqual(["status", "last-used", "limits"]);
+		});
+	});
+
+	describe("buildSummaryPreviewText", () => {
+		it("shows last-used and limits (with cooldowns) by default, status only when badges are hidden", () => {
+			const text = summary({});
+			expect(text).toContain("last used: today");
+			expect(text).toContain("limits: ");
+			expect(text).toContain("reset");
+			expect(text).not.toContain("status: active");
+
+			const withHiddenBadge = summary({ menuShowStatusBadge: false });
+			expect(withHiddenBadge).toContain("status: active");
+		});
+
+		it("drops the cooldown segment when menuShowQuotaCooldown is false", () => {
+			const text = summary({ menuShowQuotaCooldown: false });
+			expect(text).toContain("limits: ");
+			expect(text).not.toContain("reset");
+		});
+
+		it("orders parts by the configured statusline fields", () => {
+			const text = summary({
+				menuShowStatusBadge: false,
+				menuStatuslineFields: ["status", "last-used", "limits"],
+			});
+			expect(text.indexOf("status: active")).toBeLessThan(
+				text.indexOf("last used: today"),
+			);
+			expect(text.indexOf("last used: today")).toBeLessThan(
+				text.indexOf("limits: "),
+			);
+		});
+
+		it("explains why nothing is visible when every part is disabled", () => {
+			// Status field configured but the badge is shown, so the status text
+			// is suppressed: the preview explains the dependency.
+			expect(
+				summary({
+					menuShowLastUsed: false,
+					menuShowQuotaSummary: false,
+				}),
+			).toBe("status text appears only when status badges are hidden");
+
+			// No status field at all: generic nothing-visible message.
+			expect(
+				summary({
+					menuShowLastUsed: false,
+					menuShowQuotaSummary: false,
+					menuStatuslineFields: ["last-used", "limits"],
+				}),
+			).toBe("no summary text is visible with current account-list settings");
+		});
+	});
+
+	describe("buildAccountListPreview", () => {
+		it("renders the demo row with both badges by default", () => {
+			const preview = buildAccountListPreview(
+				{},
+				UI,
+				resolveMenuLayoutMode,
+			);
+			expect(preview.label).toBe("1. demo@example.com [current] [active]");
+			expect(preview.hint.endsWith("details shown on selected row only")).toBe(
+				true,
+			);
+			expect(preview.hint).toContain("\n");
+		});
+
+		it("drops badges individually and reflects the expanded-rows layout", () => {
+			const preview = buildAccountListPreview(
+				{
+					menuShowCurrentBadge: false,
+					menuShowStatusBadge: false,
+					menuLayoutMode: "expanded-rows",
+				},
+				UI,
+				resolveMenuLayoutMode,
+			);
+			expect(preview.label).toBe("1. demo@example.com");
+			expect(preview.hint.endsWith("details shown on all rows")).toBe(true);
+		});
+
+		it("derives the layout text from the legacy boolean when no explicit mode is set", () => {
+			const preview = buildAccountListPreview(
+				{ menuShowDetailsForUnselectedRows: true },
+				UI,
+				resolveMenuLayoutMode,
+			);
+			expect(preview.hint.endsWith("details shown on all rows")).toBe(true);
+		});
+	});
+
+	describe("highlightPreviewToken", () => {
+		it("returns plain text when stdout is not a TTY", () => {
+			const restore = setStdoutTty(false);
+			try {
+				expect(highlightPreviewToken("token", UI)).toBe("token");
+			} finally {
+				restore();
+			}
+		});
+
+		it("wraps the token in ANSI styling when stdout is a TTY", () => {
+			const restore = setStdoutTty(true);
+			try {
+				const highlighted = highlightPreviewToken("token", UI);
+				expect(highlighted).not.toBe("token");
+				expect(highlighted).toContain("token");
+				expect(highlighted).toMatch(/\x1b\[/);
+				expect(
+					highlighted.replace(/\x1b\[[0-9;]*m/g, ""),
+				).toBe("token");
+			} finally {
+				restore();
+			}
+		});
+
+		it("highlights only the focused part in the summary preview", () => {
+			const restore = setStdoutTty(true);
+			try {
+				const text = summary({}, "last-used");
+				const stripped = text.replace(/\x1b\[[0-9;]*m/g, "");
+				expect(stripped).toBe(summaryPlain());
+				expect(text).not.toBe(stripped);
+				const limitsSegment = text.slice(text.indexOf("limits:"));
+				expect(limitsSegment).not.toMatch(/\x1b\[/);
+			} finally {
+				restore();
+			}
+		});
+	});
+});
+
+function summaryPlain(): string {
+	const restore = setStdoutTty(false);
+	try {
+		return buildSummaryPreviewText({}, UI, resolveMenuLayoutMode, null);
+	} finally {
+		restore();
+	}
+}

--- a/test/settings-preview.test.ts
+++ b/test/settings-preview.test.ts
@@ -19,10 +19,13 @@ function summary(
 	return buildSummaryPreviewText(settings, UI, resolveMenuLayoutMode, focus);
 }
 
+// Mutates process-global state: the TTY-sensitive tests below rely on the
+// suite running sequentially (vitest's default); do not mark them concurrent.
 function setStdoutTty(value: boolean | undefined): () => void {
 	const original = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 	Object.defineProperty(process.stdout, "isTTY", {
 		value,
+		writable: true,
 		configurable: true,
 	});
 	return () => {
@@ -37,9 +40,9 @@ function setStdoutTty(value: boolean | undefined): () => void {
 describe("settings preview builders", () => {
 	describe("normalizeStatuslineFields", () => {
 		it("falls back to the documented defaults for undefined and empty input", () => {
-			expect(normalizeStatuslineFields(undefined)).toStrictEqual(
-				DEFAULT_STATUSLINE_FIELDS,
-			);
+			const fromUndefined = normalizeStatuslineFields(undefined);
+			expect(fromUndefined).toStrictEqual(DEFAULT_STATUSLINE_FIELDS);
+			expect(fromUndefined).not.toBe(DEFAULT_STATUSLINE_FIELDS);
 			const fromEmpty = normalizeStatuslineFields([]);
 			expect(fromEmpty).toStrictEqual(DEFAULT_STATUSLINE_FIELDS);
 			// Defensive copy: mutating the result must not corrupt the defaults.


### PR DESCRIPTION
## Summary

- Adds `test/settings-preview.test.ts` (12 cases) for `lib/codex-manager/settings-preview.ts` — the preview-first settings UX renderer, previously reachable only through the interactive settings-hub panels.

## What Changed

One new test file pinning, with the real `resolveMenuLayoutMode` from `settings-hub/shared.ts` (no mocks):

- **`normalizeStatuslineFields`**: undefined/empty fall back to the documented defaults (and the empty-input path returns a defensive copy, not the shared default array); duplicates collapse to first-occurrence order.
- **`buildSummaryPreviewText`**: default composition (last-used + limits with cooldowns; status text only when status badges are *hidden* — the inverse dependency the preview exists to explain); the cooldown toggle; part ordering following `menuStatuslineFields`; and both nothing-visible explanations (the status-badge-dependency note vs the generic message when no status field is configured).
- **`buildAccountListPreview`**: the demo row label with both badges, individual badge toggles, and the layout text driven by the real resolver — explicit `expanded-rows` mode and the legacy `menuShowDetailsForUnselectedRows` boolean both produce "details shown on all rows".
- **`highlightPreviewToken`**: returns plain text on non-TTY stdout; on a forced TTY it ANSI-wraps the token (stripping escapes recovers the exact plain text), and in the composed summary only the focused part carries escapes — the trailing limits segment stays clean.

TTY forcing uses `Object.defineProperty` on `process.stdout.isTTY` with the original descriptor restored in `finally`.

## Validation

- [x] `npm run typecheck` (also runs in the pre-commit hook)
- [x] `npx eslint test/settings-preview.test.ts --max-warnings=0`
- [x] `npm test -- test/settings-preview.test.ts` — 12/12

## Docs and Governance Checklist

- [x] Test-only; no user-visible behavior, commands, settings, or paths changed

## Risk and Rollback

- Risk level: minimal — one new test file, no source changes.
- Rollback plan: delete the test file.

## Additional Notes

- Independent of every other open branch; based on `main`. Complements #569's clone/equality suite, which owns the settings *data* model while this one owns the *preview rendering*.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/settings-preview.test.ts` — a 12-case direct suite for the settings-preview builders in `lib/codex-manager/settings-preview.ts`. no source changes; the three issues flagged in the previous round (sequential-execution comment, `writable: true` on the defineProperty call, and the `fromUndefined` reference-identity assertion) are all present in this version.

- **`normalizeStatuslineFields`** (2 cases): undefined/empty fall back to defaults returning a defensive copy; duplicates deduplicate to first-occurrence order.
- **`buildSummaryPreviewText`** (4 cases): default composition, cooldown toggle, field ordering, and both nothing-visible messages (status-badge-dependency note vs. generic message).
- **`buildAccountListPreview`** (3 cases): demo row with/without badges, expanded-rows layout via both the explicit `menuLayoutMode` field and the legacy `menuShowDetailsForUnselectedRows` boolean.
- **`highlightPreviewToken`** (3 cases): non-TTY plain text, TTY ANSI wrapping with strip-and-recover assertion, focused-part isolation in the composed summary.

<h3>Confidence Score: 5/5</h3>

test-only pr with no source changes; all previous review issues have been addressed in the submitted version.

the change is a single new test file that adds 12 assertions against an existing renderer module. the setStdoutTty helper correctly handles nested calls and restores the original descriptor in finally. the fromUndefined reference-identity guard is present. the sequential-execution comment is in place. no production code is touched.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/settings-preview.test.ts | new 12-case suite covering normalizeStatuslineFields, buildSummaryPreviewText, buildAccountListPreview, and highlightPreviewToken; prior review issues (concurrency note, writable:true, fromUndefined reference check) are all addressed |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: harden TTY helper and pin undefine..."](https://github.com/ndycode/codex-multi-auth/commit/52e42458948163de120bc269615a4899417de18b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36802199)</sub>

<!-- /greptile_comment -->