### PR TITLE
fix(test): correct DashboardDisplaySettings import path in settings-preview

### DIFF
--- a/test/settings-preview.test.ts
+++ b/test/settings-preview.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../lib/codex-manager/settings-preview.js";
 import { resolveMenuLayoutMode } from "../lib/codex-manager/settings-hub/shared.js";
 import { getUiRuntimeOptions } from "../lib/ui/runtime.js";
-import type { DashboardDisplaySettings } from "../lib/codex-manager/dashboard-settings.js";
+import type { DashboardDisplaySettings } from "../lib/dashboard-settings.js";
 
 const UI = getUiRuntimeOptions();
 


### PR DESCRIPTION
## What

`test/settings-preview.test.ts` imported `DashboardDisplaySettings` from `../lib/codex-manager/dashboard-settings.js` — **a path that does not exist**. The module lives at `lib/dashboard-settings.js`, which is where every other importer in the codebase resolves it from.

```diff
-import type { DashboardDisplaySettings } from "../lib/codex-manager/dashboard-settings.js";
+import type { DashboardDisplaySettings } from "../lib/dashboard-settings.js";
```

## Why it was latent

- It is an `import type`, so esbuild erases it at runtime — the test still ran and passed.
- `tsconfig.json` excludes `test/**` from the typecheck, so `tsc --noEmit` never resolved it either.

So neither the test runner nor the typechecker surfaced the broken path. It would only bite a tool that resolves test-file imports against the real filesystem (e.g. knip flagged it as an unresolved import).

## Verification

- `vitest run test/settings-preview.test.ts` → **12/12 pass**
- `tsc --noEmit` → clean
- No behavior change (type-only import).

Found while triaging the open-PR queue.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

corrects a broken `import type` path in `test/settings-preview.test.ts` — the module was pointing at the non-existent `lib/codex-manager/dashboard-settings.js` instead of the actual `lib/dashboard-settings.js`.

- fixes the unresolved import path for `DashboardDisplaySettings` to `../lib/dashboard-settings.js`, matching every other consumer in the codebase.
- no behavior change: it is a type-only import erased at runtime, and no test logic is touched.

<h3>Confidence Score: 5/5</h3>

safe to merge — one-line type-only import path fix with no runtime effect.

the change is a single corrected import path for a type that is fully erased at runtime. the new path resolves against the actual module (`lib/dashboard-settings.ts`), all 12 vitest tests pass, and no other test files carry the broken path. no token handling, filesystem, or concurrency paths are touched.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/settings-preview.test.ts | single-line import path correction; new path resolves correctly against `lib/dashboard-settings.ts`, all 12 tests pass, no logic changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["test/settings-preview.test.ts"] -->|"import type DashboardDisplaySettings"| B["lib/dashboard-settings.ts ✓"]
    C["lib/codex-manager/dashboard-settings.js ✗ (did not exist)"] -. old broken path .-> A
    B --> D["interface DashboardDisplaySettings (line 18)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["test/settings-preview.test.ts"] -->|"import type DashboardDisplaySettings"| B["lib/dashboard-settings.ts ✓"]
    C["lib/codex-manager/dashboard-settings.js ✗ (did not exist)"] -. old broken path .-> A
    B --> D["interface DashboardDisplaySettings (line 18)"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(test): correct DashboardDisplaySetti..."](https://github.com/ndycode/codex-multi-auth/commit/b8d3f2d09bee08dd00ff54c7dcad53424e6f1e9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38602373)</sub>

<!-- /greptile_comment -->