### PR TITLE
test: direct suite for settings-hub shared merge/persist helpers

### DIFF
--- a/test/settings-hub-shared.test.ts
+++ b/test/settings-hub-shared.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+	loadDashboardDisplaySettingsMock,
+	saveDashboardDisplaySettingsMock,
+	savePluginConfigMock,
+} = vi.hoisted(() => ({
+	loadDashboardDisplaySettingsMock: vi.fn(),
+	saveDashboardDisplaySettingsMock: vi.fn(),
+	savePluginConfigMock: vi.fn(),
+}));
+
+vi.mock("../lib/dashboard-settings.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/dashboard-settings.js")>()),
+	loadDashboardDisplaySettings: loadDashboardDisplaySettingsMock,
+	saveDashboardDisplaySettings: saveDashboardDisplaySettingsMock,
+	getDashboardSettingsPath: () => "/tmp/settings-hub-shared-test/settings.json",
+}));
+
+vi.mock("../lib/config.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../lib/config.js")>()),
+	savePluginConfig: savePluginConfigMock,
+}));
+
+import {
+	applyDashboardDefaultsForKeys,
+	clampBackendNumber,
+	cloneDashboardSettings,
+	copyDashboardSettingValue,
+	mergeDashboardSettingsForKeys,
+	persistBackendConfigSelectionForTests,
+	persistDashboardSettingsSelectionForTests,
+} from "../lib/codex-manager/settings-hub/shared.js";
+import { DEFAULT_DASHBOARD_DISPLAY_SETTINGS } from "../lib/dashboard-settings.js";
+import { backendSettingsEqual } from "../lib/codex-manager/backend-settings-helpers.js";
+import type { DashboardDisplaySettings } from "../lib/dashboard-settings.js";
+import type { PluginConfig } from "../lib/types.js";
+import type { BackendNumberSettingOption } from "../lib/codex-manager/backend-settings-schema.js";
+
+function busyError(): NodeJS.ErrnoException {
+	const error = new Error("locked") as NodeJS.ErrnoException;
+	error.code = "EBUSY";
+	return error;
+}
+
+describe("settings hub shared helpers", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		loadDashboardDisplaySettingsMock.mockResolvedValue({});
+		saveDashboardDisplaySettingsMock.mockResolvedValue(undefined);
+		savePluginConfigMock.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("copyDashboardSettingValue", () => {
+		it("copies scalars and clones array values", () => {
+			const source: DashboardDisplaySettings = {
+				menuShowLastUsed: false,
+				menuStatuslineFields: ["status", "limits"],
+			};
+			const target: DashboardDisplaySettings = {};
+			copyDashboardSettingValue(target, source, "menuShowLastUsed");
+			copyDashboardSettingValue(target, source, "menuStatuslineFields");
+			expect(target.menuShowLastUsed).toBe(false);
+			expect(target.menuStatuslineFields).toStrictEqual(["status", "limits"]);
+			// Arrays must be copied, not shared: mutating the target later must
+			// never write through to the source settings object.
+			expect(target.menuStatuslineFields).not.toBe(source.menuStatuslineFields);
+		});
+	});
+
+	describe("applyDashboardDefaultsForKeys", () => {
+		it("resets only the listed keys and leaves the draft untouched", () => {
+			const draft: DashboardDisplaySettings = {
+				menuShowLastUsed: false,
+				menuShowQuotaSummary: false,
+			};
+			const next = applyDashboardDefaultsForKeys(draft, ["menuShowLastUsed"]);
+			expect(next.menuShowLastUsed).toBe(
+				DEFAULT_DASHBOARD_DISPLAY_SETTINGS.menuShowLastUsed,
+			);
+			expect(next.menuShowQuotaSummary).toBe(false);
+			expect(draft.menuShowLastUsed).toBe(false);
+		});
+	});
+
+	describe("mergeDashboardSettingsForKeys", () => {
+		it("takes only the listed keys from the selection", () => {
+			const base: DashboardDisplaySettings = {
+				menuShowLastUsed: false,
+				menuShowQuotaSummary: false,
+			};
+			const selected: DashboardDisplaySettings = {
+				menuShowLastUsed: true,
+				menuShowQuotaSummary: true,
+			};
+			const merged = mergeDashboardSettingsForKeys(base, selected, [
+				"menuShowLastUsed",
+			]);
+			expect(merged.menuShowLastUsed).toBe(true);
+			expect(merged.menuShowQuotaSummary).toBe(false);
+			expect(base.menuShowLastUsed).toBe(false);
+		});
+	});
+
+	describe("persistDashboardSettingsSelection", () => {
+		it("re-reads the latest settings and merges only the panel's keys onto them", async () => {
+			// A concurrent edit to an unrelated key landed on disk after the panel
+			// loaded: the write must preserve it instead of clobbering with the
+			// panel's stale view.
+			loadDashboardDisplaySettingsMock.mockResolvedValue({
+				menuHighlightCurrentRow: false,
+			});
+			const result = await persistDashboardSettingsSelectionForTests(
+				{ menuShowLastUsed: false, menuHighlightCurrentRow: true },
+				["menuShowLastUsed"],
+				"dashboard",
+			);
+			expect(saveDashboardDisplaySettingsMock).toHaveBeenCalledTimes(1);
+			const saved = saveDashboardDisplaySettingsMock.mock
+				.calls[0]?.[0] as DashboardDisplaySettings;
+			expect(saved.menuShowLastUsed).toBe(false);
+			expect(saved.menuHighlightCurrentRow).toBe(false);
+			expect(result.menuHighlightCurrentRow).toBe(false);
+		});
+
+		it("retries transient write failures through the queued-retry policy", async () => {
+			saveDashboardDisplaySettingsMock
+				.mockRejectedValueOnce(busyError())
+				.mockResolvedValueOnce(undefined);
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const result = await persistDashboardSettingsSelectionForTests(
+				{ menuShowLastUsed: false },
+				["menuShowLastUsed"],
+				"dashboard",
+			);
+			expect(saveDashboardDisplaySettingsMock).toHaveBeenCalledTimes(2);
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(result.menuShowLastUsed).toBe(false);
+		});
+
+		it("warns and returns the selection as fallback when the write keeps failing", async () => {
+			saveDashboardDisplaySettingsMock.mockRejectedValue(
+				new Error("disk gone"),
+			);
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const selected: DashboardDisplaySettings = { menuShowLastUsed: false };
+			const result = await persistDashboardSettingsSelectionForTests(
+				selected,
+				["menuShowLastUsed"],
+				"dashboard",
+			);
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Settings save failed (dashboard) after retries: disk gone",
+			);
+			// The fallback is the clone-normalized selection (the clone fills
+			// documented defaults), never the caller's object itself.
+			expect(result).toStrictEqual(cloneDashboardSettings(selected));
+			expect(result.menuShowLastUsed).toBe(false);
+			expect(result).not.toBe(selected);
+		});
+	});
+
+	describe("persistBackendConfigSelection", () => {
+		it("saves the backend patch and returns a defensive clone of the selection", async () => {
+			const selected = {
+				unsupportedCodexFallbackChain: { "gpt-5.3-codex": ["gpt-5.2"] },
+			} as PluginConfig;
+			const result = await persistBackendConfigSelectionForTests(
+				selected,
+				"backend",
+			);
+			expect(savePluginConfigMock).toHaveBeenCalledTimes(1);
+			expect(backendSettingsEqual(result, selected)).toBe(true);
+			expect(result).not.toBe(selected);
+			expect(result.unsupportedCodexFallbackChain).not.toBe(
+				selected.unsupportedCodexFallbackChain,
+			);
+		});
+
+		it("warns and falls back to the selection clone when the save fails", async () => {
+			savePluginConfigMock.mockRejectedValue(new Error("config locked"));
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const selected = {} as PluginConfig;
+			const result = await persistBackendConfigSelectionForTests(
+				selected,
+				"backend",
+			);
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Settings save failed (backend) after retries: config locked",
+			);
+			expect(backendSettingsEqual(result, selected)).toBe(true);
+		});
+	});
+
+	describe("clampBackendNumber", () => {
+		const option = {
+			key: "fetchTimeoutMs",
+			label: "fetch timeout",
+			min: 10,
+			max: 100,
+			step: 5,
+			unit: "duration",
+		} as unknown as BackendNumberSettingOption;
+
+		it.each([
+			[5, 10],
+			[10, 10],
+			[55.4, 55],
+			[55.5, 56],
+			[100, 100],
+			[250, 100],
+		])("clamps and rounds %d to %d", (value, expected) => {
+			expect(clampBackendNumber(option, value)).toBe(expected);
+		});
+	});
+});

--- a/test/settings-hub-shared.test.ts
+++ b/test/settings-hub-shared.test.ts
@@ -142,7 +142,7 @@ describe("settings hub shared helpers", () => {
 			expect(result.menuShowLastUsed).toBe(false);
 		});
 
-		it("warns and returns the selection as fallback when the write keeps failing", async () => {
+		it("gives up immediately on a non-retryable error, warning with the fallback", async () => {
 			saveDashboardDisplaySettingsMock.mockRejectedValue(
 				new Error("disk gone"),
 			);
@@ -161,6 +161,23 @@ describe("settings hub shared helpers", () => {
 			expect(result).toStrictEqual(cloneDashboardSettings(selected));
 			expect(result.menuShowLastUsed).toBe(false);
 			expect(result).not.toBe(selected);
+			// Non-retryable: the write must fail on the first attempt, no retries.
+			expect(saveDashboardDisplaySettingsMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("exhausts all four attempts on persistent EBUSY before falling back", async () => {
+			saveDashboardDisplaySettingsMock.mockRejectedValue(busyError());
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const result = await persistDashboardSettingsSelectionForTests(
+				{ menuShowLastUsed: false },
+				["menuShowLastUsed"],
+				"dashboard",
+			);
+			expect(saveDashboardDisplaySettingsMock).toHaveBeenCalledTimes(4);
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Settings save failed (dashboard) after retries: locked",
+			);
+			expect(result.menuShowLastUsed).toBe(false);
 		});
 	});
 
@@ -191,6 +208,21 @@ describe("settings hub shared helpers", () => {
 			);
 			expect(warnSpy).toHaveBeenCalledWith(
 				"Settings save failed (backend) after retries: config locked",
+			);
+			expect(backendSettingsEqual(result, selected)).toBe(true);
+		});
+
+		it("exhausts all four attempts on persistent EBUSY for the backend path too", async () => {
+			savePluginConfigMock.mockRejectedValue(busyError());
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const selected = {} as PluginConfig;
+			const result = await persistBackendConfigSelectionForTests(
+				selected,
+				"backend",
+			);
+			expect(savePluginConfigMock).toHaveBeenCalledTimes(4);
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Settings save failed (backend) after retries: locked",
 			);
 			expect(backendSettingsEqual(result, selected)).toBe(true);
 		});


### PR DESCRIPTION
## Summary

- Adds `test/settings-hub-shared.test.ts` (14 cases) for the merge/persist helpers in `lib/codex-manager/settings-hub/shared.ts`. The module ships `...ForTests` injection variants that nothing exercised; the settings panels were the only callers.

## What Changed

One new test file, mocking only the disk seams (`loadDashboardDisplaySettings`/`saveDashboardDisplaySettings`/`savePluginConfig` via importOriginal spreads) while the merge logic, the real queued-retry policy, and the real `backendSettingsEqual`/`cloneDashboardSettings` stay live:

- **`copyDashboardSettingValue`**: array values are cloned, never shared — a later mutation of the target must not write through to the source settings object.
- **`applyDashboardDefaultsForKeys`** / **`mergeDashboardSettingsForKeys`**: only the listed keys move; inputs are never mutated.
- **`persistDashboardSettingsSelection`** — the load-merge-save transaction the panels rely on:
  - re-reads the *latest* settings inside the queue slot, so a concurrent edit to an unrelated key on disk is preserved instead of clobbered by the panel's stale view (the core reason this helper exists);
  - retries a transient `EBUSY` through the real queued-retry policy with no user-facing warning;
  - on persistent failure, warns with the exact `Settings save failed (<scope>) after retries: <message>` line and returns the clone-normalized selection as fallback (never the caller's object).
- **`persistBackendConfigSelection`**: saves the backend patch, returns a defensive clone (`unsupportedCodexFallbackChain` not reference-shared), and the warn + fallback path.
- **`clampBackendNumber`**: min/max clamping and rounding sweep.

## Validation

- [x] `npm run typecheck` (also runs in the pre-commit hook)
- [x] `npx eslint test/settings-hub-shared.test.ts --max-warnings=0`
- [x] `npm test -- test/settings-hub-shared.test.ts` — 14/14

## Docs and Governance Checklist

- [x] Test-only; no user-visible behavior, commands, settings, or paths changed

## Risk and Rollback

- Risk level: minimal — one new test file, no source changes.
- Rollback plan: delete the test file.

## Additional Notes

- Complements #569 (settings data clone/equality) and #583 (preview rendering); this one owns the merge/persist layer between them. Independent of every other open branch; based on `main`.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `test/settings-hub-shared.test.ts` with 14 cases covering the merge/persist helpers in `lib/codex-manager/settings-hub/shared.ts`. no source changes.

- **clone isolation**: verifies array values in `copyDashboardSettingValue` are never reference-shared between source and target.
- **concurrent re-read**: confirms `persistDashboardSettingsSelection` re-reads from disk inside the queue slot so a concurrent write to an unrelated key is preserved.
- **ebusy exhaustion**: both dashboard and backend paths now have four-consecutive-`EBUSY` tests that assert all four attempts fire and the warn+fallback path triggers; this closes the gap flagged in the previous review round.

<h3>Confidence Score: 5/5</h3>

test-only change with no source modifications; safe to merge.

one new test file, no production code touched. the ebusy exhaustion and fallback paths are correctly exercised; the concurrency re-read case is properly constructed. the only thing worth a follow-up is the ~750ms of real sleep in three tests, which is a run-time comfort issue, not a correctness problem.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/settings-hub-shared.test.ts | 14-case suite for settings-hub shared helpers; covers clone isolation, key-scoped merge, concurrent re-read, EBUSY exhaustion on both paths, and clampBackendNumber. Real sleep is used for retry tests (~750ms total), and one minor coverage gap around `loadDashboardDisplaySettings` call-count assertions. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant persistDashboardSettingsSelectionForTests
    participant withQueuedRetry
    participant loadDashboardDisplaySettings (mock)
    participant saveDashboardDisplaySettings (mock)

    Test->>persistDashboardSettingsSelectionForTests: selected, keys, scope
    persistDashboardSettingsSelectionForTests->>withQueuedRetry: "pathKey, task(), { sleep }"

    loop up to 4 attempts (EBUSY path)
        withQueuedRetry->>loadDashboardDisplaySettings (mock): re-read latest
        loadDashboardDisplaySettings (mock)-->>withQueuedRetry: latest settings
        withQueuedRetry->>saveDashboardDisplaySettings (mock): merged settings
        saveDashboardDisplaySettings (mock)-->>withQueuedRetry: EBUSY (or success)
        withQueuedRetry->>withQueuedRetry: sleep(backoff) if retryable
    end

    alt success
        withQueuedRetry-->>persistDashboardSettingsSelectionForTests: merged
        persistDashboardSettingsSelectionForTests-->>Test: merged
    else exhausted / non-retryable
        withQueuedRetry-->>persistDashboardSettingsSelectionForTests: throw error
        persistDashboardSettingsSelectionForTests->>persistDashboardSettingsSelectionForTests: warnPersistFailure
        persistDashboardSettingsSelectionForTests-->>Test: cloneDashboardSettings(selected)
    end
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-65-settings-hub-shared-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-65-settings-hub-shared-tests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fsettings-hub-shared.test.ts%3A20-23%0Athe%20three%20retry%2Fexhaustion%20tests%20run%20against%20real%20%60sleep%60%20%28imported%20live%20from%20%60utils.js%60%20inside%20%60shared.ts%60%29.%20that's%2050%20ms%20for%20the%20single-retry%20case%2C%20350%20ms%20each%20%2850%2B100%2B200%29%20for%20the%20two%20ebusy-exhaustion%20cases%20%E2%80%94%20roughly%20750%20ms%20of%20real%20wall-clock%20time%20added%20to%20the%20suite.%20mocking%20%60..%2F..%2Futils.js%60%20to%20stub%20%60sleep%60%20as%20%60%28%29%20%3D%3E%20Promise.resolve%28%29%60%20makes%20them%20instant%20and%20deterministic%20without%20needing%20fake-timer%20boilerplate%2C%20which%20is%20the%20pattern%20%60stream-failover.test.ts%60%20already%20uses%20for%20the%20same%20reason.%0A%0A%60%60%60suggestion%0Avi.mock%28%22..%2Flib%2Fconfig.js%22%2C%20async%20%28importOriginal%29%20%3D%3E%20%28%7B%0A%09...%28await%20importOriginal%3Ctypeof%20import%28%22..%2Flib%2Fconfig.js%22%29%3E%28%29%29%2C%0A%09savePluginConfig%3A%20savePluginConfigMock%2C%0A%7D%29%29%3B%0A%0Avi.mock%28%22..%2Flib%2Futils.js%22%2C%20async%20%28importOriginal%29%20%3D%3E%20%28%7B%0A%09...%28await%20importOriginal%3Ctypeof%20import%28%22..%2Flib%2Futils.js%22%29%3E%28%29%29%2C%0A%09sleep%3A%20%28%29%20%3D%3E%20Promise.resolve%28%29%2C%0A%7D%29%29%3B%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=584&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/settings-hub-shared.test.ts:20-23
the three retry/exhaustion tests run against real `sleep` (imported live from `utils.js` inside `shared.ts`). that's 50 ms for the single-retry case, 350 ms each (50+100+200) for the two ebusy-exhaustion cases — roughly 750 ms of real wall-clock time added to the suite. mocking `../../utils.js` to stub `sleep` as `() => Promise.resolve()` makes them instant and deterministic without needing fake-timer boilerplate, which is the pattern `stream-failover.test.ts` already uses for the same reason.

```suggestion
vi.mock("../lib/config.js", async (importOriginal) => ({
	...(await importOriginal<typeof import("../lib/config.js")>()),
	savePluginConfig: savePluginConfigMock,
}));

vi.mock("../lib/utils.js", async (importOriginal) => ({
	...(await importOriginal<typeof import("../lib/utils.js")>()),
	sleep: () => Promise.resolve(),
}));
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover EBUSY retry exhaustion for b..."](https://github.com/ndycode/codex-multi-auth/commit/8457e39d599c349176b71384b05ce641edbe02a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36804888)</sub>

<!-- /greptile_comment -->