### PR TITLE
chore(release): cut v2.3.3 stable

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Generated: 2026-04-25
 Commit: a87e005
 Validated: 2026-06-10 against commit 98d9819 (repo audit; claims re-checked against the tree, content not regenerated)
 Branch: main
-Package version: 2.3.2
+Package version: 2.3.3
 
 ## OVERVIEW
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ This repository's current stable release line is `2.x`.
 Current stable release notes live in `docs/releases/`.
 This top-level changelog preserves the foundational `0.x` milestones and points older iteration history to `docs/releases/legacy-pre-0.1-history.md`.
 
+## [2.3.3] - 2026-06-19
+
+Security and durability hardening from a deep stress audit of the rotation, persistence, and SSE-handling paths. No feature changes; routing, account-selection, and the normal auth flow are unchanged.
+See [docs/releases/v2.3.3.md](docs/releases/v2.3.3.md) for full details.
+
+### Fixed
+
+- Unbounded rate-limit window: a hostile or buggy upstream `retry-after`/quota-reset value could wedge an account unavailable for years. Retry/quota windows are now clamped to `MAX_RATE_LIMIT_DELAY_MS` (7 days), centrally in the account rate-limit setter and at source in `getQuotaNearExhaustionWaitMs` (H1)
+- Refresh-lease ownership: a slow owner whose lease expired and was stolen would unlink the new owner's lock on release, collapsing cross-process mutual exclusion. The lock now carries a per-owner nonce and `release()` only unlinks when it still matches (H2)
+- Cross-process token clobber: a routine `saveToDisk` rewrote the whole in-memory pool and could revert a single-use refresh token another process had just rotated. The save now reconciles token material from disk, adopting a strictly-newer on-disk token (H3)
+- Transient 429 over-deferral: a 30–60s 429 benched an account for the full 2h cap by folding the benign weekly window into the wait. Only genuinely-exhausted windows now count toward a 429 deferral (H4)
+- Forecast wait/recommendation: `getLiveQuotaWaitMs` took a blind max of both quota windows, overstating the wait and inverting the recommended account. It now filters to exhausted windows under usage pressure (a 429 still honors all windows) (H5)
+- SSE failures misreported as success: a mid-stream `error`, or a `response.failed` event, returned the raw SSE body at HTTP 200 — recorded as an account success and skipping rotation/retry. These now route to a synthesized non-2xx (H6/H7)
+- SSE `data:` parsing required a trailing space after the colon; spec-valid `data:value` lines were dropped (M1)
+- V1→V3 storage migration discarded the migrated account bodies, losing the scalar `rateLimitResetTime` → map `rateLimitResetTimes` conversion, so a rate-limited account looked immediately available on upgrade (M3)
+- Local-client-token store: temp-file write + rename without an `fsync` could truncate the store on crash/power-loss. The temp file is now fsynced before rename (L3)
+- OAuth `expires_in`/`expires` accepted any number; a zero/negative value minted an already-expired token and triggered a tight refresh loop. Both now require a positive integer (I1)
+- Log scrubber now masks the project's own `cma_local_…` bearer tokens in free text, alongside the existing JWT/hex/`sk-`/`Bearer` patterns (I2)
+
+### Correctness note
+
+- `response.incomplete` (e.g. hitting `max_output_tokens` or a content filter) is treated as a normal early stop: its partial response is delivered at HTTP 200 and counts as a healthy account, distinct from the `response.failed` failure path.
+
 ## [2.3.2] - 2026-06-16
 
 Self-healing recovery for an orphaned runtime-proxy app-bind. No runtime-rotation, storage, or auth behavior changed.

--- a/README.md
+++ b/README.md
@@ -383,7 +383,8 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current stable: [docs/releases/v2.3.2.md](docs/releases/v2.3.2.md) — install via `npm i -g codex-multi-auth`
+- Current stable: [docs/releases/v2.3.3.md](docs/releases/v2.3.3.md) — install via `npm i -g codex-multi-auth`
+- Previous stable: [docs/releases/v2.3.2.md](docs/releases/v2.3.2.md)
 - Previous stable: [docs/releases/v2.3.1.md](docs/releases/v2.3.1.md)
 - Previous stable: [docs/releases/v2.3.0.md](docs/releases/v2.3.0.md)
 - Previous stable: [docs/releases/v2.2.2.md](docs/releases/v2.2.2.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,8 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.3.2.md](releases/v2.3.2.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
+| [releases/v2.3.3.md](releases/v2.3.3.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
+| [releases/v2.3.2.md](releases/v2.3.2.md) | Prior stable release notes |
 | [releases/v2.3.1.md](releases/v2.3.1.md) | Prior stable release notes |
 | [releases/v2.3.0.md](releases/v2.3.0.md) | Prior stable release notes |
 | [releases/v2.3.0-beta.3.md](releases/v2.3.0-beta.3.md) | Prior prerelease notes |

--- a/docs/releases/v2.3.3.md
+++ b/docs/releases/v2.3.3.md
@@ -1,0 +1,44 @@
+## Rotation / Recovery / Refresh
+
+### Bugfixes
+
+- Clamped the rate-limit / `retry-after` window to `MAX_RATE_LIMIT_DELAY_MS` (7 days). A hostile or buggy upstream value (`retry-after-ms`, `retry-after`, or `x-codex-*-reset-*` headers — e.g. a seconds-vs-milliseconds confusion or an anti-abuse misfire) was passed through unbounded, and the setter only lower-clamped while growing `resetAt` monotonically, so a single bad response could wedge an account unavailable for ~31 years with no self-heal. The clamp is now applied centrally in `markRateLimitedWithReason` and at source in `getQuotaNearExhaustionWaitMs`, matching the long-standing clamp in the legacy reactive path (H1).
+- Added a per-owner nonce to the refresh lease. `release()` previously called `safeUnlink(lockPath)` unconditionally; if an owner's lease expired (a refresh taking ~as long as the TTL) and another process stole the lock, the slow owner would delete the new owner's lock on release, leaving two concurrent refreshers — which, because the refresh token is rotated per refresh, could submit an already-consumed token and log the account out. `release()` now reads the lock back and only unlinks when the on-disk nonce still matches; a lock written before this change (no nonce) keeps the prior best-effort behavior (H2).
+- Stopped a cross-process token clobber on routine saves. `saveToDisk` discarded the disk-loaded state and re-serialized the entire in-memory pool, so if a second process refreshed an account and wrote a rotated single-use refresh token, a routine save (cooldown, rate-limit, refund) by a long-lived proxy could last-writer-win and revert it, permanently breaking that account's next refresh. The save now reconciles per-account token material from disk under the storage lock, adopting a strictly-newer on-disk token; the refresh-commit path still wins with its own fresh token (H3).
+
+## Quota / Forecast
+
+### Bugfixes
+
+- A transient 429 no longer benches an account for the full 2h deferral cap. `markRateLimited` folded the existing weekly secondary reset (~7d out on a healthy 200 snapshot) into the primary window via `max(...)`, so a 30–60s `Retry-After` produced a multi-hour deferral. The 429 path now treats only genuinely-exhausted windows (used ≥ 100% or no usage gauge) as rate-limit windows, in both `markRateLimited` and `getDeferral`; the documented "longest active reset window" behavior for real rate-limit windows is preserved (H4).
+- Fixed the live-quota forecast overstating the wait and inverting the recommendation. `getLiveQuotaWaitMs` took a blind `max` of both quota windows, so a healthy weekly secondary (~7d) dominated a binding 5h primary that frees in seconds, and `recommendForecastAccount` then preferred a strictly-worse account. Under usage pressure it now filters to exhausted windows (mirroring the quota-cache path); a 429 still honors every active window (H5).
+
+## Request / SSE Data Path
+
+### Bugfixes
+
+- Mid-stream SSE failures are no longer reported as success. A `{"type":"error"}` event, or a terminal `response.failed` event, caused `convertSseToJson` to return the raw SSE text at HTTP 200; downstream this ran the success path, `JSON.parse` threw on the SSE body and was swallowed, and the account was recorded as a success with rotation/retry suppressed. These now resolve to a synthesized non-2xx so the caller routes to failure (H6/H7).
+- The SSE parser accepted only `data: ` with a trailing space; a spec-valid `data:value` line parsed as zero events, degrading a response to "no final response". It now accepts `data:` with optional whitespace (M1).
+- `response.incomplete` (hitting `max_output_tokens` or a content filter) is handled as a normal early stop: it carries a final response object whose partial output is the answer, so it is delivered at HTTP 200 and counts as a healthy account — distinct from the `response.failed` failure path above.
+
+## Storage / Auth / Logging
+
+### Bugfixes
+
+- V1→V3 storage migration no longer discards the migrated account bodies. `normalizeAccountStorage` rebuilt the account list from the raw V1 objects, dropping `migrateV1ToV3`'s scalar `rateLimitResetTime` → map `rateLimitResetTimes` conversion, so a rate-limited account upgrading from V1 was treated as immediately available and could burst 429s. The account list is now built from the migrated storage (M3).
+- The local-client-token store fsyncs the temp file before rename. The previous `writeFile` + `rename` left a window where a crash or power-loss after the rename could truncate the store; the temp file is now flushed with `fsync` before the rename, matching the durable-write pattern already used by the app-bind and first-run writers (L3).
+- OAuth `expires_in` (and the internal `expires`) now require a positive integer. A zero or negative value previously minted an already-expired token, which drove a tight refresh loop that consumed the single-use refresh token. A bogus value now fails schema validation instead (I1).
+- The free-text log scrubber now masks this package's own local bearer tokens (`cma_local_…`) in addition to the existing JWT, long-hex, `sk-`, and `Bearer` patterns. Structured logging already masked by key and the OAuth path is scrubbed separately; this closes the last-line-of-defense gap for the project's own token shape (I2).
+
+## Testing
+
+### Improvements
+
+- Added regression coverage for every fix: the 7-day retry-after clamp (including self-heal after the window) and the at-source quota clamp; the lease ownership nonce (a slow owner not deleting a stolen lock); the cross-process token-clobber reconciliation; the transient-429 deferral bound and the preserved "longest active reset window" semantics; the forecast exhausted-window filter and non-inverted recommendation; SSE `error` / `response.failed` → non-2xx, `response.incomplete` → 200 with partial output, and `data:` without a trailing space; the V1→V3 `rateLimitResetTimes` preservation; the OAuth `expires_in` positive-integer bound; and the `cma_local` log-masking pattern.
+- Updated four existing tests that asserted the prior buggy behavior (SSE error events returning a raw HTTP 200) to assert the corrected failure routing.
+
+## Notes
+
+- Patch release; intended for the `latest` dist-tag (`npm i -g codex-multi-auth`).
+- No runtime-rotation routing, account-selection, storage layout, or normal auth-flow behavior changed. The fixes harden failure, concurrency, and edge-case paths.
+- The multi-process fixes (H2 lease ownership, H3 token reconciliation) matter most for deployments that run more than one CLI/proxy instance against a shared auth directory; single-process usage is unaffected by those races.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.3.2",
+			"version": "2.3.3",
 			"bundleDependencies": [
 				"@codex-ai/plugin",
 				"@codex-ai/sdk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
Cuts the **v2.3.3** stable patch release — the security/durability hardening from the deep stress audit (#617, #618, #619).

## Version bump (2.3.2 → 2.3.3)
`package.json`, `package-lock.json`, `.codex-plugin/plugin.json`, and the `AGENTS.md` package-version claim.

## Docs
- `CHANGELOG.md` — `[2.3.3]` section summarizing the H1–H7 / M1 / M3 / L3 / I1 / I2 fixes and the `response.incomplete` correctness note.
- `docs/releases/v2.3.3.md` — full release notes (Rotation/Recovery, Quota/Forecast, Request/SSE, Storage/Auth/Logging, Testing, Notes).
- `docs/README.md` + `README.md` — v2.3.3 listed as current stable, v2.3.2 demoted to prior.

## Verification
- Full suite: **5014 passed, 3 skipped**; the lone failure is the pre-existing `ci-workflows` CRLF/BOM artifact on the Windows checkout, which passes on LF / Linux CI.
- `tsc`, `build`, `clean:repo:check`, and `pack:check` (769.6 kB / 914 files) all clean.
- `npm pack --dry-run` → `codex-multi-auth-2.3.3.tgz`.

No runtime-rotation routing, account-selection, storage layout, or normal auth-flow behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

pure release chore cutting v2.3.3 stable — version bumped across `package.json`, `package-lock.json`, `.codex-plugin/plugin.json`, and `AGENTS.md`, with changelog and full release notes documenting the security/durability hardening from the deep stress audit (#617–#619). no runtime code changes are in this pr; all actual fixes (H1–H7, M1, M3, L3, I1, I2) landed in the preceding prs.

- version bump is consistent across all four manifest/metadata files; `package-lock.json` root and `packages[""]` entries are both updated.
- `CHANGELOG.md` [2.3.3] entry accurately summarises every fix category, including the `response.incomplete` correctness note and the windows-relevant fsync-before-rename durability fix (L3).
- release notes explicitly call out the multi-process scope of the H2 lease-nonce and H3 token-reconciliation fixes, which is the right audience guidance for shared-auth-directory deployments.

<h3>Confidence Score: 5/5</h3>

safe to merge — purely version bump and documentation; no runtime, auth, storage, or concurrency logic touched in this pr.

all four version-bearing files are in sync at 2.3.3. the changelog and release notes accurately reflect the fixes from the preceding audit prs. the only metadata that isn't fully refreshed is the Generated/Commit/Validated block in AGENTS.md, which is intentionally left as-is (the file itself documents 'content not regenerated'). no test files are in scope here because the regression coverage landed in #617–619.

no files require special attention. AGENTS.md carries stale Commit and Validated fields by design, but the package version line is correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version bumped 2.3.2 → 2.3.3; consistent with package-lock.json and plugin.json |
| package-lock.json | both root and packages[""] entries updated to 2.3.3; no dependency changes |
| .codex-plugin/plugin.json | plugin version bumped to 2.3.3, consistent with package.json |
| AGENTS.md | package version line updated to 2.3.3; Generated/Commit/Validated metadata still points to older commits (a87e005 / 98d9819), intentional per the 'content not regenerated' annotation |
| CHANGELOG.md | new [2.3.3] section added with accurate date 2026-06-19, covering all H1–H7/M/I fixes; well-formed |
| docs/releases/v2.3.3.md | comprehensive release notes covering rotation, quota, SSE, storage, auth, logging, and testing improvements |
| README.md | current stable link updated to v2.3.3, v2.3.2 demoted to prior stable; release history is correct |
| docs/README.md | docs index table updated to v2.3.3 as current stable, v2.3.2 demoted; no issues |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["v2.3.3 release PR"] --> B["Version bumped in 4 files"]
    B --> B1["package.json\n2.3.2 → 2.3.3"]
    B --> B2["package-lock.json\n2.3.2 → 2.3.3"]
    B --> B3[".codex-plugin/plugin.json\n2.3.2 → 2.3.3"]
    B --> B4["AGENTS.md\nPackage version: 2.3.3"]
    A --> C["Docs updated"]
    C --> C1["CHANGELOG.md\n[2.3.3] section added"]
    C --> C2["docs/releases/v2.3.3.md\nFull release notes"]
    C --> C3["README.md\nCurrent stable → v2.3.3"]
    C --> C4["docs/README.md\nIndex table updated"]
    A --> D["Fixes documented\n(code changes in #617–619)"]
    D --> D1["Rotation/Recovery\nH1 rate-limit clamp\nH2 lease nonce\nH3 token reconcile"]
    D --> D2["Quota/Forecast\nH4 transient 429\nH5 forecast filter"]
    D --> D3["SSE/Request\nH6/H7 error→non-2xx\nM1 data: parser"]
    D --> D4["Storage/Auth/Logging\nM3 migration\nL3 fsync\nI1 expires_in\nI2 log masking"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["v2.3.3 release PR"] --> B["Version bumped in 4 files"]
    B --> B1["package.json\n2.3.2 → 2.3.3"]
    B --> B2["package-lock.json\n2.3.2 → 2.3.3"]
    B --> B3[".codex-plugin/plugin.json\n2.3.2 → 2.3.3"]
    B --> B4["AGENTS.md\nPackage version: 2.3.3"]
    A --> C["Docs updated"]
    C --> C1["CHANGELOG.md\n[2.3.3] section added"]
    C --> C2["docs/releases/v2.3.3.md\nFull release notes"]
    C --> C3["README.md\nCurrent stable → v2.3.3"]
    C --> C4["docs/README.md\nIndex table updated"]
    A --> D["Fixes documented\n(code changes in #617–619)"]
    D --> D1["Rotation/Recovery\nH1 rate-limit clamp\nH2 lease nonce\nH3 token reconcile"]
    D --> D2["Quota/Forecast\nH4 transient 429\nH5 forecast filter"]
    D --> D3["SSE/Request\nH6/H7 error→non-2xx\nM1 data: parser"]
    D --> D4["Storage/Auth/Logging\nM3 migration\nL3 fsync\nI1 expires_in\nI2 log masking"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(release): cut v2.3.3 stable (stres..."](https://github.com/ndycode/codex-multi-auth/commit/777a96915aa7f9fb046ff68c09b227a67c1fe03a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38624041)</sub>

<!-- /greptile_comment -->