### PR TITLE
docs: refresh the lib knowledge-base tree for the extraction era

### DIFF
--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -31,7 +31,7 @@ lib/
 ├── runtime/                       # Codex CLI/app integration helpers
 │   ├── app-bind.ts                # persistent packaged-app bind to localhost router
 │   ├── config-toml.ts             # provider config rewrite helpers
-│   ├── rotation-*.ts              # rotation-proxy selection/state/storage-meta/server-type helpers
+│   ├── rotation-*.ts              # rotation-proxy selection/state/storage-meta/server-type/token-refresh helpers
 │   ├── runtime-observability.ts   # persisted runtime counters
 │   ├── live-sync.ts               # runtime account sync
 │   ├── quota-probe.ts             # live quota probes

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -19,12 +19,19 @@ lib/
 ├── codex-manager.ts               # codex-multi-auth command dispatcher
 ├── codex-manager/
 │   ├── commands/                  # focused command implementations
+│   ├── formatters/                # shared CLI text/account/model/quota formatters
 │   ├── settings-hub.ts            # back-compat re-export stub
 │   └── settings-hub/              # shared/dashboard/backend/experimental/index panels
+├── policy/                        # runtime policy evaluation
 ├── request/                       # request transform, headers, response handling, retry/failover
+│   ├── helpers/                   # model map, input/tool utilities
+│   ├── rate-limit-decision.ts     # rate-limit/invalidation decision tree
+│   ├── stream-failover-runtime.ts # SSE failover orchestration for the runtime proxy
+│   └── ...                        # fetch helpers facade, transformer, response handler
 ├── runtime/                       # Codex CLI/app integration helpers
 │   ├── app-bind.ts                # persistent packaged-app bind to localhost router
 │   ├── config-toml.ts             # provider config rewrite helpers
+│   ├── rotation-*.ts              # rotation-proxy selection/state/storage-meta/server-type helpers
 │   ├── runtime-observability.ts   # persisted runtime counters
 │   ├── live-sync.ts               # runtime account sync
 │   ├── quota-probe.ts             # live quota probes
@@ -48,7 +55,11 @@ lib/
 ├── refresh-guardian.ts            # proactive refresh guard
 ├── preemptive-quota-scheduler.ts  # quota deferral scheduling
 ├── runtime-paths.ts               # multi-auth and Codex path resolution
-├── errors.ts                      # custom errors
+├── fs-retry.ts                    # shared withRetry/withRetrySync policies
+├── temp-path.ts                   # crypto-random temp/staging path helper
+├── budget-guard.ts                # request budget guard
+├── local-bridge.ts                # local bridge entrypoints
+├── errors.ts                      # CodexError hierarchy (typed error contracts)
 ├── logger.ts                      # diagnostics and request logging
 ├── shutdown.ts                    # graceful shutdown helpers
 ├── table-formatter.ts             # CLI table formatting
@@ -73,6 +84,8 @@ lib/
 | Failure policy | `request/failure-policy.ts` | retry/failover decisions |
 | Account selection | `rotation.ts`, `accounts.ts` | hybrid health + token bucket selection |
 | Account rate limits | `accounts/rate-limits.ts` | per-account tracking |
+| Retry policies | `fs-retry.ts` | shared `withRetry`/`withRetrySync`; every retry loop declares its policy here |
+| Temp/staging paths | `temp-path.ts` | crypto-random suffixes (audit H1); never derive temp names from `Math.random()` |
 | Storage format | `storage.ts`, `storage/` | V3 storage, backup/WAL, migration, restore, import/export |
 | Storage paths | `storage/paths.ts`, `runtime-paths.ts` | project root detection and runtime root resolution |
 | CLI commands | `codex-manager.ts`, `codex-manager/commands/` | `codex-multi-auth login/list/check/fix/doctor/...` |


### PR DESCRIPTION
## Summary

- Doc-only companion to #588 for the other knowledge base: `lib/AGENTS.md`'s curated STRUCTURE tree never picked up the module clusters the §4.1 extraction era created, so a reader following it today misses several load-bearing seams.

## What Changed

- **STRUCTURE tree** gains, in tree style: `codex-manager/formatters/` (shared CLI text/account/model/quota formatters), `policy/`, the `request/` sub-entries (`helpers/`, `rate-limit-decision.ts`, `stream-failover-runtime.ts`), the `runtime/rotation-*.ts` extraction cluster (selection/state/storage-meta/server-type helpers), plus four top-level modules: `fs-retry.ts` (the shared `withRetry`/`withRetrySync` home from §4.2), `temp-path.ts` (the crypto-random staging-path helper from audit H1), `budget-guard.ts`, and `local-bridge.ts`.
- **WHERE TO LOOK** gains two rows: "Retry policies" → `fs-retry.ts` (every retry loop declares its policy there as of #585) and "Temp/staging paths" → `temp-path.ts` (with the never-`Math.random()` reminder from H1).
- The `errors.ts` row now names the `CodexError` hierarchy, matching the typed-error contracts shipped in #586/#587.
- Kept the tree's curated style (representative entries + `└── ...` ellipses), mirroring how #588 handled the test knowledge bases.

## Validation

- [x] `npm run typecheck` (pre-commit hook)
- [x] `npm test -- test/documentation.test.ts` — passes
- [x] Every added path verified to exist on current `main`
- [ ] `npm test` / `npm run build` — not run for this markdown-only change

## Docs and Governance Checklist

- [x] No user-visible behavior changed; contributor-facing knowledge base only

## Risk and Rollback

- Risk level: minimal — markdown only.
- Rollback plan: revert the single commit.

https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNtnkLbBiXZxfQQYLMpucB)_

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

refreshes `lib/AGENTS.md` to reflect the module layout created during the §4.1 extraction era. all added paths have been verified to exist on `main`.

- **structure tree** gains `codex-manager/formatters/`, `policy/`, `request/` sub-entries, and `runtime/rotation-*.ts` (all five helpers including `token-refresh`), plus four new top-level entries: `fs-retry.ts`, `temp-path.ts`, `budget-guard.ts`, `local-bridge.ts`.
- **WHERE TO LOOK** gains "retry policies" → `fs-retry.ts` and "temp/staging paths" → `temp-path.ts`; `errors.ts` description is updated to name the `CodexError` hierarchy.

<h3>Confidence Score: 5/5</h3>

markdown-only change; every added path verified to exist on main; no runtime behavior touched.

all documented paths exist, rotation-*.ts now covers all five helpers including token-refresh, and withRetry/withRetrySync exports match the WHERE TO LOOK entry. no code changed.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/AGENTS.md | docs-only update; all added paths verified to exist on main; rotation-*.ts description now covers all five helpers including token-refresh |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    LIB[lib/] --> CM[codex-manager/]
    LIB --> POL[policy/]
    LIB --> REQ[request/]
    LIB --> RT[runtime/]
    LIB --> TOP[top-level modules]

    CM --> FMT[formatters/ ← NEW\ntext/account/model/quota]
    CM --> SCMD[commands/]

    POL --> RPT[runtime-policy.ts ← NEW]

    REQ --> HLP[helpers/ ← NEW\nmodel-map, input/tool utils]
    REQ --> RLD[rate-limit-decision.ts ← NEW]
    REQ --> SFR[stream-failover-runtime.ts ← NEW]

    RT --> ROT[rotation-*.ts ← NEW\nselection/state/storage-meta\nserver-type/token-refresh]

    TOP --> FSR[fs-retry.ts ← NEW\nwithRetry / withRetrySync]
    TOP --> TMP[temp-path.ts ← NEW\ncrypto-random staging paths]
    TOP --> BGD[budget-guard.ts ← NEW]
    TOP --> LBR[local-bridge.ts ← NEW]
    TOP --> ERR[errors.ts\nCodexError hierarchy]
```

<sub>Reviews (2): Last reviewed commit: ["docs: include token-refresh in the rotat..."](https://github.com/ndycode/codex-multi-auth/commit/d455944afa6e0d7915dd4ae24389fcc3f19b6fab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36919631)</sub>

**Context used:**

- Context used - lib/AGENTS.md ([source](https://app.greptile.com/zeian/github/ndycode/codex-multi-auth/-/custom-context?memory=ffbed5b7-f299-4c32-b3f9-f7c095ca8632))

<!-- /greptile_comment -->