### PR TITLE
feat(codex): force a specific account per invocation with --account (#623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This repository's current stable release line is `2.x`.
 Current stable release notes live in `docs/releases/`.
 This top-level changelog preserves the foundational `0.x` milestones and points older iteration history to `docs/releases/legacy-pre-0.1-history.md`.
 
+## [Unreleased]
+
+### Added
+
+- `codex-multi-auth-codex --account <index|email|id>` (and the equivalent `CODEX_MULTI_AUTH_FORCE_ACCOUNT` env var) forces a single forwarded Codex invocation onto one account. The pin is ephemeral and fail-hard: it applies to only that run's rotation-proxy instance, never mutates the persisted `switch` pin, never rotates, and errors instead of spilling onto another account when the target is unavailable or the runtime rotation proxy is disabled ([#623](https://github.com/ndycode/codex-multi-auth/issues/623))
+
 ## [2.3.3] - 2026-06-19
 
 Security and durability hardening from a deep stress audit of the rotation, persistence, and SSE-handling paths. No feature changes; routing, account-selection, and the normal auth flow are unchanged.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ For remote or headless shells, prefer `codex-multi-auth login --device-auth`.
 | --- | --- |
 | `codex-multi-auth list` | Which accounts are saved and which one is active? |
 | `codex-multi-auth switch <index>` | How do I move to a different saved account? |
+| `codex-multi-auth-codex --account <index\|email\|id>` | How do I force one account for a single wrapper session without changing my default? |
 | `codex-multi-auth forecast --live` | Which account looks best for the next session? |
 
 ### Repair

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,7 @@ These are safe for most operators and frequently used in day-to-day workflows.
 | `CODEX_MULTI_AUTH_CONFIG_PATH` | Load configuration from alternate path |
 | `CODEX_MODE=0/1` | Disable or enable Codex mode |
 | `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0/1` | Opt out/in of live Codex Responses routing through the localhost account-rotation proxy |
+| `CODEX_MULTI_AUTH_FORCE_ACCOUNT=<index\|email\|id>` | Force one account for a single forwarded `codex-multi-auth-codex` run (equivalent to the `--account` flag, which wins when both are set). Ephemeral and fail-hard; requires the runtime rotation proxy. See [Force an account for one invocation](reference/commands.md#force-an-account-for-one-invocation) |
 | `CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS=<ms>` | Override idle shutdown for the wrapper-launched Codex app helper |
 | `CODEX_MULTI_AUTH_APP_BIND_INSTALL=0/1` | Opt out/in of packaged Codex app bind self-heal during install/update or rotation enable |
 | `CODEX_MULTI_AUTH_APP_LAUNCHER_INSTALL=0/1` | Opt out/in of supported user-level launcher routing during install/update or rotation enable |
@@ -86,6 +87,7 @@ Use these only when debugging, controlled benchmarking, or maintainer workflows.
 - `CODEX_MULTI_AUTH_SYNC_CODEX_CLI`
 - `CODEX_MULTI_AUTH_REAL_CODEX_BIN`
 - `CODEX_MULTI_AUTH_BYPASS`
+- `CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX` — internal, set by the wrapper after it resolves `--account` / `CODEX_MULTI_AUTH_FORCE_ACCOUNT` to a 0-based index; the runtime rotation proxy consumes it as an ephemeral pin. Not intended to be set by hand — use `CODEX_MULTI_AUTH_FORCE_ACCOUNT` instead.
 - `CODEX_CLI_ACCOUNTS_PATH`
 - `CODEX_CLI_AUTH_PATH`
 - refresh lease tuning variables (`CODEX_AUTH_REFRESH_LEASE*`)
@@ -110,6 +112,8 @@ Keep these enabled for most environments:
 ## Runtime Rotation Proxy
 
 `codexRuntimeRotationProxy` is enabled by default. When enabled through defaults, settings, `codex-multi-auth rotation enable`, or `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=1`, the `codex-multi-auth-codex` wrapper starts a localhost-only Responses proxy for forwarded official Codex sessions, including CLI request commands, `codex app-server`, and `codex app` launches through the wrapper. The wrapper writes a temporary shadow `CODEX_HOME/config.toml` that selects a custom provider named `codex-multi-auth-runtime-proxy`, launches the official Codex surface against that provider, and removes the shadow home after the owning process exits. Set `codexRuntimeRotationProxy=false`, run `codex-multi-auth rotation disable`, or set `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` to bypass the proxy.
+
+A single forwarded run can be pinned to one account with `codex-multi-auth-codex --account <selector>` (or `CODEX_MULTI_AUTH_FORCE_ACCOUNT`). The pin is applied per-invocation by that run's own proxy instance, so it never touches the persisted `switch` pin and cannot leak across concurrent sessions. Because the proxy is required for the pin to take effect, `--account` fails hard when the proxy is disabled rather than silently using a rotated account. See [Force an account for one invocation](reference/commands.md#force-an-account-for-one-invocation).
 
 The proxy preserves request bodies and streaming responses, replaces outbound auth headers with the selected managed account, and rotates to another account before response bytes are streamed when it sees rate limits, server errors, network failures, or refresh failures. It removes hop-by-hop headers, private account metadata headers, and stale decoded `content-encoding` from client responses. If every account is unavailable, the proxy returns a structured pool-exhaustion error that points to `codex-multi-auth rotation status`.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,6 +36,7 @@ Runtime rotation is part of the current architecture. It is default-on and local
 | --- | --- | --- |
 | Local Responses proxy | Routes forwarded official Codex Responses/model traffic through a loopback provider named `codex-multi-auth-runtime-proxy` | `codex-multi-auth rotation status` |
 | Per-request account rotation | Moves to another managed account on quota, auth refresh, network, or server failure before streaming response bytes | runtime proxy |
+| Per-invocation account pin | Forces one account for a single wrapper session (ephemeral, fail-hard, never touches the persisted `switch` pin) | `codex-multi-auth-codex --account <index\|email\|id>` |
 | Shadow `CODEX_HOME` launch | Keeps temporary provider config isolated from normal official Codex state for wrapper-launched CLI sessions | `codex-multi-auth-codex` wrapper |
 | Runtime status telemetry | Shows setting state, app helper state, app bind state, account waits, cooldowns, and last-account proxy metadata | `codex-multi-auth rotation status` |
 | Reversible desktop app bind | Lets packaged Codex app launches use the same local router without patching official app files | `codex-multi-auth rotation bind-app` |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -124,6 +124,9 @@ example, when driving Codex from another tool). The selector is one of:
 - an **email** (`--account work@example.com`), or
 - an **account id** (`--account acc_...`).
 
+An all-digit selector is always treated as a 1-based index, so an account whose
+id is purely numeric cannot be targeted by id — use its index or email instead.
+
 `CODEX_MULTI_AUTH_FORCE_ACCOUNT=<selector>` has the same effect for tools that set
 environment variables more easily than command-line flags; the `--account` flag
 wins when both are present.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -89,6 +89,7 @@ Compatibility forms are supported for migrations and wrapper-routed environments
 
 | Flag | Applies to | Meaning |
 | --- | --- | --- |
+| `--account <index\|email\|id>` | `codex-multi-auth-codex` (forwarded Codex runs) | Force one account for this invocation only; the session never rotates and persisted `switch` state is untouched. Requires the runtime rotation proxy. See [Force an account for one invocation](#force-an-account-for-one-invocation) |
 | `--device-auth` | login | Use the OpenAI Codex device-code flow for remote/headless login (mutually exclusive with `--manual` / `--no-browser`) |
 | `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow (mutually exclusive with `--device-auth`) |
 | `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle, history | Print machine-readable output |
@@ -109,6 +110,34 @@ Compatibility forms are supported for migrations and wrapper-routed environments
 | `--all` | verify | Run both `--paths` and `--flagged` together |
 | `--now`, `-n` | why-selected | Recompute the current selection from live state (default) |
 | `--last`, `-l` | why-selected | Recompute selection from current state and attach the last persisted runtime snapshot |
+
+---
+
+## Force an account for one invocation
+
+`codex-multi-auth-codex --account <selector>` pins a single account for that one
+forwarded Codex run — useful when you keep separate pools (for example, personal
+and work accounts) and want a specific invocation to use a specific account (for
+example, when driving Codex from another tool). The selector is one of:
+
+- a **1-based index** (`--account 2`, matching the numbering in `codex-multi-auth list`),
+- an **email** (`--account work@example.com`), or
+- an **account id** (`--account acc_...`).
+
+`CODEX_MULTI_AUTH_FORCE_ACCOUNT=<selector>` has the same effect for tools that set
+environment variables more easily than command-line flags; the `--account` flag
+wins when both are present.
+
+The pin is **ephemeral and fail-hard**:
+
+- It applies only to this invocation and never changes the persisted `switch` pin,
+  so concurrent sessions with different `--account` values do not interfere.
+- The session never rotates. If the chosen account is rate-limited or otherwise
+  unavailable, the request fails rather than silently using a different account.
+- It requires the [runtime rotation proxy](../configuration.md#runtime-rotation-proxy).
+  If the proxy is disabled (or `CODEX_MULTI_AUTH_BYPASS=1`), or the selector does
+  not match a configured account, the wrapper exits non-zero without launching
+  Codex.
 
 ---
 

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -603,6 +603,29 @@ function writePoolExhausted(params: {
 	});
 }
 
+/**
+ * Coerce a forced-account pin from an option (number) or the launcher's env
+ * string into a normalized 0-based index, or null when absent/invalid. Invalid
+ * or negative values collapse to null so an out-of-range env value can never
+ * throw at proxy startup; chooseAccount reports the deterministic
+ * pinned-account failure per-request instead. Exported for unit tests.
+ *
+ * @internal
+ */
+export function normalizeForcedAccountIndex(
+	value: number | string | null | undefined,
+): number | null {
+	if (value === null || value === undefined) {
+		return null;
+	}
+	const parsed =
+		typeof value === "number" ? value : Number.parseInt(value.trim(), 10);
+	if (!Number.isInteger(parsed) || parsed < 0) {
+		return null;
+	}
+	return parsed;
+}
+
 export async function startRuntimeRotationProxy(
 	options: RuntimeRotationProxyOptions,
 ): Promise<RuntimeRotationProxyServer> {
@@ -647,6 +670,18 @@ export async function startRuntimeRotationProxy(
 		);
 	}
 	const now = options.now ?? Date.now;
+	// Ephemeral per-invocation pin (issue #623). Prefer an explicit option (used by
+	// tests and the in-process inline proxy); otherwise read the numeric env the
+	// launcher publishes, which is how the value reaches a detached app-helper
+	// process. Invalid/negative values are ignored (treated as "no forced pin")
+	// rather than throwing — the launcher already validated the selector, and an
+	// out-of-range index is surfaced per-request as a deterministic pinned-account
+	// failure by chooseAccount rather than crashing proxy startup.
+	const forcedAccountIndex = normalizeForcedAccountIndex(
+		options.forcedAccountIndex !== undefined
+			? options.forcedAccountIndex
+			: process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX,
+	);
 	const tokenRefreshSkewMs = getTokenRefreshSkewMs(pluginConfig);
 	const networkErrorCooldownMs = getNetworkErrorCooldownMs(pluginConfig);
 	const serverErrorCooldownMs = getServerErrorCooldownMs(pluginConfig);
@@ -697,6 +732,7 @@ export async function startRuntimeRotationProxy(
 		quotaRemainingPercentThreshold,
 		sessionAffinityStore,
 		lastObservedAffinityGeneration,
+		forcedAccountIndex,
 	});
 
 	const server = createServer((req, res) => {
@@ -899,7 +935,13 @@ async function handleRequestInner(
 		// account. The proxy itself never bumps the generation, so its own
 		// debounced disk writes do not clear affinity. See issue #474.
 		const storageMeta = readStorageMetaFromDisk();
-		const pinnedIndex = storageMeta.pinnedAccountIndex;
+		// The ephemeral --account pin (issue #623) takes precedence over the
+		// persisted `switch` pin for this invocation, without ever mutating disk
+		// state. Use `??` (not `||`) so a forced index of 0 is honored. When set,
+		// everything downstream — deterministic pick, no cursor advance, no
+		// stale-state recovery, the `codex_pinned_account_unavailable` failure —
+		// applies unchanged because it all keys off `pinnedIndex` / `isPinned`.
+		const pinnedIndex = state.forcedAccountIndex ?? storageMeta.pinnedAccountIndex;
 		const isPinned = typeof pinnedIndex === "number";
 		if (storageMeta.affinityGeneration > state.lastObservedAffinityGeneration) {
 			state.sessionAffinityStore?.clearAll();

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -671,16 +671,17 @@ export async function startRuntimeRotationProxy(
 	}
 	const now = options.now ?? Date.now;
 	// Ephemeral per-invocation pin (issue #623). Prefer an explicit option (used by
-	// tests and the in-process inline proxy); otherwise read the numeric env the
-	// launcher publishes, which is how the value reaches a detached app-helper
-	// process. Invalid/negative values are ignored (treated as "no forced pin")
-	// rather than throwing — the launcher already validated the selector, and an
-	// out-of-range index is surfaced per-request as a deterministic pinned-account
-	// failure by chooseAccount rather than crashing proxy startup.
+	// tests and the in-process inline proxy); otherwise fall back to the numeric env
+	// the launcher publishes, which is how the value reaches a detached app-helper
+	// process. `??` means both `undefined` and an explicit `null` option defer to the
+	// env, so "no option" and "no pin" behave identically. Invalid/negative values
+	// are ignored (treated as "no forced pin") rather than throwing — the launcher
+	// already validated the selector, and an out-of-range index is surfaced
+	// per-request as a deterministic pinned-account failure by chooseAccount rather
+	// than crashing proxy startup.
 	const forcedAccountIndex = normalizeForcedAccountIndex(
-		options.forcedAccountIndex !== undefined
-			? options.forcedAccountIndex
-			: process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX,
+		options.forcedAccountIndex ??
+			process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX,
 	);
 	const tokenRefreshSkewMs = getTokenRefreshSkewMs(pluginConfig);
 	const networkErrorCooldownMs = getNetworkErrorCooldownMs(pluginConfig);

--- a/lib/runtime/rotation-proxy-state.ts
+++ b/lib/runtime/rotation-proxy-state.ts
@@ -34,6 +34,13 @@ export interface RotationProxyStateInit {
 	quotaRemainingPercentThreshold: number;
 	sessionAffinityStore: SessionAffinityStore | null;
 	lastObservedAffinityGeneration: number;
+	/**
+	 * Ephemeral per-invocation account pin (0-based) or null. When a number,
+	 * the request handler treats it exactly like a manual `switch` pin — a
+	 * deterministic, fail-hard selection — but it is never written to disk, so
+	 * concurrent invocations with different pins never interfere (issue #623).
+	 */
+	forcedAccountIndex: number | null;
 }
 
 /**

--- a/lib/runtime/rotation-server-types.ts
+++ b/lib/runtime/rotation-server-types.ts
@@ -35,6 +35,15 @@ export interface RuntimeRotationProxyOptions {
 	maxRequestBodyBytes?: number;
 	fetchTimeoutMs?: number;
 	streamStallTimeoutMs?: number;
+	/**
+	 * Ephemeral, per-instance account pin (0-based) for a single invocation
+	 * (issue #623: `codex-multi-auth-codex --account`). When set, this proxy
+	 * routes every request to exactly this account and never rotates, without
+	 * touching the persisted `switch` pin on disk. Falls back to
+	 * `CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX` in the environment when omitted so
+	 * the value survives the launcher -> detached app-helper process boundary.
+	 */
+	forcedAccountIndex?: number | null;
 }
 
 export interface RequestContext {

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -307,6 +307,172 @@ function findAccountIndexByIdOrEmail(accounts, id, email) {
 	return -1;
 }
 
+// --- Forced-account selection (`--account`, issue #623) ---------------------
+//
+// `codex-multi-auth-codex --account <selector>` (or the CODEX_MULTI_AUTH_FORCE_ACCOUNT
+// env var) pins ONE account for a single invocation. The selector is resolved to a
+// 0-based index here in the launcher and published as CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX,
+// which the runtime rotation proxy consumes as an ephemeral pin — never touching the
+// persisted `switch` pin on disk. The flag wins over the env var.
+const FORCE_ACCOUNT_ENV = "CODEX_MULTI_AUTH_FORCE_ACCOUNT";
+const FORCE_ACCOUNT_INDEX_ENV = "CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX";
+
+/**
+ * Extract and strip `--account <sel>` / `--account=<sel>` from a forwarded arg
+ * list. The flag is a launcher concept; real Codex has no `--account`, so it must
+ * never be forwarded. Returns { selector, strippedArgs, error }; selector is null
+ * when the flag is absent. The last occurrence wins if repeated.
+ */
+function extractForcedAccountFlag(args) {
+	const strippedArgs = [];
+	let selector = null;
+	let sawFlag = false;
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === "--account") {
+			sawFlag = true;
+			const next = args[index + 1];
+			if (typeof next !== "string") {
+				return {
+					selector: null,
+					strippedArgs: args,
+					error:
+						"codex-multi-auth: --account requires a value (account index, email, or account id).",
+				};
+			}
+			selector = next;
+			index += 1;
+			continue;
+		}
+		if (typeof arg === "string" && arg.startsWith("--account=")) {
+			sawFlag = true;
+			selector = arg.slice("--account=".length);
+			continue;
+		}
+		strippedArgs.push(arg);
+	}
+	return { selector, strippedArgs, error: null, sawFlag };
+}
+
+/**
+ * Resolve the effective forced-account selector from args (flag) or environment,
+ * with the flag taking precedence. Returns { selector, strippedArgs, error };
+ * selector is null when neither source requests a forced account.
+ */
+function resolveForcedAccountSelector(rawArgs, env = process.env) {
+	const { selector: flagSelector, strippedArgs, error, sawFlag } =
+		extractForcedAccountFlag(rawArgs);
+	if (error) {
+		return { selector: null, strippedArgs, error };
+	}
+	if (sawFlag) {
+		const trimmed = flagSelector.trim();
+		if (trimmed.length === 0) {
+			return {
+				selector: null,
+				strippedArgs,
+				error:
+					"codex-multi-auth: --account requires a non-empty value (account index, email, or account id).",
+			};
+		}
+		return { selector: trimmed, strippedArgs, error: null };
+	}
+	const envSelector = (env[FORCE_ACCOUNT_ENV] ?? "").trim();
+	if (envSelector.length > 0) {
+		return { selector: envSelector, strippedArgs, error: null };
+	}
+	return { selector: null, strippedArgs, error: null };
+}
+
+function formatForcedAccountList(accounts) {
+	const lines = accounts.map((account, index) => {
+		const email =
+			typeof account?.email === "string" && account.email.trim().length > 0
+				? account.email.trim()
+				: `account ${index + 1}`;
+		return `  ${index + 1}. ${email}`;
+	});
+	return `Available accounts:\n${lines.join("\n")}`;
+}
+
+/**
+ * Resolve a forced-account selector to a 0-based index against the same scoped
+ * accounts pool the runtime rotation proxy will load. Selector forms: a 1-based
+ * integer index, an email, or an account id. Returns { ok, index } or
+ * { ok: false, error }.
+ */
+async function resolveForcedAccountIndex(selector, env = process.env) {
+	const accountsDir = await resolveStatusAccountsDir(env);
+	const storage = readJsonFileQuiet(resolveAccountsPath(env, accountsDir));
+	const accounts = Array.isArray(storage?.accounts) ? storage.accounts : [];
+	if (accounts.length === 0) {
+		return {
+			ok: false,
+			error:
+				"codex-multi-auth: --account was set but no Codex accounts are configured. Run `codex-multi-auth login` first.",
+		};
+	}
+	if (/^\d+$/.test(selector)) {
+		const oneBased = Number.parseInt(selector, 10);
+		if (oneBased < 1 || oneBased > accounts.length) {
+			return {
+				ok: false,
+				error: `codex-multi-auth: --account ${selector} is out of range (have ${accounts.length} account${
+					accounts.length === 1 ? "" : "s"
+				}).\n${formatForcedAccountList(accounts)}`,
+			};
+		}
+		return { ok: true, index: oneBased - 1 };
+	}
+	const index = findAccountIndexByIdOrEmail(accounts, selector, selector);
+	if (index < 0) {
+		return {
+			ok: false,
+			error: `codex-multi-auth: --account "${selector}" did not match any configured account.\n${formatForcedAccountList(accounts)}`,
+		};
+	}
+	return { ok: true, index };
+}
+
+/**
+ * Preflight the `--account` flag / env var before forwarding to Codex. On success
+ * returns { forwardArgs } with the flag stripped and (when a forced account was
+ * requested) CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX published on the environment for
+ * the proxy to consume. On failure returns { error } so the caller can exit
+ * non-zero WITHOUT launching Codex — a forced account must never silently fall
+ * back to a different one.
+ */
+async function applyForcedAccountSelection(rawArgs, env = process.env) {
+	const forced = resolveForcedAccountSelector(rawArgs, env);
+	if (forced.error) {
+		return { error: forced.error };
+	}
+	if (forced.selector === null) {
+		// Defensive: the resolved-index var is internal and only ever set below.
+		// Clear any stray value from the ambient environment so a request without
+		// --account can never inherit an unintended pin.
+		delete env[FORCE_ACCOUNT_INDEX_ENV];
+		return { forwardArgs: rawArgs };
+	}
+	// The pin can only be honored when the runtime rotation proxy is active for
+	// this command; otherwise the run would silently use a non-forced account,
+	// so fail hard instead of ignoring the flag.
+	if (!(await isRuntimeRotationProxyEnabled(forced.strippedArgs, env))) {
+		return {
+			error: [
+				"codex-multi-auth: --account requires the runtime rotation proxy, which is not active for this command.",
+				"Enable it with `codex-multi-auth rotation enable`, and make sure CODEX_MULTI_AUTH_BYPASS is not set.",
+			].join("\n"),
+		};
+	}
+	const resolved = await resolveForcedAccountIndex(forced.selector, env);
+	if (!resolved.ok) {
+		return { error: resolved.error };
+	}
+	env[FORCE_ACCOUNT_INDEX_ENV] = String(resolved.index);
+	return { forwardArgs: forced.strippedArgs };
+}
+
 function resolveModelFamilyForStatus(model) {
 	const normalized = typeof model === "string" ? model.trim().toLowerCase() : "";
 	if (normalized.startsWith("gpt-5.2")) return "gpt-5.2";
@@ -4766,12 +4932,22 @@ async function main() {
 		return 1;
 	}
 
+	// Resolve `--account` / CODEX_MULTI_AUTH_FORCE_ACCOUNT before forwarding: strip
+	// the launcher-only flag from the Codex args and publish the resolved pin, or
+	// fail hard so a forced account can never silently fall back to another one.
+	const forcedAccount = await applyForcedAccountSelection(rawArgs, process.env);
+	if (forcedAccount.error) {
+		console.error(forcedAccount.error);
+		return 1;
+	}
+	const forwardArgs = forcedAccount.forwardArgs;
+
 	await autoSyncManagerActiveSelectionIfEnabled();
-	await maybePrintForwardStatusLine(rawArgs);
+	await maybePrintForwardStatusLine(forwardArgs);
 	maybeRefreshQuotaCacheInBackground();
 	try {
-		return await withForwardedRuntimeObservability(rawArgs, () =>
-			forwardToRealCodex(realCodexBin, rawArgs),
+		return await withForwardedRuntimeObservability(forwardArgs, () =>
+			forwardToRealCodex(realCodexBin, forwardArgs),
 		);
 	} finally {
 		await autoSyncManagerActiveSelectionIfEnabled();

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -823,15 +823,20 @@ function maybeRefreshQuotaCacheInBackground(env = process.env) {
 	// process. The close/error handlers below remove the lock dir, but if the parent
 	// exits before the child settles they will NOT fire — in that case the lock is
 	// reclaimed by the 10-minute stale-lock recovery in acquireStatusRefreshLock.
+	const refreshChildEnv = {
+		...env,
+		CODEX_MULTI_AUTH_STATUS_REFRESH_CHILD: "1",
+		CODEX_MULTI_AUTH_STATUSLINE: "0",
+	};
+	// A forced-account pin is scoped to a single forwarded Codex run; this
+	// management child (`forecast`) must never inherit it, so it can never be
+	// coupled to a specific account if a future change routes it through the proxy.
+	delete refreshChildEnv[FORCE_ACCOUNT_INDEX_ENV];
 	const child = spawn(
 		process.execPath,
 		[scriptPath, "forecast", "--live", "--json"],
 		{
-			env: {
-				...env,
-				CODEX_MULTI_AUTH_STATUS_REFRESH_CHILD: "1",
-				CODEX_MULTI_AUTH_STATUSLINE: "0",
-			},
+			env: refreshChildEnv,
 			stdio: "ignore",
 			detached: true,
 		},

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -305,6 +305,13 @@ function createRuntimeRotationProxyFixtureModule(fixtureRoot: string): string {
 			"",
 			"export async function startRuntimeRotationProxy() {",
 			"  const baseUrl = process.env.CODEX_MULTI_AUTH_TEST_PROXY_BASE_URL ?? 'http://127.0.0.1:4567';",
+			// Opt-in (#623): record the forced-account pin env the proxy process actually
+			// observed, so a test can prove the value crossed the launcher -> detached
+			// app-helper boundary. Gated so it never perturbs the exact-marker assertions
+			// in other tests.
+			"  if ((process.env.CODEX_MULTI_AUTH_TEST_PROXY_MARKER_FORCED ?? '').trim() === '1') {",
+			"    appendMarker(`forced-index-env:${process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX ?? ''}`);",
+			"  }",
 			"  if ((process.env.CODEX_MULTI_AUTH_TEST_PROXY_MARKER_ENV ?? '').trim() === '1') {",
 			"    appendMarker(`codex-home-env:${process.env.CODEX_HOME ?? ''}`);",
 			"    appendMarker(`real-home-env:${process.env.CODEX_MULTI_AUTH_REAL_CODEX_HOME ?? ''}`);",
@@ -980,6 +987,124 @@ describe("codex bin wrapper", () => {
 		// account 2 -> 0-based index 1, published for the proxy to consume.
 		expect(output).toContain("FORCED_INDEX:1");
 		// The launcher-only flag must never reach real Codex.
+		expect(output).not.toContain("--account");
+	});
+
+	it.each([
+		["email", ["exec", "--account", "account-2@example.com", "status"], {}, "1"],
+		["account id", ["exec", "--account", "acc_2", "status"], {}, "1"],
+		["--account= form", ["exec", "--account=3", "status"], {}, "2"],
+		[
+			"CODEX_MULTI_AUTH_FORCE_ACCOUNT env var",
+			["exec", "status"],
+			{ CODEX_MULTI_AUTH_FORCE_ACCOUNT: "2" },
+			"1",
+		],
+	])(
+		"resolves the forced account by %s and publishes its 0-based index (#623)",
+		(_label, args, extraEnv, expectedIndex) => {
+			const fixtureRoot = createWrapperFixture();
+			createRuntimeRotationProxyFixtureModule(fixtureRoot);
+			const originalHome = join(fixtureRoot, "codex-home");
+			writeAccountsFixture(originalHome, 3);
+			writeFileSync(
+				join(originalHome, "config.toml"),
+				'model_provider = "openai"\n',
+				"utf8",
+			);
+			const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+				"#!/usr/bin/env node",
+				'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
+				'console.log(`FORCED_INDEX:${process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX ?? ""}`);',
+				"process.exit(0);",
+			]);
+
+			const result = runWrapper(fixtureRoot, args, {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				OPENAI_API_KEY: undefined,
+				...extraEnv,
+			});
+
+			const output = combinedOutput(result);
+			expect(result.status).toBe(0);
+			expect(output).toContain(`FORCED_INDEX:${expectedIndex}`);
+			expect(output).not.toContain("--account");
+		},
+	);
+
+	it("the flag wins over CODEX_MULTI_AUTH_FORCE_ACCOUNT when both are set (#623)", () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const originalHome = join(fixtureRoot, "codex-home");
+		writeAccountsFixture(originalHome, 3);
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			'model_provider = "openai"\n',
+			"utf8",
+		);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'console.log(`FORCED_INDEX:${process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX ?? ""}`);',
+			"process.exit(0);",
+		]);
+
+		const result = runWrapper(
+			fixtureRoot,
+			["exec", "--account", "1", "status"],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				CODEX_MULTI_AUTH_FORCE_ACCOUNT: "3",
+				OPENAI_API_KEY: undefined,
+			},
+		);
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(0);
+		// Flag `--account 1` (index 0) wins over env `...FORCE_ACCOUNT=3` (index 2).
+		expect(output).toContain("FORCED_INDEX:0");
+	});
+
+	it("propagates the resolved --account index into the detached app-helper proxy (#623)", () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const markerPath = join(fixtureRoot, "forced-helper-marker.txt");
+		mkdirSync(originalHome, { recursive: true });
+		writeAccountsFixture(originalHome, 3);
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			'model_provider = "openai"\n',
+			"utf8",
+		);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
+			"process.exit(0);",
+		]);
+
+		// Bare args (no forwarded subcommand) classify as the interactive TUI, which
+		// routes through a freshly spawned detached app-helper process — the one path
+		// where the pin can only travel by environment.
+		const result = runWrapper(fixtureRoot, ["--account", "2"], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_HOME: originalHome,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+			CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "1000",
+			CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+			CODEX_MULTI_AUTH_TEST_PROXY_MARKER_FORCED: "1",
+			OPENAI_API_KEY: undefined,
+		});
+
+		const output = combinedOutput(result);
+		if (result.status !== 0) {
+			throw new Error(output);
+		}
+		// The helper process saw the resolved index (account 2 -> 0-based 1).
+		expect(readFileSync(markerPath, "utf8")).toContain("forced-index-env:1");
 		expect(output).not.toContain("--account");
 	});
 

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -344,6 +344,25 @@ function createCustomFakeCodexBin(rootDir: string, lines: string[]): string {
 	return fakeBin;
 }
 
+// Write a minimal accounts pool at <codexHome>/multi-auth/openai-codex-accounts.json
+// (the global dir the launcher resolves when the dist scoping helpers are absent),
+// so --account (#623) selector resolution has a pool to match against.
+function writeAccountsFixture(codexHome: string, count: number): void {
+	const dir = join(codexHome, "multi-auth");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(
+		join(dir, "openai-codex-accounts.json"),
+		JSON.stringify({
+			version: 3,
+			accounts: Array.from({ length: count }, (_unused, index) => ({
+				email: `account-${index + 1}@example.com`,
+				accountId: `acc_${index + 1}`,
+			})),
+		}),
+		"utf8",
+	);
+}
+
 function createFakeNativeCodexBin(rootDir: string): string {
 	if (process.platform === "win32") {
 		const fakeBin = join(rootDir, `fake-native-codex-${createdDirs.length}.ps1`);
@@ -879,6 +898,89 @@ describe("codex bin wrapper", () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("FORWARDED:--version");
+	});
+
+	it("errors when --account has no value (#623)", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createFakeCodexBin(fixtureRoot);
+		const result = runWrapper(fixtureRoot, ["exec", "--account"], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+		});
+
+		expect(result.status).toBe(1);
+		expect(combinedOutput(result)).toContain("--account requires a value");
+	});
+
+	it("errors when --account is used but runtime rotation is disabled (#623)", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createFakeCodexBin(fixtureRoot);
+		const result = runWrapper(fixtureRoot, ["exec", "--account", "1", "status"], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "0",
+		});
+
+		expect(result.status).toBe(1);
+		expect(combinedOutput(result)).toContain(
+			"requires the runtime rotation proxy",
+		);
+	});
+
+	it("errors when the --account index is out of range (#623)", () => {
+		const fixtureRoot = createWrapperFixture();
+		const fakeBin = createFakeCodexBin(fixtureRoot);
+		const codexHome = join(fixtureRoot, "codex-home");
+		writeAccountsFixture(codexHome, 2);
+
+		const result = runWrapper(
+			fixtureRoot,
+			["exec", "--account", "99", "status"],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: codexHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+			},
+		);
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(1);
+		expect(output).toContain("out of range");
+		expect(output).toContain("Available accounts");
+	});
+
+	it("strips --account and publishes the resolved 0-based index for the proxy (#623)", () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const originalHome = join(fixtureRoot, "codex-home");
+		writeAccountsFixture(originalHome, 3);
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			'model_provider = "openai"\n',
+			"utf8",
+		);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
+			'console.log(`FORCED_INDEX:${process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX ?? ""}`);',
+			"process.exit(0);",
+		]);
+
+		const result = runWrapper(
+			fixtureRoot,
+			["exec", "--account", "2", "status"],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				OPENAI_API_KEY: undefined,
+			},
+		);
+
+		const output = combinedOutput(result);
+		expect(result.status).toBe(0);
+		// account 2 -> 0-based index 1, published for the proxy to consume.
+		expect(output).toContain("FORCED_INDEX:1");
+		// The launcher-only flag must never reach real Codex.
+		expect(output).not.toContain("--account");
 	});
 
 	it("repairs local session index and suppresses known Codex rollout-store noise", () => {

--- a/test/rotation-proxy-state.test.ts
+++ b/test/rotation-proxy-state.test.ts
@@ -65,6 +65,7 @@ function stateInit(): RotationProxyStateInit {
 		quotaRemainingPercentThreshold: 0,
 		sessionAffinityStore: null,
 		lastObservedAffinityGeneration: 0,
+		forcedAccountIndex: null,
 	};
 }
 

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -7,6 +7,7 @@ import {
 	startRuntimeRotationProxy,
 	buildTokenInvalidationBody,
 	chooseAccount,
+	normalizeForcedAccountIndex,
 	type RuntimeRotationProxyServer,
 } from "../lib/runtime-rotation-proxy.js";
 import { SessionAffinityStore } from "../lib/session-affinity.js";
@@ -317,6 +318,25 @@ afterEach(async () => {
 	clearCircuitBreakers();
 	resetRefreshQueue();
 	__resetRoutingMutexForTests();
+});
+
+describe("normalizeForcedAccountIndex (#623)", () => {
+	it("accepts non-negative integers from numbers and strings", () => {
+		expect(normalizeForcedAccountIndex(0)).toBe(0);
+		expect(normalizeForcedAccountIndex(3)).toBe(3);
+		expect(normalizeForcedAccountIndex("2")).toBe(2);
+		expect(normalizeForcedAccountIndex("  4 ")).toBe(4);
+	});
+
+	it("returns null for absent, blank, or invalid values", () => {
+		expect(normalizeForcedAccountIndex(null)).toBeNull();
+		expect(normalizeForcedAccountIndex(undefined)).toBeNull();
+		expect(normalizeForcedAccountIndex("")).toBeNull();
+		expect(normalizeForcedAccountIndex("   ")).toBeNull();
+		expect(normalizeForcedAccountIndex("abc")).toBeNull();
+		expect(normalizeForcedAccountIndex(-1)).toBeNull();
+		expect(normalizeForcedAccountIndex(1.5)).toBeNull();
+	});
 });
 
 describe("runtime rotation proxy", () => {
@@ -714,6 +734,64 @@ describe("runtime rotation proxy", () => {
 		});
 		expect(proxy.getStatus()).not.toHaveProperty("lastAccountEmail");
 		expect(JSON.parse(calls[0]?.bodyText ?? "{}")).toEqual(requestBody);
+	});
+
+	it("routes every request to the ephemeral forced account without rotating (#623)", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 3));
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			textEventStream("data: forwarded\n\n"),
+		);
+		const proxy = await startProxy({
+			accountManager,
+			fetchImpl,
+			options: { forcedAccountIndex: 2 },
+		});
+		const body = {
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+		};
+
+		const first = await postResponses(proxy, body);
+		const second = await postResponses(proxy, body);
+
+		expect(first.status).toBe(HTTP_STATUS.OK);
+		expect(second.status).toBe(HTTP_STATUS.OK);
+		expect(calls).toHaveLength(2);
+		// Both requests pinned to account 3 (index 2); no rotation to 1 or 2.
+		expect(calls[0]?.headers.get("authorization")).toBe("Bearer access-3");
+		expect(calls[1]?.headers.get("authorization")).toBe("Bearer access-3");
+		expect(calls[0]?.headers.get(OPENAI_HEADERS.ACCOUNT_ID)).toBe("acc_3");
+		expect(proxy.getStatus()).toMatchObject({
+			lastAccountIndex: 2,
+			lastAccountId: "acc_3",
+		});
+	});
+
+	it("fails hard (503, no upstream call) when the forced account is unavailable (#623)", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			textEventStream("data: should-not-be-reached\n\n"),
+		);
+		const proxy = await startProxy({
+			accountManager,
+			fetchImpl,
+			// Out of range for a 2-account pool: the pin is deterministic, so this
+			// must fail rather than spill onto a different account.
+			options: { forcedAccountIndex: 5 },
+		});
+
+		const response = await postResponses(proxy, {
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+		});
+
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		// The whole point of --account: it never rotates to another account.
+		expect(calls).toHaveLength(0);
 	});
 
 	it("forwards model discovery requests through managed account auth", async () => {

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -318,6 +318,9 @@ afterEach(async () => {
 	clearCircuitBreakers();
 	resetRefreshQueue();
 	__resetRoutingMutexForTests();
+	// Forced-account pin (#623) is read from the ambient env by startRuntimeRotationProxy;
+	// never let one test's value bleed into the next.
+	delete process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX;
 });
 
 describe("normalizeForcedAccountIndex (#623)", () => {
@@ -792,6 +795,55 @@ describe("runtime rotation proxy", () => {
 		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
 		// The whole point of --account: it never rotates to another account.
 		expect(calls).toHaveLength(0);
+	});
+
+	it("reads the forced account from CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX env when no option is passed (#623)", async () => {
+		// This is the exact mechanism the pin uses to cross the launcher -> detached
+		// app-helper process boundary: no option, env only.
+		process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX = "2";
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 3));
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			textEventStream("data: forwarded\n\n"),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, {
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+		});
+
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.headers.get("authorization")).toBe("Bearer access-3");
+		expect(proxy.getStatus()).toMatchObject({ lastAccountIndex: 2 });
+	});
+
+	it("prefers an explicit forcedAccountIndex option over the env value (#623)", async () => {
+		process.env.CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX = "2";
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 3));
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			textEventStream("data: forwarded\n\n"),
+		);
+		const proxy = await startProxy({
+			accountManager,
+			fetchImpl,
+			options: { forcedAccountIndex: 0 },
+		});
+
+		const response = await postResponses(proxy, {
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+		});
+
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		expect(calls).toHaveLength(1);
+		// Option index 0 wins over env index 2; also proves index 0 is honored.
+		expect(calls[0]?.headers.get("authorization")).toBe("Bearer access-1");
+		expect(proxy.getStatus()).toMatchObject({ lastAccountIndex: 0 });
 	});
 
 	it("forwards model discovery requests through managed account auth", async () => {


### PR DESCRIPTION
Closes #623.

## Summary

- Adds `codex-multi-auth-codex --account <index|email|id>` (and the equivalent `CODEX_MULTI_AUTH_FORCE_ACCOUNT` env var) to pin a single account for one forwarded Codex run — for users who keep separate account pools (e.g. personal vs. work) and want a specific invocation to use a specific account (e.g. when driving Codex from another tool).

## What Changed

- **Launcher (`scripts/codex.js`)**: parses `--account` / `--account=` (flag wins over `CODEX_MULTI_AUTH_FORCE_ACCOUNT`), strips the launcher-only flag from the args forwarded to real Codex, resolves the selector to a 0-based index against the same scoped accounts pool the proxy loads, and publishes `CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX` for the proxy. Selector forms: 1-based index, email, or account id.
- **Runtime rotation proxy (`lib/runtime-rotation-proxy.ts`, `rotation-proxy-state.ts`, `rotation-server-types.ts`)**: new `forcedAccountIndex` option (falls back to the env var so it survives the launcher → detached app-helper process boundary), consumed as `pinnedIndex = state.forcedAccountIndex ?? storageMeta.pinnedAccountIndex`. This reuses the existing deterministic-pin path, so no other selection logic changes.
- **Ephemeral & leak-safe**: the pin lives only on that invocation's own proxy instance, never mutates the persisted `switch` pin, and cannot leak across concurrent sessions.
- **Fail-hard by design**: an unavailable target yields the existing `codex_pinned_account_unavailable` error rather than spilling onto another account; the wrapper exits non-zero (without launching Codex) when the selector does not resolve or the runtime rotation proxy is disabled.
- **Extension point for pools**: selector handling is isolated so a future `--account <group>` can layer on without reworking the single-pin path (documented, not built).

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — ran the affected suites in full: `test/runtime-rotation-proxy.test.ts` and `test/codex-bin-wrapper.test.ts` (195 passing, incl. 8 new). One pre-existing, unrelated proxy test (`evicts oldest local thread goal fallbacks…`) hits the default 5s vitest timeout on this Windows box — reproduced identically on clean `main`; passes at `--testTimeout=20000`.
- [x] `npm test -- test/documentation.test.ts`
- [x] `npm run build`

## Docs and Governance Checklist

- [x] README updated (Daily use command table)
- [ ] `docs/getting-started.md` (onboarding flow unchanged)
- [x] `docs/features.md` updated (new capability row)
- [x] relevant `docs/reference/*` pages updated (`commands.md` flag + dedicated section; `configuration.md` env vars + proxy note)
- [ ] `docs/upgrade.md` (no migration behavior change)
- [x] `SECURITY.md` / `CONTRIBUTING.md` reviewed — no account emails/tokens added to proxy client response headers or logs; selector-error output lists emails only on the user's own stderr, consistent with existing `list`/status output.

## Risk and Rollback

- Risk level: **Low**. Additive; when `--account`/env are unset, behavior is byte-for-byte unchanged (the internal index env is also proactively cleared). Reuses the audited deterministic-pin path.
- Rollback plan: revert this PR; no storage/migration changes, so no data cleanup needed.

## Additional Notes

- New tests: proxy-level (deterministic selection to the forced account, fail-hard 503 with no upstream call, `normalizeForcedAccountIndex` unit) and launcher-level (missing value, rotation disabled, out-of-range, strip + index publish).
- CHANGELOG: added under `## [Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to force a single account for one Codex wrapper run using `--account <index|email|id>` or an environment variable.
  * The selected account is used only for that invocation and does not change the saved default account.

* **Bug Fixes**
  * Improved failure handling when a forced account can’t be used or the rotation proxy is disabled, preventing fallback to another account.

* **Documentation**
  * Updated usage, configuration, and command reference docs to cover the new account-forcing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

adds `codex-multi-auth-codex --account <index|email|id>` (and `CODEX_MULTI_AUTH_FORCE_ACCOUNT`) to pin a single account for one forwarded codex run without touching the persisted switch pin. the implementation is additive and fail-hard: an unknown selector or disabled proxy exits non-zero before launching codex, and the forced pin reuses the existing deterministic-pin path in the proxy with no rotation.

- **launcher** (`scripts/codex.js`): parses and strips `--account`/`--account=`, resolves the selector to a 0-based index against the scoped accounts pool, and publishes `CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX`; also removes the index from the background forecast child's env to prevent pin bleed.
- **proxy** (`lib/runtime-rotation-proxy.ts`, `rotation-proxy-state.ts`, `rotation-server-types.ts`): `normalizeForcedAccountIndex` coerces the option or env string; `state.forcedAccountIndex ?? storageMeta.pinnedAccountIndex` plumbs the ephemeral pin into the existing deterministic-pin path per request.
- **tests** (`test/codex-bin-wrapper.test.ts`, `test/runtime-rotation-proxy.test.ts`): 8 new tests covering error paths, all selector forms (numeric/email/id/env/equals), flag-wins-over-env precedence, fail-hard 503 with no upstream call, and the detached app-helper env boundary.

<h3>Confidence Score: 5/5</h3>

safe to merge; the feature is purely additive and the existing forwarding path is byte-for-byte unchanged when --account and CODEX_MULTI_AUTH_FORCE_ACCOUNT are both unset.

the new code is well-scoped: flag parsing, selector resolution, and env publication are isolated to the launcher; the proxy change is a single ?? expression that reuses the audited deterministic-pin path. the background refresh child env cleanup correctly deletes the internal index var, though the user-facing selector is left (flagged as a suggestion). no storage changes, no concurrency issues on the proxy side since forcedAccountIndex lives in per-instance state.

scripts/codex.js — the background refresh child inherits CODEX_MULTI_AUTH_FORCE_ACCOUNT (user-facing selector) even though CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX (resolved index) is correctly deleted.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/codex.js | adds --account flag parsing, selector resolution, and env publication; correct overall but CODEX_MULTI_AUTH_FORCE_ACCOUNT is not scrubbed from the background refresh child env |
| lib/runtime-rotation-proxy.ts | adds normalizeForcedAccountIndex and wires forcedAccountIndex into the per-request pinnedIndex path; ?? correctly handles index 0; logic is sound |
| lib/runtime/rotation-proxy-state.ts | adds required forcedAccountIndex field to RotationProxyStateInit; clean type change |
| lib/runtime/rotation-server-types.ts | adds optional forcedAccountIndex to RuntimeRotationProxyOptions with clear fallback-to-env semantics documented |
| test/runtime-rotation-proxy.test.ts | adds normalizeForcedAccountIndex unit tests and proxy-level pin/fail-hard/env-crossing tests; afterEach cleanup for CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX is correct |
| test/codex-bin-wrapper.test.ts | adds 8 new launcher tests covering error paths, numeric/email/id/env/equals-form selectors, flag-wins-over-env, and the detached app-helper boundary; solid coverage |
| test/rotation-proxy-state.test.ts | adds forcedAccountIndex: null to stateInit fixture; minimal required update |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant Launcher as scripts/codex.js
    participant Proxy as runtime-rotation-proxy.ts
    participant Account as AccountManager
    participant Codex as Real Codex CLI

    User->>Launcher: codex-multi-auth-codex --account 2 exec
    Launcher->>Launcher: "extractForcedAccountFlag()<br/>strips --account 2, selector=2"
    Launcher->>Launcher: isRuntimeRotationProxyEnabled() → true
    Launcher->>Launcher: "resolveForcedAccountIndex(2)<br/>reads accounts.json, returns index=1"
    Launcher->>Launcher: "set CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX=1"
    Launcher->>Proxy: "startRuntimeRotationProxy({forcedAccountIndex: 1})"
    Proxy->>Proxy: "normalizeForcedAccountIndex(option ?? env)<br/>stores in state.forcedAccountIndex=1"
    Launcher->>Codex: forward exec (stripped args, no --account)
    Codex->>Proxy: POST /v1/responses
    Proxy->>Proxy: "pinnedIndex = state.forcedAccountIndex(1) ?? storageMeta.pinnedAccountIndex"
    Proxy->>Account: pick account[1] (deterministic, no rotation)
    Account-->>Proxy: access token
    Proxy->>Proxy: inject auth headers for account[1]
    Proxy-->>Codex: 200 OK (streamed)
    Codex-->>User: output
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant Launcher as scripts/codex.js
    participant Proxy as runtime-rotation-proxy.ts
    participant Account as AccountManager
    participant Codex as Real Codex CLI

    User->>Launcher: codex-multi-auth-codex --account 2 exec
    Launcher->>Launcher: "extractForcedAccountFlag()<br/>strips --account 2, selector=2"
    Launcher->>Launcher: isRuntimeRotationProxyEnabled() → true
    Launcher->>Launcher: "resolveForcedAccountIndex(2)<br/>reads accounts.json, returns index=1"
    Launcher->>Launcher: "set CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX=1"
    Launcher->>Proxy: "startRuntimeRotationProxy({forcedAccountIndex: 1})"
    Proxy->>Proxy: "normalizeForcedAccountIndex(option ?? env)<br/>stores in state.forcedAccountIndex=1"
    Launcher->>Codex: forward exec (stripped args, no --account)
    Codex->>Proxy: POST /v1/responses
    Proxy->>Proxy: "pinnedIndex = state.forcedAccountIndex(1) ?? storageMeta.pinnedAccountIndex"
    Proxy->>Account: pick account[1] (deterministic, no rotation)
    Account-->>Proxy: access token
    Proxy->>Proxy: inject auth headers for account[1]
    Proxy-->>Codex: 200 OK (streamed)
    Codex-->>User: output
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/codex-bin-wrapper.test.ts`, line 469-551 ([link](https://github.com/ndycode/codex-multi-auth/blob/dc0158791459515b9aec4fdd59a139476aa1879e/test/codex-bin-wrapper.test.ts#L469-L551)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **missing vitest coverage for the env-var fallback path and non-numeric selectors**

   the four new launcher tests only exercise the numeric `--account` flag form. three paths that could silently break are not covered:

   - `CODEX_MULTI_AUTH_FORCE_ACCOUNT=<selector>` env var fallback (the flag-vs-env precedence logic in `resolveForcedAccountSelector` is only reachable via this path)
   - email selector (`--account work@example.com`) and account-id selector (`--account acc_...`) against `findAccountIndexByIdOrEmail`
   - `--account=<value>` equals-sign form (parsed separately from the space form in `extractForcedAccountFlag`)

   `writeAccountsFixture` already provides everything needed to write these; adding one test per path would close the gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/codex-bin-wrapper.test.ts
   Line: 469-551

   Comment:
   **missing vitest coverage for the env-var fallback path and non-numeric selectors**

   the four new launcher tests only exercise the numeric `--account` flag form. three paths that could silently break are not covered:

   - `CODEX_MULTI_AUTH_FORCE_ACCOUNT=<selector>` env var fallback (the flag-vs-env precedence logic in `resolveForcedAccountSelector` is only reachable via this path)
   - email selector (`--account work@example.com`) and account-id selector (`--account acc_...`) against `findAccountIndexByIdOrEmail`
   - `--account=<value>` equals-sign form (parsed separately from the space form in `extractForcedAccountFlag`)

   `writeAccountsFixture` already provides everything needed to write these; adding one test per path would close the gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2F623-force-account%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F623-force-account%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fcodex-bin-wrapper.test.ts%0ALine%3A%20469-551%0A%0AComment%3A%0A**missing%20vitest%20coverage%20for%20the%20env-var%20fallback%20path%20and%20non-numeric%20selectors**%0A%0Athe%20four%20new%20launcher%20tests%20only%20exercise%20the%20numeric%20%60--account%60%20flag%20form.%20three%20paths%20that%20could%20silently%20break%20are%20not%20covered%3A%0A%0A-%20%60CODEX_MULTI_AUTH_FORCE_ACCOUNT%3D%3Cselector%3E%60%20env%20var%20fallback%20%28the%20flag-vs-env%20precedence%20logic%20in%20%60resolveForcedAccountSelector%60%20is%20only%20reachable%20via%20this%20path%29%0A-%20email%20selector%20%28%60--account%20work%40example.com%60%29%20and%20account-id%20selector%20%28%60--account%20acc_...%60%29%20against%20%60findAccountIndexByIdOrEmail%60%0A-%20%60--account%3D%3Cvalue%3E%60%20equals-sign%20form%20%28parsed%20separately%20from%20the%20space%20form%20in%20%60extractForcedAccountFlag%60%29%0A%0A%60writeAccountsFixture%60%20already%20provides%20everything%20needed%20to%20write%20these%3B%20adding%20one%20test%20per%20path%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Fcodex-multi-auth&pr=624&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test/fix: address code review on --accou..."](https://github.com/ndycode/codex-multi-auth/commit/d488f4ecfc25c4e8a735321cc8052c617099dea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42983486)</sub>

<!-- /greptile_comment -->