### PR TITLE
chore(release): cut v2.3.0 stable

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.3.0-beta.3",
+  "version": "2.3.0",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Generated: 2026-04-25
 Commit: a87e005
 Validated: 2026-06-10 against commit 98d9819 (repo audit; claims re-checked against the tree, content not regenerated)
 Branch: main
-Package version: 2.3.0-beta.3
+Package version: 2.3.0
 
 ## OVERVIEW
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This repository's current stable release line is `2.x`.
 Current stable release notes live in `docs/releases/`.
 This top-level changelog preserves the foundational `0.x` milestones and points older iteration history to `docs/releases/legacy-pre-0.1-history.md`.
 
+## [2.3.0] - 2026-06-15
+
+First stable cut of the `2.3.0` line. Promotes the `2.3.0-beta` series to stable and adds three runtime-rotation durability fixes landed after `beta.3`.
+See [docs/releases/v2.3.0.md](docs/releases/v2.3.0.md) for full details.
+
+### Fixed
+
+- Stale-runtime recovery deadlock: the rotation proxy returned a permanent `503 "All managed Codex accounts are temporarily unavailable"` even with healthy accounts, because persisted per-account transient state (cooldowns, rate-limit windows) was restored on reload and the recovery guard refused to run against it (#606, #607)
+- Cooldown not persisted when an account has no resolvable `accountId` — a restart inside the window dropped the cooldown and re-selected the broken account (#608)
+- Rate-limit window not persisted in the short-retry 429 path — same durability gap as the missing-accountId branch, in the runtime fetch loop (#609)
+
+### Notes
+
+- Published under the `latest` dist-tag (`npm i -g codex-multi-auth`).
+- Includes everything from the `2.3.0-beta.1` → `2.3.0-beta.3` prereleases.
+
+---
+
 ## [2.3.0-beta.3] - 2026-06-11
 
 Stream backpressure fix, deduplication fixpoint, retry-loop consolidation, typed errors, 20 new test suites, dead code pruned.

--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current prerelease: [docs/releases/v2.3.0-beta.3.md](docs/releases/v2.3.0-beta.3.md) — install via `npm i -g codex-multi-auth@beta`
-- Current stable: [docs/releases/v2.2.2.md](docs/releases/v2.2.2.md) — install via `npm i -g codex-multi-auth`
+- Current stable: [docs/releases/v2.3.0.md](docs/releases/v2.3.0.md) — install via `npm i -g codex-multi-auth`
+- Previous stable: [docs/releases/v2.2.2.md](docs/releases/v2.2.2.md)
 - Previous stable: [docs/releases/v2.2.1.md](docs/releases/v2.2.1.md)
 - Previous stable: [docs/releases/v2.2.0.md](docs/releases/v2.2.0.md)
 - Previous stable: [docs/releases/v2.1.12.md](docs/releases/v2.1.12.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,9 +32,10 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.3.0-beta.3.md](releases/v2.3.0-beta.3.md) | Current prerelease notes (install via `npm i -g codex-multi-auth@beta`) |
+| [releases/v2.3.0.md](releases/v2.3.0.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
+| [releases/v2.3.0-beta.3.md](releases/v2.3.0-beta.3.md) | Prior prerelease notes |
 | [releases/v2.3.0-beta.2.md](releases/v2.3.0-beta.2.md) | Prior prerelease notes |
-| [releases/v2.2.2.md](releases/v2.2.2.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
+| [releases/v2.2.2.md](releases/v2.2.2.md) | Prior stable release notes |
 | [releases/v2.2.1.md](releases/v2.2.1.md) | Prior stable release notes |
 | [releases/v2.2.0.md](releases/v2.2.0.md) | Prior stable release notes |
 | [releases/v2.1.12.md](releases/v2.1.12.md) | Prior stable release notes |

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -1,0 +1,28 @@
+# v2.3.0
+
+First stable release of the `2.3.0` line. Promotes the `2.3.0-beta.1` → `2.3.0-beta.3` prereleases to stable and adds three runtime-rotation durability fixes landed after `beta.3`.
+
+Install: `npm i -g codex-multi-auth`
+
+## Runtime Rotation
+
+### Bugfixes
+
+- **Stale-runtime recovery deadlock (#606, #607).** The rotation proxy could return a permanent `503 "All managed Codex accounts are temporarily unavailable for this runtime request."` even when accounts were healthy and `doctor` passed. Per-account transient state (`coolingDownUntil`, `cooldownReason`, `rateLimitResetTimes`) is serialized to disk, so the stale-runtime recovery path's `loadFromDisk()` restored the same state that had wedged the pool, while the recovery guard refused to run whenever any account's skip reason was `rate-limited` or `cooling-down*`. The guard now only suppresses recovery on `policy-blocked` (external, unchanged by a reload), and `recoverStaleRuntimeState` clears per-account transient state (`AccountManager.clearAccountTransientState()`) and flushes it to disk before publishing the reloaded manager. The two halves are coupled — each is pinned by a regression test that fails if the other is reverted.
+
+- **Cooldown not persisted in the missing-`accountId` branch (#608).** When `resolveAccountId` returned null, the runtime loop marked the account cooling down but — unlike every sibling cooldown branch (network-error, 429, server-error, 401) — never scheduled a disk write. A restart inside the cooldown window dropped the cooldown and immediately re-selected the still-broken account. Added the missing `saveToDiskDebounced()`.
+
+- **Rate-limit window not persisted in the short-retry 429 path (#609).** The short-retry branch of the runtime fetch loop mutated the disk-serialized `rateLimitResetTimes` via `markRateLimitedWithReason` and then slept/retried without persisting, unlike the full-rotation branch beside it. A crash during the retry sleep lost the reset time. Added the missing `saveToDiskDebounced()`.
+
+## Notes
+
+- These three fixes share one root cause class: transient account state (cooldowns, rate-limit windows) is persisted to disk, so any code path that mutates it must also schedule a write, or a restart silently drops it. All mutation sites were audited; the three above were the gaps.
+- The existing `codex-multi-auth rotation reset-rate-limits` command remains available as a manual escape hatch.
+- All prior `2.3.0-beta` changes are included — see [v2.3.0-beta.3](v2.3.0-beta.3.md) and [v2.3.0-beta.2](v2.3.0-beta.2.md) for the stream-backpressure fix, dedup fixpoint, retry-loop consolidation, typed errors, decomposition work, and the new test suites.
+
+## Validation
+
+- `npm run lint`, `npm run typecheck` — clean
+- `npm test` — full suite green (4920 passed / 3 skipped / 0 failed)
+- `npm test -- test/documentation.test.ts` — green
+- `npm run build`, `npm run pack:check` — within pack budget

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.3.0-beta.3",
+	"version": "2.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.3.0-beta.3",
+			"version": "2.3.0",
 			"bundleDependencies": [
 				"@codex-ai/plugin",
 				"@codex-ai/sdk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.3.0-beta.3",
+	"version": "2.3.0",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Cut **v2.3.0 stable** — promotes the `2.3.0-beta` line to stable and ships the three runtime-rotation durability fixes merged after `beta.3`:

- **#607** — break the stale-recovery deadlock on persisted transient account state (fixes **#606**, the reported permanent-503 bug)
- **#608** — persist cooldown when an account has no resolvable `accountId`
- **#609** — persist the rate-limit window in the short-retry 429 path

These three share one root-cause class (transient state is serialized to disk, so every mutation site must schedule a write); all mutation sites were audited and these were the gaps.

## What Changed

Version-coupled manifests bumped `2.3.0-beta.3` → `2.3.0`:
- `package.json`, `package-lock.json`, `.codex-plugin/plugin.json`, `AGENTS.md`
- `README.md` + `docs/README.md` release portals: v2.3.0 listed as current stable; beta.3/beta.2 demoted to prior prerelease; v2.2.2 demoted to prior stable
- `CHANGELOG.md` entry added
- `docs/releases/v2.3.0.md` created (required by `documentation.test.ts` coupling assertions)

No source code changes — the fixes already landed via #607/#608/#609. This PR is the release metadata bump only.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (4920 passed, 3 skipped, 0 failures)
- [x] `npm test -- test/documentation.test.ts` (26 passed — version coupling verified)
- [x] `npm run build`
- [x] `npm run pack:check` (`codex-multi-auth@2.3.0`, 1,062,597 bytes / 1201 files — within budget)

## Docs and Governance Checklist

- [x] README updated (release portal — current stable now v2.3.0)
- [ ] `docs/getting-started.md` updated (no onboarding change)
- [ ] `docs/features.md` updated (no capability change)
- [ ] relevant `docs/reference/*` pages updated (no command/setting change)
- [ ] `docs/upgrade.md` updated (no migration behavior change)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low. Metadata/docs only; the functional changes were each independently reviewed and merged.
- Rollback plan: revert this commit (does not touch runtime code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

metadata-only release cut promoting `2.3.0-beta.3` to stable `2.3.0`. no source code changes — the three durability fixes (#607, #608, #609) already landed via their own prs.

- version bumped to `2.3.0` across `package.json`, `package-lock.json`, `.codex-plugin/plugin.json`, and `AGENTS.md`
- `CHANGELOG.md` entry added and `docs/releases/v2.3.0.md` created (required by `documentation.test.ts` coupling assertions)
- release portals in `README.md` and `docs/README.md` updated: `v2.3.0` is current stable, `v2.2.2` and the beta series demoted accordingly

<h3>Confidence Score: 4/5</h3>

safe to merge — pure metadata bump with no runtime code changes; the only issue is a changelog date one day ahead of the actual cut date.

all eight changed files are version strings, release notes, and doc portal updates. no source, config, or test logic is touched. the single finding is the CHANGELOG.md entry dated 2026-06-15 when the pr is being merged on 2026-06-14.

CHANGELOG.md — the release date is one day in the future and should be corrected before tagging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version bumped from `2.3.0-beta.3` to `2.3.0`; no other changes |
| package-lock.json | lockfile version fields updated to match `2.3.0`; no dependency changes |
| .codex-plugin/plugin.json | plugin version bumped to `2.3.0`; no other fields changed |
| CHANGELOG.md | new `[2.3.0]` entry added; date is `2026-06-15` but cut date is `2026-06-14` |
| AGENTS.md | package version header updated to `2.3.0`; no content changes |
| README.md | release portal updated: `v2.3.0` listed as current stable, `v2.2.2` demoted to previous stable, beta line removed |
| docs/README.md | release table updated: `v2.3.0` as current stable, `v2.3.0-beta.3` demoted to prior prerelease, `v2.2.2` demoted to prior stable |
| docs/releases/v2.3.0.md | new release notes file created for v2.3.0; content is accurate and matches CHANGELOG and PR description |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["2.3.0-beta.3 (HEAD before PR)"] --> B["Version bump in\npackage.json / package-lock.json\n.codex-plugin/plugin.json / AGENTS.md"]
    B --> C["CHANGELOG.md entry added\n[2.3.0] - 2026-06-15"]
    B --> D["docs/releases/v2.3.0.md created\n(documentation.test.ts coupling)"]
    B --> E["README.md + docs/README.md\nrelease portals updated"]
    C --> F["2.3.0 stable published\nnpm i -g codex-multi-auth"]
    D --> F
    E --> F
    F --> G["latest dist-tag"]
    A --> H["Prior fixes already merged\n#607 stale-recovery deadlock\n#608 missing-accountId cooldown\n#609 short-retry 429 persist"]
    H --> F
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22release%2Fv2.3.0%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22release%2Fv2.3.0%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACHANGELOG.md%3A10%0Athe%20changelog%20entry%20is%20dated%20%602026-06-15%60%20but%20today%20is%20%602026-06-14%60.%20the%20pr%20is%20being%20cut%20today%2C%20so%20the%20date%20is%20one%20day%20in%20the%20future.%20this%20will%20show%20up%20as%20a%20future-dated%20entry%20in%20changelog%20tooling%20and%20any%20consumers%20that%20parse%2Fsort%20by%20date.%0A%0A%60%60%60suggestion%0A%23%23%20%5B2.3.0%5D%20-%202026-06-14%0A%60%60%60%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=610&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
CHANGELOG.md:10
the changelog entry is dated `2026-06-15` but today is `2026-06-14`. the pr is being cut today, so the date is one day in the future. this will show up as a future-dated entry in changelog tooling and any consumers that parse/sort by date.

```suggestion
## [2.3.0] - 2026-06-14
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): cut v2.3.0 stable"](https://github.com/ndycode/codex-multi-auth/commit/02ed50f60df9e000b4f2355d862f68bcdaab90e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37520616)</sub>

<!-- /greptile_comment -->