### PR TITLE
refactor: migrate the last two hand-rolled retry loops to withRetry

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -880,37 +880,32 @@ export async function savePluginConfig(
 			// writer. Mirrors the unified-settings save path (writeSettingsRecordAsync
 			// CAS).
 			await withConfigFileLock(envPath, async () => {
-				for (let attempt = 0; attempt < 3; attempt += 1) {
-					const expectedMtimeMs = await getConfigFileMtimeMs(envPath);
-					const envConfigState = await readConfigRecordForSave(envPath);
-					if (envConfigState.status === "unreadable") {
-						throw new Error(
-							`Aborting config save because ${envPath} is unreadable.`,
-						);
-					}
-					const existingConfig =
-						envConfigState.status === "ok"
-							? sanitizeStoredPluginConfigRecord(envConfigState.record)
-							: null;
-					const merged = {
-						...(existingConfig ?? {}),
-						...sanitizedPatch,
-					};
-					try {
+				// CAS retry: ESTALE means the file's mtime moved between our stat and
+				// the write, so each attempt re-stats, re-reads, and re-merges against
+				// the latest on-disk state before writing again.
+				await withRetry(
+					async () => {
+						const expectedMtimeMs = await getConfigFileMtimeMs(envPath);
+						const envConfigState = await readConfigRecordForSave(envPath);
+						if (envConfigState.status === "unreadable") {
+							throw new Error(
+								`Aborting config save because ${envPath} is unreadable.`,
+							);
+						}
+						const existingConfig =
+							envConfigState.status === "ok"
+								? sanitizeStoredPluginConfigRecord(envConfigState.record)
+								: null;
+						const merged = {
+							...(existingConfig ?? {}),
+							...sanitizedPatch,
+						};
 						await writeJsonFileAtomicWithRetry(envPath, merged, {
 							expectedMtimeMs,
 						});
-						return;
-					} catch (error) {
-						if (
-							(error as NodeJS.ErrnoException).code !== "ESTALE" ||
-							attempt >= 2
-						) {
-							throw error;
-						}
-						// Loop: re-stat, re-read, re-merge against the latest on-disk state.
-					}
-				}
+					},
+					{ maxAttempts: 3, backoffMs: 0, retryableCodes: ["ESTALE"] },
+				);
 			});
 		});
 		return;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1838,24 +1838,17 @@ async function saveAccountsUnlocked(storage: AccountStorageV3): Promise<void> {
 				fs.writeFile(tempPath, content, { encoding: "utf-8", mode: 0o600 }),
 			),
 		statTemp: (tempPath: string) => fs.stat(tempPath),
-		renameTempToPath: async (tempPath: string) => {
-			let lastError: NodeJS.ErrnoException | null = null;
-			for (let attempt = 0; attempt < 5; attempt++) {
-				try {
-					await fs.rename(tempPath, path);
-					return;
-				} catch (renameError) {
-					const code = (renameError as NodeJS.ErrnoException).code;
-					if (code === "EPERM" || code === "EBUSY") {
-						lastError = renameError as NodeJS.ErrnoException;
-						await new Promise((r) => setTimeout(r, 10 * 2 ** attempt));
-						continue;
-					}
-					throw renameError;
-				}
-			}
-			if (lastError) throw lastError;
-		},
+		renameTempToPath: (tempPath: string) =>
+			// Windows can hold the destination briefly (AV/indexer); retry only the
+			// lock codes rename actually surfaces there, on the original
+			// 10ms-doubling schedule. (The hand-rolled loop this replaces also
+			// slept once more after the final failure; withRetry rethrows
+			// immediately instead.)
+			withRetry(() => fs.rename(tempPath, path), {
+				maxAttempts: 5,
+				backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
+				retryableCodes: ["EPERM", "EBUSY"],
+			}),
 		cleanupResetMarker: async () => {
 			try {
 				await fs.unlink(resetMarkerPath);

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -3976,6 +3976,87 @@ describe("storage", () => {
 			}
 		});
 
+		it("retries the temp-to-final rename on transient EPERM and succeeds", async () => {
+			const now = Date.now();
+			const storagePath = getStoragePath();
+
+			// A predecessor that failed mid-test can leak its own fs.rename spy;
+			// restore first so the passthrough binding captures the real rename
+			// instead of recursing into this test's mock.
+			vi.restoreAllMocks();
+			const originalRename = fs.rename.bind(fs);
+			let tempRenameAttempts = 0;
+			const renameSpy = vi
+				.spyOn(fs, "rename")
+				.mockImplementation(async (oldPath, newPath) => {
+					const sourcePath = String(oldPath);
+					if (sourcePath.endsWith(".tmp") && String(newPath) === storagePath) {
+						tempRenameAttempts += 1;
+						if (tempRenameAttempts <= 2) {
+							const err = new Error(
+								"EPERM temp rename",
+							) as NodeJS.ErrnoException;
+							err.code = "EPERM";
+							throw err;
+						}
+					}
+					return originalRename(oldPath as string, newPath as string);
+				});
+			try {
+				await saveAccounts({
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [{ refreshToken: "token", addedAt: now, lastUsed: now }],
+				});
+
+				expect(tempRenameAttempts).toBe(3);
+				const saved = JSON.parse(
+					await fs.readFile(storagePath, "utf-8"),
+				) as {
+					accounts?: Array<{ refreshToken?: string }>;
+				};
+				expect(saved.accounts?.[0]?.refreshToken).toBe("token");
+			} finally {
+				renameSpy.mockRestore();
+			}
+		});
+
+		it("does not retry the temp-to-final rename on non-lock errors", async () => {
+			const now = Date.now();
+			const storagePath = getStoragePath();
+
+			// Same leaked-spy guard as the EPERM retry case above.
+			vi.restoreAllMocks();
+			const originalRename = fs.rename.bind(fs);
+			let tempRenameAttempts = 0;
+			const renameSpy = vi
+				.spyOn(fs, "rename")
+				.mockImplementation(async (oldPath, newPath) => {
+					const sourcePath = String(oldPath);
+					if (sourcePath.endsWith(".tmp") && String(newPath) === storagePath) {
+						tempRenameAttempts += 1;
+						const err = new Error(
+							"ENOSPC temp rename",
+						) as NodeJS.ErrnoException;
+						err.code = "ENOSPC";
+						throw err;
+					}
+					return originalRename(oldPath as string, newPath as string);
+				});
+			try {
+				await expect(
+					saveAccounts({
+						version: 3 as const,
+						activeIndex: 0,
+						accounts: [{ refreshToken: "token", addedAt: now, lastUsed: now }],
+					}),
+				).rejects.toThrow(/ENOSPC temp rename|Failed to save accounts/);
+				expect(tempRenameAttempts).toBe(1);
+			} finally {
+				renameSpy.mockRestore();
+			}
+		});
+
 		it("rotates backups and retains historical snapshots", async () => {
 			const now = Date.now();
 			const storagePath = getStoragePath();


### PR DESCRIPTION
## Summary

- Closes out the audit's §4.2 retry consolidation (finding M7): the last two hand-rolled retry loops in the codebase now go through the shared `withRetry` in `lib/fs-retry.ts`. After this, `grep "for (let attempt"` over `lib/` finds nothing — every retry policy is declared, not re-implemented.

## What Changed

**`lib/storage.ts` — `renameTempToPath`** (the temp→final rename inside the account save path): the manual EPERM/EBUSY loop becomes

```ts
withRetry(() => fs.rename(tempPath, path), {
	maxAttempts: 5,
	backoffMs: (attempt) => 10 * 2 ** (attempt - 1),
	retryableCodes: ["EPERM", "EBUSY"],
})
```

Policy is byte-identical (same codes, same 5 attempts, same 10/20/40/80ms schedule) with one deliberate difference, called out in a code comment: the old loop slept once more (160ms) *after* the final failed attempt before rethrowing; `withRetry` documents and implements "no delay after the final attempt", so exhaustion now surfaces 160ms sooner.

**`lib/config.ts` — `savePluginConfig` env-path branch**: the mtime CAS loop becomes `withRetry` over the whole read-merge-write operation (`retryableCodes: ["ESTALE"]`, 3 attempts, no delay). Each retry naturally re-stats, re-reads, and re-merges because the reads live inside the operation. The `Aborting config save … unreadable` error carries no `code`, so it still propagates immediately, exactly as before.

**`test/storage.test.ts`** — two new tests pin the rename policy through the real `saveAccounts` path: EPERM twice then success (asserts exactly 3 attempts and the saved file content), and ENOSPC failing fast with exactly 1 attempt. Both start with `vi.restoreAllMocks()`: the neighbouring environment-failing tests in sandboxed containers can leak an `fs.rename` spy when they die mid-test, and a passthrough binding captured from a leaked spy recurses into the new test's own mock. (That same leak is why the pre-existing staged-rename test appears in the §7 environment baseline.)

## Validation

- [x] `npm run typecheck` (also in the pre-commit hook)
- [x] `npx eslint lib/storage.ts lib/config.ts test/storage.test.ts --max-warnings=0`
- [x] `npm test -- test/config-save.test.ts test/fs-retry.test.ts test/account-save.test.ts test/unified-settings.test.ts` — 73/73 (config-save's existing ESTALE re-read/re-merge tests pass unchanged against the migrated CAS)
- [x] `npm test -- test/storage.test.ts` — failure names are a strict subset (19) of the 23-name `docs/audits/evidence/test-baseline-2026-06-10.txt` environment block for this file; zero new names, and both new tests pass even in the poisoned full-suite ordering
- [ ] `npm run build` deferred to CI

## Docs and Governance Checklist

- [x] No user-visible command/setting/path surface changed; pure internal refactor with identical retry policies

## Risk and Rollback

- Risk level: low — both call sites keep their exact attempt counts, retryable code sets, and backoff schedules; the only timing change is dropping a pointless 160ms sleep before the rename loop's final rethrow. The ESTALE CAS semantics are pinned by existing `config-save.test.ts` cases that pass unchanged.
- Rollback plan: revert the single commit; the two new tests fail against the restored hand-rolled loops only if the policy itself regresses, so they remain valid either way.

## Additional Notes

- §4.2's first batch (the `withRetry` helper itself plus the config/quota-cache/recovery/uninstall migrations) landed earlier in the cycle; this is the planned second, final batch.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

completes §4.2 retry consolidation (audit finding M7): the last two hand-rolled retry loops in `lib/` are replaced with `withRetry` from `lib/fs-retry.ts`, making every retry policy in the codebase declared rather than re-implemented.

- `lib/storage.ts` — `renameTempToPath` adopts `withRetry` with the original EPERM/EBUSY codes, 5 attempts, and 10ms-doubling schedule; the only intentional behavioral change (explicitly documented) is that the 160ms sleep after the 5th failed attempt is dropped before rethrowing.
- `lib/config.ts` — the ESTALE CAS loop in `savePluginConfig` moves to `withRetry` with `backoffMs: 0` and 3 attempts; semantics are byte-identical including immediate rethrow for the code-less "unreadable" error.
- `test/storage.test.ts` — two new tests pin the rename retry policy end-to-end: EPERM×2→success (3 attempts, correct file content) and ENOSPC→fast-fail (1 attempt).

<h3>Confidence Score: 4/5</h3>

safe to merge — both migrated call sites preserve their exact attempt counts, retryable code sets, and inter-attempt backoff schedules; the one deliberate change (dropping a trailing no-op 160ms sleep in the rename path) is low-risk and well-documented

the `vi.restoreAllMocks()` calls added inside the test bodies are the only rough edge: they work correctly against today's `beforeEach` (which sets up no spies), but if a spy-based fixture is ever added to that hook the broad restore will silently tear it down and produce confusing test failures

test/storage.test.ts — the `vi.restoreAllMocks()` pattern in the two new tests; all other changes are straightforward migrations

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage.ts | migrates `renameTempToPath` to `withRetry`; backoff schedule (10/20/40/80ms, EPERM+EBUSY, 5 attempts) is byte-identical to the old loop — the only difference (explicitly documented) is dropping the trailing 160ms sleep after the 5th failed attempt before rethrowing |
| lib/config.ts | migrates the ESTALE CAS loop in `savePluginConfig` to `withRetry`; semantics are identical — 3 attempts, no inter-attempt delay (`backoffMs: 0`), immediate rethrow on non-ESTALE errors and on the "unreadable" code-less error |
| test/storage.test.ts | two new tests pin the rename retry policy (EPERM×2→success, ENOSPC→fast-fail); `vi.restoreAllMocks()` guard inside the test body is correct for today's `beforeEach` (no spies) but fragile if spy setup is ever added there |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant withRetry
    participant fs

    Note over Caller,fs: storage.ts — renameTempToPath (maxAttempts=5, EPERM/EBUSY)
    Caller->>withRetry: rename(tempPath, path)
    withRetry->>fs: rename() [attempt 1]
    fs-->>withRetry: EPERM/EBUSY → sleep 10ms
    withRetry->>fs: rename() [attempt 2]
    fs-->>withRetry: EPERM/EBUSY → sleep 20ms
    withRetry->>fs: rename() [attempt N ≤ 5]
    fs-->>withRetry: success or exhausted → rethrow immediately

    Note over Caller,fs: config.ts — savePluginConfig CAS (maxAttempts=3, ESTALE, no delay)
    Caller->>withRetry: stat+read+merge+write
    withRetry->>fs: writeJsonFileAtomicWithRetry [attempt 1]
    fs-->>withRetry: ESTALE → retry immediately
    withRetry->>fs: writeJsonFileAtomicWithRetry [attempt 2]
    fs-->>withRetry: ESTALE → retry immediately
    withRetry->>fs: writeJsonFileAtomicWithRetry [attempt 3]
    fs-->>withRetry: success or exhausted → rethrow
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-66-retry-loop-migration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-66-retry-loop-migration%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fstorage.test.ts%3A3986-3987%0A**%60vi.restoreAllMocks%28%29%60%20inside%20test%20body%20wipes%20%60beforeEach%60%20spies**%0A%0Athe%20current%20%60beforeEach%60%20for%20this%20describe%20block%20only%20calls%20%60vi.useFakeTimers%60%20and%20creates%20a%20temp%20dir%20%E2%80%94%20no%20spies%20%E2%80%94%20so%20this%20is%20safe%20today.%20but%20%60vi.restoreAllMocks%28%29%60%20runs%20*after*%20%60beforeEach%60%20fires%2C%20meaning%20any%20spy%20added%20there%20in%20future%20%28e.g.%20an%20%60fs.stat%60%20stub%20for%20a%20flaky%20fixture%29%20would%20be%20silently%20torn%20down%20before%20this%20test%20runs.%20a%20narrower%20fix%20%E2%80%94%20e.g.%20%60if%20%28vi.isMockFunction%28fs.rename%29%29%20vi.mocked%28fs.rename%29.mockRestore%28%29%60%20%E2%80%94%20targets%20only%20the%20leaked%20spy%20without%20the%20broad%20side-effect.%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fstorage.test.ts%3A4023-4028%0A**same%20%60vi.restoreAllMocks%28%29%60%20fragility%20in%20the%20ENOSPC%20test**%0A%0Athe%20identical%20broad-restore%20pattern%20appears%20in%20the%20second%20new%20test.%20the%20same%20concern%20applies%3A%20a%20future%20%60beforeEach%60%20spy%20on%20%60fs.stat%60%2C%20%60fs.writeFile%60%2C%20etc.%20would%20be%20silently%20cleared%20before%20this%20test%20body%20runs.%20both%20occurrences%20should%20use%20a%20targeted%20restore%20if%20the%20upstream%20spy-leak%20fix%20is%20deferred.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=585&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/storage.test.ts:3986-3987
**`vi.restoreAllMocks()` inside test body wipes `beforeEach` spies**

the current `beforeEach` for this describe block only calls `vi.useFakeTimers` and creates a temp dir — no spies — so this is safe today. but `vi.restoreAllMocks()` runs *after* `beforeEach` fires, meaning any spy added there in future (e.g. an `fs.stat` stub for a flaky fixture) would be silently torn down before this test runs. a narrower fix — e.g. `if (vi.isMockFunction(fs.rename)) vi.mocked(fs.rename).mockRestore()` — targets only the leaked spy without the broad side-effect.

### Issue 2 of 2
test/storage.test.ts:4023-4028
**same `vi.restoreAllMocks()` fragility in the ENOSPC test**

the identical broad-restore pattern appears in the second new test. the same concern applies: a future `beforeEach` spy on `fs.stat`, `fs.writeFile`, etc. would be silently cleared before this test body runs. both occurrences should use a targeted restore if the upstream spy-leak fix is deferred.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: migrate the last two hand-roll..."](https://github.com/ndycode/codex-multi-auth/commit/70e2a06f5c5c924fbf6f43d99b28c506ef1c7312) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36916451)</sub>

<!-- /greptile_comment -->