### PR TITLE
refactor: throw CodexValidationError from rotation-proxy startup guards

### DIFF
--- a/docs/reference/error-contracts.md
+++ b/docs/reference/error-contracts.md
@@ -106,6 +106,16 @@ Invalid named-parameter calls (missing or wrongly typed required fields, or unkn
 
 ---
 
+## Typed Error Classes
+
+`lib/errors.ts` exports a `CodexError` hierarchy (`CodexApiError`, `CodexAuthError`, `CodexNetworkError`, `CodexValidationError`, `CodexRateLimitError`, `StorageError`, `CodexUnavailableError`). Every subclass carries a stable string `code` (the `ErrorCode` constants) plus class-specific fields, so callers can branch on `instanceof` or `code` instead of message text.
+
+Startup-validation guarantees backed by these types:
+
+- `startRuntimeRotationProxy` throws `CodexValidationError` with `field: "clientApiKey"` when no client API key is supplied, and `CodexValidationError` with `field: "host"` (offending host in `context.host`) when asked to bind a non-loopback host. Messages are unchanged from earlier releases; only the class tightened.
+
+---
+
 ## Related
 
 - [public-api.md](public-api.md)

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -46,6 +46,7 @@ import {
 } from "./policy/runtime-policy.js";
 import { isWorkspaceDisabledError } from "./request/fetch-helpers.js";
 import { createLogger, maskString, runWithCorrelationId } from "./logger.js";
+import { CodexValidationError } from "./errors.js";
 import {
 	buildPinnedUnavailableErrorBody,
 	buildTokenInvalidationBody,
@@ -620,9 +621,10 @@ export async function startRuntimeRotationProxy(
 	// binding a non-loopback host would expose every managed account to the
 	// network, so it is refused unconditionally.
 	if (!isLoopbackHost(host)) {
-		throw new Error(
+		throw new CodexValidationError(
 			`Runtime rotation proxy refuses to bind non-loopback host "${host}". ` +
 				"It forwards managed OAuth tokens and is loopback-only.",
+			{ field: "host", expected: "a loopback host", context: { host } },
 		);
 	}
 	// Normalize the validated host into its two representations exactly once so the
@@ -639,7 +641,10 @@ export async function startRuntimeRotationProxy(
 			? options.clientApiKey.trim()
 			: null;
 	if (!clientApiKey) {
-		throw new Error("Runtime rotation proxy requires a clientApiKey.");
+		throw new CodexValidationError(
+			"Runtime rotation proxy requires a clientApiKey.",
+			{ field: "clientApiKey", expected: "a non-empty string" },
+		);
 	}
 	const now = options.now ?? Date.now;
 	const tokenRefreshSkewMs = getTokenRefreshSkewMs(pluginConfig);

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { request } from "node:http";
 import { AccountManager } from "../lib/accounts.js";
+import { CodexValidationError } from "../lib/errors.js";
 import { HTTP_STATUS, OPENAI_HEADERS } from "../lib/constants.js";
 import {
 	startRuntimeRotationProxy,
@@ -331,6 +332,41 @@ describe("runtime rotation proxy", () => {
 				upstreamBaseUrl: "https://example.test/backend-api",
 			} as Parameters<typeof startRuntimeRotationProxy>[0]),
 		).rejects.toThrow("clientApiKey");
+	});
+
+	// §4.3 error-contract adoption: the startup guards throw typed validation
+	// errors so callers can branch on the class/field instead of message text.
+	it("throws CodexValidationError with the offending field from both startup guards", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now));
+		const { fetchImpl } = createRecordingFetch(() => textEventStream());
+
+		const missingKey = await startRuntimeRotationProxy({
+			accountManager,
+			fetchImpl,
+			upstreamBaseUrl: "https://example.test/backend-api",
+		} as Parameters<typeof startRuntimeRotationProxy>[0]).then(
+			() => null,
+			(error: unknown) => error,
+		);
+		expect(missingKey).toBeInstanceOf(CodexValidationError);
+		expect((missingKey as CodexValidationError).field).toBe("clientApiKey");
+
+		const badHost = await startRuntimeRotationProxy({
+			accountManager,
+			fetchImpl,
+			clientApiKey: DEFAULT_CLIENT_API_KEY,
+			host: "0.0.0.0",
+			upstreamBaseUrl: "https://example.test/backend-api",
+		}).then(
+			() => null,
+			(error: unknown) => error,
+		);
+		expect(badHost).toBeInstanceOf(CodexValidationError);
+		expect((badHost as CodexValidationError).field).toBe("host");
+		expect((badHost as CodexValidationError).context).toEqual({
+			host: "0.0.0.0",
+		});
 	});
 
 	// Regression (runtime-proxy-01): the proxy forwards managed OAuth tokens and must

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -351,6 +351,9 @@ describe("runtime rotation proxy", () => {
 		);
 		expect(missingKey).toBeInstanceOf(CodexValidationError);
 		expect((missingKey as CodexValidationError).field).toBe("clientApiKey");
+		expect((missingKey as CodexValidationError).expected).toBe(
+			"a non-empty string",
+		);
 
 		const badHost = await startRuntimeRotationProxy({
 			accountManager,
@@ -364,6 +367,7 @@ describe("runtime rotation proxy", () => {
 		);
 		expect(badHost).toBeInstanceOf(CodexValidationError);
 		expect((badHost as CodexValidationError).field).toBe("host");
+		expect((badHost as CodexValidationError).expected).toBe("a loopback host");
 		expect((badHost as CodexValidationError).context).toEqual({
 			host: "0.0.0.0",
 		});


### PR DESCRIPTION
## Summary

- First slice of the audit's §4.3 error-contract adoption (finding M11): the two startup guards in `startRuntimeRotationProxy` now throw `CodexValidationError` with machine-readable metadata instead of bare `Error`, and the guarantee is documented in `docs/reference/error-contracts.md`.

## What Changed

**`lib/runtime-rotation-proxy.ts`** — two conversions, messages byte-identical:

- The loopback-only host refusal (runtime-proxy-01 defense) throws `CodexValidationError` with `field: "host"`, `expected: "a loopback host"`, and the offending host in `context.host`.
- The missing-`clientApiKey` check throws `CodexValidationError` with `field: "clientApiKey"`, `expected: "a non-empty string"`.

Since messages are unchanged, every existing message-matching caller and test (`rejects.toThrow("clientApiKey")`, `/non-loopback/i`, `/loopback-only/i`) passes untouched; callers gain `instanceof CodexValidationError` and the stable `CODEX_VALIDATION_ERROR` code.

**`docs/reference/error-contracts.md`** — new "Typed Error Classes" section: lists the `lib/errors.ts` hierarchy and records the startup-guard guarantee, so the contract doc is backed by machine-readable types as §4.3 intended. It sits next to the existing note that the dual-call helpers deliberately throw native `TypeError` (that convention is unchanged).

**`test/runtime-rotation-proxy.test.ts`** — one new test capturing both guard rejections and asserting the class, `field`, and `context` payloads.

## Scope Note

The three remaining bare throws in `lib/config.ts` (`Aborting config save because … is unreadable.`) are deliberately deferred: one of them sits inside the ESTALE CAS block that open PR #585 rewrites, and converting them now would make my own two open PRs conflict. They'll be a tiny follow-up once #585 merges. After that, the three files §4.3 names carry no bare throws (fetch-helpers already has none — it returns mapped Responses by design).

## Validation

- [x] `npm run typecheck` (also in the pre-commit hook)
- [x] `npx eslint lib/runtime-rotation-proxy.ts test/runtime-rotation-proxy.test.ts --max-warnings=0`
- [x] `npm test -- test/runtime-rotation-proxy.test.ts` — 77 passed; the only 2 failures are the documented IPv6-disabled-container baseline names (`EAFNOSUPPORT ::1`, both present verbatim in `docs/audits/evidence/test-baseline-2026-06-10.txt`)
- [ ] `npm run build` deferred to CI

## Docs and Governance Checklist

- [x] `docs/reference/error-contracts.md` updated in the same PR as the behavior it documents
- [x] No user-visible message, command, or path changed; `CodexValidationError extends CodexError extends Error`, so all `instanceof Error` handling is unaffected

## Risk and Rollback

- Risk level: low — error class tightened, message and throw conditions identical. The only observable difference is richer metadata on the error object.
- Rollback plan: revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

tightens the two startup guards in `startRuntimeRotationProxy` from bare `Error` to `CodexValidationError` with machine-readable `field`, `expected`, and `context` fields, and documents the contract in `error-contracts.md`. messages are byte-identical, so all existing message-matching callers and tests are unaffected.

- `lib/runtime-rotation-proxy.ts`: host and clientApiKey guards now throw `CodexValidationError`; callers gain `instanceof` branching and the stable `CODEX_VALIDATION_ERROR` code.
- `test/runtime-rotation-proxy.test.ts`: new test covers both guards end-to-end, asserting `field`, `expected`, and `context` payloads.
- `docs/reference/error-contracts.md`: new "Typed Error Classes" section records the error hierarchy and the startup-guard guarantee.

<h3>Confidence Score: 5/5</h3>

safe to merge — error class tightened, throw conditions and messages unchanged, backward-compatible via inheritance

both guards are narrow, deterministic throws at startup; the change only adds metadata to the thrown object. `CodexValidationError` extends `CodexError` extends `Error`, so all `instanceof Error` and message-matching paths in existing callers and tests continue to work. the new test fully covers `field`, `expected`, and `context` for both guards.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime-rotation-proxy.ts | two bare throws converted to CodexValidationError with structured field/expected/context metadata; import added; no logic change |
| test/runtime-rotation-proxy.test.ts | new test exercises both startup guards and asserts instanceof, field, expected, and context; prior feedback on expected assertions was addressed |
| docs/reference/error-contracts.md | new "Typed Error Classes" section documents the CodexError hierarchy and startRuntimeRotationProxy startup-guard guarantees; accurate against errors.ts |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[startRuntimeRotationProxy called] --> B{isLoopbackHost host?}
    B -- no --> C[throw CodexValidationError\nfield: host\nexpected: a loopback host\ncontext: host]
    B -- yes --> D{clientApiKey non-empty?}
    D -- no --> E[throw CodexValidationError\nfield: clientApiKey\nexpected: a non-empty string]
    D -- yes --> F[continue startup…]
```

<sub>Reviews (2): Last reviewed commit: ["test: assert the expected field from bot..."](https://github.com/ndycode/codex-multi-auth/commit/5433ee08a658c613de877ebade142213686e72e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36917468)</sub>

<!-- /greptile_comment -->