### PR TITLE
fix(sse): deliver response.incomplete partial output as 200, not 502

### DIFF
--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -596,18 +596,26 @@ function maybeCaptureResponseEvent(
 		return;
 	}
 
-	// response.failed / response.incomplete are terminal failure events in the
-	// Responses streaming protocol: HTTP is still 200 but the turn did not
-	// succeed. Treat them as errors so the stream is not misclassified as a
-	// successful response and misattributed as an account success (stress audit
-	// H7). response.incomplete (e.g. hit max_output_tokens) is routine.
-	if (data.type === "response.failed" || data.type === "response.incomplete") {
+	// response.failed is a genuine terminal failure: the turn did not produce a
+	// usable result even though HTTP opened 200. Treat it as an error so the
+	// stream is not misclassified as a successful response and misattributed as
+	// an account success (stress audit H7).
+	if (data.type === "response.failed") {
 		log.warn("SSE terminal failure event received", { type: data.type });
 		state.encounteredError = true;
 		return;
 	}
 
-	if (data.type === "response.done" || data.type === "response.completed") {
+	// response.completed / response.done / response.incomplete are all terminal
+	// envelopes that carry a final response object. response.incomplete (e.g.
+	// hitting max_output_tokens or a content filter) is a NORMAL early stop whose
+	// partial output is the answer — it must be delivered to the client and
+	// counts as a healthy account, not a failure (re-audit correction to H7).
+	if (
+		data.type === "response.done" ||
+		data.type === "response.completed" ||
+		data.type === "response.incomplete"
+	) {
 		if (isRecord(data.response)) {
 			state.finalResponse = { ...data.response };
 		}

--- a/test/response-handler.test.ts
+++ b/test/response-handler.test.ts
@@ -880,14 +880,18 @@ data: {"type":"response.failed","response":{"id":"r1","status":"failed"}}
 			expect(result.status).toBeGreaterThanOrEqual(400);
 		});
 
-		it('H7: response.incomplete terminal event yields a non-2xx response', async () => {
+		it('H7: response.incomplete delivers the partial response as a 200 success', async () => {
+			// Hitting max_output_tokens / a content filter is a NORMAL early stop.
+			// The partial response object is the answer and the account is healthy,
+			// so it must be delivered as 200 (re-audit correction to H7).
 			const sseContent = `data: {"type":"response.created","response":{"id":"r2"}}
-data: {"type":"response.incomplete","response":{"id":"r2","status":"incomplete"}}
+data: {"type":"response.incomplete","response":{"id":"r2","status":"incomplete","output":"partial"}}
 `;
 			const response = new Response(sseContent, { status: 200, statusText: 'OK' });
 			const result = await convertSseToJson(response, new Headers());
-			expect(result.ok).toBe(false);
-			expect(result.status).toBeGreaterThanOrEqual(400);
+			expect(result.ok).toBe(true);
+			const body = await result.json();
+			expect(body).toMatchObject({ id: 'r2', status: 'incomplete' });
 		});
 
 		it('control: a clean response.completed stream is still a 200 success', async () => {


### PR DESCRIPTION
Follow-up correction to the stress-audit H7 fix (#617), found by re-auditing the merged fixes.

## Problem

The H7 fix routed both `response.failed` **and** `response.incomplete` to a synthesized non-2xx error. But `response.incomplete` is the **normal** terminal envelope when generation stops early (`max_output_tokens`, content filter) — it carries a full response object whose partial output *is* the answer, and the account is healthy. Treating it as a failure discarded valid output and forced needless retry/failover on a routine token-cap stop.

## Fix

- `response.failed` (and mid-stream `error`) → genuine failure → synthesized non-2xx (unchanged).
- `response.incomplete` → captured like `response.completed`/`response.done` → delivered to the client at **HTTP 200**, recorded as an account success.

## Verification

- `tsc --noEmit` clean; 98 SSE/response-handler/chaos tests pass.
- Updated the H7 `response.incomplete` regression test to assert 200 + partial body (was asserting non-2xx).
- Full suite green (the only failure on this Windows box is the pre-existing `ci-workflows` CRLF/BOM artifact, which passes on LF/Linux CI).

Sources on the semantics: [OpenAI community — streaming events guide](https://community.openai.com/t/responses-api-streaming-the-simple-guide-to-events/1363122), [incomplete due to max_output_tokens](https://community.openai.com/t/incomplete-api-responses-due-to-max-output-tokens-limit-during-batch-processing/1353095).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

corrects the h7 fix from #617: `response.incomplete` is moved from the error branch (synthesized non-2xx) into the success branch alongside `response.completed`/`response.done`, so the partial response object from a token-cap or content-filter stop is captured and delivered to the client at http 200. `response.failed` continues to set `encounteredError` and produce a non-2xx as intended.

- `maybeCaptureResponseEvent` now only routes `response.failed` (and mid-stream `error`) to the error path; `response.incomplete` falls through to `state.finalResponse` capture and `notifyResponseId`, consistent with the other terminal envelopes.
- the h7 regression test is updated to assert `result.ok === true` and `body.status === 'incomplete'`, replacing the prior non-2xx assertions.

<h3>Confidence Score: 4/5</h3>

safe to merge; the reclassification of response.incomplete is correct and the error guard in finalizeParsedResponse ensures response.failed still wins on conflict

the core logic change is sound and the updated regression test validates the new 200 path. the only gaps are two missing vitest cases: one for incomplete events without a response body, and one for the realistic mid-stream delta-then-incomplete scenario that exercises the merge path. neither represents a current defect in the changed code.

test/response-handler.test.ts — the h7 test only covers a bare incomplete event with no preceding delta events; adding a delta-then-incomplete fixture would close the remaining coverage gap

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/response-handler.ts | moves response.incomplete from the error branch to the success branch so partial output is captured and returned as HTTP 200; logic is correct and handles both error-first and incomplete-first ordering via finalizeParsedResponse's error guard |
| test/response-handler.test.ts | H7 regression test updated to assert 200 + partial body; covers basic incomplete to 200 path but lacks a test for the realistic token-cap scenario with preceding delta events, leaving the merge path unexercised |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SSE event received] --> B{event type?}
    B -->|error| C[encounteredError = true]
    B -->|response.failed| C
    B -->|response.done / response.completed / response.incomplete| D{isRecord data.response?}
    D -->|yes| E[state.finalResponse = data.response]
    D -->|no| F[skip capture]
    E --> G[finalizeParsedResponse]
    F --> G
    C --> H[return encounteredError=true]
    H --> I[synthesize non-2xx]
    G --> J{encounteredError?}
    J -->|yes| K[return null to non-2xx]
    J -->|no| L{finalResponse set?}
    L -->|yes| M[merge deltas, return 200 JSON]
    L -->|no| N[empty-stream passthrough]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SSE event received] --> B{event type?}
    B -->|error| C[encounteredError = true]
    B -->|response.failed| C
    B -->|response.done / response.completed / response.incomplete| D{isRecord data.response?}
    D -->|yes| E[state.finalResponse = data.response]
    D -->|no| F[skip capture]
    E --> G[finalizeParsedResponse]
    F --> G
    C --> H[return encounteredError=true]
    H --> I[synthesize non-2xx]
    G --> J{encounteredError?}
    J -->|yes| K[return null to non-2xx]
    J -->|no| L{finalResponse set?}
    L -->|yes| M[merge deltas, return 200 JSON]
    L -->|no| N[empty-stream passthrough]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fsse-incomplete-delivers-partial%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsse-incomplete-delivers-partial%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fresponse-handler.test.ts%3A883-895%0A**missing%20vitest%20coverage%20for%20realistic%20token-cap%20scenario**%0A%0Athe%20test%20fixture%20has%20no%20preceding%20%60response.output_text.delta%60%20events%20before%20the%20%60response.incomplete%60%20terminal.%20the%20actual%20production%20case%20for%20a%20token-cap%20stop%20is%20a%20partial%20stream%20of%20deltas%20followed%20by%20%60response.incomplete%60%20%E2%80%94%20that%20accumulated%20text%20must%20survive%20%60mergeOutputItemsIntoResponse%60%20%2F%20%60applyAccumulatedOutputText%60.%20a%20test%20that%20sends%20a%20few%20delta%20events%20and%20then%20%60response.incomplete%60%20would%20exercise%20the%20full%20merge%20path%20and%20confirm%20the%20partial%20output%20string%20is%20in%20the%20final%20200%20body.%20without%20it%2C%20the%20re-audit%20claim%20%22partial%20output%20is%20the%20answer%22%20is%20not%20fully%20validated%20by%20the%20suite.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Frequest%2Fresponse-handler.ts%3A614-624%0A**no%20observability%20when%20response.incomplete%20is%20received**%0A%0A%60response.incomplete%60%20previously%20triggered%20%60log.warn%28%22SSE%20terminal%20failure%20event%20received%22%29%60.%20now%20it%20silently%20succeeds%20with%20no%20log%20entry.%20on%20a%20production%20box%20debugging%20token-cap%20or%20content-filter%20stops%2C%20there's%20no%20trace%20in%20the%20request%20log%20to%20distinguish%20a%20clean%20%60response.completed%60%20from%20an%20early%20%60response.incomplete%60.%20a%20%60log.info%60%20%28or%20at%20least%20%60logRequest%60%29%20noting%20the%20incomplete%20terminal%20event%20would%20be%20cheap%20and%20valuable%20for%20operators%20on%20windows%20and%20linux%20alike.%0A%0A&repo=ndycode%2Fcodex-multi-auth&pr=618&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/response-handler.test.ts:883-895
**missing vitest coverage for realistic token-cap scenario**

the test fixture has no preceding `response.output_text.delta` events before the `response.incomplete` terminal. the actual production case for a token-cap stop is a partial stream of deltas followed by `response.incomplete` — that accumulated text must survive `mergeOutputItemsIntoResponse` / `applyAccumulatedOutputText`. a test that sends a few delta events and then `response.incomplete` would exercise the full merge path and confirm the partial output string is in the final 200 body. without it, the re-audit claim "partial output is the answer" is not fully validated by the suite.

### Issue 2 of 2
lib/request/response-handler.ts:614-624
**no observability when response.incomplete is received**

`response.incomplete` previously triggered `log.warn("SSE terminal failure event received")`. now it silently succeeds with no log entry. on a production box debugging token-cap or content-filter stops, there's no trace in the request log to distinguish a clean `response.completed` from an early `response.incomplete`. a `log.info` (or at least `logRequest`) noting the incomplete terminal event would be cheap and valuable for operators on windows and linux alike.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sse): deliver response.incomplete pa..."](https://github.com/ndycode/codex-multi-auth/commit/ce49a91660d46cee50b546c90592ce093cea032a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38618762)</sub>

<!-- /greptile_comment -->