### PR TITLE
fix(rotation): persist rate-limit window in short-retry 429 path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2282,6 +2282,12 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 															modelFamily,
 															model,
 														);
+														// Persist the rate-limit window like the full-rotation
+														// branch below (line ~2327). markRateLimitedWithReason
+														// mutates `rateLimitResetTimes`, which is serialized to
+														// disk; without this a crash during the retry sleep loses
+														// the cooldown and the account is re-selected on restart.
+														accountManager.saveToDiskDebounced();
 
 														if (
 															accountManager.shouldShowAccountToast(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5546,6 +5546,106 @@ describe("OpenAIOAuthPlugin runtime toast forwarding", () => {
 		expect(globalThis.fetch).toHaveBeenCalledTimes(2);
 	});
 
+	it("persists rate-limit window to disk on short-cooldown 429 (saveToDiskDebounced regression)", async () => {
+		const { AccountManager } = await import("../lib/accounts.js");
+		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");
+		const rateLimitBackoffModule = await import(
+			"../lib/request/rate-limit-backoff.js"
+		);
+
+		const saveToDiskDebounced = vi.fn();
+		const manager = {
+			getAccountCount: () => 1,
+			getCurrentOrNextForFamilyHybrid: () => ({
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+			}),
+			getCurrentOrNextForFamily: () => ({
+				index: 0,
+				accountId: "acc-1",
+				email: "alpha@example.com",
+				refreshToken: "refresh-1",
+			}),
+			getCurrentWorkspace: () => null,
+			getAccountByIndex: () => null,
+			getAccountsSnapshot: () => [],
+			isAccountAvailableForFamily: () => true,
+			toAuthDetails: () => ({
+				type: "oauth" as const,
+				access: "access-token",
+				refresh: "refresh-1",
+				expires: Date.now() + 60_000,
+			}),
+			hasRefreshToken: () => true,
+			saveToDiskDebounced,
+			updateFromAuth: () => {},
+			clearAuthFailures: () => {},
+			incrementAuthFailures: () => 1,
+			saveToDisk: async () => {},
+			markAccountCoolingDown: () => {},
+			markRateLimited: () => {},
+			markRateLimitedWithReason: () => {},
+			consumeToken: () => true,
+			refundToken: () => {},
+			syncCodexCliActiveSelectionForIndex: async () => {},
+			markSwitched: () => {},
+			removeAccount: () => {},
+			recordFailure: () => {},
+			recordSuccess: () => {},
+			recordRateLimit: () => {},
+			getMinWaitTimeForFamily: () => 0,
+			shouldShowAccountToast: () => false,
+			markToastShown: () => {},
+			setActiveIndex: () => null,
+		};
+		vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValue(
+			manager as never,
+		);
+		// Short cooldown: 1000ms < 5000ms threshold -> short-retry branch
+		vi.mocked(fetchHelpersModule.handleErrorResponse).mockResolvedValueOnce({
+			response: new Response("rate limited", { status: 429 }),
+			rateLimit: { retryAfterMs: 1000, code: "rate_limit_exceeded" },
+			errorBody: "rate limited",
+		} as never);
+		vi.mocked(rateLimitBackoffModule.getRateLimitBackoff).mockReturnValueOnce({
+			attempt: 1,
+			delayMs: 500,
+		});
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ content: "ok" }), { status: 200 }),
+			);
+
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = (await OpenAIOAuthPlugin({
+			client: mockClient,
+		} as never)) as unknown as PluginType;
+		const sdk = await plugin.auth.loader(getOAuthAuth, {
+			options: {},
+			models: {},
+		});
+		const response = await sdk.fetch!(
+			"https://api.openai.com/v1/chat/completions",
+			{
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-5.1" }),
+			},
+		);
+
+		// The request should ultimately succeed (short-retry -> 200)
+		expect(response.status).toBe(200);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+		// Regression guard: the short-retry branch MUST call saveToDiskDebounced so
+		// the rateLimitResetTimes mutation from markRateLimitedWithReason survives a
+		// crash during the retry sleep (mirrors the full-rotation branch below it).
+		expect(saveToDiskDebounced).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not rotate on 404 with unrelated body (not a usage limit)", async () => {
 		const { AccountManager } = await import("../lib/accounts.js");
 		const fetchHelpersModule = await import("../lib/request/fetch-helpers.js");


### PR DESCRIPTION
## Summary

- Found by a **pre-release deep stress-test sweep** (verification gauntlet + adversarial probes). The gauntlet was all-green; an adversarial persistence-audit probe found a third instance of the cooldown-persistence gap class fixed by #607 and #608 — this one in `index.ts`.
- The **short-retry** branch of the runtime fetch loop marks the account rate-limited via `markRateLimitedWithReason` (which mutates the disk-serialized `rateLimitResetTimes`) and `recordRateLimit`, then sleeps and retries — but never called `saveToDiskDebounced()`. The sibling **full-rotation** branch directly below it does persist (line ~2327).
- A crash during the retry sleep (or before any later save) lost the rate-limit reset time; on restart the account was immediately re-selected, defeating the cooldown.

## What Changed

- `index.ts` — add `accountManager.saveToDiskDebounced()` after `recordRateLimit()` in the short-retry branch, mirroring the full-rotation branch. One line + explanatory comment.
- `test/index.test.ts` — regression test in the fetch-handler suite: a 429 with a sub-threshold cooldown drives the short-retry path, the retry returns 200, and the test asserts `saveToDiskDebounced` was called once. Fails without the fix (verified by mutation).

## Severity

Low–medium. Like #608, this is a durability gap, not a live crash — the in-memory cooldown still works within a process. It only manifests if the process restarts inside the retry window. Fixing it makes the short-retry branch consistent with the full-rotation branch and the #607/#608 precedent.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (4920 passed, 3 skipped, 0 failures)
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [ ] relevant `docs/reference/*` pages updated (if commands/settings/paths changed)
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

No user-visible surface changed — internal fetch-loop consistency fix.

## Risk and Rollback

- Risk level: low. Adds one debounced disk write on a path that previously skipped it; matches the established sibling-branch pattern.
- Rollback plan: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `saveToDiskDebounced()` to the short-retry 429 branch in `index.ts`, closing a durability gap where a crash during the retry sleep could lose the rate-limit window and allow the account to be immediately re-selected on restart.

- `index.ts`: one-line fix placed after `recordRateLimit()` in the short-retry branch, mirroring the identical call sequence already present in the full-rotation branch at line ~2333.
- `test/index.test.ts`: regression test drives the short-retry path with a 1000 ms cooldown, lets it succeed on the second fetch, and asserts `saveToDiskDebounced` was called exactly once.

<h3>Confidence Score: 4/5</h3>

safe to merge — one-line change on a well-understood path, mirrors the sibling branch exactly, and is covered by a targeted regression test.

the fix is minimal and correct. the only observation is that the new regression test (and its sibling) sleep ~1 second in real time because `sleep` is not mocked, making the suite slightly slower and non-deterministic under jitter. no functional or correctness issues found.

test/index.test.ts — the new test and its sibling at line 5470 both incur a real ~1 s sleep; fake timers would align them with the timer-controlled tests already present in the same describe block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.ts | adds saveToDiskDebounced() in the short-retry 429 branch, directly after recordRateLimit(), mirroring the full-rotation branch at line ~2333. change is minimal, placement is correct, comment is accurate. |
| test/index.test.ts | regression test correctly validates saveToDiskDebounced is called once on the short-retry path. sleep is not mocked, so the test incurs a real ~1s wait; fake timers would be more consistent with other timer-controlled tests in the same suite. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetch loop: 429 response] --> B{cooldownMs <= shortRetryThreshold\nAND retryCount < MAX_SHORT_RETRY?}
    B -- yes: short-retry branch --> C[markRateLimitedWithReason]
    C --> D[recordRateLimit]
    D --> E["saveToDiskDebounced() ✅ NEW"]
    E --> F[sleep + continue]
    F --> A
    B -- no: full-rotation branch --> G[markRateLimitedWithReason]
    G --> H[recordRateLimit]
    H --> I[saveToDiskDebounced existing]
    I --> J[break — rotate account]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fpersist-cooldown-short-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpersist-cooldown-short-retry%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Findex.test.ts%3A5549-5649%0A%60sleep%60%20is%20not%20mocked%20here%2C%20so%20the%20test%20incurs%20a%20real%20%60~1%20s%60%20wait%20%28%60addJitter%28Math.max%28100%2C%201000%29%2C%200.2%29%60%20%E2%89%88%20800%E2%80%931200%20ms%29.%20other%20tests%20in%20this%20same%20describe%20block%20%28e.g.%20the%20%60useFakeTimers%60%20%2B%20%60advanceTimersByTimeAsync%281000%29%60%20pattern%20at%20line%205115%29%20control%20time%20explicitly.%20the%20sibling%20test%20at%20line%205470%20has%20the%20same%20gap%20%E2%80%94%20this%20PR%20doubles%20the%20accumulated%20wall-clock%20cost.%20consider%20wrapping%20the%20%60sleep%60%20call%20with%20fake%20timers%20to%20keep%20the%20suite%20deterministic%20and%20fast.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/index.test.ts:5549-5649
`sleep` is not mocked here, so the test incurs a real `~1 s` wait (`addJitter(Math.max(100, 1000), 0.2)` ≈ 800–1200 ms). other tests in this same describe block (e.g. the `useFakeTimers` + `advanceTimersByTimeAsync(1000)` pattern at line 5115) control time explicitly. the sibling test at line 5470 has the same gap — this PR doubles the accumulated wall-clock cost. consider wrapping the `sleep` call with fake timers to keep the suite deterministic and fast.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rotation): persist rate-limit window..."](https://github.com/ndycode/codex-multi-auth/commit/4bd69a8deb9b0eb269e5312da3e5db0c2def49b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37519703)</sub>

<!-- /greptile_comment -->