### PR TITLE
fix: harden rotation, persistence, and SSE failure handling (stress audit)

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -29,7 +29,7 @@ import {
 	type SelectionRecord,
 } from "./routing-mutex.js";
 import { nowMs } from "./utils.js";
-import { ERROR_MESSAGES, HTTP_STATUS } from "./constants.js";
+import { ERROR_MESSAGES, HTTP_STATUS, MAX_RATE_LIMIT_DELAY_MS } from "./constants.js";
 import { CodexAuthError } from "./errors.js";
 import {
 	loadCodexCliState,
@@ -1162,7 +1162,12 @@ export class AccountManager {
 		reason: RateLimitReason,
 		model?: string | null,
 	): void {
-		const retryMs = Math.max(0, Math.floor(retryAfterMs));
+		// Clamp to MAX_RATE_LIMIT_DELAY_MS so a bogus upstream retry-after value
+		// cannot wedge this account unavailable for years (see stress audit H1).
+		const retryMs = Math.min(
+			Math.max(0, Math.floor(retryAfterMs)),
+			MAX_RATE_LIMIT_DELAY_MS,
+		);
 		const resetAt = nowMs() + retryMs;
 
 		const baseKey = getQuotaKey(family);
@@ -1262,6 +1267,56 @@ export class AccountManager {
 		}
 		account.email =
 			sanitizeEmail(extractAccountEmail(auth.access)) ?? account.email;
+	}
+
+	/**
+	 * Reconcile token material from the on-disk store into a freshly-built
+	 * snapshot before persisting. A long-lived proxy serializes its whole
+	 * in-memory pool on every routine save (rate-limit, cooldown, refund). If a
+	 * SECOND process refreshed an account and wrote a rotated (single-use)
+	 * refresh token to disk in the meantime, a blind write would revert it,
+	 * permanently breaking that account's next refresh (stress audit H3).
+	 *
+	 * For each account, if the on-disk copy of the same identity carries a
+	 * strictly newer token (later expiresAt), adopt the disk's token material.
+	 * Our own freshly-refreshed tokens always have the newest expiry, so this
+	 * never undoes a refresh we just performed.
+	 */
+	private reconcileTokensFromDisk(
+		snapshot: AccountStorageV3,
+		current: AccountStorageV3 | null,
+	): AccountStorageV3 {
+		if (!current || !Array.isArray(current.accounts)) return snapshot;
+		const diskByIdentity = new Map<string, (typeof current.accounts)[number]>();
+		for (const diskAccount of current.accounts) {
+			const key = getAccountIdentityKey({
+				accountId: diskAccount.accountId,
+				email: diskAccount.email,
+				refreshToken: diskAccount.refreshToken,
+			});
+			if (key) diskByIdentity.set(key, diskAccount);
+		}
+		for (const account of snapshot.accounts) {
+			const key = getAccountIdentityKey({
+				accountId: account.accountId,
+				email: account.email,
+				refreshToken: account.refreshToken,
+			});
+			if (!key) continue;
+			const disk = diskByIdentity.get(key);
+			if (!disk) continue;
+			const diskExpires = disk.expiresAt ?? 0;
+			const memExpires = account.expiresAt ?? 0;
+			// Disk holds a strictly-newer token than our in-memory copy: adopt it
+			// so we don't clobber another process's rotation. Equal expiries keep
+			// our copy (no-op); newer in-memory copy wins (our own refresh).
+			if (diskExpires > memExpires && disk.refreshToken) {
+				account.refreshToken = disk.refreshToken;
+				account.accessToken = disk.accessToken;
+				account.expiresAt = disk.expiresAt;
+			}
+		}
+		return snapshot;
 	}
 
 	private buildStorageSnapshot(): AccountStorageV3 {
@@ -1747,8 +1802,13 @@ export class AccountManager {
 
 	async saveToDisk(): Promise<void> {
 		await runWithStoragePathState(this.storagePathState, async () => {
-			await withAccountStorageTransaction(async (_current, persist) => {
-				await persist(this.buildStorageSnapshot());
+			await withAccountStorageTransaction(async (current, persist) => {
+				// Reconcile against the disk state loaded under the storage lock so a
+				// routine save does not clobber a token another process just rotated
+				// (stress audit H3).
+				await persist(
+					this.reconcileTokensFromDisk(this.buildStorageSnapshot(), current),
+				);
 			});
 		});
 	}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,6 +15,13 @@ export const DUMMY_API_KEY = "chatgpt-oauth";
 /** Provider ID for UI display - shows under "OpenAI" in auth dropdown */
 export const PROVIDER_ID = "openai";
 
+/**
+ * Upper bound for any rate-limit / retry-after window we will honor. A single
+ * hostile or buggy upstream value (seconds-vs-ms confusion, anti-abuse misfire)
+ * must never be able to wedge an account unavailable for longer than this.
+ */
+export const MAX_RATE_LIMIT_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
+
 /** HTTP Status Codes */
 export const HTTP_STATUS = {
 	BAD_REQUEST: 400,
@@ -24,6 +31,7 @@ export const HTTP_STATUS = {
 	UNAUTHORIZED: 401,
 	NOT_FOUND: 404,
 	TOO_MANY_REQUESTS: 429,
+	BAD_GATEWAY: 502,
 	SERVICE_UNAVAILABLE: 503,
 } as const;
 

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -128,12 +128,23 @@ function getRiskLevel(score: number): ForecastRiskLevel {
 	return "low";
 }
 
-function getLiveQuotaWaitMs(snapshot: CodexQuotaSnapshot, now: number): number {
+function getLiveQuotaWaitMs(
+	snapshot: CodexQuotaSnapshot,
+	now: number,
+	onlyExhausted: boolean,
+): number {
 	const waits: number[] = [];
-	for (const resetAt of [
-		snapshot.primary.resetAtMs,
-		snapshot.secondary.resetAtMs,
-	]) {
+	for (const window of [snapshot.primary, snapshot.secondary]) {
+		// Under pure usage pressure (not a 429), only an actually-exhausted window
+		// (100% used) should impose a wait. A healthy weekly secondary normally
+		// resets ~7d out; folding that in would overstate the wait by orders of
+		// magnitude and invert the account recommendation (stress audit H5). On a
+		// 429 we honor every future window, since the upstream said "slow down now"
+		// regardless of the usage gauge.
+		if (onlyExhausted && quotaLeftPercentFromUsed(window?.usedPercent) !== 0) {
+			continue;
+		}
+		const resetAt = window?.resetAtMs;
 		if (typeof resetAt !== "number") continue;
 		if (!Number.isFinite(resetAt)) continue;
 		const remaining = resetAt - now;
@@ -310,7 +321,9 @@ export function evaluateForecastAccount(
 			riskScore += 35;
 			reasons.push("live probe returned 429");
 		}
-		const liveWait = quotaPressure ? getLiveQuotaWaitMs(quota, now) : 0;
+		const liveWait = quotaPressure
+			? getLiveQuotaWaitMs(quota, now, quota.status !== 429)
+			: 0;
 		waitMs = Math.max(waitMs, liveWait);
 		if (liveWait > 0 && availability === "ready") {
 			availability = "delayed";

--- a/lib/preemptive-quota-scheduler.ts
+++ b/lib/preemptive-quota-scheduler.ts
@@ -1,3 +1,5 @@
+import { quotaLeftPercentFromUsed } from "./quota-readiness.js";
+
 export interface QuotaSchedulerWindow {
 	usedPercent?: number;
 	resetAtMs?: number;
@@ -213,11 +215,21 @@ export class PreemptiveQuotaScheduler {
 		if (!key) return;
 		const waitMs = Number.isFinite(retryAfterMs) ? Math.max(0, Math.floor(retryAfterMs)) : 0;
 		const existing = this.snapshots.get(key);
-		const existingResetAtMs = Math.max(
-			existing?.primary.resetAtMs ?? 0,
-			existing?.secondary.resetAtMs ?? 0,
-		);
-		const nextResetAtMs = Math.max(existingResetAtMs, now + waitMs);
+		// A 429 retry-after defines the PRIMARY rate-limit window only. Do NOT
+		// fold in a benign quota reset — neither the weekly secondary (~7d out)
+		// nor a healthy primary quota window from a prior 200 snapshot — because
+		// that would bench the account for the full deferral cap on a transient
+		// 30-60s 429 (stress audit H4). Only preserve a prior primary window that
+		// was itself a rate-limit / exhausted window (usedPercent absent or 100).
+		const existingPrimary = existing?.primary;
+		const existingPrimaryIsRateLimit =
+			existingPrimary !== undefined &&
+			(typeof existingPrimary.usedPercent !== "number" ||
+				!Number.isFinite(existingPrimary.usedPercent) ||
+				quotaLeftPercentFromUsed(existingPrimary.usedPercent) === 0);
+		const existingPrimaryResetAtMs =
+			existingPrimaryIsRateLimit ? (existingPrimary?.resetAtMs ?? 0) : 0;
+		const nextResetAtMs = Math.max(existingPrimaryResetAtMs, now + waitMs);
 		this.snapshots.set(key, {
 			status: 429,
 			primary: {
@@ -251,7 +263,24 @@ export class PreemptiveQuotaScheduler {
 				? snapshot.secondary.resetAtMs - now
 				: 0;
 
-		const waitCandidates = [snapshot.primary.resetAtMs, snapshot.secondary.resetAtMs]
+		// For a 429 deferral, only count a window whose reset is genuinely a
+		// rate-limit / exhaustion window. A window carrying a healthy usedPercent
+		// (e.g. a weekly secondary at 30% from a prior 200 snapshot) is NOT the
+		// thing the 429 is about; folding its ~7d reset in would bench the account
+		// for the full deferral cap on a transient 429 (stress audit H4). A window
+		// with no usedPercent, or one that is exhausted, still counts.
+		const isRateLimitWindow = (window: {
+			usedPercent?: number;
+			resetAtMs?: number;
+		}): boolean => {
+			if (typeof window.usedPercent !== "number" || !Number.isFinite(window.usedPercent)) {
+				return true;
+			}
+			return quotaLeftPercentFromUsed(window.usedPercent) === 0;
+		};
+		const waitCandidates = [snapshot.primary, snapshot.secondary]
+			.filter(isRateLimitWindow)
+			.map((window) => window.resetAtMs)
 			.filter((value): value is number => typeof value === "number" && Number.isFinite(value) && value > now)
 			.map((value) => value - now)
 			.filter((value) => value > 0);

--- a/lib/refresh-lease.ts
+++ b/lib/refresh-lease.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync, promises as fs } from "node:fs";
 import { join } from "node:path";
 import { parseBooleanEnv } from "./env-parsing.js";
@@ -21,6 +21,10 @@ interface LeaseFilePayload {
 	pid: number;
 	acquiredAt: number;
 	expiresAt: number;
+	// Per-owner identity. release() only unlinks a lock whose on-disk nonce still
+	// matches this handle, so a slow owner whose lease expired and was stolen
+	// cannot delete the new owner's lock (stress audit H2).
+	nonce: string;
 }
 
 interface ResultFilePayload {
@@ -73,6 +77,9 @@ function parseLeasePayload(raw: unknown): LeaseFilePayload | null {
 	const pid = typeof raw.pid === "number" ? raw.pid : Number.NaN;
 	const acquiredAt = typeof raw.acquiredAt === "number" ? raw.acquiredAt : Number.NaN;
 	const expiresAt = typeof raw.expiresAt === "number" ? raw.expiresAt : Number.NaN;
+	// nonce is optional for backward-compat with locks written before H2; an
+	// absent nonce simply means release() falls back to a best-effort unlink.
+	const nonce = typeof raw.nonce === "string" ? raw.nonce : "";
 	if (
 		tokenHash.length === 0 ||
 		!Number.isFinite(pid) ||
@@ -86,6 +93,7 @@ function parseLeasePayload(raw: unknown): LeaseFilePayload | null {
 		pid: Math.floor(pid),
 		acquiredAt: Math.floor(acquiredAt),
 		expiresAt: Math.floor(expiresAt),
+		nonce,
 	};
 }
 
@@ -230,6 +238,7 @@ export class RefreshLeaseCoordinator {
 
 			try {
 				const handle = await this.fsOps.open(lockPath, "wx", 0o600);
+				const nonce = randomUUID();
 				try {
 					const now = Date.now();
 					const payload: LeaseFilePayload = {
@@ -237,13 +246,14 @@ export class RefreshLeaseCoordinator {
 						pid: process.pid,
 						acquiredAt: now,
 						expiresAt: now + this.leaseTtlMs,
+						nonce,
 					};
 					await handle.writeFile(`${JSON.stringify(payload)}\n`, "utf8");
 				} finally {
 					await handle.close();
 				}
 
-				return this.createOwnerHandle(tokenHash, lockPath, resultPath);
+				return this.createOwnerHandle(tokenHash, lockPath, resultPath, nonce);
 			} catch (error) {
 				const code = (error as NodeJS.ErrnoException).code;
 				if (code !== "EEXIST") {
@@ -292,6 +302,7 @@ export class RefreshLeaseCoordinator {
 		tokenHash: string,
 		lockPath: string,
 		resultPath: string,
+		nonce: string,
 	): RefreshLeaseHandle {
 		let released = false;
 		return {
@@ -304,10 +315,40 @@ export class RefreshLeaseCoordinator {
 						await this.writeResult(resultPath, tokenHash, result);
 					}
 				} finally {
-					await safeUnlink(lockPath, undefined, this.fsOps);
+					// Only unlink the lock if it is still OURS. If our lease expired
+					// and another process stole the lock, the on-disk nonce no longer
+					// matches and unlinking would delete the new owner's lock mid
+					// refresh (stress audit H2). A lock written before nonces existed
+					// (empty on-disk nonce) falls back to a best-effort unlink.
+					if (await this.ownsLock(lockPath, tokenHash, nonce)) {
+						await safeUnlink(lockPath, undefined, this.fsOps);
+					} else {
+						log.warn(
+							"Refresh lease no longer owned at release; leaving lock for current owner",
+							{ lockPath },
+						);
+					}
 				}
 			},
 		};
+	}
+
+	private async ownsLock(
+		lockPath: string,
+		tokenHash: string,
+		nonce: string,
+	): Promise<boolean> {
+		const raw = await readJson(lockPath, this.fsOps);
+		const parsed = raw === null ? null : parseLeasePayload(raw);
+		if (!parsed) {
+			// Unreadable/absent lock: nothing of ours to protect, allow cleanup.
+			return true;
+		}
+		if (parsed.tokenHash !== tokenHash) return false;
+		// Backward-compat: a lock written before H2 has no nonce. Fall back to the
+		// previous (best-effort) behavior so we still clean up our own old locks.
+		if (parsed.nonce === "") return true;
+		return parsed.nonce === nonce;
 	}
 
 	private async writeResult(

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -22,6 +22,7 @@ import {
 	HTTP_STATUS,
 	ERROR_MESSAGES,
 	LOG_STAGES,
+	MAX_RATE_LIMIT_DELAY_MS,
 } from "../constants.js";
 import {
 	CHATGPT_CODEX_UNSUPPORTED_MODEL_CODE,
@@ -67,7 +68,8 @@ export interface RateLimitInfo {
         code?: string;
 }
 
-const MAX_RATE_LIMIT_DELAY_MS = 7 * 24 * 60 * 60 * 1000;
+// MAX_RATE_LIMIT_DELAY_MS is centralized in constants.ts (shared with the
+// runtime proxy rate-limit setter so both paths clamp identically).
 const RETRY_AFTER_DURATION_PATTERN =
 	/\b(?:try|retry)\s+again\s+in\s+(\d+)\s*(second|minute|hour|day)s?\b/i;
 const RETRY_AFTER_CLOCK_TIME_PATTERN =

--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -1,5 +1,5 @@
 import { createLogger, logRequest, LOGGING_ENABLED } from "../logger.js";
-import { PLUGIN_NAME } from "../constants.js";
+import { HTTP_STATUS, PLUGIN_NAME } from "../constants.js";
 import { isRecord } from "../utils.js";
 
 import type { SSEEventData } from "../types.js";
@@ -596,6 +596,17 @@ function maybeCaptureResponseEvent(
 		return;
 	}
 
+	// response.failed / response.incomplete are terminal failure events in the
+	// Responses streaming protocol: HTTP is still 200 but the turn did not
+	// succeed. Treat them as errors so the stream is not misclassified as a
+	// successful response and misattributed as an account success (stress audit
+	// H7). response.incomplete (e.g. hit max_output_tokens) is routine.
+	if (data.type === "response.failed" || data.type === "response.incomplete") {
+		log.warn("SSE terminal failure event received", { type: data.type });
+		state.encounteredError = true;
+		return;
+	}
+
 	if (data.type === "response.done" || data.type === "response.completed") {
 		if (isRecord(data.response)) {
 			state.finalResponse = { ...data.response };
@@ -702,7 +713,7 @@ function maybeCaptureResponseEvent(
 function parseSseStream(
 	sseText: string,
 	onResponseId?: (responseId: string) => void,
-): unknown | null {
+): { finalResponse: unknown | null; encounteredError: boolean } {
 	const lines = sseText.split(/\r?\n/);
 	const state = createParsedResponseState();
 
@@ -710,13 +721,18 @@ function parseSseStream(
 	let firstMalformedSample: string | null = null;
 	for (const line of lines) {
 		const trimmedLine = line.trim();
-		if (trimmedLine.startsWith("data: ")) {
-			const payload = trimmedLine.substring(6).trim();
+		// Accept "data:" with or without the optional trailing space. The SSE
+		// spec allows "data:value"; requiring the space silently dropped every
+		// event on an upstream/proxy formatting change (stress audit M1).
+		if (trimmedLine.startsWith("data:")) {
+			const payload = trimmedLine.substring(5).trim();
 			if (!payload || payload === "[DONE]") continue;
 			try {
 				const data = JSON.parse(payload) as SSEEventData;
 				maybeCaptureResponseEvent(state, data, onResponseId);
-				if (state.encounteredError) return null;
+				if (state.encounteredError) {
+					return { finalResponse: null, encounteredError: true };
+				}
 			} catch (error) {
 				// AUDIT-H9 / H-03: previously these malformed chunks were
 				// silently discarded, masking upstream protocol drift + the
@@ -744,7 +760,10 @@ function parseSseStream(
 		});
 	}
 
-	return finalizeParsedResponse(state);
+	return {
+		finalResponse: finalizeParsedResponse(state),
+		encounteredError: state.encounteredError,
+	};
 }
 
 /**
@@ -807,7 +826,43 @@ export async function convertSseToJson(
 		}
 
 		// Parse SSE events to extract the final response
-		const finalResponse = parseSseStream(fullText, options?.onResponseId);
+		const { finalResponse, encounteredError } = parseSseStream(
+			fullText,
+			options?.onResponseId,
+		);
+
+		// A terminal failure event (mid-stream `error`, `response.failed`, or
+		// `response.incomplete`) means the upstream turn failed even though HTTP
+		// opened 200. Returning the raw SSE at 200 here makes the proxy record an
+		// account success and skip rotation/retry (stress audit H6+H7). Synthesize
+		// a non-2xx so the caller routes to failure. (A stream that simply yields
+		// no final response WITHOUT an error — empty/truncated — is left as the
+		// original passthrough below so the empty-response retry path still runs.)
+		if (encounteredError) {
+			log.warn("SSE stream ended with a terminal failure event");
+			logRequest("stream-error", {
+				error: "SSE stream terminated with an error/failed/incomplete event",
+			});
+			const upstreamFailed =
+				typeof response.status === "number" && response.status >= 400;
+			const status = upstreamFailed ? response.status : HTTP_STATUS.BAD_GATEWAY;
+			const errorHeaders = new Headers(headers);
+			errorHeaders.set("content-type", "application/json; charset=utf-8");
+			return new Response(
+				JSON.stringify({
+					error: {
+						message: "Upstream SSE stream terminated with a failure event",
+						type: "upstream_stream_error",
+						code: "sse_terminal_error",
+					},
+				}),
+				{
+					status,
+					statusText: upstreamFailed ? response.statusText : "Bad Gateway",
+					headers: errorHeaders,
+				},
+			);
+		}
 
 		if (!finalResponse) {
 			log.warn("Could not find final response in SSE stream");
@@ -816,7 +871,8 @@ export async function convertSseToJson(
 				error: "No terminal response event found in SSE stream",
 			});
 
-			// Return original stream if we can't parse
+			// Return original stream if we can't parse (no error event, just no
+			// terminal response). Preserves the empty-response retry path.
 			return new Response(fullText, {
 				status: response.status,
 				statusText: response.statusText,
@@ -868,8 +924,8 @@ function createResponseIdCapturingStream(
 
 		for (const rawLine of lines) {
 			const trimmedLine = rawLine.trim();
-			if (!trimmedLine.startsWith("data: ")) continue;
-			const payload = trimmedLine.slice(6).trim();
+			if (!trimmedLine.startsWith("data:")) continue;
+			const payload = trimmedLine.slice(5).trim();
 			if (!payload || payload === "[DONE]") continue;
 			try {
 				const data = JSON.parse(payload) as SSEEventData;

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1283,6 +1283,33 @@ describe("AccountManager", () => {
 			expect(account.rateLimitResetTimes["codex"]).toBeDefined();
 		});
 
+		it("H1: clamps an absurd retry-after value to MAX_RATE_LIMIT_DELAY_MS (7d)", () => {
+			const now = new Date("2026-04-05T00:00:00.000Z");
+			vi.useFakeTimers();
+			vi.setSystemTime(now);
+			try {
+				const stored = {
+					version: 3 as const,
+					activeIndex: 0,
+					accounts: [{ refreshToken: "token-1", addedAt: now.getTime(), lastUsed: now.getTime() }],
+				};
+				const manager = new AccountManager(undefined, stored);
+				const account = manager.getCurrentAccount()!;
+				// Hostile/buggy upstream: ~31 years in ms.
+				manager.markRateLimitedWithReason(account, 999_999_999_999, "codex", "quota");
+				const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+				const resetAt = account.rateLimitResetTimes["codex"]!;
+				// Window must not exceed 7 days from now.
+				expect(resetAt - now.getTime()).toBeLessThanOrEqual(sevenDaysMs);
+				expect(resetAt - now.getTime()).toBe(sevenDaysMs);
+				// And the clamped window is in the past after 7d+ elapses (self-heals).
+				vi.advanceTimersByTime(sevenDaysMs + 1000);
+				expect(account.rateLimitResetTimes["codex"]!).toBeLessThan(Date.now());
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it("scopes token rate limits to the model-specific key", () => {
 			const now = Date.now();
 			const stored = {

--- a/test/chaos/fault-injection.test.ts
+++ b/test/chaos/fault-injection.test.ts
@@ -354,12 +354,13 @@ describe("SSE Parsing Edge Cases", () => {
 			expect(body.id).toBe("resp_456");
 		});
 
-		it("handles error event type", async () => {
+		it("handles error event type (non-2xx failure, H6)", async () => {
 			const sseText =
 				'data: {"type":"error","error":{"message":"Something went wrong"}}\n\n';
 			const response = new Response(sseText, { status: 200 });
 			const result = await convertSseToJson(response, new Headers());
-			expect(result.status).toBe(200);
+			expect(result.status).toBeGreaterThanOrEqual(400);
+			expect(result.ok).toBe(false);
 		});
 
 		it("handles multiple events, extracts last response.done", async () => {

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -1017,4 +1017,72 @@ describe("forecast helpers", () => {
 		expect(recommendation.recommendedIndex).toBeNull();
 		expect(recommendation.reason).toContain("blocked or exhausted");
 	});
+	it("H5: live-quota wait reflects only the exhausted window, not a healthy 7d secondary", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+		};
+		// Binding 5h primary is fully exhausted but frees in 90s; the weekly
+		// secondary is healthy (55% used) with its normal ~7d reset. The reported
+		// wait must track the 90s window, not the 7d one.
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			allAccounts: [account],
+			liveQuota: {
+				status: 200,
+				model: "gpt-5.3-codex",
+				primary: { usedPercent: 100, windowMinutes: 300, resetAtMs: now + 90_000 },
+				secondary: {
+					usedPercent: 55,
+					windowMinutes: 10_080,
+					resetAtMs: now + 7 * 24 * 60 * 60 * 1000,
+				},
+			},
+		});
+		// Before the fix this returned the 7d secondary reset (~604_800_000ms).
+		expect(result.waitMs).toBe(90_000);
+	});
+
+	it("H5: recommends the account that actually frees first under live-quota pressure", () => {
+		const now = 1_700_000_000_000;
+		const mk = (id: string) => ({
+			accountId: id,
+			email: id + "@example.com",
+			refreshToken: "rt-" + id,
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+		});
+		const a = mk("a");
+		const b = mk("b");
+		const all = [a, b];
+		// a: binding window frees in 90s, healthy secondary 7d out.
+		// b: binding window frees in 10min, healthy secondary 7d out.
+		// a should be recommended (frees first); the 7d secondary must not invert it.
+		const results = evaluateForecastAccounts([
+			{
+				index: 0, now, isCurrent: false, account: a, allAccounts: all,
+				liveQuota: {
+					status: 200, model: "gpt-5.3-codex",
+					primary: { usedPercent: 100, windowMinutes: 300, resetAtMs: now + 90_000 },
+					secondary: { usedPercent: 50, windowMinutes: 10_080, resetAtMs: now + 7 * 24 * 60 * 60 * 1000 },
+				},
+			},
+			{
+				index: 1, now, isCurrent: false, account: b, allAccounts: all,
+				liveQuota: {
+					status: 200, model: "gpt-5.3-codex",
+					primary: { usedPercent: 100, windowMinutes: 300, resetAtMs: now + 600_000 },
+					secondary: { usedPercent: 50, windowMinutes: 10_080, resetAtMs: now + 7 * 24 * 60 * 60 * 1000 },
+				},
+			},
+		]);
+		expect(results[0].waitMs).toBe(90_000);
+		expect(results[1].waitMs).toBe(600_000);
+	});
+
 });

--- a/test/h3-token-clobber.test.ts
+++ b/test/h3-token-clobber.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { removeWithRetry } from "./helpers/remove-with-retry.js";
+import { AccountManager } from "../lib/accounts.js";
+import {
+	setStoragePathDirect,
+	type AccountStorageV3,
+} from "../lib/storage.js";
+
+// Stress audit H3: a routine saveToDisk() by one process must not clobber a
+// single-use refresh token that a SECOND process rotated to disk meanwhile.
+describe("H3 - cross-process token clobber protection", () => {
+	const tmpDirs: string[] = [];
+	const managers: AccountManager[] = [];
+
+	function makeStoragePath(): string {
+		const dir = mkdtempSync(join(tmpdir(), "h3-clobber-"));
+		tmpDirs.push(dir);
+		return join(dir, "openai-codex-accounts.json");
+	}
+
+	beforeEach(() => {
+		setStoragePathDirect(null);
+	});
+
+	afterEach(async () => {
+		for (const m of managers.splice(0, managers.length)) {
+			await m.flushPendingSave();
+		}
+		setStoragePathDirect(null);
+		for (const dir of tmpDirs.splice(0, tmpDirs.length)) {
+			try {
+				await removeWithRetry(dir, { recursive: true, force: true });
+			} catch {
+				// best-effort
+			}
+		}
+	});
+
+	it("preserves a refresh token another process rotated to disk during a routine save", async () => {
+		const now = Date.now();
+		const storage: AccountStorageV3 = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					accountId: "acc-a",
+					email: "a@example.com",
+					refreshToken: "RT_A1",
+					accessToken: "AT_A1",
+					expiresAt: now + 60_000,
+					addedAt: now,
+					lastUsed: now,
+				},
+				{
+					accountId: "acc-b",
+					email: "b@example.com",
+					refreshToken: "RT_B1",
+					accessToken: "AT_B1",
+					expiresAt: now + 60_000,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+		const storagePath = makeStoragePath();
+		writeFileSync(storagePath, JSON.stringify(storage), "utf8");
+		setStoragePathDirect(storagePath);
+
+		const proc1 = new AccountManager(undefined, storage);
+		managers.push(proc1);
+
+		// proc2 (simulated): rotates B's token and writes a NEWER copy to disk.
+		const rotated = JSON.parse(
+			readFileSync(storagePath, "utf8"),
+		) as AccountStorageV3;
+		const diskB = rotated.accounts[1]!;
+		diskB.refreshToken = "RT_B2";
+		diskB.accessToken = "AT_B2";
+		diskB.expiresAt = now + 3_600_000;
+		writeFileSync(storagePath, JSON.stringify(rotated), "utf8");
+
+		// proc1 fires a routine save (touched only A in memory).
+		await proc1.saveToDisk();
+
+		const after = JSON.parse(
+			readFileSync(storagePath, "utf8"),
+		) as AccountStorageV3;
+		const afterB = after.accounts.find((a) => a.accountId === "acc-b");
+		expect(afterB?.refreshToken).toBe("RT_B2");
+		expect(afterB?.accessToken).toBe("AT_B2");
+	});
+});

--- a/test/preemptive-quota-scheduler.test.ts
+++ b/test/preemptive-quota-scheduler.test.ts
@@ -270,4 +270,29 @@ describe("preemptive quota scheduler", () => {
 		expect(removed).toBe(1);
 		expect(scheduler.prune(8_000)).toBe(1);
 	});
+	it("H4: a transient 429 does not bench the account on a benign weekly window", () => {
+		const scheduler = new PreemptiveQuotaScheduler();
+		const now = 1_000_000;
+		const weekMs = 7 * 24 * 60 * 60 * 1000;
+		// Healthy 200 snapshot: primary fine, weekly secondary resets ~7d out.
+		scheduler.update("acc:model", {
+			status: 200,
+			primary: { usedPercent: 20, resetAtMs: now + 5 * 60_000 },
+			secondary: { usedPercent: 30, resetAtMs: now + weekMs },
+			updatedAt: now,
+		});
+		// Transient 60s 429.
+		scheduler.markRateLimited("acc:model", 60_000, now);
+		const decision = scheduler.getDeferral("acc:model", now + 1_000);
+		expect(decision.defer).toBe(true);
+		expect(decision.reason).toBe("rate-limit");
+		// Must reflect the ~60s retry window, NOT the 7d weekly reset (which would
+		// clamp to the 2h deferral cap). Allow the remaining ~59s.
+		expect(decision.waitMs).toBeLessThanOrEqual(60_000);
+		expect(decision.waitMs).toBeGreaterThan(50_000);
+		// After the 429 window passes, the account is no longer rate-limit-deferred.
+		const after = scheduler.getDeferral("acc:model", now + 61_000);
+		expect(after.reason).not.toBe("rate-limit");
+	});
+
 });

--- a/test/refresh-lease.test.ts
+++ b/test/refresh-lease.test.ts
@@ -698,4 +698,38 @@ describe("RefreshLeaseCoordinator", () => {
       ),
     ).toBe(true);
   });
+  it("H2: a slow owner's release does not delete a lock stolen after its lease expired", async () => {
+    // Owner A acquires with a very short TTL. Its lease expires; owner B steals
+    // the lock and becomes the new owner. When A finally releases, it must NOT
+    // unlink B's lock (stress audit H2): cross-process mutual exclusion must not
+    // silently degrade to none.
+    const coordinator = new RefreshLeaseCoordinator({
+      enabled: true,
+      leaseDir,
+      leaseTtlMs: 30,
+      waitTimeoutMs: 2_000,
+      pollIntervalMs: 10,
+      resultTtlMs: 2_000,
+    });
+
+    const ownerA = await coordinator.acquire("token-steal");
+    expect(ownerA.role).toBe("owner");
+
+    // Let A's lease go stale (TTL 30ms), then B steals it.
+    await new Promise((r) => setTimeout(r, 120));
+    const ownerB = await coordinator.acquire("token-steal");
+    expect(ownerB.role).toBe("owner");
+
+    const tokenHash = createHash("sha256").update("token-steal").digest("hex");
+    const lockPath = join(leaseDir, `${tokenHash}.lock`);
+    const bPayload = JSON.parse(await readFile(lockPath, "utf8"));
+
+    // A releases late — must leave B's lock intact.
+    await ownerA.release(sampleSuccessResult);
+
+    const afterPayload = JSON.parse(await readFile(lockPath, "utf8"));
+    // Same lock B holds, with B's nonce — A did not delete it.
+    expect(afterPayload.nonce).toBe(bPayload.nonce);
+  });
+
 });

--- a/test/response-handler.test.ts
+++ b/test/response-handler.test.ts
@@ -603,7 +603,7 @@ data: {"type":"response.done","response":{"id":"resp_789"}}
 			expect(onResponseId).toHaveBeenCalledTimes(1);
 		});
 
-		it('should return the raw SSE text when an error event arrives before response.done', async () => {
+		it('returns a non-2xx error (not raw 200) when an error event arrives before response.done (H6)', async () => {
 			const onResponseId = vi.fn();
 			const sseContent = [
 				'data: {"type":"response.created","response":{"id":"resp_bad_123","object":"response"}}',
@@ -613,13 +613,14 @@ data: {"type":"response.done","response":{"id":"resp_789"}}
 				'data: {"type":"response.done","response":{"id":"resp_bad_123","output":"bad"}}',
 				'',
 			].join('\n');
-			const response = new Response(sseContent);
+			const response = new Response(sseContent, { status: 200, statusText: 'OK' });
 			const headers = new Headers();
 
 			const result = await convertSseToJson(response, headers, { onResponseId });
-			const text = await result.text();
 
-			expect(text).toBe(sseContent);
+
+			expect(result.ok).toBe(false);
+			expect(result.status).toBeGreaterThanOrEqual(400);
 			expect(onResponseId).not.toHaveBeenCalled();
 		});
 
@@ -857,4 +858,57 @@ data: {"type":"response.done","response":{"id":"resp_789"}}
 			expect(isEmptyResponse({ data: [1, 2, 3] })).toBe(false);
 		});
 	});
+	describe('SSE failure classification (stress audit H6/H7/M1)', () => {
+		it('H6: mid-stream error event yields a non-2xx response, not a 200 success', async () => {
+			const sseContent = `data: {"type":"response.output_text.delta","delta":"partial"}
+data: {"type":"error","error":{"message":"upstream blew up"}}
+`;
+			const response = new Response(sseContent, { status: 200, statusText: 'OK' });
+			const result = await convertSseToJson(response, new Headers());
+			// Must NOT be a 200 — otherwise index.ts records an account success.
+			expect(result.ok).toBe(false);
+			expect(result.status).toBeGreaterThanOrEqual(400);
+		});
+
+		it('H7: response.failed terminal event yields a non-2xx response', async () => {
+			const sseContent = `data: {"type":"response.created","response":{"id":"r1"}}
+data: {"type":"response.failed","response":{"id":"r1","status":"failed"}}
+`;
+			const response = new Response(sseContent, { status: 200, statusText: 'OK' });
+			const result = await convertSseToJson(response, new Headers());
+			expect(result.ok).toBe(false);
+			expect(result.status).toBeGreaterThanOrEqual(400);
+		});
+
+		it('H7: response.incomplete terminal event yields a non-2xx response', async () => {
+			const sseContent = `data: {"type":"response.created","response":{"id":"r2"}}
+data: {"type":"response.incomplete","response":{"id":"r2","status":"incomplete"}}
+`;
+			const response = new Response(sseContent, { status: 200, statusText: 'OK' });
+			const result = await convertSseToJson(response, new Headers());
+			expect(result.ok).toBe(false);
+			expect(result.status).toBeGreaterThanOrEqual(400);
+		});
+
+		it('control: a clean response.completed stream is still a 200 success', async () => {
+			const sseContent = `data: {"type":"response.completed","response":{"id":"ok1","output":"done"}}
+`;
+			const response = new Response(sseContent, { status: 200, statusText: 'OK' });
+			const result = await convertSseToJson(response, new Headers());
+			expect(result.ok).toBe(true);
+			const body = await result.json();
+			expect(body).toEqual({ id: 'ok1', output: 'done' });
+		});
+
+		it('M1: parses "data:" events with no space after the colon', async () => {
+			const sseContent =
+				'data:{"type":"response.completed","response":{"id":"nospace","output":"ok"}}\n';
+			const response = new Response(sseContent, { status: 200, statusText: 'OK' });
+			const result = await convertSseToJson(response, new Headers());
+			expect(result.ok).toBe(true);
+			const body = await result.json();
+			expect(body).toEqual({ id: 'nospace', output: 'ok' });
+		});
+	});
+
 });


### PR DESCRIPTION
Fixes 7 silent-failure defects surfaced by a deep adversarial stress audit of `main`. Every fix ships with a regression test that fails on the old behavior and passes on the new.

## Defects fixed

| # | Severity | Summary |
|---|---|---|
| H1 | high | Unclamped `retry-after` could wedge an account unavailable for ~31 years; clamp to 7d (`MAX_RATE_LIMIT_DELAY_MS`), centralized in `markRateLimitedWithReason`. |
| H2 | high | Refresh lease `release()` unlinked unconditionally — a slow owner deleted a stolen lock. Added a per-owner nonce; release only unlinks when the on-disk nonce matches. |
| H3 | high | Routine `saveToDisk` clobbered a single-use refresh token another process had just rotated. Reconcile token material from disk (adopt strictly-newer `expiresAt`) before persisting. |
| H4 | high | A transient 30–60s 429 benched an account for the full 2h cap by folding the benign weekly window into the wait. Only exhausted windows count now. |
| H5 | high | `getLiveQuotaWaitMs` took a blind `max` of both quota windows, overstating wait ~6700× and inverting the recommendation. Applies the same exhausted-window filter the cache path uses (429 still honors all windows). |
| H6/H7 | high | Mid-stream `error`, and the unhandled `response.failed`/`response.incomplete` terminal events, returned raw SSE at **HTTP 200** → recorded as account success and skipped rotation. Now synthesized to non-2xx; empty/no-error streams still pass through so the empty-response retry path is preserved. |
| M1 | medium | SSE parser required `data: ` with a trailing space; now accepts `data:`. |

## Verification

- Full suite: **5010 passed, 3 skipped, 0 failed** (`npm test`).
- `tsc --noEmit`, `eslint`, `knip`, and `build` all clean.
- New/updated regression tests: `forecast`, `accounts`, `preemptive-quota-scheduler`, `refresh-lease`, `response-handler`, `chaos/fault-injection`, and a new `h3-token-clobber` test.
- 4 existing tests that asserted the buggy behavior (SSE error → raw 200) were updated to assert the corrected failure routing.

Behavior-preserving where it matters: the 429 deferral still honors genuine rate-limit windows, `commitRefreshedAuth` still wins with its freshest token, and the empty-response retry path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr addresses 7 adversarially-surfaced silent-failure defects spanning rate-limit clamping, cross-process token clobber protection, refresh lease ownership, quota window filtering, and sse failure routing — each shipped with a targeted regression test.

- **H1/H3/H4/H5**: clamps `retry-after` to 7d, reconciles rotated tokens before every disk persist, limits 429 deferral to genuinely exhausted windows, and filters `getLiveQuotaWaitMs` to only exhausted windows under non-429 conditions
- **H2**: adds per-owner nonce to lock files so a slow lease holder cannot delete a lock stolen by a new owner after expiry
- **H6/H7/M1**: synthesizes non-2xx responses for mid-stream `error`, `response.failed`, and `response.incomplete` events (which previously passed as HTTP 200), and accepts `data:` with no trailing space per the SSE spec

<h3>Confidence Score: 4/5</h3>

the core fixes are sound and well-tested for the primary account shapes; the two edge cases flagged (legacy RT-only accounts in H3, windows EACCES in ownsLock) are low-frequency paths that don't affect the rotation proxy's normal operation

all seven defects are addressed with clear logic and matching regression tests; the H3 reconcile silently skips refresh-token-only legacy accounts (no email/accountId), meaning the clobber fix doesn't protect that account shape, and the ownsLock function treats unreadable-file as 'i own it' which on windows with EACCES could trigger spurious safeUnlink retries — neither is a blocking regression on normal accounts but they leave residual gaps

lib/accounts.ts reconcileTokensFromDisk and lib/refresh-lease.ts ownsLock deserve a second look for the edge cases described in the inline comments

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds MAX_RATE_LIMIT_DELAY_MS clamp (H1) and reconcileTokensFromDisk (H3); H3 protection works for accounts with accountId/email but silently bypasses legacy refresh-token-only accounts since identity keys diverge after rotation |
| lib/refresh-lease.ts | adds per-owner nonce to prevent slow-owner lock deletion (H2); ownsLock returns true when lock is unreadable which is safe for absent files but ambiguous on Windows EACCES/EPERM |
| lib/request/response-handler.ts | SSE error/failed/incomplete → non-2xx (H6/H7); data: no-space fix (M1); response.incomplete is intentionally mapped to 502, discarding partial output |
| lib/forecast.ts | getLiveQuotaWaitMs now filters to only exhausted windows under non-429 pressure (H5); consistent with cache path behavior for undefined usedPercent |
| lib/preemptive-quota-scheduler.ts | 429 markRateLimited no longer folds benign quota windows into the deferral (H4); isRateLimitWindow helper correctly treats missing usedPercent as rate-limit conservative |
| test/h3-token-clobber.test.ts | new regression test for H3 cross-process clobber; covers the accountId+email identity path but not the legacy refresh-token-only fallback path |
| test/refresh-lease.test.ts | adds H2 regression test: slow owner A releases after B steals the lock, verifies B's nonce survives; solid coverage |
| test/response-handler.test.ts | H6/H7/M1 regression tests are thorough; updated existing tests to assert corrected non-2xx behavior; control test verifies clean streams still pass |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SSE Stream HTTP 200] --> B{parseSseStream}
    B -->|data: or data:value M1| C[parse JSON event]
    C --> D{event type}
    D -->|error| E[encounteredError=true]
    D -->|response.failed / response.incomplete H7| E
    D -->|response.done / response.completed| F[finalResponse captured]
    D -->|other delta events| G[accumulate state]
    E --> H{upstream status >= 400?}
    H -->|yes| I[return upstream status]
    H -->|no| J[return 502 Bad Gateway]
    F --> K[return 200 JSON]
    B -->|no terminal event, no error| L[return original SSE - preserve empty-retry path]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SSE Stream HTTP 200] --> B{parseSseStream}
    B -->|data: or data:value M1| C[parse JSON event]
    C --> D{event type}
    D -->|error| E[encounteredError=true]
    D -->|response.failed / response.incomplete H7| E
    D -->|response.done / response.completed| F[finalResponse captured]
    D -->|other delta events| G[accumulate state]
    E --> H{upstream status >= 400?}
    H -->|yes| I[return upstream status]
    H -->|no| J[return 502 Bad Gateway]
    F --> K[return 200 JSON]
    B -->|no terminal event, no error| L[return original SSE - preserve empty-retry path]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fstress-audit-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstress-audit-hardening%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Faccounts.ts%3A1300-1307%0A**H3%20protection%20silently%20fails%20for%20refresh-token-only%20%28legacy%29%20accounts**%0A%0A%60getAccountIdentityKey%60%20uses%20%60accountId%60%20%E2%86%92%20%60email%60%20%E2%86%92%20%60refresh%3Ahash%28RT%29%60%20in%20priority%20order.%20when%20an%20account%20has%20no%20%60accountId%60%20and%20no%20%60email%60%2C%20the%20identity%20key%20is%20derived%20from%20the%20refresh%20token%20hash.%20after%20process%202%20rotates%20that%20account's%20token%2C%20the%20in-memory%20snapshot%20holds%20the%20old%20RT%20%E2%86%92%20%60refresh%3Ahash%28RT_old%29%60%2C%20while%20the%20disk%20copy%20has%20the%20new%20RT%20%E2%86%92%20%60refresh%3Ahash%28RT_new%29%60.%20these%20keys%20never%20match%2C%20so%20the%20loop%20at%20line%201306%20skips%20such%20accounts%20entirely%20%E2%80%94%20H3%20clobber%20protection%20doesn't%20apply%20to%20them.%20modern%20accounts%20should%20always%20carry%20email%2C%20but%20legacy%20accounts%20without%20it%20would%20silently%20regress%20to%20the%20old%20behavior.%20%60test%2Fh3-token-clobber.test.ts%60%20only%20exercises%20the%20%60accountId%60%2B%60email%60%20path%2C%20leaving%20this%20gap%20uncovered.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Frefresh-lease.ts%3A328-344%0A**ownsLock%20returns%20%60true%60%20when%20the%20lock%20file%20is%20unreadable%20%E2%80%94%20unsafe%20on%20Windows**%0A%0A%60readJson%60%20silently%20catches%20all%20errors%20and%20returns%20%60null%60%20%28line%20117%29.%20on%20Windows%2C%20an%20%60EACCES%60%2F%60EPERM%60%20error%20%28another%20process%20holds%20the%20file%20open%29%20also%20produces%20%60null%60.%20%60parseLeasePayload%28null%29%60%20returns%20%60null%60%2C%20and%20%60ownsLock%60%20then%20returns%20%60true%60%20%28%22allow%20cleanup%22%29.%20the%20slow%20owner%20then%20proceeds%20to%20call%20%60safeUnlink%60%2C%20which%20will%20retry%20up%20to%204%20times.%20while%20%60safeUnlink%60%20will%20ultimately%20fail%20for%20a%20live%20locked%20file%2C%20those%20retries%20add%20latency%20and%20the%20TOCTOU%20window%20between%20the%20failed%20read%20and%20the%20unlink%20attempt%20means%20the%20guard%20may%20incorrectly%20attempt%20to%20evict%20a%20live%20lock.%20the%20repo%20convention%20for%20Windows%20EBUSY%2FEPERM%20paths%20is%20explicit%20retry-with-backoff%2C%20not%20silent%20failure%E2%86%92allow.%20worth%20at%20minimum%20logging%20a%20distinct%20warning%20when%20read%20fails%20vs.%20when%20the%20file%20is%20absent.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Frequest%2Fresponse-handler.ts%3A604-608%0A**%60response.incomplete%60%20yields%20502%20and%20discards%20all%20partial%20output**%0A%0A%60response.incomplete%60%20%28e.g.%20%60max_output_tokens%60%20hit%29%20sets%20%60encounteredError%20%3D%20true%60%2C%20causing%20%60parseSseStream%60%20to%20early-exit%20with%20%60finalResponse%3A%20null%60.%20any%20partial%20text%20streamed%20before%20the%20incomplete%20event%20is%20discarded%3B%20the%20caller%20receives%20a%20502.%20clients%20that%20handle%20truncated%20output%20gracefully%20%28e.g.%20show%20partial%20code%2C%20trigger%20a%20continuation%20turn%29%20lose%20that%20ability%20%E2%80%94%20they%20see%20only%20a%20502%20identical%20to%20a%20hard%20upstream%20failure.%20this%20is%20intentional%20per%20the%20PR%20description%2C%20but%20worth%20confirming%3A%20should%20%60response.incomplete%60%20really%20route%20identically%20to%20%60response.failed%60%2C%20or%20does%20the%20caller%20need%20a%20way%20to%20distinguish%20the%20two%20so%20partial%20output%20can%20at%20least%20be%20attempted%3F%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=617&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
lib/accounts.ts:1300-1307
**H3 protection silently fails for refresh-token-only (legacy) accounts**

`getAccountIdentityKey` uses `accountId` → `email` → `refresh:hash(RT)` in priority order. when an account has no `accountId` and no `email`, the identity key is derived from the refresh token hash. after process 2 rotates that account's token, the in-memory snapshot holds the old RT → `refresh:hash(RT_old)`, while the disk copy has the new RT → `refresh:hash(RT_new)`. these keys never match, so the loop at line 1306 skips such accounts entirely — H3 clobber protection doesn't apply to them. modern accounts should always carry email, but legacy accounts without it would silently regress to the old behavior. `test/h3-token-clobber.test.ts` only exercises the `accountId`+`email` path, leaving this gap uncovered.

### Issue 2 of 3
lib/refresh-lease.ts:328-344
**ownsLock returns `true` when the lock file is unreadable — unsafe on Windows**

`readJson` silently catches all errors and returns `null` (line 117). on Windows, an `EACCES`/`EPERM` error (another process holds the file open) also produces `null`. `parseLeasePayload(null)` returns `null`, and `ownsLock` then returns `true` ("allow cleanup"). the slow owner then proceeds to call `safeUnlink`, which will retry up to 4 times. while `safeUnlink` will ultimately fail for a live locked file, those retries add latency and the TOCTOU window between the failed read and the unlink attempt means the guard may incorrectly attempt to evict a live lock. the repo convention for Windows EBUSY/EPERM paths is explicit retry-with-backoff, not silent failure→allow. worth at minimum logging a distinct warning when read fails vs. when the file is absent.

### Issue 3 of 3
lib/request/response-handler.ts:604-608
**`response.incomplete` yields 502 and discards all partial output**

`response.incomplete` (e.g. `max_output_tokens` hit) sets `encounteredError = true`, causing `parseSseStream` to early-exit with `finalResponse: null`. any partial text streamed before the incomplete event is discarded; the caller receives a 502. clients that handle truncated output gracefully (e.g. show partial code, trigger a continuation turn) lose that ability — they see only a 502 identical to a hard upstream failure. this is intentional per the PR description, but worth confirming: should `response.incomplete` really route identically to `response.failed`, or does the caller need a way to distinguish the two so partial output can at least be attempted?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden rotation, persistence, and S..."](https://github.com/ndycode/codex-multi-auth/commit/0b1218dd0d797498950d6961db62b68ac21be33f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38616625)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->