### PR TITLE
fix(app-bind): self-heal orphaned runtime-proxy bind with no backup (#614)

### DIFF
--- a/lib/runtime/app-bind.ts
+++ b/lib/runtime/app-bind.ts
@@ -9,7 +9,9 @@ import { fileURLToPath } from "node:url";
 import { withFileOperationRetry } from "../fs-retry.js";
 import { getCodexMultiAuthDir } from "../runtime-paths.js";
 import {
+	configHasRuntimeRotationProvider,
 	restoreConfigTomlFromRuntimeRotationProvider,
+	restoreConfigTomlFromRuntimeRotationProviderWithoutBackup,
 	rewriteConfigTomlForRuntimeRotationProvider,
 } from "./config-toml.js";
 
@@ -81,6 +83,13 @@ export interface AppBindRouterStatus {
 export interface AppBindStatus {
 	bound: boolean;
 	running: boolean;
+	/**
+	 * True when config.toml is bound to the runtime proxy but the app-bind state
+	 * file is gone (orphaned bind, #614). In this case `bound` is also true and
+	 * `state` is null — the config needs `unbind-app` to recover even though the
+	 * normal state-file tracking is missing.
+	 */
+	unmanagedBind: boolean;
 	state: AppBindState | null;
 	router: AppBindRouterStatus | null;
 	paths: AppBindPaths;
@@ -612,9 +621,19 @@ export async function getAppBindStatus(options: AppBindOptions = {}): Promise<Ap
 	const paths = resolveAppBindPaths(options);
 	const state = await readAppBindState(paths.statePath);
 	const router = await readRouterStatus(paths.statusPath);
+	// When no state file is present, the bind may still be live in config.toml
+	// (orphaned bind, #614). Detect that from the config directly so status and
+	// downstream callers don't report a bound config as "not configured".
+	let unmanagedBind = false;
+	if (state === null) {
+		const current = await readConfigIfExists(paths.configPath);
+		unmanagedBind =
+			current.existed && configHasRuntimeRotationProvider(current.content);
+	}
 	return {
-		bound: state !== null,
+		bound: state !== null || unmanagedBind,
 		running: router !== null && router.state === "running" && isProcessAlive(router.pid),
+		unmanagedBind,
 		state,
 		router,
 		paths,
@@ -765,6 +784,7 @@ async function unbindCodexAppRuntimeRotationLocked(
 	}
 
 	const backup = await readAppBindBackup(paths.backupPath);
+	let selfHealed = false;
 	if (backup) {
 		const current = await readConfigIfExists(backup.configPath);
 		if (state && current.existed && sha256(current.content) !== state.boundConfigHash) {
@@ -786,6 +806,22 @@ async function unbindCodexAppRuntimeRotationLocked(
 				restoreConfigTomlFromAppBind(current.content, ""),
 			);
 		}
+	} else {
+		// Orphaned-bind recovery (#614): no backup and no state file, but the
+		// config may still be bound to the runtime proxy (e.g. the state/backup
+		// were lost while config.toml stayed rewritten). The state-file checks
+		// above can't see this, so consult the config directly and self-heal it
+		// back to a working provider when it is bound.
+		const current = await readConfigIfExists(paths.configPath);
+		if (current.existed && configHasRuntimeRotationProvider(current.content)) {
+			await atomicWriteFile(
+				paths.configPath,
+				restoreConfigTomlFromRuntimeRotationProviderWithoutBackup(
+					current.content,
+				),
+			);
+			selfHealed = true;
+		}
 	}
 
 	for (const candidate of [
@@ -801,15 +837,31 @@ async function unbindCodexAppRuntimeRotationLocked(
 	}
 
 	const status = await getAppBindStatus(options);
+	let message: string;
+	if (backup) {
+		message = `Unbound Codex app config ${backup.configPath}`;
+	} else if (selfHealed) {
+		message = `Restored Codex app config ${paths.configPath} from an orphaned runtime-proxy bind (no backup was present)`;
+	} else {
+		message = "Codex app bind was not configured";
+	}
 	return {
 		status,
-		message: backup
-			? `Unbound Codex app config ${backup.configPath}`
-			: "Codex app bind was not configured",
+		message,
 	};
 }
 
 export function formatAppBindStatus(status: AppBindStatus): string {
+	if (status.unmanagedBind && !status.state) {
+		return [
+			`Codex app bind: bound but unmanaged (config=${status.paths.configPath} points at the runtime proxy, but no app-bind state/backup is present)`,
+			[
+				"Run `codex-multi-auth rotation unbind-app` to restore the original",
+				"Codex provider/config. This recovers the orphaned bind even though no",
+				"backup was saved (#614).",
+			].join(" "),
+		].join("\n");
+	}
 	if (!status.bound || !status.state) return "Codex app bind: not configured";
 	const parts = [
 		status.running ? "running" : "configured but router not running",

--- a/lib/runtime/config-toml.ts
+++ b/lib/runtime/config-toml.ts
@@ -271,3 +271,65 @@ export function restoreConfigTomlFromRuntimeRotationProvider(
 		),
 	);
 }
+
+/**
+ * Detects whether a config.toml is currently bound to the runtime rotation
+ * proxy — either the top-level `model_provider` points at the proxy id, or the
+ * proxy `[model_providers.<id>]` block is present. Used to recover an orphaned
+ * bind whose app-bind state/backup files were lost: in that situation the
+ * state-file-based status check reports "not configured" even though the config
+ * is still bound, so unbind/status must consult the config itself.
+ */
+export function configHasRuntimeRotationProvider(rawConfig: string): boolean {
+	if (rawConfig.length === 0) return false;
+	const providerTable = `model_providers.${RUNTIME_ROTATION_PROXY_PROVIDER_ID}`;
+	let inTopLevel = true;
+	for (const line of rawConfig.split(/\r?\n/)) {
+		const tableName = readTomlTableName(line);
+		if (tableName !== null) {
+			if (tableName === providerTable) return true;
+			inTopLevel = false;
+			continue;
+		}
+		if (
+			inTopLevel &&
+			/^\s*model_provider\s*=/.test(line) &&
+			line.includes(RUNTIME_ROTATION_PROXY_PROVIDER_ID)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Restores a bound config when no backup of the user's original config exists
+ * (the orphaned-bind recovery path). Strips the proxy provider block and any
+ * bind-written top-level lines, and — because there is no original
+ * `model_provider` line to bring back — falls back to `defaultProvider`
+ * (Codex's native `"openai"`) so the config is left on a working provider
+ * rather than the dangling proxy id.
+ */
+export function restoreConfigTomlFromRuntimeRotationProviderWithoutBackup(
+	currentConfig: string,
+	defaultProvider = "openai",
+): string {
+	const lineEnding = currentConfig.includes("\r\n") ? "\r\n" : "\n";
+	// Synthesize a minimal "original" config carrying only the default
+	// top-level model_provider, so the shared restore path rewrites the proxy
+	// line back to a usable provider instead of leaving it dangling.
+	const syntheticOriginal = `model_provider = ${tomlStringLiteral(defaultProvider)}${lineEnding}`;
+	const restored = restoreConfigTomlFromRuntimeRotationProvider(
+		currentConfig,
+		syntheticOriginal,
+	);
+	// Normalize line endings to match the input config. The shared restore path
+	// derives its EOL from intermediate state, which can collapse to "\n" when
+	// the bound config was almost entirely proxy content; pin it back to the
+	// original style so a CRLF (Windows-authored) config stays CRLF.
+	if (lineEnding === "\r\n") {
+		return restored.replace(/\r?\n/g, "\r\n");
+	}
+	return restored.replace(/\r\n/g, "\n");
+}
+

--- a/lib/runtime/config-toml.ts
+++ b/lib/runtime/config-toml.ts
@@ -136,15 +136,31 @@ export function restoreTopLevelModelProvider(
 	}
 
 	if (!handled && originalLine) {
-		// Splice the restored line into the root table — appending at tail
-		// would land it inside whatever section appears last in `output`.
-		const firstSectionIdx = output.findIndex(
-			(line) => readTomlTableName(line) !== null,
-		);
-		if (firstSectionIdx === -1) {
-			output.push(originalLine);
-		} else {
-			output.splice(firstSectionIdx, 0, originalLine);
+		// Only splice the original line back when the current config has no
+		// top-level model_provider at all (bind stripped it). If a non-proxy
+		// top-level model_provider already exists — e.g. a half-orphaned config
+		// where the proxy block is present but the provider line already points
+		// elsewhere — inserting another line would create a duplicate top-level
+		// key and produce invalid TOML. In that case the existing line is
+		// already correct, so leave it untouched.
+		const hasTopLevelModelProvider = (() => {
+			for (const line of output) {
+				if (readTomlTableName(line) !== null) return false;
+				if (/^\s*model_provider\s*=/.test(line)) return true;
+			}
+			return false;
+		})();
+		if (!hasTopLevelModelProvider) {
+			// Splice the restored line into the root table — appending at tail
+			// would land it inside whatever section appears last in `output`.
+			const firstSectionIdx = output.findIndex(
+				(line) => readTomlTableName(line) !== null,
+			);
+			if (firstSectionIdx === -1) {
+				output.push(originalLine);
+			} else {
+				output.splice(firstSectionIdx, 0, originalLine);
+			}
 		}
 	}
 

--- a/test/app-bind.test.ts
+++ b/test/app-bind.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	bindCodexAppRuntimeRotation,
 	formatAppBindStatus,
+	getAppBindStatus,
 	resolveAppBindPaths,
 	restoreConfigTomlFromAppBind,
 	rewriteConfigTomlForAppBind,
@@ -811,5 +812,92 @@ describe("Codex app runtime rotation bind", () => {
 
 		expect(statSync(logPath).size).toBeLessThan(2048);
 		expect(await readFile(logPath, "utf8")).toContain("log truncated");
+	});
+});
+
+describe("orphaned app-bind recovery (#614)", () => {
+	const boundConfig = [
+		'model_provider = "codex-multi-auth-runtime-proxy"',
+		"[profiles.default]",
+		'model = "gpt-5"',
+		"",
+		"[model_providers.codex-multi-auth-runtime-proxy]",
+		'name = "codex-multi-auth"',
+		'base_url = "http://127.0.0.1:51758"',
+		"requires_openai_auth = false",
+		'wire_api = "responses"',
+		"",
+	].join("\n");
+
+	async function seedOrphanedBind(): Promise<{
+		root: string;
+		codexHome: string;
+		env: NodeJS.ProcessEnv;
+	}> {
+		const root = await createTempRoot("codex-app-bind-orphan-");
+		const codexHome = join(root, "codex-home");
+		const env = {
+			CODEX_MULTI_AUTH_DIR: join(root, "multi-auth"),
+			CODEX_MULTI_AUTH_APP_BIND_CODEX_HOME: codexHome,
+		};
+		await mkdir(codexHome, { recursive: true });
+		// Bound config on disk, but NO state file and NO backup (the orphan case).
+		await writeFile(join(codexHome, "config.toml"), boundConfig, "utf8");
+		return { root, codexHome, env };
+	}
+
+	it("reports unmanagedBind when config is bound but no state file exists", async () => {
+		const { root, env } = await seedOrphanedBind();
+		const status = await getAppBindStatus({ platform: "linux", home: root, env });
+		expect(status.bound).toBe(true);
+		expect(status.unmanagedBind).toBe(true);
+		expect(status.state).toBeNull();
+		expect(formatAppBindStatus(status)).toContain("bound but unmanaged");
+	});
+
+	it("self-heals a bound config with no backup/state on unbind", async () => {
+		const { root, codexHome, env } = await seedOrphanedBind();
+
+		const unbound = await unbindCodexAppRuntimeRotation({
+			platform: "linux",
+			home: root,
+			env,
+			spawnDetached: false,
+		});
+
+		const restored = await readFile(join(codexHome, "config.toml"), "utf8");
+		expect(restored).toContain('model_provider = "openai"');
+		expect(restored).not.toContain("codex-multi-auth-runtime-proxy");
+		expect(restored).toContain("[profiles.default]");
+		expect(unbound.message).toContain("orphaned runtime-proxy bind");
+		expect(unbound.status.bound).toBe(false);
+		expect(unbound.status.unmanagedBind).toBe(false);
+	});
+
+	it("is a no-op for an already-clean config", async () => {
+		const root = await createTempRoot("codex-app-bind-clean-");
+		const codexHome = join(root, "codex-home");
+		const env = {
+			CODEX_MULTI_AUTH_DIR: join(root, "multi-auth"),
+			CODEX_MULTI_AUTH_APP_BIND_CODEX_HOME: codexHome,
+		};
+		await mkdir(codexHome, { recursive: true });
+		await writeFile(
+			join(codexHome, "config.toml"),
+			'model_provider = "openai"\n',
+			"utf8",
+		);
+
+		const unbound = await unbindCodexAppRuntimeRotation({
+			platform: "linux",
+			home: root,
+			env,
+			spawnDetached: false,
+		});
+
+		expect(unbound.message).toBe("Codex app bind was not configured");
+		expect(await readFile(join(codexHome, "config.toml"), "utf8")).toBe(
+			'model_provider = "openai"\n',
+		);
 	});
 });

--- a/test/app-bind.test.ts
+++ b/test/app-bind.test.ts
@@ -874,6 +874,49 @@ describe("orphaned app-bind recovery (#614)", () => {
 		expect(unbound.status.unmanagedBind).toBe(false);
 	});
 
+	it("self-heals a half-orphan (proxy block present, model_provider already native) without duplicating keys", async () => {
+		const root = await createTempRoot("codex-app-bind-half-orphan-");
+		const codexHome = join(root, "codex-home");
+		const env = {
+			CODEX_MULTI_AUTH_DIR: join(root, "multi-auth"),
+			CODEX_MULTI_AUTH_APP_BIND_CODEX_HOME: codexHome,
+		};
+		await mkdir(codexHome, { recursive: true });
+		// Top-level provider is already native, but the proxy block lingers — the
+		// partial-orphan case that previously produced a duplicate model_provider.
+		await writeFile(
+			join(codexHome, "config.toml"),
+			[
+				'model_provider = "openai"',
+				"[profiles.default]",
+				'model = "gpt-5"',
+				"",
+				"[model_providers.codex-multi-auth-runtime-proxy]",
+				'name = "codex-multi-auth"',
+				'wire_api = "responses"',
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		const unbound = await unbindCodexAppRuntimeRotation({
+			platform: "linux",
+			home: root,
+			env,
+			spawnDetached: false,
+		});
+
+		const restored = await readFile(join(codexHome, "config.toml"), "utf8");
+		const providerLines = (
+			restored.match(/^\s*model_provider\s*=/gm) ?? []
+		).length;
+		expect(providerLines).toBe(1);
+		expect(restored).toContain('model_provider = "openai"');
+		expect(restored).not.toContain("codex-multi-auth-runtime-proxy");
+		expect(restored).toContain("[profiles.default]");
+		expect(unbound.status.bound).toBe(false);
+	});
+
 	it("is a no-op for an already-clean config", async () => {
 		const root = await createTempRoot("codex-app-bind-clean-");
 		const codexHome = join(root, "codex-home");

--- a/test/app-bind.test.ts
+++ b/test/app-bind.test.ts
@@ -818,6 +818,7 @@ describe("Codex app runtime rotation bind", () => {
 describe("orphaned app-bind recovery (#614)", () => {
 	const boundConfig = [
 		'model_provider = "codex-multi-auth-runtime-proxy"',
+		"disable_response_storage = false",
 		"[profiles.default]",
 		'model = "gpt-5"',
 		"",
@@ -868,6 +869,7 @@ describe("orphaned app-bind recovery (#614)", () => {
 		const restored = await readFile(join(codexHome, "config.toml"), "utf8");
 		expect(restored).toContain('model_provider = "openai"');
 		expect(restored).not.toContain("codex-multi-auth-runtime-proxy");
+		expect(restored).not.toContain("disable_response_storage");
 		expect(restored).toContain("[profiles.default]");
 		expect(unbound.message).toContain("orphaned runtime-proxy bind");
 		expect(unbound.status.bound).toBe(false);

--- a/test/config-toml-restore.test.ts
+++ b/test/config-toml-restore.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+	configHasRuntimeRotationProvider,
+	restoreConfigTomlFromRuntimeRotationProviderWithoutBackup,
 	restoreTopLevelModelProvider,
 	restoreTopLevelResponseStorage,
 } from "../lib/runtime/config-toml.js";
@@ -111,5 +113,80 @@ describe("restoreTopLevelResponseStorage", () => {
 		const restored = restoreTopLevelResponseStorage(current, original);
 		// In-section setting should survive — only top-level residue is dropped.
 		expect(restored).toContain("disable_response_storage = false");
+	});
+});
+
+describe("configHasRuntimeRotationProvider", () => {
+	it("detects a top-level model_provider bound to the proxy", () => {
+		const config =
+			'model_provider = "codex-multi-auth-runtime-proxy"\n[profiles.default]\nmodel = "gpt-5"\n';
+		expect(configHasRuntimeRotationProvider(config)).toBe(true);
+	});
+
+	it("detects the proxy provider block even when model_provider is native", () => {
+		const config =
+			'model_provider = "openai"\n[model_providers.codex-multi-auth-runtime-proxy]\nname = "codex-multi-auth"\n';
+		expect(configHasRuntimeRotationProvider(config)).toBe(true);
+	});
+
+	it("returns false for an unbound config", () => {
+		const config = 'model_provider = "openai"\n[profiles.default]\nmodel = "gpt-5"\n';
+		expect(configHasRuntimeRotationProvider(config)).toBe(false);
+	});
+
+	it("returns false for empty config", () => {
+		expect(configHasRuntimeRotationProvider("")).toBe(false);
+	});
+
+	it("does not match a proxy id that only appears inside a non-provider section", () => {
+		// A stray mention in some other section's value must not be treated as a
+		// top-level bind (the top-level scan stops at the first table header).
+		const config =
+			'[profiles.default]\nnote = "codex-multi-auth-runtime-proxy"\n';
+		expect(configHasRuntimeRotationProvider(config)).toBe(false);
+	});
+});
+
+describe("restoreConfigTomlFromRuntimeRotationProviderWithoutBackup", () => {
+	it("rewrites a bound model_provider to the default and strips the proxy block", () => {
+		const bound = [
+			'model_provider = "codex-multi-auth-runtime-proxy"',
+			"[profiles.default]",
+			'model = "gpt-5"',
+			"",
+			"[model_providers.codex-multi-auth-runtime-proxy]",
+			'name = "codex-multi-auth"',
+			'base_url = "http://127.0.0.1:51758"',
+			"requires_openai_auth = false",
+			'wire_api = "responses"',
+			"",
+		].join("\n");
+
+		const restored =
+			restoreConfigTomlFromRuntimeRotationProviderWithoutBackup(bound);
+
+		expect(restored).toContain('model_provider = "openai"');
+		expect(restored).not.toContain("codex-multi-auth-runtime-proxy");
+		expect(restored).toContain("[profiles.default]");
+		expect(configHasRuntimeRotationProvider(restored)).toBe(false);
+	});
+
+	it("honors a custom default provider", () => {
+		const bound = 'model_provider = "codex-multi-auth-runtime-proxy"\n';
+		const restored = restoreConfigTomlFromRuntimeRotationProviderWithoutBackup(
+			bound,
+			"my-provider",
+		);
+		expect(restored).toContain('model_provider = "my-provider"');
+	});
+
+	it("preserves CRLF endings when recovering", () => {
+		const bound =
+			'model_provider = "codex-multi-auth-runtime-proxy"\r\n[model_providers.codex-multi-auth-runtime-proxy]\r\nname = "codex-multi-auth"\r\n';
+		const restored =
+			restoreConfigTomlFromRuntimeRotationProviderWithoutBackup(bound);
+		expect(restored).toContain('model_provider = "openai"');
+		expect(restored).not.toContain("codex-multi-auth-runtime-proxy");
+		expect(restored.replace(/\r\n/g, "")).not.toContain("\n");
 	});
 });

--- a/test/config-toml-restore.test.ts
+++ b/test/config-toml-restore.test.ts
@@ -189,4 +189,55 @@ describe("restoreConfigTomlFromRuntimeRotationProviderWithoutBackup", () => {
 		expect(restored).not.toContain("codex-multi-auth-runtime-proxy");
 		expect(restored.replace(/\r\n/g, "")).not.toContain("\n");
 	});
+
+	it("does not duplicate model_provider when the top-level line is already non-proxy (half-orphan)", () => {
+		// The proxy *block* is present but the top-level model_provider already
+		// points at a real provider. Recovery must strip the block and leave the
+		// single existing line — inserting a second one is invalid TOML.
+		const halfOrphan = [
+			'model_provider = "openai"',
+			"[profiles.default]",
+			'model = "gpt-5"',
+			"",
+			"[model_providers.codex-multi-auth-runtime-proxy]",
+			'name = "codex-multi-auth"',
+			'base_url = "http://127.0.0.1:51758"',
+			'wire_api = "responses"',
+			"",
+		].join("\n");
+
+		const restored =
+			restoreConfigTomlFromRuntimeRotationProviderWithoutBackup(halfOrphan);
+
+		const providerLines = (
+			restored.match(/^\s*model_provider\s*=/gm) ?? []
+		).length;
+		expect(providerLines).toBe(1);
+		expect(restored).toContain('model_provider = "openai"');
+		expect(restored).not.toContain("codex-multi-auth-runtime-proxy");
+		expect(restored).toContain("[profiles.default]");
+	});
+
+	it("drops bind-injected disable_response_storage during no-backup recovery", () => {
+		// A full bind injects `disable_response_storage = false` at top level;
+		// recovery with no backup must remove that residue.
+		const bound = [
+			'model_provider = "codex-multi-auth-runtime-proxy"',
+			"disable_response_storage = false",
+			"[profiles.default]",
+			'model = "gpt-5"',
+			"",
+			"[model_providers.codex-multi-auth-runtime-proxy]",
+			'name = "codex-multi-auth"',
+			'wire_api = "responses"',
+			"",
+		].join("\n");
+
+		const restored =
+			restoreConfigTomlFromRuntimeRotationProviderWithoutBackup(bound);
+
+		expect(restored).toContain('model_provider = "openai"');
+		expect(restored).not.toContain("disable_response_storage");
+		expect(restored).not.toContain("codex-multi-auth-runtime-proxy");
+	});
 });


### PR DESCRIPTION
Fixes #614.

## Problem

When app-bind rewrites the real `~/.codex/config.toml` to the runtime-proxy provider but its state/backup files are later lost (cleanup, partial unbind, a marker-less re-run of first-run setup, crash), the config stays bound while the tooling goes blind:

- `getAppBindStatus` and `rotation status` infer "bound" **only** from `app-bind/*.json`, so they report **"not configured"** even though `config.toml` still has `model_provider = "codex-multi-auth-runtime-proxy"` + the proxy block.
- `unbind-app` keys restoration off the backup file, so with no backup it's a **no-op** ("Codex app bind was not configured").

Net: the user's Codex CLI/Desktop is routed to a dead proxy port with no automated recovery — hand-editing `config.toml` was the only fix. (Reproduced live during 2.3.1 smoke testing; it bound the real config twice.)

## Fix

**`lib/runtime/config-toml.ts`**
- `configHasRuntimeRotationProvider(rawConfig)` — detects a bound config from either the top-level `model_provider` or the proxy `[model_providers.<id>]` block (top-level scan stops at the first table, so a stray mention elsewhere isn't a false positive).
- `restoreConfigTomlFromRuntimeRotationProviderWithoutBackup(currentConfig, defaultProvider = "openai")` — strips the proxy block and, with no original backup line to restore, falls the top-level provider back to `openai`. Pins line endings to the input style (fixes a CRLF-collapse edge).

**`lib/runtime/app-bind.ts`**
- `unbindCodexAppRuntimeRotationLocked` now self-heals: when there's no backup **and** no state but `config.toml` is still bound, it restores the config directly and reports `Restored Codex app config … from an orphaned runtime-proxy bind (no backup was present)`.
- `getAppBindStatus` derives `bound` from the config when no state file exists and exposes a new `unmanagedBind` flag.
- `formatAppBindStatus` surfaces **"bound but unmanaged"** with the `unbind-app` remedy instead of "not configured".

## Testing

- 11 new regression tests across `config-toml-restore.test.ts` (detection true/false/empty/stray-mention; no-backup restore incl. custom provider + CRLF) and `app-bind.test.ts` (unmanaged-status detection, self-heal unbind end-to-end, clean-config no-op).
- Verified end-to-end against a simulated orphaned bind in an isolated temp home: status → "bound but unmanaged"; `unbind-app` → restores `model_provider = "openai"`, removes the proxy block, preserves other sections; after → `bound=false, unmanaged=false`.
- `npm run build`, `typecheck`, eslint clean. Full suite: **4947 passed, 3 skipped** (was 4936).
- No behavior change to the normal backed-up bind/unbind path (existing app-bind/config-toml tests unchanged and green).

## Release

Targets `main`; will ship in the next patch (2.3.2). Can't go into the already-published 2.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes the orphaned app-bind scenario where `config.toml` stayed bound to the runtime proxy after state/backup files were lost, leaving the user stuck on a dead port with no automated recovery path.

- `configHasRuntimeRotationProvider` lets `getAppBindStatus` and `unbind-app` consult the config directly when no state file is present, exposing a new `unmanagedBind` flag and "bound but unmanaged" status message.
- `restoreConfigTomlFromRuntimeRotationProviderWithoutBackup` synthesizes a minimal original config (`model_provider = "openai"`) and delegates to the shared restore path; correctly handles the half-orphan case (proxy block present, top-level provider already native) to avoid producing duplicate TOML keys, and pins CRLF line endings for Windows-authored configs.
- 11 new regression tests cover detection, no-backup restore, half-orphan duplicate-key guard, CRLF preservation, `disable_response_storage` cleanup, and the full self-heal unbind flow.

<h3>Confidence Score: 5/5</h3>

safe to merge; recovery logic is correct, the half-orphan duplicate-key fix is test-covered, and CRLF handling is explicit for Windows configs

the core detection and restore functions are well-isolated and tested across all meaningful variants. the only gap is that startup-registration files (launchAgent/Windows startup) are not attempted during orphaned recovery, which could leave a stale startup entry after a crash-orphan — but this doesn't corrupt data or block normal operation

lib/runtime/app-bind.ts — the orphaned self-heal branch at line 809 skips startup file cleanup; worth a follow-up to attempt best-effort deletion of paths.startupPath and paths.launchAgentPath in the existing cleanup loop

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime/app-bind.ts | adds orphaned-bind detection in getAppBindStatus and self-heal recovery in unbindCodexAppRuntimeRotationLocked; startup artifact cleanup is missing in the orphaned path |
| lib/runtime/config-toml.ts | adds configHasRuntimeRotationProvider (detects proxy bind from config directly) and restoreConfigTomlFromRuntimeRotationProviderWithoutBackup (no-backup recovery with CRLF normalization and half-orphan duplicate-key guard) |
| test/app-bind.test.ts | 4 new integration tests covering unmanaged-status detection, self-heal end-to-end, half-orphan duplicate-key guard, and clean-config no-op; all use temp-dir isolation |
| test/config-toml-restore.test.ts | 7 new unit tests covering detection (true/false/empty/stray-mention/half-orphan) and no-backup restore (default provider, custom provider, CRLF, half-orphan duplicate-key, disable_response_storage cleanup) |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[unbindCodexAppRuntimeRotation] --> B[withAppBindLock]
    B --> C[readAppBindState]
    C --> D{state exists?}
    D -- yes --> E[stopRouter / removeAppBindStartup]
    E --> F[readAppBindBackup]
    D -- no --> F
    F --> G{backup exists?}
    G -- yes --> H[restoreConfigTomlFromAppBind\nusing backup content]
    G -- no --> I{state exists?}
    I -- yes --> J[restoreConfigTomlFromAppBind\nusing empty backup]
    I -- no --> K[readConfigIfExists paths.configPath]
    K --> L{configHasRuntimeRotationProvider?}
    L -- yes --> M[restoreConfigTomlFromRuntimeRotationProviderWithoutBackup\nself-heal orphaned bind]
    L -- no --> N[no-op: not configured]
    M --> O[selfHealed = true]
    H --> P[cleanup statePath / backupPath / statusPath]
    J --> P
    O --> P
    N --> P
    P --> Q[getAppBindStatus]
    Q --> R{state === null?}
    R -- yes --> S[readConfigIfExists\nconfigHasRuntimeRotationProvider]
    S --> T[unmanagedBind = true/false]
    R -- no --> U[unmanagedBind = false]
    T --> V[return AppBindStatus]
    U --> V
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[unbindCodexAppRuntimeRotation] --> B[withAppBindLock]
    B --> C[readAppBindState]
    C --> D{state exists?}
    D -- yes --> E[stopRouter / removeAppBindStartup]
    E --> F[readAppBindBackup]
    D -- no --> F
    F --> G{backup exists?}
    G -- yes --> H[restoreConfigTomlFromAppBind\nusing backup content]
    G -- no --> I{state exists?}
    I -- yes --> J[restoreConfigTomlFromAppBind\nusing empty backup]
    I -- no --> K[readConfigIfExists paths.configPath]
    K --> L{configHasRuntimeRotationProvider?}
    L -- yes --> M[restoreConfigTomlFromRuntimeRotationProviderWithoutBackup\nself-heal orphaned bind]
    L -- no --> N[no-op: not configured]
    M --> O[selfHealed = true]
    H --> P[cleanup statePath / backupPath / statusPath]
    J --> P
    O --> P
    N --> P
    P --> Q[getAppBindStatus]
    Q --> R{state === null?}
    R -- yes --> S[readConfigIfExists\nconfigHasRuntimeRotationProvider]
    S --> T[unmanagedBind = true/false]
    R -- no --> U[unmanagedBind = false]
    T --> V[return AppBindStatus]
    U --> V
```

</a>

<sub>Reviews (3): Last reviewed commit: ["test(app-bind): assert disable\_response\_..."](https://github.com/ndycode/codex-multi-auth/commit/a490274ce88197bde81b382bdcd4e6b50151b65d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37897417)</sub>

<!-- /greptile_comment -->