### PR TITLE
feat(contrib): SwiftBar menu bar quota plugin for macOS

### DIFF
--- a/contrib/swiftbar/README.md
+++ b/contrib/swiftbar/README.md
@@ -3,14 +3,14 @@
 A menu bar widget for [SwiftBar](https://github.com/swiftbar/SwiftBar) that shows
 per-account Codex quota from the local codex-multi-auth cache.
 
-```
+```text
 ⚡88·[90]          ← menu bar title: 5h-window remaining % per account,
                      brackets mark the account currently serving requests
 ```
 
 Opening the menu renders one card per managed account:
 
-```
+```text
 ╭──────────────────────────────────╮
 │ ● account-a               ACTIVE │
 │ 5h █████████░   88%  → 4h 42m    │

--- a/contrib/swiftbar/README.md
+++ b/contrib/swiftbar/README.md
@@ -1,0 +1,62 @@
+# SwiftBar Quota Plugin (macOS)
+
+A menu bar widget for [SwiftBar](https://github.com/swiftbar/SwiftBar) that shows
+per-account Codex quota from the local codex-multi-auth cache.
+
+```
+⚡88·[90]          ← menu bar title: 5h-window remaining % per account,
+                     brackets mark the account currently serving requests
+```
+
+Opening the menu renders one card per managed account:
+
+```
+╭──────────────────────────────────╮
+│ ● account-a               ACTIVE │
+│ 5h █████████░   88%  → 4h 42m    │
+│ 7d ████████░░   83%  → 6d 18h    │
+╰──────────────────────────────────╯
+╭──────────────────────────────────╮
+│ ○ account-b                 IDLE │
+│ 5h █████████░   90%  → 4h 33m    │
+│ 7d █████████░   86%  → 8h 16m    │
+╰──────────────────────────────────╯
+```
+
+- Green card / `●` / `ACTIVE`: the account the runtime rotation router last
+  served a request with (falls back to the stored active index).
+- `5h` / `7d`: the two Codex quota windows — bar, remaining percent, and a
+  countdown to the window reset (`4h 42m` style).
+- Rows turn orange below 30% remaining and red below 10%.
+
+## Install
+
+```bash
+brew install --cask swiftbar          # if not installed
+mkdir -p ~/.swiftbar-plugins
+cp contrib/swiftbar/codex-quota.5m.sh ~/.swiftbar-plugins/
+chmod +x ~/.swiftbar-plugins/codex-quota.5m.sh
+open -a SwiftBar                      # pick ~/.swiftbar-plugins as the plugin folder
+```
+
+## Data source and refresh model
+
+The plugin reads the local quota cache (`quota-cache.json`), account store, and
+runtime observability files under `~/.codex/multi-auth/` (or
+`CODEX_MULTI_AUTH_DIR`). Reading the cache costs **zero quota**: the cache is
+updated passively from the rate-limit headers of real Codex traffic flowing
+through the rotation proxy, and by explicit live checks.
+
+- The `5m` in the filename is SwiftBar's re-read interval (cache only).
+- The menu re-reads the cache every time it is opened (`refreshOnOpen`).
+- **Live refresh** in the menu runs `codex-multi-auth check`, which sends one
+  minimal probe per account and consumes a small amount of quota.
+
+## Notes
+
+- macOS only (SwiftBar). Card borders require a Menlo-native glyph set; if you
+  edit the card interior, avoid CJK or emoji — they render in a fallback font
+  with non-integer widths and break the right border alignment.
+- The cache file formats are internal to codex-multi-auth and may change
+  between versions; the plugin fails soft (shows `⚡?`) when they do.
+- Account names shown are the local-part of each account email.

--- a/contrib/swiftbar/codex-quota.5m.sh
+++ b/contrib/swiftbar/codex-quota.5m.sh
@@ -8,13 +8,21 @@
 # <swiftbar.runInBash>true</swiftbar.runInBash>
 #
 # Reads the local codex-multi-auth quota cache (zero quota cost). The cache is
-# refreshed passively by real Codex traffic through the rotation proxy; the
-# "Live refresh" menu item triggers one explicit probe per account.
+# written by quota-bearing commands (`check`, `forecast --live`, the interactive
+# dashboard); the "Live refresh" menu item runs one such check, sending a
+# minimal probe per account.
+
+if [ "$(uname -s)" != "Darwin" ]; then
+	echo "⚡"
+	echo "---"
+	echo "Codex quota plugin requires macOS (SwiftBar) | color=gray"
+	exit 0
+fi
 
 if [ "$1" = "livecheck" ]; then
 	export PATH="/usr/local/bin:/opt/homebrew/bin:$HOME/.npm-global/bin:$PATH"
-	codex-multi-auth check >/dev/null 2>&1
-	exit 0
+	codex-multi-auth check
+	exit $?
 fi
 
 SELF="$0"
@@ -60,6 +68,12 @@ def fmt_reset(ms):
     if h > 0:
         return f"{h}h {m}m"
     return f"{m}m"
+
+def clamp_pct(value):
+    try:
+        return max(0, min(100, int(value)))
+    except (TypeError, ValueError):
+        return 0
 
 def bar(remaining, slots=10):
     filled = round(remaining / 100 * slots)
@@ -111,7 +125,7 @@ for aid in order:
         newest = max(newest, q.get("updatedAt", 0))
         for key, label in (("primary", "5h"), ("secondary", "7d")):
             win = q.get(key, {})
-            rem = 100 - win.get("usedPercent", 0)
+            rem = clamp_pct(100 - clamp_pct(win.get("usedPercent", 0)))
             reset = fmt_reset(win["resetAtMs"]) if win.get("resetAtMs") else "-"
             rows.append((pad(f"{label} {bar(rem)}  {rem:>3}%  → {reset}", W), quota_color(rem)))
             if key == "primary":

--- a/contrib/swiftbar/codex-quota.5m.sh
+++ b/contrib/swiftbar/codex-quota.5m.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# <swiftbar.title>Codex Multi-Auth Quota</swiftbar.title>
+# <swiftbar.version>v1.0</swiftbar.version>
+# <swiftbar.author>codex-multi-auth contributors</swiftbar.author>
+# <swiftbar.about>macOS menu bar cards for codex-multi-auth account quota (5h/7d windows, active-account marker, reset countdowns)</swiftbar.about>
+# <swiftbar.dependencies>codex-multi-auth,python3</swiftbar.dependencies>
+# <swiftbar.refreshOnOpen>true</swiftbar.refreshOnOpen>
+# <swiftbar.runInBash>true</swiftbar.runInBash>
+#
+# Reads the local codex-multi-auth quota cache (zero quota cost). The cache is
+# refreshed passively by real Codex traffic through the rotation proxy; the
+# "Live refresh" menu item triggers one explicit probe per account.
+
+if [ "$1" = "livecheck" ]; then
+	export PATH="/usr/local/bin:/opt/homebrew/bin:$HOME/.npm-global/bin:$PATH"
+	codex-multi-auth check >/dev/null 2>&1
+	exit 0
+fi
+
+SELF="$0"
+
+/usr/bin/python3 - "$SELF" <<'PYEOF'
+import json, os, sys, time
+
+SELF = sys.argv[1]
+HOME = os.path.expanduser("~")
+DATA_DIR = os.environ.get("CODEX_MULTI_AUTH_DIR") or os.path.join(HOME, ".codex", "multi-auth")
+CACHE = os.path.join(DATA_DIR, "quota-cache.json")
+STORE = os.path.join(DATA_DIR, "openai-codex-accounts.json")
+OBSERV = os.path.join(DATA_DIR, "runtime-observability.json")
+
+GREEN = "#34C759"
+GRAY = "#9A9A9E"
+RED = "#FF3B30"
+ORANGE = "#FF9F0A"
+# Card interior must stay within Menlo-native glyphs (ASCII, box drawing,
+# block elements, arrows, geometric circles). CJK or emoji fall back to other
+# fonts with non-integer widths and break the right border alignment.
+W = 32
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+def pad(s, width):
+    return s + " " * max(0, width - len(s))
+
+def fmt_reset(ms):
+    left = int(ms / 1000 - time.time())
+    if left <= 0:
+        return "now"
+    d, r = divmod(left, 86400)
+    h, r = divmod(r, 3600)
+    m = r // 60
+    if d > 0:
+        return f"{d}d {h}h"
+    if h > 0:
+        return f"{h}h {m}m"
+    return f"{m}m"
+
+def bar(remaining, slots=10):
+    filled = round(remaining / 100 * slots)
+    return "█" * filled + "░" * (slots - filled)
+
+def quota_color(rem):
+    if rem < 10: return RED
+    if rem < 30: return ORANGE
+    return None
+
+cache = load(CACHE)
+store = load(STORE)
+if not cache or not store:
+    print("⚡?")
+    print("---")
+    print("Cannot read quota cache or account store | color=red")
+    print(f"Expected under: {DATA_DIR} | size=11 color=gray")
+    sys.exit(0)
+
+emails, order = {}, []
+for acc in store.get("accounts", []):
+    aid = acc.get("accountId", "")
+    emails[aid] = acc.get("email", aid[-6:] if aid else "?")
+    order.append(aid)
+
+by_id = cache.get("byAccountId", {})
+
+observ = load(OBSERV) or {}
+active_id = observ.get("lastAccountId")
+if active_id not in order:
+    idx = store.get("activeIndex")
+    active_id = order[idx] if isinstance(idx, int) and 0 <= idx < len(order) else None
+
+titles, blocks = [], []
+newest = 0
+for aid in order:
+    email = emails.get(aid, "?")
+    short = email.split("@")[0]
+    is_active = (aid == active_id)
+    frame = GREEN if is_active else GRAY
+    dot = "●" if is_active else "○"
+    tag = "ACTIVE" if is_active else "IDLE"
+    rows = [(pad(f"{dot} {short}", W - len(tag)) + tag, None)]
+    q = by_id.get(aid)
+    if not q:
+        titles.append("?")
+        rows.append((pad("no quota data", W), None))
+    else:
+        newest = max(newest, q.get("updatedAt", 0))
+        for key, label in (("primary", "5h"), ("secondary", "7d")):
+            win = q.get(key, {})
+            rem = 100 - win.get("usedPercent", 0)
+            reset = fmt_reset(win["resetAtMs"]) if win.get("resetAtMs") else "-"
+            rows.append((pad(f"{label} {bar(rem)}  {rem:>3}%  → {reset}", W), quota_color(rem)))
+            if key == "primary":
+                titles.append(f"[{rem}]" if is_active else str(rem))
+    blocks.append((frame, rows))
+
+print("⚡" + "·".join(titles))
+print("---")
+style = "font=Menlo size=12 trim=false emojize=false"
+for frame, rows in blocks:
+    print(f"╭{'─' * (W + 2)}╮ | color={frame} {style}")
+    for text, override in rows:
+        print(f"│ {text} │ | color={override or frame} {style}")
+    print(f"╰{'─' * (W + 2)}╯ | color={frame} {style}")
+if newest:
+    age_min = int((time.time() - newest / 1000) / 60)
+    age = "just now" if age_min < 1 else (f"{age_min}m ago" if age_min < 60 else f"{age_min//60}h ago")
+    print(f"Cache updated {age} | size=11 color=gray")
+print(f"Live refresh (one probe per account) | bash={SELF} param1=livecheck terminal=false refresh=true")
+print("Reload from cache | refresh=true")
+PYEOF


### PR DESCRIPTION
## What

Adds an optional SwiftBar plugin under `contrib/swiftbar/` that renders per-account quota cards in the macOS menu bar:

```
⚡88·[90]        ← title: 5h-window remaining % per account, brackets = account currently serving requests

╭──────────────────────────────────╮
│ ● account-a               ACTIVE │
│ 5h █████████░   88%  → 4h 42m    │
│ 7d ████████░░   83%  → 6d 18h    │
╰──────────────────────────────────╯
╭──────────────────────────────────╮
│ ○ account-b                 IDLE │
│ 5h █████████░   90%  → 4h 33m    │
│ 7d █████████░   86%  → 8h 16m    │
╰──────────────────────────────────╯
```

- Active account resolved from runtime observability (`lastAccountId`), falling back to the stored active index
- 5h/7d windows with remaining %, text progress bar, and reset countdown; rows turn orange <30% and red <10%
- Reads only the local quota cache → **zero quota cost**; an explicit "Live refresh" menu action runs `codex-multi-auth check` (one probe per account)
- Single self-contained script (re-invokes itself with a `livecheck` arg for the menu action); honors `CODEX_MULTI_AUTH_DIR`

## Why

With runtime rotation, "how much quota does each account have left, and which one is serving right now" becomes the question users ask most. A glanceable menu bar view answers it without shelling out to `check` (and without spending probes).

## Notes

- `contrib/` is outside the npm `files` whitelist, so the published package is unchanged
- Fails soft (`⚡?`) if the internal cache format changes
- Card interior is restricted to Menlo-native glyphs; the README documents why (CJK/emoji fallback fonts break border alignment)
- Tested on macOS 15 + SwiftBar 2.x against a live two-account pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds a self-contained swiftbar plugin under `contrib/swiftbar/` that renders per-account codex quota cards in the macOS menu bar, reading only the local cache (zero quota cost) with an optional live-refresh menu action.

- `codex-quota.5m.sh` embeds a python3 heredoc that parses `quota-cache.json`, `openai-codex-accounts.json`, and `runtime-observability.json` to render 5h/7d progress bars with color-coded thresholds and reset countdowns; active account is resolved from `lastAccountId` with fallback to `activeIndex`
- the `livecheck` dispatch re-invokes the script with a hardcoded PATH that misses nvm/volta installs, causing silent failures for users who installed via nvm; the header row's `pad()` also has no truncation guard for long email local-parts, which can blow past `W=32` and break border alignment

<h3>Confidence Score: 5/5</h3>

safe to merge — contrib-only change, outside npm files whitelist, no core lib or proxy code touched

the plugin is fully isolated in contrib/, cache reads are read-only, clamp_pct correctly bounds floats to ints, and fail-soft behavior is consistent throughout; the two issues found are cosmetic display concerns that don’t affect the rotation proxy or auth flow

contrib/swiftbar/codex-quota.5m.sh — header truncation and livecheck PATH coverage worth a second look before publicising the install guide widely

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| contrib/swiftbar/codex-quota.5m.sh | new self-contained bash+python3 swiftbar plugin; quota % rows are correctly bounded via clamp_pct, but the header row has no truncation guard for long email local-parts, and the livecheck PATH omits nvm/volta bin dirs causing silent failures for common installs |
| contrib/swiftbar/README.md | new readme covering install, data source, refresh model, and glyph constraints; accurate and complete |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([SwiftBar invokes script]) --> B{arg == livecheck?}
    B -- yes --> C[export hardcoded PATH]
    C --> D[codex-multi-auth check]
    D --> E([exit])
    B -- no --> F{uname == Darwin?}
    F -- no --> G([show error, exit])
    F -- yes --> H[invoke python3 heredoc]
    H --> I[load quota-cache.json]
    I --> J{files readable?}
    J -- no --> K([print error])
    J -- yes --> L[resolve active_id]
    L --> M[build quota rows per account]
    M --> N[print title bar]
    N --> O[print card blocks]
    O --> P[print Live refresh action]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
contrib/swiftbar/codex-quota.5m.sh:119
`pad()` adds spaces but never truncates. the header row is `pad(f"{dot} {short}", W - len(tag)) + tag`, so if `short` exceeds `W - len(tag) - 2` chars (24 chars for ACTIVE, 26 for IDLE) the right border blows past `W=32` — the same alignment issue the Menlo-glyph note is guarding against. org emails like `firstname.lastname.department@company.com` easily hit this. clipping `short` to `W - len(tag) - 3` (with a trailing `…`) before building the row keeps the card width bounded.

### Issue 2 of 2
contrib/swiftbar/codex-quota.5m.sh:22-25
the hardcoded PATH for `livecheck` omits nvm paths (`~/.nvm/versions/node/*/bin`) and volta paths (`~/.volta/bin`). most macOS devs who followed the codex-multi-auth install docs used nvm, so `codex-multi-auth` lives in an nvm-managed bin and won't be found here. since `terminal=false` is set, the 127 exit is invisible — the menu item appears to do nothing. appending `$HOME/.nvm/versions/node/*/bin` via glob, or delegating to `npx --no codex-multi-auth check`, would cover the common case.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(contrib): address review feedback on..."](https://github.com/ndycode/codex-multi-auth/commit/756fdde19e754c38ce0b14a21026071935e38279) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36965743)</sub>

<!-- /greptile_comment -->