### PR TITLE
fix(rotation): persist cooldown when account has no resolvable accountId

### DIFF
--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1063,6 +1063,12 @@ async function handleRequestInner(
 					DEFAULT_AUTH_FAILURE_COOLDOWN_MS,
 					"auth-failure",
 				);
+				// Persist the cooldown like every other cooldown branch in this loop
+				// (network-error, 429, server-error, 401). `coolingDownUntil`/
+				// `cooldownReason` are serialized in the V3 snapshot, so without this
+				// a restart inside the cooldown window loses it and immediately
+				// re-selects the still-broken account.
+				accountManager.saveToDiskDebounced();
 				exhaustionReason = "auth-failure";
 				transientAttempts += 1;
 				transientExhaustionReason = "auth-failure";

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1694,7 +1694,9 @@ describe("runtime rotation proxy", () => {
 		const response = await postResponses(proxy, { model: "gpt-5-codex" });
 		await response.text();
 
-		// No upstream request is issued — the account is cooled down before send.
+		// No upstream request is issued — the account is cooled down before send,
+		// exhausting the single-account pool.
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
 		expect(calls).toHaveLength(0);
 		expect(accountManager.getAccountByIndex(0)?.cooldownReason).toBe("auth-failure");
 		expect(accountManager.getAccountByIndex(0)?.coolingDownUntil).toBeGreaterThan(now);

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1662,6 +1662,45 @@ describe("runtime rotation proxy", () => {
 		expect(saveToDiskDebouncedSpy).toHaveBeenCalled();
 	});
 
+	it("persists the cooldown when an account has no resolvable accountId", async () => {
+		const now = Date.now();
+		// Account with no stored accountId and a non-JWT access token, so
+		// resolveAccountId returns null and the missing-accountId cooldown branch
+		// fires. The cooldown must be persisted like every other cooldown branch
+		// so a restart inside the window honors it (regression: this branch used
+		// to mutate cooldown state without scheduling a disk write).
+		const storage: AccountStorageV3 = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					email: "no-id@example.com",
+					refreshToken: "refresh-1",
+					accessToken: "plain-access-not-a-jwt",
+					expiresAt: now + 3_600_000,
+					addedAt: now - 60_000,
+					lastUsed: now - 60_000,
+					enabled: true,
+				},
+			],
+		};
+		const accountManager = new AccountManager(undefined, storage);
+		expect(accountManager.getAccountByIndex(0)?.accountId).toBeUndefined();
+		const saveToDiskDebouncedSpy = vi.spyOn(accountManager, "saveToDiskDebounced");
+		const { calls, fetchImpl } = createRecordingFetch(() => textEventStream());
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, { model: "gpt-5-codex" });
+		await response.text();
+
+		// No upstream request is issued — the account is cooled down before send.
+		expect(calls).toHaveLength(0);
+		expect(accountManager.getAccountByIndex(0)?.cooldownReason).toBe("auth-failure");
+		expect(accountManager.getAccountByIndex(0)?.coolingDownUntil).toBeGreaterThan(now);
+		expect(saveToDiskDebouncedSpy).toHaveBeenCalled();
+	});
+
 	it("deduplicates concurrent expired-token refresh and persistence", async () => {
 		const now = Date.now();
 		const storage = createStorage(now, 1);


### PR DESCRIPTION
## Summary

- Found via a codebase-wide bug-hunt sweep (12 subsystem hunters → adversarial verification → synthesis). One confirmed defect survived verification: a cooldown-persistence gap in the runtime rotation loop.
- The missing-accountId branch in `runRotationLoop` marks the account cooling down via `markAccountCoolingDown` but was the **lone cooldown branch that never called `saveToDiskDebounced()`**. Every other cooldown branch in the same function persists its mutation: network-error, 429, server-error, and 401 invalidation.
- Because `coolingDownUntil`/`cooldownReason` are serialized in the V3 storage snapshot, a process restart inside the 30s cooldown window dropped the cooldown and immediately re-selected the still-broken account.

## What Changed

- `lib/runtime-rotation-proxy.ts` — add the missing `accountManager.saveToDiskDebounced()` after `markAccountCoolingDown` in the missing-accountId branch, mirroring the network-error branch directly below it. Added a comment explaining the persistence requirement.
- `test/runtime-rotation-proxy.test.ts` — regression test: an account with no stored `accountId` and a non-JWT access token drives `resolveAccountId` to return null, the branch fires, no upstream request is issued, and the cooldown is persisted. The test fails without the fix (verified by mutation).

## Severity

Low. No upstream request is issued (token refresh already succeeded), the cooldown is only 30s, and a restart within the window degrades gracefully — the account is simply re-selected, re-cooled in memory, and rotation proceeds to the next account. This is a consistency/durability gap, not a cascading failure. Fixing it makes the branch consistent with every other cooldown path.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (4911 passed, 3 skipped, 0 failures)
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

No user-visible surface changed — internal rotation-loop consistency fix.

## Risk and Rollback

- Risk level: low. Adds one debounced disk write on an already-degraded path that previously skipped it; matches the established pattern of every sibling branch.
- Rollback plan: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

patches the one cooldown branch in `runRotationLoop` that mutated cooldown state without scheduling a disk write. every other branch (network-error, 429, server-error, 401 invalidation) already calls `saveToDiskDebounced()`; the no-accountId branch did not, so a process restart inside the 30s window dropped the cooldown and could immediately re-select the still-broken account.

- `lib/runtime-rotation-proxy.ts` — adds `accountManager.saveToDiskDebounced()` after `markAccountCoolingDown` in the missing-accountId branch, with a comment explaining the V3 serialization requirement.
- `test/runtime-rotation-proxy.test.ts` — adds a regression test that confirms no upstream call is issued, the account receives the expected cooldown fields, the response is 503, and `saveToDiskDebounced` is called.

<h3>Confidence Score: 5/5</h3>

safe to merge — one-line addition on an already-degraded path that previously skipped a debounced disk write, matching the established pattern of every sibling cooldown branch

the change is minimal and surgical: one saveToDiskDebounced() call added to close a consistency gap between the no-accountId branch and its three sibling branches; no new code paths, no new state, no behavioral change except durability of the cooldown across restarts; regression test correctly exercises the branch end-to-end and would have failed before the fix

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime-rotation-proxy.ts | adds the missing saveToDiskDebounced() call after markAccountCoolingDown in the no-accountId branch, making it consistent with every other cooldown branch (network-error, 429, server-error, 401); the one-line addition with explanatory comment is correct and minimal |
| test/runtime-rotation-proxy.test.ts | new regression test exercises the no-accountId branch end-to-end: verifies no upstream call, 503 response status, cooldown fields, and saveToDiskDebounced invocation; test setup (non-JWT access token, no stored accountId) correctly forces the branch under test |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runRotationLoop iteration] --> B[ensureFreshAccessToken]
    B -->|not ok, invalidated| C[return 401 to client]
    B -->|not ok, retryable| D[transientAttempts++, continue]
    B -->|ok| E[resolveAccountId]
    E -->|null: no accountId| F[markAccountCoolingDown\nauthFailureCooldownMs]
    F --> G["saveToDiskDebounced() ✅ ADDED"]
    G --> H[transientAttempts++, continue]
    E -->|resolved| I[send upstream request]
    I -->|network error| J[markAccountCoolingDown\nnetworkErrorCooldownMs]
    J --> K[saveToDiskDebounced]
    I -->|429| L[markRateLimitedWithReason]
    L --> M[saveToDiskDebounced]
    I -->|5xx| N[markAccountCoolingDown\nserverErrorCooldownMs]
    N --> O[saveToDiskDebounced]
    I -->|success| P[stream response to client]
```

<sub>Reviews (3): Last reviewed commit: ["test(rotation): assert exhaustion status..."](https://github.com/ndycode/codex-multi-auth/commit/0f50e3f8050aa2749cb8ec0dc32ce40d3a49955d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37517172)</sub>

<!-- /greptile_comment -->