### PR TITLE
docs: refresh test knowledge-base counts and list the new suites

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -58,6 +58,7 @@ test/
 ├── health-check.test.ts            # runHealthCheck quick + live probe paths
 ├── logger.test.ts                  # logging functionality
 ├── login-flow.test.ts              # runAuthLogin transports and cap handling
+├── login-menu-accounts.test.ts     # account-row assembly for the login menu
 ├── login-menu-actions.test.ts      # manage actions, identity re-resolution
 ├── login-menu-data.test.ts         # dashboard row view model, drift sync
 ├── login-oauth-selection.test.ts   # login-oauth account selection

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -5,7 +5,7 @@ Commit: b0ef65d
 
 ## OVERVIEW
 Vitest suites for OAuth flow, request transforms, response handling, rotation logic, storage, CLI management, repo hygiene, and more.
-**3847 tests** across **257 test files** with 80%+ coverage threshold.
+**4909 tests** across **317 test files** with 80%+ coverage threshold.
 
 ## STRUCTURE
 ```
@@ -13,6 +13,7 @@ test/
 ├── accounts.test.ts                # multi-account storage/rotation
 ├── ansi.test.ts                    # ANSI escape helpers
 ├── audit.test.ts                   # rotating file audit log
+├── auth-menu-builder.test.ts       # auth dashboard view-model formatters
 ├── auth-menu-hotkeys.test.ts       # auth menu hotkey behavior
 ├── auth-rate-limit.test.ts         # token bucket for auth
 ├── auth.test.ts                    # OAuth PKCE + JWT decoding
@@ -54,7 +55,12 @@ test/
 ├── input-utils.test.ts             # input filtering
 ├── install-codex-auth.test.ts      # installer tests
 ├── live-account-sync.test.ts       # live account sync
+├── health-check.test.ts            # runHealthCheck quick + live probe paths
 ├── logger.test.ts                  # logging functionality
+├── login-flow.test.ts              # runAuthLogin transports and cap handling
+├── login-menu-actions.test.ts      # manage actions, identity re-resolution
+├── login-menu-data.test.ts         # dashboard row view model, drift sync
+├── login-oauth-selection.test.ts   # login-oauth account selection
 ├── model-map.test.ts               # model name normalization
 ├── oauth-server.integration.test.ts # OAuth server (port 1455)
 ├── package-bin.test.ts             # package.json bin field
@@ -64,14 +70,18 @@ test/
 ├── preemptive-quota-scheduler.test.ts # quota deferral
 ├── proactive-refresh.test.ts       # token refresh before expiry
 ├── property/
+│   ├── account-identity.property.test.ts # identity matching/dedup invariants
 │   ├── helpers.ts                  # property test utilities
+│   ├── model-fallback.property.test.ts # unsupported-model fallback invariants
 │   ├── rotation.property.test.ts   # rotation property tests
 │   ├── setup.test.ts               # property test setup
 │   ├── setup.ts                    # property test config
+│   ├── settings-write-queue.property.test.ts # write-queue ordering/clamp invariants
 │   └── transformer.property.test.ts # transformer property tests
 ├── quota-cache.test.ts             # quota cache
 ├── quota-probe.test.ts             # quota probe
 ├── rate-limit-backoff.test.ts      # exponential backoff
+├── rate-limit-decision.test.ts     # rate-limit/invalidation decision tree
 ├── recovery-constants.test.ts      # recovery constants
 ├── recovery-storage.test.ts        # recovery storage
 ├── recovery.test.ts                # session recovery
@@ -82,13 +92,18 @@ test/
 ├── request-transformer.test.ts     # request body transforms
 ├── response-handler-logging.test.ts # SSE handler logging branches
 ├── response-handler.test.ts        # SSE to JSON conversion
+├── rotation-account-selection.test.ts # chooseAccount tiers, pin discipline
 ├── rotation-integration.test.ts    # rotation integration, Windows cleanup
+├── rotation-proxy-state.test.ts    # proxy state init, stale-state recovery
+├── rotation-token-refresh.test.ts  # ensureFreshAccessToken refresh/cooldown
 ├── rotation.test.ts                # account selection
 ├── runtime-paths.test.ts           # runtime path resolution
 ├── schemas.test.ts                 # Zod schema validation
 ├── select.test.ts                  # select prompt tests
 ├── server.unit.test.ts             # OAuth server unit tests
 ├── session-affinity.test.ts        # session affinity
+├── settings-hub-shared.test.ts     # settings merge/persist transaction
+├── settings-write-queue.test.ts    # queued settings write retry policy
 ├── shutdown.test.ts                # graceful shutdown
 ├── storage-async.test.ts           # async storage operations
 ├── storage-recovery-paths.test.ts  # storage recovery paths

--- a/test/README.md
+++ b/test/README.md
@@ -57,6 +57,7 @@ test/
 ├── health-check.test.ts               # runHealthCheck quick + live probe paths
 ├── logger.test.ts                     # Logging functionality tests
 ├── login-flow.test.ts                 # runAuthLogin transports and cap handling
+├── login-menu-accounts.test.ts        # Account-row assembly for the login menu
 ├── login-menu-actions.test.ts         # Manage actions, identity re-resolution
 ├── login-menu-data.test.ts            # Dashboard row view model, drift sync
 ├── login-oauth-selection.test.ts      # Login-oauth account selection

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the test suite for the OpenAI Codex OAuth plugin.
 
-**Stats**: 2071 tests across 87 test files with 80%+ coverage threshold.
+**Stats**: 4909 tests across 317 test files with 80%+ coverage threshold.
 
 ## Test Structure
 
@@ -12,6 +12,7 @@ test/
 ├── accounts.test.ts                   # Multi-account storage/rotation tests
 ├── ansi.test.ts                       # ANSI escape helpers
 ├── audit.test.ts                      # Rotating file audit log tests
+├── auth-menu-builder.test.ts          # Auth dashboard view-model formatters
 ├── auth-menu-hotkeys.test.ts          # Auth menu hotkey behavior
 ├── auth-rate-limit.test.ts            # Token bucket rate limiting
 ├── auth.test.ts                       # OAuth authentication tests (PKCE + JWT)
@@ -53,7 +54,12 @@ test/
 ├── input-utils.test.ts               # Input filtering tests
 ├── install-codex-auth.test.ts         # Installer tests
 ├── live-account-sync.test.ts          # Live account sync
+├── health-check.test.ts               # runHealthCheck quick + live probe paths
 ├── logger.test.ts                     # Logging functionality tests
+├── login-flow.test.ts                 # runAuthLogin transports and cap handling
+├── login-menu-actions.test.ts         # Manage actions, identity re-resolution
+├── login-menu-data.test.ts            # Dashboard row view model, drift sync
+├── login-oauth-selection.test.ts      # Login-oauth account selection
 ├── model-map.test.ts                  # Model name normalization tests
 ├── oauth-server.integration.test.ts   # OAuth server integration (port 1455)
 ├── package-bin.test.ts                # package.json bin field
@@ -63,14 +69,18 @@ test/
 ├── preemptive-quota-scheduler.test.ts # Quota deferral
 ├── proactive-refresh.test.ts          # Token refresh before expiry
 ├── property/
+│   ├── account-identity.property.test.ts # Identity matching/dedup invariants
 │   ├── helpers.ts                     # Property test utilities
+│   ├── model-fallback.property.test.ts # Unsupported-model fallback invariants
 │   ├── rotation.property.test.ts      # Rotation property-based tests
 │   ├── setup.test.ts                  # Property test setup
 │   ├── setup.ts                       # Property test config
+│   ├── settings-write-queue.property.test.ts # Write-queue ordering/clamp invariants
 │   └── transformer.property.test.ts   # Transformer property tests
 ├── quota-cache.test.ts                # Quota cache
 ├── quota-probe.test.ts                # Quota probe
 ├── rate-limit-backoff.test.ts         # Exponential backoff tests
+├── rate-limit-decision.test.ts        # Rate-limit/invalidation decision tree
 ├── recovery-constants.test.ts         # Recovery constants tests
 ├── recovery-storage.test.ts           # Recovery storage tests
 ├── recovery.test.ts                   # Session recovery tests
@@ -81,13 +91,18 @@ test/
 ├── request-transformer.test.ts        # Request transformation tests
 ├── response-handler-logging.test.ts   # SSE handler logging branches
 ├── response-handler.test.ts           # Response handling tests (SSE to JSON)
+├── rotation-account-selection.test.ts # chooseAccount tiers, pin discipline
 ├── rotation-integration.test.ts       # Rotation integration, Windows cleanup
+├── rotation-proxy-state.test.ts       # Proxy state init, stale-state recovery
+├── rotation-token-refresh.test.ts     # ensureFreshAccessToken refresh/cooldown
 ├── rotation.test.ts                   # Account selection tests
 ├── runtime-paths.test.ts              # Runtime path resolution
 ├── schemas.test.ts                    # Zod schema validation tests
 ├── select.test.ts                     # Select prompt tests
 ├── server.unit.test.ts                # OAuth server unit tests
 ├── session-affinity.test.ts           # Session affinity
+├── settings-hub-shared.test.ts        # Settings merge/persist transaction
+├── settings-write-queue.test.ts       # Queued settings write retry policy
 ├── shutdown.test.ts                   # Graceful shutdown tests
 ├── storage-async.test.ts              # Async storage operation tests
 ├── storage-recovery-paths.test.ts     # Storage recovery paths


### PR DESCRIPTION
## Summary

- Doc-only. The two test-directory knowledge bases had drifted badly behind the direct-coverage wave: `test/AGENTS.md` claimed **3847 tests / 257 files** and `test/README.md` claimed **2071 / 87**, while the suite actually stands at **4909 tests across 317 files** (counts from a clean full-suite run on current `main`). None of the wave's ~33 new test files appeared in either curated tree.

## What Changed

- Both headline stats updated to 4909 tests / 317 files.
- Both curated trees gain entries for the wave's load-bearing new suites, placed alphabetically and matching each file's existing description style: the login quartet (`login-oauth-selection`, `login-menu-actions`, `login-flow`, `login-menu-data`), the rotation trio (`rotation-account-selection`, `rotation-token-refresh`, `rotation-proxy-state`), the settings pair (`settings-write-queue`, `settings-hub-shared`), plus `health-check`, `auth-menu-builder`, and `rate-limit-decision`.
- The `property/` subtree gains the three new fast-check suites (`account-identity`, `model-fallback`, `settings-write-queue`).
- The trees are deliberately curated (≈93 entries for 257 files before this change), so this adds the representative subset rather than all 33 new files — consistent with the existing convention.

## Validation

- [x] `npm run typecheck` (pre-commit hook)
- [x] `npm test -- test/documentation.test.ts test/repo-hygiene.test.ts` — 35/35
- [x] Counts cross-checked against the full-suite canary on current `main` (`Tests 4909`, `Test Files 317`)
- [ ] `npm test` / `npm run build` — not run for this markdown-only change

## Docs and Governance Checklist

- [x] No user-visible behavior changed; contributor-facing test docs only

## Risk and Rollback

- Risk level: minimal — markdown only; the trees are illustrative, not load-bearing for any tooling.
- Rollback plan: revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

doc-only refresh of the two test knowledge-base files, bumping headline stats from stale values (3847/257 and 2071/87) to the current full-suite counts (4909/317) and adding curated tree entries for the ~13 most representative new suites from the recent direct-coverage wave.

- headline stats corrected in both `test/AGENTS.md` and `test/README.md`; the gap between the two files (2071 vs 3847) is also closed, both now show the same authoritative figure
- new entries cover the login quintet (including `login-menu-accounts`), rotation trio, settings pair, `health-check`, `auth-menu-builder`, `rate-limit-decision`, and three `property/` fast-check suites — all placed inline with existing description style
- two alphabetical ordering slip-ups introduced: `health-check.test.ts` landed after `live-account-sync` instead of after `health.test.ts`, and `settings-write-queue.property.test.ts` landed after both `setup.*` files instead of before them

<h3>Confidence Score: 5/5</h3>

markdown-only change with no runtime impact; safe to merge

both files are purely illustrative documentation — no tooling reads these trees, no code paths are affected, and the stat corrections are cross-checked against a clean full-suite run. the two ordering nits are cosmetic and don't affect correctness.

no files require special attention beyond the two ordering fixes noted above

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/AGENTS.md | headline stats updated (3847→4909 tests, 257→317 files) and 13 new suite entries added; two minor alphabetical ordering issues: `health-check` placed after `live-account-sync` and `settings-write-queue.property` placed after `setup.*` |
| test/README.md | mirrors AGENTS.md changes — stats updated (2071→4909, 87→317) and same 13 entries added with identical ordering issues in both `health-check` placement and `property/settings-write-queue` position |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["test suite — 4909 tests / 317 files"] --> B["top-level suites"]
    A --> C["property/"]
    B --> D["login quintet\nlogin-flow · login-menu-accounts\nlogin-menu-actions · login-menu-data\nlogin-oauth-selection"]
    B --> E["rotation trio\nrotation-account-selection\nrotation-token-refresh\nrotation-proxy-state"]
    B --> F["settings pair\nsettings-hub-shared\nsettings-write-queue"]
    B --> G["singles\nhealth-check · auth-menu-builder\nrate-limit-decision"]
    C --> H["account-identity.property\nmodel-fallback.property\nsettings-write-queue.property"]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Faudit-69-test-docs-refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Faudit-69-test-docs-refresh%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2FAGENTS.md%3A57-59%0A%60health-check.test.ts%60%20is%20inserted%20after%20%60live-account-sync%60%20but%20%60h%60%20sorts%20before%20%60i%60%2F%60l%60%2C%20so%20it%20belongs%20much%20earlier%20%E2%80%94%20right%20after%20%60health.test.ts%60.%20same%20mis-ordering%20applies%20to%20%60settings-write-queue.property.test.ts%60%20in%20the%20%60property%2F%60%20subtree%3A%20%60settings%60%20%3C%20%60setup%60%20alphabetically%20%28%60i%60%20%3C%20%60u%60%20at%20position%205%29%2C%20so%20it%20should%20precede%20both%20%60setup.test.ts%60%20and%20%60setup.ts%60.%20the%20pr%20description%20promises%20alphabetical%20placement%2C%20and%20%60test%2FREADME.md%60%20has%20the%20identical%20two%20problems.%0A%0A%60%60%60suggestion%0A%E2%94%9C%E2%94%80%E2%94%80%20health-check.test.ts%20%20%20%20%20%20%20%20%20%20%20%20%23%20runHealthCheck%20quick%20%2B%20live%20probe%20paths%0A%E2%94%9C%E2%94%80%E2%94%80%20live-account-sync.test.ts%20%20%20%20%20%20%20%23%20live%20account%20sync%0A%E2%94%9C%E2%94%80%E2%94%80%20logger.test.ts%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20logging%20functionality%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2FAGENTS.md%3A78-81%0A%60settings-write-queue.property.test.ts%60%20sorts%20before%20%60setup.*%60%20%28%60setti%60%20%3C%20%60setu%60%29%2C%20so%20it%20should%20appear%20ahead%20of%20both%20setup%20files%20to%20maintain%20the%20stated%20alphabetical%20order.%0A%0A%60%60%60suggestion%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20settings-write-queue.property.test.ts%20%23%20write-queue%20ordering%2Fclamp%20invariants%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20setup.test.ts%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20property%20test%20setup%0A%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20setup.ts%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%23%20property%20test%20config%0A%E2%94%82%20%20%20%E2%94%94%E2%94%80%E2%94%80%20transformer.property.test.ts%20%23%20transformer%20property%20tests%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=588&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/AGENTS.md:57-59
`health-check.test.ts` is inserted after `live-account-sync` but `h` sorts before `i`/`l`, so it belongs much earlier — right after `health.test.ts`. same mis-ordering applies to `settings-write-queue.property.test.ts` in the `property/` subtree: `settings` < `setup` alphabetically (`i` < `u` at position 5), so it should precede both `setup.test.ts` and `setup.ts`. the pr description promises alphabetical placement, and `test/README.md` has the identical two problems.

```suggestion
├── health-check.test.ts            # runHealthCheck quick + live probe paths
├── live-account-sync.test.ts       # live account sync
├── logger.test.ts                  # logging functionality
```

### Issue 2 of 2
test/AGENTS.md:78-81
`settings-write-queue.property.test.ts` sorts before `setup.*` (`setti` < `setu`), so it should appear ahead of both setup files to maintain the stated alphabetical order.

```suggestion
│   ├── settings-write-queue.property.test.ts # write-queue ordering/clamp invariants
│   ├── setup.test.ts               # property test setup
│   ├── setup.ts                    # property test config
│   └── transformer.property.test.ts # transformer property tests
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: list login-menu-accounts beside it..."](https://github.com/ndycode/codex-multi-auth/commit/2c4f648e2a7c60802168a8b5a3227eb87bc3e587) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36919085)</sub>

<!-- /greptile_comment -->