### PR TITLE
refactor: abort unreadable config saves with a typed StorageError

### DIFF
--- a/docs/reference/error-contracts.md
+++ b/docs/reference/error-contracts.md
@@ -113,6 +113,7 @@ Invalid named-parameter calls (missing or wrongly typed required fields, or unkn
 Startup-validation guarantees backed by these types:
 
 - `startRuntimeRotationProxy` throws `CodexValidationError` with `field: "clientApiKey"` when no client API key is supplied, and `CodexValidationError` with `field: "host"` (offending host in `context.host`) when asked to bind a non-loopback host. Messages are unchanged from earlier releases; only the class tightened.
+- `savePluginConfig` aborts with `StorageError` (`code: "UNREADABLE"`, `path` = the config file, actionable `hint`, read-classifier message as `cause`) when the existing config file cannot be read. Messages are unchanged from earlier releases; only the class tightened.
 
 ---
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { parseBooleanEnv } from "./env-parsing.js";
 import { withRetry, withRetrySync } from "./fs-retry.js";
 import { logWarn } from "./logger.js";
+import { StorageError } from "./errors.js";
 import {
 	getCodexHomeDir,
 	getCodexMultiAuthDir,
@@ -859,6 +860,24 @@ function sanitizePluginConfigForSave(config: Partial<PluginConfig>): {
  * @param configPatch - Partial PluginConfig containing changes to persist; undefined fields are ignored.
  * @returns void
  */
+/**
+ * Typed abort for a config save that found the existing file unreadable
+ * (audit §4.3): same message as the historical bare Error, but callers can
+ * now branch on `instanceof StorageError` / the path field instead of text.
+ */
+function unreadableConfigSaveError(
+	configPath: string,
+	errorMessage: string,
+): StorageError {
+	return new StorageError(
+		`Aborting config save because ${configPath} is unreadable.`,
+		"UNREADABLE",
+		configPath,
+		"Fix or remove the unreadable config file, then retry the save.",
+		new Error(errorMessage),
+	);
+}
+
 export async function savePluginConfig(
 	configPatch: Partial<PluginConfig>,
 ): Promise<void> {
@@ -888,8 +907,9 @@ export async function savePluginConfig(
 						const expectedMtimeMs = await getConfigFileMtimeMs(envPath);
 						const envConfigState = await readConfigRecordForSave(envPath);
 						if (envConfigState.status === "unreadable") {
-							throw new Error(
-								`Aborting config save because ${envPath} is unreadable.`,
+							throw unreadableConfigSaveError(
+								envPath,
+								envConfigState.errorMessage,
 							);
 						}
 						const existingConfig =
@@ -915,8 +935,9 @@ export async function savePluginConfig(
 	await withConfigSaveLock(unifiedPath, async () => {
 		const unifiedConfigState = await readConfigRecordForSave(unifiedPath);
 		if (unifiedConfigState.status === "unreadable") {
-			throw new Error(
-				`Aborting config save because ${unifiedPath} is unreadable.`,
+			throw unreadableConfigSaveError(
+				unifiedPath,
+				unifiedConfigState.errorMessage,
 			);
 		}
 		const unifiedConfigRecord =
@@ -930,8 +951,9 @@ export async function savePluginConfig(
 			? await readConfigRecordForSave(legacyPath)
 			: null;
 		if (legacyConfigState?.status === "unreadable") {
-			throw new Error(
-				`Aborting config save because ${legacyPath} is unreadable.`,
+			throw unreadableConfigSaveError(
+				legacyPath as string,
+				legacyConfigState.errorMessage,
 			);
 		}
 		const legacyConfig =

--- a/test/config-save.test.ts
+++ b/test/config-save.test.ts
@@ -455,6 +455,47 @@ describe("plugin config save paths", () => {
     expect(parsed).toEqual({ codexMode: true, preserved: 1 });
   });
 
+  // §4.3 error-contract adoption: the unreadable-abort is a typed StorageError
+  // carrying the config path, so callers can branch on the class/path instead
+  // of the message text (which is unchanged).
+  it("aborts with a typed StorageError naming the unreadable config path", async () => {
+    const configPath = join(tempDir, "plugin-config.json");
+    process.env.CODEX_MULTI_AUTH_CONFIG_PATH = configPath;
+    await fs.writeFile(configPath, JSON.stringify({ codexMode: true }), "utf8");
+
+    const originalReadFile = fs.readFile.bind(fs);
+    const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      const [targetPath] = args;
+      if (targetPath === configPath) {
+        const error = new Error("busy") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return originalReadFile(...args);
+    });
+
+    try {
+      const { savePluginConfig } = await import("../lib/config.js");
+      const { StorageError } = await import("../lib/errors.js");
+      const thrown = await savePluginConfig({ codexMode: false }).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(thrown).toBeInstanceOf(StorageError);
+      expect((thrown as InstanceType<typeof StorageError>).path).toBe(
+        configPath,
+      );
+      expect((thrown as InstanceType<typeof StorageError>).code).toBe(
+        "UNREADABLE",
+      );
+      expect((thrown as Error).message).toBe(
+        `Aborting config save because ${configPath} is unreadable.`,
+      );
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
   it("treats non-retryable env-path read failures as unreadable", async () => {
     const configPath = join(tempDir, "plugin-config.json");
     process.env.CODEX_MULTI_AUTH_CONFIG_PATH = configPath;


### PR DESCRIPTION
## Summary

- Second slice of the audit's §4.3 error-contract adoption (finding M11), unblocked by #585's merge: the three `Aborting config save because <path> is unreadable.` throws in `savePluginConfig` now produce a typed `StorageError` instead of a bare `Error`. With #586 (merged) and this PR, the three files §4.3 names carry no bare throws — M11 is fully executed.

## What Changed

**`lib/config.ts`** — one new `unreadableConfigSaveError(configPath, errorMessage)` helper replaces the three inline throws (env-path branch inside the ESTALE CAS, unified path, legacy path). It returns a `StorageError` carrying:

- the byte-identical historical message (existing `rejects.toThrow("unreadable")` assertions and CLI output are unchanged),
- `code: "UNREADABLE"` (following the existing non-errno precedent of `"UNKNOWN"` in the storage layer),
- `path` = the offending config file,
- an actionable hint ("Fix or remove the unreadable config file, then retry the save."),
- the read-classifier's message as `cause` for debuggability.

The typed throw still propagates immediately through the ESTALE `withRetry` (its code is not `ESTALE` → non-retryable), exactly as before.

**`docs/reference/error-contracts.md`** — adds the `savePluginConfig` guarantee to the "Typed Error Classes" section that #586 introduced (branch rebased onto post-#586 `main` so the section exists here).

**`test/config-save.test.ts`** — new test pinning the class, `path`, `code`, and exact message through the real `savePluginConfig` env path, alongside the three existing unreadable tests which pass unchanged.

## Validation

- [x] `npm run typecheck` (also in the pre-commit hook)
- [x] `npx eslint lib/config.ts test/config-save.test.ts --max-warnings=0`
- [x] `npm test -- test/config-save.test.ts` — 21/21 (the three pre-existing unreadable-abort tests pass without modification, proving message compatibility)
- [x] Full-suite canary on clean post-merge-storm `main` completed just before this branch: exactly the 58-name environment baseline, zero new names
- [ ] `npm run build` deferred to CI

## Docs and Governance Checklist

- [x] `docs/reference/error-contracts.md` updated in the same PR as the behavior it documents
- [x] No user-visible message, command, or path changed; `StorageError extends CodexError extends Error`, so all `instanceof Error` handling is unaffected

## Risk and Rollback

- Risk level: low — error class tightened, message and throw conditions identical; the only observable difference is richer metadata on the error object.
- Rollback plan: revert the two commits.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

replaces three inline `new Error(...)` throws in `savePluginConfig` with a typed `StorageError` via a new `unreadableConfigSaveError` factory, satisfying audit §4.3. the `"UNREADABLE"` code is not in the ESTALE `withRetry`'s `retryableCodes` list, so retry behavior is unchanged; message text is byte-identical, preserving existing test assertions.

- `lib/config.ts`: adds the `unreadableConfigSaveError` factory returning a `StorageError` with `code`, `path`, `hint`, and `cause`; all three unreadable-abort throw sites updated.
- `test/config-save.test.ts`: new test verifies `instanceof StorageError`, `path`, `code`, and message through the env-path branch with an `EBUSY` read spy.
- `docs/reference/error-contracts.md`: one-line contract guarantee added for `savePluginConfig`'s new typed error.

<h3>Confidence Score: 4/5</h3>

safe to merge; the only observable change is richer metadata on the thrown error object — message text, throw conditions, and retry behavior are all identical to before

the three throw sites are straightforward substitutions, the ESTALE retry loop correctly non-retries the new StorageError (code "UNREADABLE" is absent from retryableCodes: ["ESTALE"]), and the new test covers the core contract. the savePluginConfig JSDoc block is left orphaned above the helper, which is a cosmetic gap but doesn't affect runtime behavior.

lib/config.ts — the original savePluginConfig JSDoc block is now detached from the function; worth fixing before merging to keep IDE hover docs accurate

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/config.ts | three bare Error throws replaced by a typed StorageError via a small factory; retry behavior through the ESTALE withRetry loop is unaffected ("UNREADABLE" is not in retryableCodes: ["ESTALE"]); the original savePluginConfig JSDoc is now orphaned above the helper and detached from the function |
| test/config-save.test.ts | new test pins instanceof StorageError, path, code, and message through the real env-path branch; env var cleanup is handled by the existing afterEach restore loop; hint and cause are not asserted but that's a minor gap |
| docs/reference/error-contracts.md | one-line guarantee added for savePluginConfig's StorageError; matches the implementation exactly |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant S as savePluginConfig
    participant R as readConfigRecordForSave
    participant F as unreadableConfigSaveError
    participant W as withRetry (ESTALE)

    C->>S: savePluginConfig(patch)
    S->>W: withRetry([ESTALE], op)
    W->>R: readConfigRecordForSave(path)
    alt "status === "unreadable""
        R-->>W: "{ status: "unreadable", errorMessage }"
        W->>F: unreadableConfigSaveError(path, msg)
        F-->>W: "StorageError(code="UNREADABLE")"
        note over W: "UNREADABLE" not in ["ESTALE"] → rethrow immediately
        W-->>S: throws StorageError
        S-->>C: throws StorageError
    else "status === "ok" or "missing""
        R-->>W: config record
        W->>W: merge + write
        W-->>S: void
        S-->>C: void
    end
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-68-config-typed-errors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-68-config-typed-errors%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fconfig.ts%3A850-881%0A**JSDoc%20block%20orphaned%20from%20%60savePluginConfig%60**%0A%0Ainserting%20%60unreadableConfigSaveError%60%20between%20the%20existing%20JSDoc%20and%20the%20%60savePluginConfig%60%20declaration%20means%20TypeScript%2FIDEs%20now%20attach%20the%20%60%40param%20configPatch%60%20%2F%20%60%40returns%20void%60%20block%20to%20the%20helper%20%28as%20the%20immediately-preceding%20comment%29%20and%20%60savePluginConfig%60%20itself%20has%20no%20JSDoc%20at%20all.%20the%20fix%20is%20to%20move%20the%20%60unreadableConfigSaveError%60%20function%20%28with%20its%20own%20JSDoc%29%20above%20the%20savePluginConfig%20documentation%20block%2C%20or%20move%20the%20savePluginConfig%20JSDoc%20block%20to%20sit%20directly%20above%20its%20%60export%20async%20function%60%20declaration.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=587&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/config.ts:850-881
**JSDoc block orphaned from `savePluginConfig`**

inserting `unreadableConfigSaveError` between the existing JSDoc and the `savePluginConfig` declaration means TypeScript/IDEs now attach the `@param configPatch` / `@returns void` block to the helper (as the immediately-preceding comment) and `savePluginConfig` itself has no JSDoc at all. the fix is to move the `unreadableConfigSaveError` function (with its own JSDoc) above the savePluginConfig documentation block, or move the savePluginConfig JSDoc block to sit directly above its `export async function` declaration.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: record the savePluginConfig typed-..."](https://github.com/ndycode/codex-multi-auth/commit/75445822133c54eab1f07623fa616d88da7d78dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36918424)</sub>

<!-- /greptile_comment -->