### PR TITLE
fix(rotation): break stale-recovery deadlock on transient account state

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -672,8 +672,8 @@ export class AccountManager {
 
 	/**
 	 * Wipe per-account transient state — active cooldowns and all rate-limit
-	 * reset windows — across every managed account, then persist the cleared
-	 * pool so the next reload does not restore it.
+	 * reset windows — across every managed account, then schedule a debounced
+	 * persist of the cleared pool.
 	 *
 	 * `resetVolatileRuntimeState` only clears process-global singletons (rotation
 	 * trackers, circuit breakers); the cooldown timestamps and `rateLimitResetTimes`
@@ -681,6 +681,11 @@ export class AccountManager {
 	 * `buildStorageSnapshot`. The stale-runtime recovery path reloads accounts
 	 * from that snapshot, so without this the same transient state that wedged the
 	 * pool is restored verbatim and recovery never escapes it (issue #606).
+	 *
+	 * The in-memory clear is immediate (it is what unblocks the live pool). The
+	 * disk write is debounced via `saveToDiskDebounced`, so a caller that needs
+	 * the cleared state to survive a restart should `await flushPendingSave()`
+	 * afterwards rather than rely on the debounce window completing.
 	 */
 	clearAccountTransientState(): void {
 		if (this.accounts.length === 0) return;

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -65,6 +65,7 @@ export {
 	getQuotaKey,
 	clampNonNegativeInt,
 	clearExpiredRateLimits,
+	clearAllRateLimits,
 	isRateLimitedForQuotaKey,
 	isRateLimitedForFamily,
 	formatWaitTime,
@@ -91,6 +92,7 @@ import {
 	clampNonNegativeInt,
 	getQuotaKey,
 	clearExpiredRateLimits,
+	clearAllRateLimits,
 	isRateLimitedForFamily,
 	formatWaitTime,
 	type RateLimitReason,
@@ -666,6 +668,30 @@ export class AccountManager {
 	static resetVolatileRuntimeState(): void {
 		resetTrackers();
 		resetAllCircuitBreakers();
+	}
+
+	/**
+	 * Wipe per-account transient state — active cooldowns and all rate-limit
+	 * reset windows — across every managed account, then persist the cleared
+	 * pool so the next reload does not restore it.
+	 *
+	 * `resetVolatileRuntimeState` only clears process-global singletons (rotation
+	 * trackers, circuit breakers); the cooldown timestamps and `rateLimitResetTimes`
+	 * maps live on the `ManagedAccount` objects and are serialized to disk by
+	 * `buildStorageSnapshot`. The stale-runtime recovery path reloads accounts
+	 * from that snapshot, so without this the same transient state that wedged the
+	 * pool is restored verbatim and recovery never escapes it (issue #606).
+	 */
+	clearAccountTransientState(): void {
+		if (this.accounts.length === 0) return;
+		// Snapshot the reference list so a concurrent mutation of `this.accounts`
+		// (e.g. removeAccount) cannot reshape the array mid-iteration.
+		for (const account of [...this.accounts]) {
+			this.clearAccountCooldown(account);
+			clearAllRateLimits(account);
+			account.lastRateLimitReason = undefined;
+		}
+		this.saveToDiskDebounced();
 	}
 
 	setActiveIndex(index: number): ManagedAccount | null {

--- a/lib/accounts/rate-limits.ts
+++ b/lib/accounts/rate-limits.ts
@@ -53,6 +53,20 @@ export function clearExpiredRateLimits(entity: RateLimitedEntity): void {
 	}
 }
 
+/**
+ * Remove every rate-limit reset entry from `entity`, regardless of whether the
+ * window has expired. Unlike {@link clearExpiredRateLimits}, this drops
+ * still-future entries too. Used by the stale-runtime recovery path to give a
+ * reloaded account pool a clean slate so transient state persisted to disk
+ * cannot keep the pool wedged (issue #606).
+ */
+export function clearAllRateLimits(entity: RateLimitedEntity): void {
+	const keys = Object.keys(entity.rateLimitResetTimes);
+	for (const key of keys) {
+		delete entity.rateLimitResetTimes[key];
+	}
+}
+
 export function isRateLimitedForQuotaKey(entity: RateLimitedEntity, key: QuotaKey): boolean {
 	const resetTime = entity.rateLimitResetTimes[key];
 	return resetTime !== undefined && nowMs() < resetTime;

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -982,10 +982,15 @@ async function handleRequestInner(
 					exhaustionReason === "no-account" &&
 					(policyDecision?.blockedAccountIndexes.size ?? 0) === 0 &&
 					![...accountSkipReasons.values()].some(
-						(reason) =>
-							reason === "rate-limited" ||
-							reason.startsWith("cooling-down") ||
-							reason === "policy-blocked",
+						// Only policy blocks still suppress stale-state recovery: a policy
+						// decision is external and won't change across a disk reload, so
+						// reloading cannot help. "rate-limited" and "cooling-down*" are
+						// transient states that recovery is *designed* to escape — they are
+						// persisted to disk (buildStorageSnapshot) and so survive a reload,
+						// which previously deadlocked the pool against the very recovery that
+						// would clear them. recoverStaleRuntimeState now wipes that transient
+						// state after reloading, so let those reasons through (issue #606).
+						(reason) => reason === "policy-blocked",
 					)
 				) {
 					reloadedAfterNoAccount = true;

--- a/lib/runtime/rotation-proxy-state.ts
+++ b/lib/runtime/rotation-proxy-state.ts
@@ -116,6 +116,13 @@ export async function recoverStaleRuntimeState(
 		// window until the next exhaustion. Availability is preferred over
 		// honoring backoff in this already-degraded state.
 		reloaded.clearAccountTransientState();
+		// Force the cleared snapshot to disk now rather than waiting out the
+		// debounce window inside clearAccountTransientState. If the process
+		// exited during that window the next startup would reload the wedged
+		// snapshot; flushing here makes the "next reload starts clean" guarantee
+		// durable across a restart, not just best-effort. Recovery is rare
+		// (full-pool exhaustion), so the extra synchronous write is cheap.
+		await reloaded.flushPendingSave();
 		state.activeAccountManager = reloaded;
 		state.knownAccountManagers.add(reloaded);
 		state.lastStaleRuntimeReloadAt = Date.now();

--- a/lib/runtime/rotation-proxy-state.ts
+++ b/lib/runtime/rotation-proxy-state.ts
@@ -99,6 +99,23 @@ export async function recoverStaleRuntimeState(
 		recordRuntimeReset("pool-exhausted-no-account");
 		const reloaded = await AccountManager.loadFromDisk();
 		reloaded.setRoutingMutexMode(state.routingMutexMode);
+		// Wipe per-account cooldowns and rate-limit windows on the freshly
+		// reloaded pool. `resetVolatileRuntimeState` above only cleared global
+		// singletons (trackers, circuit breakers); the per-account transient
+		// state is serialized to disk, so loadFromDisk restores the same state
+		// that wedged the pool. Clearing it here gives recovery a real clean
+		// slate before any request can pick up the manager (issue #606). Runs
+		// before the `state.activeAccountManager` assignment so no concurrent
+		// request can observe the reloaded manager with stale state.
+		//
+		// This also drops still-future rate-limit windows from genuine upstream
+		// 429s, not just stale ones from a dead prior process. That is the
+		// intended trade-off: recovery only runs at full pool exhaustion, where
+		// the alternative is a hard 503 anyway, and the 1s reload dedupe bounds
+		// re-probing to ~1/sec — the upstream simply re-429s and re-populates the
+		// window until the next exhaustion. Availability is preferred over
+		// honoring backoff in this already-degraded state.
+		reloaded.clearAccountTransientState();
 		state.activeAccountManager = reloaded;
 		state.knownAccountManagers.add(reloaded);
 		state.lastStaleRuntimeReloadAt = Date.now();

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1494,6 +1494,7 @@ describe("AccountManager", () => {
 				"gpt-5.2",
 			);
 			expect(Object.keys(account.rateLimitResetTimes).length).toBeGreaterThan(0);
+			expect(account.lastRateLimitReason).toBe("tokens");
 
 			manager.clearAccountTransientState();
 
@@ -1501,7 +1502,63 @@ describe("AccountManager", () => {
 			expect(account.lastRateLimitReason).toBeUndefined();
 		});
 
-		it("persists the cleared pool so a reload does not restore stale state", () => {
+		it("clears cooldown and rate-limit state together on the same account", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			// A real stuck account from #606 carries both states at once; prove the
+			// method clears both in one pass rather than short-circuiting.
+			manager.markAccountCoolingDown(account, 60_000, "server-error");
+			manager.markRateLimitedWithReason(account, 60_000, "codex", "quota");
+			expect(manager.isAccountCoolingDown(account)).toBe(true);
+			expect(Object.keys(account.rateLimitResetTimes).length).toBeGreaterThan(0);
+
+			manager.clearAccountTransientState();
+
+			expect(account.coolingDownUntil).toBeUndefined();
+			expect(account.cooldownReason).toBeUndefined();
+			expect(account.rateLimitResetTimes).toEqual({});
+			expect(account.lastRateLimitReason).toBeUndefined();
+		});
+
+		it("clears mixed per-account state without throwing on clean accounts", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-3", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const coolingDown = manager.getAccountByIndex(0)!;
+			const rateLimited = manager.getAccountByIndex(1)!;
+			const clean = manager.getAccountByIndex(2)!;
+			manager.markAccountCoolingDown(coolingDown, 60_000, "network-error");
+			manager.markRateLimitedWithReason(rateLimited, 60_000, "codex", "quota");
+
+			expect(() => manager.clearAccountTransientState()).not.toThrow();
+
+			expect(coolingDown.coolingDownUntil).toBeUndefined();
+			expect(rateLimited.rateLimitResetTimes).toEqual({});
+			expect(clean.coolingDownUntil).toBeUndefined();
+			expect(clean.rateLimitResetTimes).toEqual({});
+		});
+
+		it("persists the cleared pool so a reload does not restore stale state", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockClear();
+
 			const now = Date.now();
 			const stored = {
 				version: 3 as const,
@@ -1512,11 +1569,18 @@ describe("AccountManager", () => {
 			const manager = new AccountManager(undefined, stored);
 			const account = manager.getCurrentAccount()!;
 			manager.markAccountCoolingDown(account, 60_000, "server-error");
-			const saveSpy = vi.spyOn(manager, "saveToDiskDebounced");
+			manager.markRateLimitedWithReason(account, 60_000, "codex", "quota");
 
 			manager.clearAccountTransientState();
+			// Flush so we assert against the actual persisted snapshot, not just
+			// that a save was scheduled — this is the #606 durability guarantee.
+			await manager.flushPendingSave();
 
-			expect(saveSpy).toHaveBeenCalledTimes(1);
+			expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+			const persisted = mockSaveAccounts.mock.calls[0]?.[0];
+			expect(persisted?.accounts[0]?.coolingDownUntil).toBeUndefined();
+			expect(persisted?.accounts[0]?.cooldownReason).toBeUndefined();
+			expect(persisted?.accounts[0]?.rateLimitResetTimes ?? {}).toEqual({});
 		});
 
 		it("is a no-op when no accounts are loaded", () => {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1447,6 +1447,91 @@ describe("AccountManager", () => {
 		});
 	});
 
+	describe("clearAccountTransientState", () => {
+		it("clears active cooldowns on every account", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+					{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+				],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const first = manager.getAccountByIndex(0)!;
+			const second = manager.getAccountByIndex(1)!;
+			manager.markAccountCoolingDown(first, 60_000, "network-error");
+			manager.markAccountCoolingDown(second, 60_000, "server-error");
+
+			manager.clearAccountTransientState();
+
+			expect(manager.isAccountCoolingDown(first)).toBe(false);
+			expect(manager.isAccountCoolingDown(second)).toBe(false);
+			expect(first.coolingDownUntil).toBeUndefined();
+			expect(first.cooldownReason).toBeUndefined();
+			expect(second.coolingDownUntil).toBeUndefined();
+			expect(second.cooldownReason).toBeUndefined();
+		});
+
+		it("clears all rate-limit reset windows, including ones still in the future", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			manager.markRateLimitedWithReason(account, 60_000, "codex", "quota");
+			manager.markRateLimitedWithReason(
+				account,
+				60_000,
+				"codex",
+				"tokens",
+				"gpt-5.2",
+			);
+			expect(Object.keys(account.rateLimitResetTimes).length).toBeGreaterThan(0);
+
+			manager.clearAccountTransientState();
+
+			expect(account.rateLimitResetTimes).toEqual({});
+			expect(account.lastRateLimitReason).toBeUndefined();
+		});
+
+		it("persists the cleared pool so a reload does not restore stale state", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "token-1", addedAt: now, lastUsed: now }],
+			};
+
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			manager.markAccountCoolingDown(account, 60_000, "server-error");
+			const saveSpy = vi.spyOn(manager, "saveToDiskDebounced");
+
+			manager.clearAccountTransientState();
+
+			expect(saveSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("is a no-op when no accounts are loaded", () => {
+			const manager = new AccountManager(undefined, {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [],
+			});
+			const saveSpy = vi.spyOn(manager, "saveToDiskDebounced");
+
+			expect(() => manager.clearAccountTransientState()).not.toThrow();
+			expect(saveSpy).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("auth failure tracking", () => {
 		it("increments consecutive auth failures", () => {
 			const now = Date.now();

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1899,6 +1899,9 @@ describe("runtime rotation proxy", () => {
 		}
 		const reloadedManager = new AccountManager(undefined, reloadedStorage);
 		const clearSpy = vi.spyOn(reloadedManager, "clearAccountTransientState");
+		const flushSpy = vi
+			.spyOn(reloadedManager, "flushPendingSave")
+			.mockResolvedValue();
 		const loadSpy = vi
 			.spyOn(AccountManager, "loadFromDisk")
 			.mockResolvedValueOnce(reloadedManager);
@@ -1917,6 +1920,9 @@ describe("runtime rotation proxy", () => {
 			expect(loadSpy).toHaveBeenCalledTimes(1);
 			expect(resetSpy).toHaveBeenCalledTimes(1);
 			expect(clearSpy).toHaveBeenCalledTimes(1);
+			// The cleared snapshot is flushed to disk synchronously so a restart
+			// inside the debounce window cannot reload the wedged state.
+			expect(flushSpy).toHaveBeenCalledTimes(1);
 			// After clearing, the reloaded accounts are selectable again.
 			expect(reloadedManager.getAccountByIndex(0)?.coolingDownUntil).toBeUndefined();
 			expect(reloadedManager.getAccountByIndex(0)?.rateLimitResetTimes).toEqual({});
@@ -1925,6 +1931,7 @@ describe("runtime rotation proxy", () => {
 			loadSpy.mockRestore();
 			resetSpy.mockRestore();
 			clearSpy.mockRestore();
+			flushSpy.mockRestore();
 		}
 	});
 

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1840,30 +1840,139 @@ describe("runtime rotation proxy", () => {
 				"server-error",
 			);
 		}
+		// With every account cooling down, the proxy now *attempts* stale-runtime
+		// recovery (issue #606): cooling-down is transient and no longer suppresses
+		// the reload. Force that reload to fail so this test still exercises the
+		// final-exhaustion path and its skip-reason reporting deterministically.
+		const loadSpy = vi
+			.spyOn(AccountManager, "loadFromDisk")
+			.mockRejectedValue(new Error("reload unavailable"));
 		const { calls, fetchImpl } = createRecordingFetch(() =>
 			new Response("should not be called", { status: HTTP_STATUS.OK }),
 		);
 		const proxy = await startProxy({ accountManager, fetchImpl });
 
-		const response = await postResponses(proxy, { model: "gpt-5-codex" });
-		const payload = (await response.json()) as {
-			error: {
-				code: string;
-				reason: string;
-				account_skip_reasons: Record<string, string>;
-				hint: string;
+		try {
+			const response = await postResponses(proxy, { model: "gpt-5-codex" });
+			const payload = (await response.json()) as {
+				error: {
+					code: string;
+					reason: string;
+					account_skip_reasons: Record<string, string>;
+					hint: string;
+				};
 			};
-		};
 
-		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
-		expect(payload.error.code).toBe("codex_runtime_rotation_pool_exhausted");
-		expect(payload.error.reason).toBe("no-account");
-		expect(payload.error.account_skip_reasons).toMatchObject({
-			"0": "cooling-down:network-error",
-			"1": "cooling-down:server-error",
-		});
-		expect(payload.error.hint).toContain("rotation reset-runtime");
-		expect(calls).toHaveLength(0);
+			expect(loadSpy).toHaveBeenCalledTimes(1);
+			expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+			expect(payload.error.code).toBe("codex_runtime_rotation_pool_exhausted");
+			expect(payload.error.reason).toBe("no-account");
+			expect(payload.error.account_skip_reasons).toMatchObject({
+				"0": "cooling-down:network-error",
+				"1": "cooling-down:server-error",
+			});
+			expect(payload.error.hint).toContain("rotation reset-runtime");
+			expect(calls).toHaveLength(0);
+		} finally {
+			loadSpy.mockRestore();
+		}
+	});
+
+	it("recovers from an all-cooling-down pool by reloading and clearing transient state (issue #606)", async () => {
+		const now = Date.now();
+		// Persisted cooldown/rate-limit state survives a reload, so the reloaded
+		// pool carries the same wedged transient state. recoverStaleRuntimeState
+		// must clear it before the manager is used, otherwise selection deadlocks
+		// against the very recovery meant to escape it.
+		const staleStorage = createStorage(now, 2);
+		for (const account of staleStorage.accounts) {
+			account.coolingDownUntil = now + 60_000;
+			account.cooldownReason = "server-error";
+			account.rateLimitResetTimes = { codex: now + 60_000 };
+		}
+		const staleManager = new AccountManager(undefined, staleStorage);
+		const reloadedStorage = createStorage(now, 2);
+		for (const account of reloadedStorage.accounts) {
+			account.coolingDownUntil = now + 60_000;
+			account.cooldownReason = "server-error";
+			account.rateLimitResetTimes = { codex: now + 60_000 };
+		}
+		const reloadedManager = new AccountManager(undefined, reloadedStorage);
+		const clearSpy = vi.spyOn(reloadedManager, "clearAccountTransientState");
+		const loadSpy = vi
+			.spyOn(AccountManager, "loadFromDisk")
+			.mockResolvedValueOnce(reloadedManager);
+		const resetSpy = vi.spyOn(AccountManager, "resetVolatileRuntimeState");
+		const { calls, fetchImpl } = createRecordingFetch(() => textEventStream());
+		try {
+			const proxy = await startProxy({
+				accountManager: staleManager,
+				fetchImpl,
+			});
+
+			const response = await postResponses(proxy, { model: "gpt-5-codex" });
+			await response.text();
+
+			expect(response.status).toBe(HTTP_STATUS.OK);
+			expect(loadSpy).toHaveBeenCalledTimes(1);
+			expect(resetSpy).toHaveBeenCalledTimes(1);
+			expect(clearSpy).toHaveBeenCalledTimes(1);
+			// After clearing, the reloaded accounts are selectable again.
+			expect(reloadedManager.getAccountByIndex(0)?.coolingDownUntil).toBeUndefined();
+			expect(reloadedManager.getAccountByIndex(0)?.rateLimitResetTimes).toEqual({});
+			expect(calls).toHaveLength(1);
+		} finally {
+			loadSpy.mockRestore();
+			resetSpy.mockRestore();
+			clearSpy.mockRestore();
+		}
+	});
+
+	it("does not attempt stale-runtime recovery when accounts are policy-blocked (issue #606)", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		// A policy decision is external and will not change across a disk reload,
+		// so a policy-blocked pool must continue to suppress stale-runtime
+		// recovery. `allowed` stays true so the request proceeds into account
+		// selection, where every account is rejected as policy-blocked and
+		// selection returns null. Recovery is then gated off by the guard's
+		// `blockedAccountIndexes.size === 0` precondition — the path that keeps a
+		// policy block from being papered over by a reload.
+		const policySpy = vi
+			.spyOn(runtimePolicy, "evaluateRuntimePolicy")
+			.mockResolvedValue({
+				allowed: true,
+				statusCode: 200,
+				errorCode: null,
+				reasons: [],
+				projectKey: null,
+				blockedAccountIndexes: new Set<number>([0, 1]),
+				scoreBoostByAccount: {},
+				budgetEvaluations: [],
+			});
+		const loadSpy = vi.spyOn(AccountManager, "loadFromDisk");
+		const { calls, fetchImpl } = createRecordingFetch(() => textEventStream());
+		try {
+			const proxy = await startProxy({ accountManager, fetchImpl });
+
+			const response = await postResponses(proxy, { model: "gpt-5-codex" });
+			const payload = (await response.json()) as {
+				error: { code: string; account_skip_reasons: Record<string, string> };
+			};
+
+			expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+			expect(payload.error.code).toBe("codex_runtime_rotation_pool_exhausted");
+			expect(payload.error.account_skip_reasons).toMatchObject({
+				"0": "policy-blocked",
+				"1": "policy-blocked",
+			});
+			// Recovery must be suppressed: loadFromDisk is never called.
+			expect(loadSpy).not.toHaveBeenCalled();
+			expect(calls).toHaveLength(0);
+		} finally {
+			policySpy.mockRestore();
+			loadSpy.mockRestore();
+		}
 	});
 
 	it("deduplicates concurrent stale-runtime reload recovery", async () => {


### PR DESCRIPTION
Fixes #606.

## Summary

- The runtime rotation proxy returns a permanent `503 "All managed Codex accounts are temporarily unavailable"` even when accounts are healthy and `doctor` passes 17/17, because stale-runtime recovery is **deadlocked against the very transient state it is meant to clear**.
- Per-account cooldowns (`coolingDownUntil`/`cooldownReason`) and `rateLimitResetTimes` are serialized to disk by `buildStorageSnapshot`, so `recoverStaleRuntimeState`'s `loadFromDisk()` restores the same state that wedged the pool. `AccountManager.resetVolatileRuntimeState()` only clears global singletons (rotation trackers, circuit breakers), not this per-account state.
- The recovery guard then refused to reload when any account's skip reason was `"rate-limited"` or `"cooling-down*"` — so the only path that could clear the stuck state never fired. Accounts can't be selected because of transient state, and recovery can't run because of that same state.

## What Changed

The two halves are coupled; **neither fixes the deadlock alone** (each is pinned by a regression test that fails if the other is reverted):

- `lib/runtime-rotation-proxy.ts` — relax the recovery guard (was `:984-989`) so only `"policy-blocked"` still suppresses recovery. A policy decision is external and won't change across a reload; `"rate-limited"`/`"cooling-down*"` are transient states recovery is designed to escape.
- `lib/accounts/rate-limits.ts` — add `clearAllRateLimits(entity)` (mirrors `clearExpiredRateLimits` but removes **all** entries, including still-future ones).
- `lib/accounts.ts` — re-export the helper; add `AccountManager.clearAccountTransientState()` (no-op when empty; per account clears cooldown + all rate-limit windows + `lastRateLimitReason`, then `saveToDiskDebounced()` so the cleared pool is persisted and a later reload can't restore it).
- `lib/runtime/rotation-proxy-state.ts` — call `reloaded.clearAccountTransientState()` after `loadFromDisk()` and **before** publishing the reloaded manager to `state.activeAccountManager`, so no concurrent request observes stale state. The clear runs inside the existing single-flight `staleRuntimeReloadPromise`.
- Tests in `test/accounts.test.ts` and `test/runtime-rotation-proxy.test.ts`.

### Tests

- `clearAccountTransientState` unit tests: clears cooldowns on every account; clears all rate-limit windows (incl. future); persists via `saveToDiskDebounced`; no-op when no accounts loaded.
- An all-cooling-down pool now recovers via reload to `200` (verified to fail with the old guard **and** to fail if the clear call is removed — both halves required).
- Policy-blocked pools still do **not** trigger a reload (`loadFromDisk` never called) and surface `policy-blocked` skip reasons in the 503 body.
- Repurposed the existing "includes per-account skip reasons" test: recovery is now attempted for cooling-down, so it forces the reload to reject and asserts the exhaustion body still reports skip reasons.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (4916 passed, 3 skipped, 0 failures)
- [x] `npm test -- test/documentation.test.ts` (26 passed)
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

No user-visible API/CLI/config surface changed — this is an internal recovery-path fix. The existing manual workaround (`rotation reset-rate-limits`) still works and now serves as a belt-and-suspenders escape hatch rather than the only escape.

## Risk and Rollback

- **Risk level:** low–medium. Recovery only runs at full pool exhaustion (where the alternative is a hard 503). Bounded against thrash by the one-shot `reloadedAfterNoAccount` per-request flag and the 1s `STALE_RUNTIME_RELOAD_DEDUPE_MS` window (~1 reload/sec max).
- **Known trade-off (documented in code):** clearing rate-limit windows also drops still-future windows from genuine upstream 429s, so during a real total upstream rate-limit the proxy re-probes ~1/sec instead of honoring the full backoff. This is intentional — availability over backoff in an already-degraded, fully-exhausted state — and worth watching in metrics.
- **Rollback plan:** revert this commit. The two source changes are coupled; revert both together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes the stale-recovery deadlock (issue #606) where a permanent 503 was returned even with healthy accounts because per-account cooldowns and rate-limit windows are serialized to disk, so `loadFromDisk` restored the same wedged state that triggered recovery.

- **guard relaxed** in `runtime-rotation-proxy.ts`: `\"rate-limited\"` and `\"cooling-down*\"` no longer suppress recovery — only `\"policy-blocked\"` does, since a policy decision is external and won't change across a reload.
- **`clearAllRateLimits`** added to `rate-limits.ts` (drops all windows including still-future ones); `clearAccountTransientState()` added to `AccountManager` (clears cooldowns + rate-limit windows + `lastRateLimitReason` on every account with snapshot-safe iteration).
- **`recoverStaleRuntimeState`** now calls `clearAccountTransientState()` then `flushPendingSave()` synchronously before publishing the reloaded manager, ensuring no concurrent request observes stale state and the cleared snapshot survives a process restart within the debounce window.

<h3>Confidence Score: 5/5</h3>

safe to merge — the fix is scoped to the full-pool-exhaustion path, concurrency is correct, and the synchronous flush before manager publication addresses the restart race.

both halves of the fix are logically sound: the guard change is narrowly targeted and the clear runs inside the single-flight promise before the manager is published, so no request can observe stale state. the synchronous `flushPendingSave` after `clearAccountTransientState` closes the restart-race window. storage writes go through `withFileOperationRetry`, so windows EBUSY/EPERM is handled. no correctness gaps found.

test/rotation-proxy-state.test.ts lacks unit-level assertions for the new clear+flush sequence in recoverStaleRuntimeState; lib/accounts/rate-limits.ts has no direct test for clearAllRateLimits

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts/rate-limits.ts | adds `clearAllRateLimits` — correctly mutates the existing object in-place (preserving references held elsewhere) rather than replacing it; no direct unit test for the new export |
| lib/accounts.ts | adds `clearAccountTransientState` with snapshot-based iteration to guard against concurrent `removeAccount` reshaping; re-exports `clearAllRateLimits`; JSDoc correctly documents the debounce vs flush contract |
| lib/runtime/rotation-proxy-state.ts | calls `clearAccountTransientState` then `flushPendingSave` before assigning `state.activeAccountManager`, fixing the restart race noted in prior review; both calls are inside the single-flight `staleRuntimeReloadPromise` so no concurrent request observes stale state |
| lib/runtime-rotation-proxy.ts | guard now only suppresses recovery on `"policy-blocked"`; the `blockedAccountIndexes.size === 0` pre-check and the skip-reason filter are belt-and-suspenders and consistent |
| test/accounts.test.ts | six new tests for `clearAccountTransientState` covering: cooldown clear, rate-limit clear (incl. future windows), mixed state, clean accounts no-throw, persistence via flush, no-op on empty pool |
| test/runtime-rotation-proxy.test.ts | three new integration tests: recovery from all-cooling-down pool, policy-blocked pool suppresses recovery, and repurposed exhaustion-with-skip-reasons test; `rotation-proxy-state.test.ts` not updated with unit-level spy assertions for the new recovery sequence |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Req as Request
    participant Proxy as rotation-proxy
    participant Recovery as recoverStaleRuntimeState
    participant AM as AccountManager
    participant Disk as Disk

    Req->>Proxy: POST /responses
    Proxy->>Proxy: selectAccount() returns null
    Note over Proxy: old: rate-limited/cooling-down suppressed recovery
    Note over Proxy: new: only policy-blocked suppresses recovery
    Proxy->>Recovery: recoverStaleRuntimeState(state)
    Recovery->>Recovery: resetVolatileRuntimeState()
    Recovery->>AM: loadFromDisk()
    AM-->>Recovery: reloaded manager with stale transient state
    Recovery->>AM: clearAccountTransientState()
    Note over AM: clears coolingDownUntil, rateLimitResetTimes, lastRateLimitReason
    Recovery->>AM: flushPendingSave()
    AM->>Disk: saveToDisk() synchronous write
    Disk-->>AM: saved
    Recovery->>Proxy: "state.activeAccountManager = reloaded"
    Proxy->>Proxy: retry selectAccount() finds account
    Proxy-->>Req: 200 stream
```

<sub>Reviews (2): Last reviewed commit: ["test(accounts): harden clearAccountTrans..."](https://github.com/ndycode/codex-multi-auth/commit/4549d31216fd1106785fe1df69c3c4d0a02e52a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37514094)</sub>

<!-- /greptile_comment -->