### PR TITLE
feat(models): add GPT-5.6 Sol / Terra / Luna support

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -17,7 +17,7 @@ These files are optional model/provider templates for host/plugin configurations
 
 ## Defaults Included
 
-- Current documented OpenAI/Codex model families (`gpt-5.5`, `gpt-5.4`, and `gpt-5.3-codex`)
+- Current documented OpenAI/Codex model families (`gpt-5.6-sol`/`terra`/`luna`, `gpt-5.5`, `gpt-5.4`, and `gpt-5.3-codex`)
 - `store: false`
 - `include: ["reasoning.encrypted_content"]`
 - Sensible fallback behavior for unsupported model entitlements

--- a/config/codex-modern.json
+++ b/config/codex-modern.json
@@ -15,6 +15,145 @@
         "store": false
       },
       "models": {
+        "gpt-5.6-sol": {
+          "name": "GPT 5.6 Sol (OAuth)",
+          "limit": {
+            "context": 372000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "max": {
+              "reasoningEffort": "max",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "ultra": {
+              "reasoningEffort": "ultra",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
+        "gpt-5.6-terra": {
+          "name": "GPT 5.6 Terra (OAuth)",
+          "limit": {
+            "context": 372000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "max": {
+              "reasoningEffort": "max",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "ultra": {
+              "reasoningEffort": "ultra",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
+        "gpt-5.6-luna": {
+          "name": "GPT 5.6 Luna (OAuth)",
+          "limit": {
+            "context": 372000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "max": {
+              "reasoningEffort": "max",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
         "gpt-5.5": {
           "name": "GPT 5.5 (OAuth)",
           "limit": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,10 @@ Some Windows installs expose Codex only as a packaged `shell:AppsFolder` app ent
 
 The shipped config templates expose first-class current OpenAI model aliases:
 
-- `config/codex-modern.json` includes `gpt-5.5` and `gpt-5.5-pro`
+- `config/codex-modern.json` includes the GPT-5.6 tiers (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`), plus `gpt-5.5` and `gpt-5.5-pro`
+- GPT-5.6 adds two reasoning tiers above `xhigh`: `max`, and `ultra` on Sol/Terra only. `ultra` selects Codex's automatic subagent delegation and is sent to the API as `max`, mirroring upstream Codex
+- no GPT-5.6 tier accepts `none` or `minimal` reasoning effort; requests using them are coerced up to `low`
+- `gpt-5.6` on its own resolves to Sol, the flagship tier; the legacy `gpt-5` alias still resolves to `gpt-5.5`
 - `config/codex-modern.json` and `config/codex-legacy.json` expose current documented GPT-5.5, GPT-5.4, and GPT-5.3 Codex model IDs
 - deprecated Codex selectors such as `gpt-5-codex` and `gpt-5.1-codex*` are treated as compatibility aliases and retried on the current documented Codex model when the ChatGPT Codex surface rejects them
 - the wrapper and optional plugin-host runtime try those models directly and only fall back to `gpt-5.4` after a real ChatGPT Codex unsupported-model response

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -102,3 +102,34 @@ export const ACCOUNT_LIMITS = {
 	/** Number of consecutive auth failures before auto-removing account */
 	MAX_AUTH_FAILURES_BEFORE_REMOVAL: 3,
 } as const;
+
+/**
+ * Every reasoning-effort level, weakest first.
+ *
+ * Single source of truth: the effort union and the model-id suffix pattern in
+ * `lib/request/request-transformer.ts` are both derived from this, so a new
+ * tier cannot be added to one and forgotten in the other.
+ *
+ * `max` and `ultra` arrived with GPT-5.6.
+ */
+export const REASONING_EFFORTS = [
+	"none",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+	"ultra",
+] as const;
+
+/**
+ * `ultra` is selectable but never reaches the wire: Codex rewrites it to `max`
+ * before the request is sent (see `reasoning_effort_for_request` in
+ * codex-rs/core/src/client.rs). It denotes automatic subagent delegation on the
+ * client, not a distinct backend effort level.
+ */
+export type ModelReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
+/** Effort levels the Responses API actually accepts. */
+export type WireReasoningEffort = Exclude<ModelReasoningEffort, "ultra">;

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -7,26 +7,15 @@
  * transformer, prompt selection, and CLI diagnostics.
  */
 
-/**
- * `max` and `ultra` arrived with GPT-5.6.
- *
- * `ultra` is selectable but never reaches the wire: Codex rewrites it to `max`
- * before the request is sent (see `reasoning_effort_for_request` in
- * codex-rs/core/src/client.rs). It denotes automatic subagent delegation on the
- * client, not a distinct backend effort level.
- */
-export type ModelReasoningEffort =
-	| "none"
-	| "minimal"
-	| "low"
-	| "medium"
-	| "high"
-	| "xhigh"
-	| "max"
-	| "ultra";
+// The effort union lives in the leaf constants module so the base types layer
+// (`lib/types.ts`) can depend on it without importing this file, which would
+// close a cycle through `lib/schemas.ts`. Re-exported here for existing callers.
+import type {
+	ModelReasoningEffort,
+	WireReasoningEffort,
+} from "../../constants.js";
 
-/** Effort levels the Responses API actually accepts. */
-export type WireReasoningEffort = Exclude<ModelReasoningEffort, "ultra">;
+export type { ModelReasoningEffort, WireReasoningEffort };
 
 export type PromptModelFamily =
 	| "gpt-5-codex"

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -7,13 +7,26 @@
  * transformer, prompt selection, and CLI diagnostics.
  */
 
+/**
+ * `max` and `ultra` arrived with GPT-5.6.
+ *
+ * `ultra` is selectable but never reaches the wire: Codex rewrites it to `max`
+ * before the request is sent (see `reasoning_effort_for_request` in
+ * codex-rs/core/src/client.rs). It denotes automatic subagent delegation on the
+ * client, not a distinct backend effort level.
+ */
 export type ModelReasoningEffort =
 	| "none"
 	| "minimal"
 	| "low"
 	| "medium"
 	| "high"
-	| "xhigh";
+	| "xhigh"
+	| "max"
+	| "ultra";
+
+/** Effort levels the Responses API actually accepts. */
+export type WireReasoningEffort = Exclude<ModelReasoningEffort, "ultra">;
 
 export type PromptModelFamily =
 	| "gpt-5-codex"
@@ -112,6 +125,38 @@ export const QUOTA_PROBE_MODEL_CHAIN = [
 ] as const;
 
 const LEGACY_CODEX_MODEL = "gpt-5-codex";
+
+/**
+ * GPT-5.6 tiers, per the upstream Codex catalog
+ * (openai/codex `codex-rs/models-manager/models.json`).
+ *
+ * Sol and Terra expose `ultra`; Luna stops at `max`. No tier accepts `none` or
+ * `minimal`, so those aliases are deliberately never generated for them.
+ */
+const GPT_5_6_SOL_MODEL = "gpt-5.6-sol";
+const GPT_5_6_TERRA_MODEL = "gpt-5.6-terra";
+const GPT_5_6_LUNA_MODEL = "gpt-5.6-luna";
+
+/** Bare `gpt-5.6` is OpenAI's documented alias for the flagship (Sol) tier. */
+const GPT_5_6_FLAGSHIP_ALIAS = "gpt-5.6";
+
+const GPT_5_6_SOL_TERRA_EFFORTS = [
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+	"ultra",
+] as const satisfies readonly ModelReasoningEffort[];
+
+const GPT_5_6_LUNA_EFFORTS = [
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const satisfies readonly ModelReasoningEffort[];
+
 const GPT_5_5_CANONICAL_MODEL = "gpt-5.5";
 const GPT_5_5_PRO_CANONICAL_MODEL = "gpt-5.5-pro";
 const GPT_5_5_RELEASE_MODEL = "gpt-5.5-2026-04-23";
@@ -197,6 +242,30 @@ export const MODEL_PROFILES: Record<string, ModelProfile> = {
 		supportedReasoningEfforts: ["medium"],
 		capabilities: TOOL_CAPABILITIES.compactOnly,
 	},
+	// GPT-5.6 ships its base instructions inline in the upstream model catalog
+	// rather than as a `gpt_5_6_prompt.md`, so these stay on the GPT-5.2 prompt
+	// family alongside the other post-5.2 general models.
+	[GPT_5_6_SOL_MODEL]: {
+		normalizedModel: GPT_5_6_SOL_MODEL,
+		promptFamily: "gpt-5.2",
+		defaultReasoningEffort: "low",
+		supportedReasoningEfforts: GPT_5_6_SOL_TERRA_EFFORTS,
+		capabilities: TOOL_CAPABILITIES.full,
+	},
+	[GPT_5_6_TERRA_MODEL]: {
+		normalizedModel: GPT_5_6_TERRA_MODEL,
+		promptFamily: "gpt-5.2",
+		defaultReasoningEffort: "medium",
+		supportedReasoningEfforts: GPT_5_6_SOL_TERRA_EFFORTS,
+		capabilities: TOOL_CAPABILITIES.full,
+	},
+	[GPT_5_6_LUNA_MODEL]: {
+		normalizedModel: GPT_5_6_LUNA_MODEL,
+		promptFamily: "gpt-5.2",
+		defaultReasoningEffort: "medium",
+		supportedReasoningEfforts: GPT_5_6_LUNA_EFFORTS,
+		capabilities: TOOL_CAPABILITIES.full,
+	},
 	[GPT_5_5_CANONICAL_MODEL]: {
 		normalizedModel: GPT_5_5_CANONICAL_MODEL,
 		promptFamily: "gpt-5.2",
@@ -261,6 +330,38 @@ function addReasoningAliases(alias: string, normalizedModel: string): void {
 	}
 }
 
+/**
+ * Register a model plus one alias per effort it actually supports.
+ *
+ * Unlike `addReasoningAliases`, this does not assume the global variant list:
+ * GPT-5.6 rejects `none`/`minimal` and only Sol/Terra accept `ultra`.
+ */
+function addEffortAliases(
+	alias: string,
+	normalizedModel: string,
+	efforts: readonly ModelReasoningEffort[],
+): void {
+	addAlias(alias, normalizedModel);
+	for (const effort of efforts) {
+		addAlias(`${alias}-${effort}`, normalizedModel);
+	}
+}
+
+function addGpt56Aliases(): void {
+	addEffortAliases(GPT_5_6_SOL_MODEL, GPT_5_6_SOL_MODEL, GPT_5_6_SOL_TERRA_EFFORTS);
+	addEffortAliases(
+		GPT_5_6_TERRA_MODEL,
+		GPT_5_6_TERRA_MODEL,
+		GPT_5_6_SOL_TERRA_EFFORTS,
+	);
+	addEffortAliases(GPT_5_6_LUNA_MODEL, GPT_5_6_LUNA_MODEL, GPT_5_6_LUNA_EFFORTS);
+	addEffortAliases(
+		GPT_5_6_FLAGSHIP_ALIAS,
+		GPT_5_6_SOL_MODEL,
+		GPT_5_6_SOL_TERRA_EFFORTS,
+	);
+}
+
 function addGeneralAliases(): void {
 	addReasoningAliases(GPT_5_5_CANONICAL_MODEL, GPT_5_5_CANONICAL_MODEL);
 	addReasoningAliases(GPT_5_5_RELEASE_MODEL, GPT_5_5_CANONICAL_MODEL);
@@ -315,6 +416,7 @@ function addCodexAliases(): void {
 
 addCodexAliases();
 addGeneralAliases();
+addGpt56Aliases();
 
 export { MODEL_MAP };
 
@@ -412,6 +514,29 @@ function resolveCodexCatalogModel(modelId: string): string | undefined {
 	return undefined;
 }
 
+/**
+ * Resolve GPT-5.6 identifiers that are not exact aliases (for example a future
+ * `gpt-5.6-terra-fast`).
+ *
+ * Without this, the general GPT-5 resolver sees minor `6`, finds no catalog
+ * entry, and silently falls back to the stable 5.5 model — running a different
+ * model than the caller asked for. Unrecognised tiers resolve to Sol, matching
+ * OpenAI's bare `gpt-5.6` alias.
+ */
+function resolveGpt56CatalogModel(modelId: string): string | undefined {
+	const tokens = tokenizeModelId(modelId);
+	const gptIndex = tokens.indexOf("gpt");
+	const isGpt56 =
+		gptIndex !== -1 && tokens[gptIndex + 1] === "5" && tokens[gptIndex + 2] === "6";
+	if (!isGpt56 || tokens.includes("codex")) {
+		return undefined;
+	}
+
+	if (tokens.includes("terra")) return GPT_5_6_TERRA_MODEL;
+	if (tokens.includes("luna")) return GPT_5_6_LUNA_MODEL;
+	return GPT_5_6_SOL_MODEL;
+}
+
 function resolveGeneralGpt5CatalogModel(modelId: string): string | undefined {
 	const tokens = tokenizeModelId(modelId);
 	const gptIndex = tokens.indexOf("gpt");
@@ -494,6 +619,11 @@ export function resolveNormalizedModel(model: string | undefined): string {
 	const codexCatalogModel = resolveCodexCatalogModel(modelId);
 	if (codexCatalogModel) {
 		return codexCatalogModel;
+	}
+
+	const gpt56CatalogModel = resolveGpt56CatalogModel(modelId);
+	if (gpt56CatalogModel) {
+		return gpt56CatalogModel;
 	}
 
 	const generalGpt5CatalogModel = resolveGeneralGpt5CatalogModel(modelId);

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -7,6 +7,7 @@ import {
 	getModelProfile,
 	resolveNormalizedModel,
 	type ModelReasoningEffort,
+	type WireReasoningEffort,
 } from "./helpers/model-map.js";
 import {
 	filterHostSystemPromptsWithCachedPrompt,
@@ -63,6 +64,28 @@ export function normalizeModel(model: string | undefined): string {
 	return resolveNormalizedModel(model);
 }
 
+const REASONING_EFFORTS = [
+	"none",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+	"ultra",
+] as const satisfies readonly ModelReasoningEffort[];
+
+/**
+ * Matches a trailing reasoning-effort suffix on a model id.
+ *
+ * The lookbehind guards the `max` alternative only: `gpt-5.1-codex-max` is a
+ * model id that ends in `-max`, not Codex at `max` effort, and stripping it
+ * would reroute the request. `gpt-5-codex-low` must still parse `low`, so the
+ * guard cannot wrap the whole group.
+ */
+const VARIANT_SUFFIX_PATTERN =
+	/(?:-(none|minimal|low|medium|high|xhigh|ultra)|(?<!codex)-(max))$/i;
+
 /**
  * Extract configuration for a specific model
  * Merges global options with model-specific options (model-specific takes precedence)
@@ -84,24 +107,14 @@ export function getModelConfig(
 		name: string,
 	): ConfigOptions["reasoningEffort"] | undefined => {
 		const stripped = stripProviderPrefix(name).toLowerCase();
-		const match = stripped.match(/-(none|minimal|low|medium|high|xhigh)$/);
+		const match = stripped.match(VARIANT_SUFFIX_PATTERN);
 		if (!match) return undefined;
-		const variant = match[1];
-		if (
-			variant === "none" ||
-			variant === "minimal" ||
-			variant === "low" ||
-			variant === "medium" ||
-			variant === "high" ||
-			variant === "xhigh"
-		) {
-			return variant;
-		}
-		return undefined;
+		const variant = match[1] ?? match[2];
+		return REASONING_EFFORTS.find((effort) => effort === variant);
 	};
 
 	const removeVariantSuffix = (name: string): string =>
-		stripProviderPrefix(name).replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
+		stripProviderPrefix(name).replace(VARIANT_SUFFIX_PATTERN, "");
 
 	const findModelEntry = (
 		candidates: string[],
@@ -457,12 +470,18 @@ export function getReasoningConfig(
 	const profile = getModelProfile(modelName);
 	const defaultEffort = profile.defaultReasoningEffort;
 	const requestedEffort = userConfig.reasoningEffort ?? defaultEffort;
-	const effort = coerceReasoningEffort(
+	const coercedEffort = coerceReasoningEffort(
 		profile.normalizedModel,
 		requestedEffort,
 		profile.supportedReasoningEfforts,
 		defaultEffort,
 	);
+
+	// `ultra` is a client-side tier: upstream Codex rewrites Ultra -> Max in
+	// `reasoning_effort_for_request` before the request leaves the client, so the
+	// API never sees it. Mirror that here rather than sending a value it rejects.
+	const effort: WireReasoningEffort =
+		coercedEffort === "ultra" ? "max" : coercedEffort;
 
 	const summary = sanitizeReasoningSummary(userConfig.reasoningSummary);
 
@@ -482,6 +501,10 @@ const REASONING_FALLBACKS: Record<
 	medium: ["medium", "low", "high", "minimal", "none", "xhigh"],
 	high: ["high", "medium", "xhigh", "low", "minimal", "none"],
 	xhigh: ["xhigh", "high", "medium", "low", "minimal", "none"],
+	// `max` and `ultra` only exist on GPT-5.6. Step down one rung at a time so a
+	// request against a pre-5.6 model lands on that model's strongest tier.
+	max: ["max", "xhigh", "high", "medium", "low", "minimal", "none"],
+	ultra: ["ultra", "max", "xhigh", "high", "medium", "low", "minimal", "none"],
 } as const;
 
 function coerceReasoningEffort(
@@ -489,7 +512,7 @@ function coerceReasoningEffort(
 	effort: ModelReasoningEffort,
 	supportedEfforts: readonly ModelReasoningEffort[],
 	defaultEffort: ModelReasoningEffort,
-): ReasoningConfig["effort"] {
+): ModelReasoningEffort {
 	if (supportedEfforts.includes(effort)) {
 		return effort;
 	}

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -3,11 +3,14 @@ import { TOOL_REMAP_MESSAGE } from "../prompts/codex.js";
 import { CODEX_HOST_BRIDGE } from "../prompts/codex-host-bridge.js";
 import { getHostCodexPrompt } from "../prompts/host-codex-prompt.js";
 import {
+	REASONING_EFFORTS,
+	type ModelReasoningEffort,
+	type WireReasoningEffort,
+} from "../constants.js";
+import {
 	getModelCapabilities,
 	getModelProfile,
 	resolveNormalizedModel,
-	type ModelReasoningEffort,
-	type WireReasoningEffort,
 } from "./helpers/model-map.js";
 import {
 	filterHostSystemPromptsWithCachedPrompt,
@@ -64,27 +67,21 @@ export function normalizeModel(model: string | undefined): string {
 	return resolveNormalizedModel(model);
 }
 
-const REASONING_EFFORTS = [
-	"none",
-	"minimal",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
-	"max",
-	"ultra",
-] as const satisfies readonly ModelReasoningEffort[];
-
 /**
  * Matches a trailing reasoning-effort suffix on a model id.
  *
- * The lookbehind guards the `max` alternative only: `gpt-5.1-codex-max` is a
- * model id that ends in `-max`, not Codex at `max` effort, and stripping it
- * would reroute the request. `gpt-5-codex-low` must still parse `low`, so the
- * guard cannot wrap the whole group.
+ * The alternation is derived from `REASONING_EFFORTS` so a new tier cannot be
+ * added to the union and silently forgotten here.
+ *
+ * `max` is split into its own alternative because it needs a lookbehind:
+ * `gpt-5.1-codex-max` is a model id that ends in `-max`, not Codex at `max`
+ * effort, and stripping it would reroute the request. The guard cannot wrap the
+ * whole group -- `gpt-5-codex-low` must still parse `low`.
  */
-const VARIANT_SUFFIX_PATTERN =
-	/(?:-(none|minimal|low|medium|high|xhigh|ultra)|(?<!codex)-(max))$/i;
+const VARIANT_SUFFIX_PATTERN = new RegExp(
+	`(?:-(${REASONING_EFFORTS.filter((effort) => effort !== "max").join("|")})|(?<!codex)-(max))$`,
+	"i",
+);
 
 /**
  * Extract configuration for a specific model

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,8 +1,5 @@
 import type { Auth, Provider, Model } from "@codex-ai/sdk";
-import type {
-	ModelReasoningEffort,
-	WireReasoningEffort,
-} from "./request/helpers/model-map.js";
+import type { ModelReasoningEffort, WireReasoningEffort } from "./constants.js";
 
 export type {
 	PluginConfigFromSchema as PluginConfig,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,8 @@
 import type { Auth, Provider, Model } from "@codex-ai/sdk";
+import type {
+	ModelReasoningEffort,
+	WireReasoningEffort,
+} from "./request/helpers/model-map.js";
 
 export type {
 	PluginConfigFromSchema as PluginConfig,
@@ -21,7 +25,8 @@ export interface UserConfig {
 }
 
 export interface ConfigOptions {
-	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	/** `ultra` is accepted here but always resolves to `max` before the request. */
+	reasoningEffort?: ModelReasoningEffort;
 	reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on";
 	textVerbosity?: "low" | "medium" | "high";
 	promptCacheRetention?: PromptCacheRetention;
@@ -36,7 +41,11 @@ export type PromptCacheRetention =
 	| (string & {});
 
 export interface ReasoningConfig {
-	effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	/**
+	 * Effort as sent to the API. `ultra` is absent by construction: it is a
+	 * client-side tier that always resolves to `max` before the request is built.
+	 */
+	effort: WireReasoningEffort;
 	summary: "auto" | "concise" | "detailed";
 }
 

--- a/lib/usage/pricing.ts
+++ b/lib/usage/pricing.ts
@@ -44,6 +44,24 @@ const MODEL_PRICING: Record<string, UsageModelPricing> = {
 		cachedInputUsdPerMillion: 0.2,
 		reasoningUsdPerMillion: 12,
 	},
+	"gpt-5.6-sol": {
+		inputUsdPerMillion: 5,
+		outputUsdPerMillion: 30,
+		cachedInputUsdPerMillion: 0.5,
+		reasoningUsdPerMillion: 30,
+	},
+	"gpt-5.6-terra": {
+		inputUsdPerMillion: 2.5,
+		outputUsdPerMillion: 15,
+		cachedInputUsdPerMillion: 0.25,
+		reasoningUsdPerMillion: 15,
+	},
+	"gpt-5.6-luna": {
+		inputUsdPerMillion: 1,
+		outputUsdPerMillion: 6,
+		cachedInputUsdPerMillion: 0.1,
+		reasoningUsdPerMillion: 6,
+	},
 };
 
 function normalizeModelName(model: string | null | undefined): string | null {

--- a/test/gpt56-models.test.ts
+++ b/test/gpt56-models.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import {
+	getModelProfile,
+	getNormalizedModel,
+	isKnownModel,
+	resolveNormalizedModel,
+} from "../lib/request/helpers/model-map.js";
+import {
+	getModelConfig,
+	getReasoningConfig,
+} from "../lib/request/request-transformer.js";
+import { estimateUsageCostUsd } from "../lib/usage/pricing.js";
+
+describe("GPT-5.6 (Sol / Terra / Luna)", () => {
+	describe("model resolution", () => {
+		it("maps each tier to its own canonical id", () => {
+			expect(getNormalizedModel("gpt-5.6-sol")).toBe("gpt-5.6-sol");
+			expect(getNormalizedModel("gpt-5.6-terra")).toBe("gpt-5.6-terra");
+			expect(getNormalizedModel("gpt-5.6-luna")).toBe("gpt-5.6-luna");
+			expect(isKnownModel("gpt-5.6-terra")).toBe(true);
+		});
+
+		it("treats bare `gpt-5.6` as the flagship Sol tier", () => {
+			expect(getNormalizedModel("gpt-5.6")).toBe("gpt-5.6-sol");
+			expect(getNormalizedModel("gpt-5.6-high")).toBe("gpt-5.6-sol");
+		});
+
+		it("keeps effort aliases on their own tier", () => {
+			expect(getNormalizedModel("gpt-5.6-terra-xhigh")).toBe("gpt-5.6-terra");
+			expect(getNormalizedModel("gpt-5.6-luna-max")).toBe("gpt-5.6-luna");
+			expect(getNormalizedModel("gpt-5.6-sol-ultra")).toBe("gpt-5.6-sol");
+		});
+
+		it("does not invent `none`/`minimal` aliases that GPT-5.6 rejects", () => {
+			expect(getNormalizedModel("gpt-5.6-sol-none")).toBeUndefined();
+			expect(getNormalizedModel("gpt-5.6-terra-minimal")).toBeUndefined();
+		});
+
+		it("does not invent an `ultra` alias for Luna", () => {
+			expect(getNormalizedModel("gpt-5.6-luna-ultra")).toBeUndefined();
+		});
+
+		it("resolves unrecognised 5.6 ids to a 5.6 tier, never silently to 5.5", () => {
+			expect(resolveNormalizedModel("gpt-5.6-terra-fast")).toBe("gpt-5.6-terra");
+			expect(resolveNormalizedModel("gpt-5.6-luna-fast")).toBe("gpt-5.6-luna");
+			expect(resolveNormalizedModel("gpt-5.6-sol-2026-06-26")).toBe("gpt-5.6-sol");
+		});
+
+		it("leaves the legacy `gpt-5` alias pointing at 5.5", () => {
+			expect(getNormalizedModel("gpt-5")).toBe("gpt-5.5");
+			expect(getNormalizedModel("gpt-5-high")).toBe("gpt-5.5");
+		});
+
+		it("does not disturb the Codex Max alias, which also ends in `-max`", () => {
+			expect(getNormalizedModel("gpt-5.1-codex-max")).toBe("gpt-5.3-codex");
+			expect(getNormalizedModel("codex-max")).toBe("gpt-5.3-codex");
+		});
+	});
+
+	describe("reasoning effort", () => {
+		it("mirrors the upstream per-tier defaults", () => {
+			expect(getReasoningConfig("gpt-5.6-sol", {}).effort).toBe("low");
+			expect(getReasoningConfig("gpt-5.6-terra", {}).effort).toBe("medium");
+			expect(getReasoningConfig("gpt-5.6-luna", {}).effort).toBe("medium");
+		});
+
+		it("passes `max` through untouched", () => {
+			expect(
+				getReasoningConfig("gpt-5.6-sol", { reasoningEffort: "max" }).effort,
+			).toBe("max");
+			expect(
+				getReasoningConfig("gpt-5.6-luna", { reasoningEffort: "max" }).effort,
+			).toBe("max");
+		});
+
+		// Upstream `reasoning_effort_for_request` rewrites Ultra -> Max before the
+		// request is sent, so `ultra` must never reach the API.
+		it("rewrites `ultra` to `max` on the wire for Sol and Terra", () => {
+			expect(
+				getReasoningConfig("gpt-5.6-sol", { reasoningEffort: "ultra" }).effort,
+			).toBe("max");
+			expect(
+				getReasoningConfig("gpt-5.6-terra", { reasoningEffort: "ultra" }).effort,
+			).toBe("max");
+		});
+
+		it("still lands Luna on `max` when `ultra` is requested", () => {
+			expect(
+				getReasoningConfig("gpt-5.6-luna", { reasoningEffort: "ultra" }).effort,
+			).toBe("max");
+		});
+
+		it("steps `max`/`ultra` down to the strongest tier a pre-5.6 model supports", () => {
+			expect(
+				getReasoningConfig("gpt-5.5", { reasoningEffort: "max" }).effort,
+			).toBe("xhigh");
+			expect(
+				getReasoningConfig("gpt-5.5", { reasoningEffort: "ultra" }).effort,
+			).toBe("xhigh");
+			expect(
+				getReasoningConfig("gpt-5.1", { reasoningEffort: "ultra" }).effort,
+			).toBe("high");
+		});
+
+		it("upgrades `none` to a supported effort, since no 5.6 tier accepts it", () => {
+			const effort = getReasoningConfig("gpt-5.6-sol", {
+				reasoningEffort: "none",
+			}).effort;
+			expect(effort).not.toBe("none");
+			expect(effort).toBe("low");
+		});
+	});
+
+	describe("effort suffix parsed from the model name", () => {
+		// getModelConfig only surfaces an effort when the user's config declares a
+		// matching `variants` entry, so the suffix parser is exercised through one.
+		const config = {
+			global: {},
+			models: {
+				"gpt-5.6-sol": {
+					variants: {
+						xhigh: { reasoningEffort: "xhigh" },
+						max: { reasoningEffort: "max" },
+						ultra: { reasoningEffort: "ultra" },
+					},
+				},
+				"gpt-5-codex": {
+					variants: { low: { reasoningEffort: "low" } },
+				},
+				// Deliberately keyed on the base id. A `-max` strip would wrongly
+				// resolve `gpt-5.1-codex-max` onto this entry.
+				"gpt-5.1-codex": {
+					options: { textVerbosity: "high" },
+				},
+			},
+		} as unknown as Parameters<typeof getModelConfig>[1];
+
+		it("reads `max` and `ultra` off the model id", () => {
+			expect(getModelConfig("gpt-5.6-sol-max", config).reasoningEffort).toBe(
+				"max",
+			);
+			expect(getModelConfig("gpt-5.6-sol-ultra", config).reasoningEffort).toBe(
+				"ultra",
+			);
+			expect(
+				getModelConfig("openai/gpt-5.6-sol-ultra", config).reasoningEffort,
+			).toBe("ultra");
+		});
+
+		it("still parses ordinary efforts, including on codex ids", () => {
+			expect(getModelConfig("gpt-5.6-sol-xhigh", config).reasoningEffort).toBe(
+				"xhigh",
+			);
+			expect(getModelConfig("gpt-5-codex-low", config).reasoningEffort).toBe(
+				"low",
+			);
+		});
+
+		it("does not strip `-max` off Codex Max, whose id merely ends that way", () => {
+			// If `-max` were stripped, this would resolve onto the `gpt-5.1-codex`
+			// entry above and pick up its textVerbosity.
+			expect(getModelConfig("gpt-5.1-codex-max", config).textVerbosity).toBeUndefined();
+			expect(getModelConfig("gpt-5.1-codex", config).textVerbosity).toBe("high");
+		});
+	});
+
+	describe("profiles", () => {
+		it("exposes ultra only where upstream does", () => {
+			expect(getModelProfile("gpt-5.6-sol").supportedReasoningEfforts).toContain(
+				"ultra",
+			);
+			expect(
+				getModelProfile("gpt-5.6-terra").supportedReasoningEfforts,
+			).toContain("ultra");
+			expect(
+				getModelProfile("gpt-5.6-luna").supportedReasoningEfforts,
+			).not.toContain("ultra");
+		});
+
+		it("never advertises `none` for a 5.6 tier", () => {
+			for (const model of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+				expect(
+					getModelProfile(model).supportedReasoningEfforts,
+				).not.toContain("none");
+			}
+		});
+	});
+
+	describe("pricing", () => {
+		it("prices each tier per the published rates", () => {
+			const tokens = {
+				inputTokens: 1_000_000,
+				outputTokens: 0,
+				cachedInputTokens: 0,
+				reasoningTokens: 0,
+				totalTokens: 1_000_000,
+			};
+			expect(estimateUsageCostUsd("gpt-5.6-sol", tokens)).toBeCloseTo(5, 5);
+			expect(estimateUsageCostUsd("gpt-5.6-terra", tokens)).toBeCloseTo(2.5, 5);
+			expect(estimateUsageCostUsd("gpt-5.6-luna", tokens)).toBeCloseTo(1, 5);
+		});
+	});
+});

--- a/test/gpt56-models.test.ts
+++ b/test/gpt56-models.test.ts
@@ -10,6 +10,45 @@ import {
 	getReasoningConfig,
 } from "../lib/request/request-transformer.js";
 import { estimateUsageCostUsd } from "../lib/usage/pricing.js";
+import { REASONING_EFFORTS } from "../lib/constants.js";
+
+describe("reasoning-effort suffix pattern", () => {
+	// The suffix pattern is derived from REASONING_EFFORTS. Driving this test
+	// from the same list means a new tier added to the union but missed by the
+	// pattern fails here, rather than silently breaking suffix parsing. A
+	// snapshot of the regex source would not catch that: a re-hardcoded list
+	// matching today's tiers would still pass.
+	const config = {
+		global: {},
+		models: {
+			"gpt-5.6-sol": {
+				variants: Object.fromEntries(
+					REASONING_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]),
+				),
+			},
+			// Keyed on the base id: selecting `-max` here would prove the suffix
+			// was stripped off a model whose name merely ends in `-max`.
+			"gpt-5.1-codex": {
+				variants: { max: { reasoningEffort: "max" } },
+			},
+		},
+	} as unknown as Parameters<typeof getModelConfig>[1];
+
+	it.each(REASONING_EFFORTS)("parses the `%s` suffix off a model id", (effort) => {
+		expect(getModelConfig(`gpt-5.6-sol-${effort}`, config).reasoningEffort).toBe(
+			effort,
+		);
+	});
+
+	it("never treats Codex Max's trailing `-max` as an effort suffix", () => {
+		expect(getModelConfig("gpt-5.1-codex-max", config).reasoningEffort).not.toBe(
+			"max",
+		);
+		expect(
+			getModelConfig("gpt-5.1-codex-max", config).reasoningEffort,
+		).toBeUndefined();
+	});
+});
 
 describe("GPT-5.6 (Sol / Terra / Luna)", () => {
 	describe("model resolution", () => {

--- a/test/model-map.test.ts
+++ b/test/model-map.test.ts
@@ -53,7 +53,7 @@ describe("model map", () => {
 		it("returns undefined for unknown exact identifiers", () => {
 			expect(getNormalizedModel("unknown-model")).toBeUndefined();
 			expect(getNormalizedModel("gpt-6")).toBeUndefined();
-			expect(getNormalizedModel("gpt-5.6")).toBeUndefined();
+			expect(getNormalizedModel("gpt-5.7")).toBeUndefined();
 			expect(getNormalizedModel("")).toBeUndefined();
 		});
 	});

--- a/test/module-boundaries.test.ts
+++ b/test/module-boundaries.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function readLibFile(relativePath: string): string {
+	return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function importSpecifiers(source: string): string[] {
+	return [...source.matchAll(/from\s+"([^"]+)"/g)].map((match) => match[1]);
+}
+
+describe("module boundaries", () => {
+	// `lib/types.ts` is the base types layer. `lib/schemas.ts` imports
+	// `lib/request/helpers/model-map.ts`, and `lib/types.ts` imports
+	// `lib/schemas.ts` -- so if `lib/types.ts` reached back into `lib/request/**`
+	// it would close an import cycle. `import-x/no-cycle` does not catch this on
+	// its own, because model-map itself no longer imports the types layer.
+	it("keeps lib/types.ts out of the lib/request/** layer", () => {
+		const specifiers = importSpecifiers(readLibFile("lib/types.ts"));
+		const offenders = specifiers.filter((specifier) =>
+			specifier.includes("request/"),
+		);
+		expect(offenders).toEqual([]);
+	});
+
+	it("sources the reasoning-effort types from the leaf constants module", () => {
+		const specifiers = importSpecifiers(readLibFile("lib/types.ts"));
+		expect(specifiers).toContain("./constants.js");
+	});
+
+	it("keeps lib/constants.ts a leaf with no intra-repo imports", () => {
+		const specifiers = importSpecifiers(readLibFile("lib/constants.ts"));
+		const internal = specifiers.filter((specifier) => specifier.startsWith("."));
+		expect(internal).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds the three GPT-5.6 tiers (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) as first-class models, with bare `gpt-5.6` aliased to Sol.
- Adds two reasoning tiers above `xhigh`: `max` (all three tiers) and `ultra` (Sol/Terra only).
- Fixes two latent bugs found while wiring this up (details below).

Facts were taken from the upstream Codex catalog (`openai/codex` → `codex-rs/models-manager/models.json`) and `codex-rs/core/src/client.rs`, not the prose API docs — the docs pages contradict each other on whether a `max` tier exists, and quote a context window for the API surface that does not match the Codex backend.

## What Changed

- **`lib/request/helpers/model-map.ts`** — `ModelReasoningEffort` gains `max` + `ultra`; new `WireReasoningEffort` excludes `ultra`. Adds the three model profiles, per-tier effort aliases, and a dedicated 5.6 resolver.
- **`lib/request/request-transformer.ts`** — exhaustive fallback rows for `max`/`ultra`; rewrites `ultra` → `max` before the request is built; guarded effort-suffix pattern.
- **`lib/types.ts`** — `ConfigOptions.reasoningEffort` accepts `ultra`; `ReasoningConfig.effort` is `WireReasoningEffort`, so `ultra` cannot reach the wire by construction.
- **`lib/usage/pricing.ts`** — Sol $5/$30, Terra $2.50/$15, Luna $1/$6 per 1M tokens (cached input at 10% of input, matching existing entries).
- **`config/codex-modern.json`** — the three tiers, 372k context, no `none` variant, `ultra` only on Sol/Terra.
- **`docs/configuration.md`, `config/README.md`** — document the new tiers and the `ultra` → `max` behavior.
- **`test/gpt56-models.test.ts`** — new, 20 tests.

### Catalog facts encoded

| Tier | Efforts | Default |
|---|---|---|
| `gpt-5.6-sol` | low, medium, high, xhigh, max, **ultra** | `low` |
| `gpt-5.6-terra` | low, medium, high, xhigh, max, **ultra** | `medium` |
| `gpt-5.6-luna` | low, medium, high, xhigh, max | `medium` |

No tier accepts `none` or `minimal`; those coerce up rather than being sent.

### `ultra` never reaches the wire

Upstream `reasoning_effort_for_request` rewrites `Ultra → Max` **unconditionally** before sending:

```rust
fn reasoning_effort_for_request(effort: ReasoningEffortConfig) -> ReasoningEffortConfig {
    match effort {
        ReasoningEffortConfig::Ultra => ReasoningEffortConfig::Max,
        effort => effort,
    }
}
```

`ultra` denotes client-side subagent delegation, not a distinct backend effort. Sending it would be rejected. It stays selectable in config and is emitted as `max`.

### Two latent bugs fixed

1. **`gpt-5.1-codex-max` already ends in `-max`.** Naively adding `max` to the effort-suffix pattern strips it to `gpt-5.1-codex`, silently rerouting every Codex Max request. The lookbehind is scoped to the `max` alternative only (`gpt-5-codex-low` must still parse `low`). Covered by a regression test that was confirmed to fail when the guard is removed.
2. **Unrecognised `gpt-5.6-*` ids resolved to `gpt-5.5`.** The general GPT-5 resolver has no minor `6`, so it fell through to the "stable" variant — meaning `gpt-5.6-sol` silently ran 5.5 before this change. A dedicated 5.6 resolver now catches these.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm test -- test/documentation.test.ts` (26 passed)
- [x] `npm run build`

Full suite: **5045 passed**, 6 skipped. The 3 failures (`ci-workflows`, `plugin-manifest`, `runtime-rotation-proxy`) are **pre-existing** — verified by stashing this branch and re-running them against clean `main` (`82b36af`), where they fail identically. None touch models, efforts, or pricing.

## Docs and Governance Checklist

- [x] README updated (if user-visible behavior changed) — n/a; model list lives in `docs/configuration.md` + `config/README.md`, both updated
- [ ] `docs/getting-started.md` updated (onboarding flow unchanged)
- [ ] `docs/features.md` updated (no new capability surface)
- [x] relevant `docs/reference/*` pages updated — `docs/configuration.md`
- [ ] `docs/upgrade.md` updated (no migration behavior change)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- **Risk level: low.** Purely additive for existing users. Legacy `gpt-5` still resolves to `gpt-5.5`; `DEFAULT_MODEL` and `QUOTA_PROBE_MODEL_CHAIN` are untouched, so 5.6 is strictly opt-in. The only behavior change to an existing path is the `codex-max` suffix guard, which fixes a bug that would otherwise have been introduced here.
- **Rollback:** revert the single commit; no migrations, no persisted state, no config rewrites.

## Additional Notes

Deliberately **not** included, as each changes behavior for existing users and deserves its own call:

- `DEFAULT_MODEL` still `gpt-5.5` (upstream Codex now defaults to Sol).
- `QUOTA_PROBE_MODEL_CHAIN` unchanged — live/quota probes still hit 5.5 first.
- No unsupported-model fallback chain for 5.6 → 5.5. If an account lacks 5.6 access the request fails rather than degrading. Worth adding if 5.6 access is uneven across accounts.
- No `CHANGELOG.md` entry yet.

5.6 is routed to the `gpt-5.2` prompt family because no `gpt_5_6_prompt.md` exists upstream — 5.6 ships its base instructions inline in `models.json`, and `gpt-5.5` already reuses that family the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017a48odxu9pEVoYpkw3m26V

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds first-class support for gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna with two new reasoning tiers (`max` and `ultra`), where `ultra` is a client-side alias that rewrites to `max` before the wire. also fixes two latent bugs: a codex-max suffix-stripping collision and a silent gpt-5.6-* → 5.5 fallback.

- `ModelReasoningEffort`/`WireReasoningEffort` moved to `lib/constants.ts` as a leaf module to break a latent import cycle; `VARIANT_SUFFIX_PATTERN` in `request-transformer.ts` is now derived from `REASONING_EFFORTS` so a new tier can't be silently missed
- three model profiles added with per-tier effort lists, pricing, and a dedicated `resolveGpt56CatalogModel` resolver; the lookbehind guard `(?<!codex)-(max)` prevents stripping `-max` from `gpt-5.1-codex-max`
- `lib/config.ts` `getUnsupportedCodexFallbackChain` normalizer retains a hardcoded `-(none|minimal|low|medium|high|xhigh)` pattern that was not updated — fallback chain keys written with `-max` or `-ultra` suffixes will not normalize correctly

<h3>Confidence Score: 4/5</h3>

safe to merge for all existing users; the one real defect is confined to an opt-in advanced config feature that no existing users have configured for GPT-5.6 yet

the fallback-chain normalizer in lib/config.ts carries a duplicate hardcoded effort-suffix list that wasn't updated — users who write gpt-5.6-sol-max or gpt-5.6-sol-ultra as keys in unsupportedCodexFallbackChain will silently get no-op fallback behavior because the key stays un-normalized in the map. the rest of the change is correct and well-tested

lib/config.ts line 1244 — the getUnsupportedCodexFallbackChain normalizer

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/constants.ts | adds REASONING_EFFORTS array and ModelReasoningEffort/WireReasoningEffort types as a leaf module; correctly excludes ultra from WireReasoningEffort |
| lib/request/helpers/model-map.ts | adds three GPT-5.6 profiles, addEffortAliases helper, addGpt56Aliases, and resolveGpt56CatalogModel; lookbehind guard on -max is correct; resolver order (codex → 5.6 → general) is safe |
| lib/request/request-transformer.ts | VARIANT_SUFFIX_PATTERN derives from REASONING_EFFORTS and guards -max with lookbehind; ultra→max rewrite before the wire is correct; REASONING_FALLBACKS extended for max/ultra |
| lib/types.ts | ConfigOptions.reasoningEffort widened to ModelReasoningEffort; ReasoningConfig.effort tightened to WireReasoningEffort (excludes ultra); module boundary respected — no import from lib/request/** |
| lib/config.ts | getUnsupportedCodexFallbackChain normalizer has a hardcoded effort-suffix regex that was not updated — max/ultra suffixes on fallback-chain keys won't be stripped, silently breaking the feature for GPT-5.6 entries |
| lib/usage/pricing.ts | adds Sol/Terra/Luna pricing at $5/$30, $2.50/$15, $1/$6 per 1M tokens; cached rates at 10% of input; reasoning rate equals output rate, matching existing pattern |
| config/codex-modern.json | adds all three 5.6 tiers at 372k/128k context/output; Sol and Terra include ultra variant; Luna correctly omits it; no none/minimal variants |
| test/gpt56-models.test.ts | 20 tests covering resolution, effort coercion, suffix parsing, profiles, and pricing; regression test for codex-max suffix guard; missing vitest coverage for config.ts fallback-chain normalizer with max/ultra |
| test/module-boundaries.test.ts | new import-cycle guard using readFileSync + regex; importSpecifiers only matches double-quoted imports so single-quoted would be invisible; safe given ESLint quote enforcement but fragile by construction |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["user config: model = 'gpt-5.6-sol-max'"] --> B["getModelConfig()\nVARIANT_SUFFIX_PATTERN strips -max\n(?<!codex)-(max)"]
    B --> C["model key = 'gpt-5.6-sol'\neffort = 'max'"]
    C --> D["normalizeModel()\nresolveNormalizedModel()"]
    D --> E{In MODEL_MAP?}
    E -- yes --> F["'gpt-5.6-sol' (exact alias)"]
    E -- no --> G["resolveGpt56CatalogModel()\ntokens includes 'terra'? luna? default→sol"]
    F --> H["getModelProfile()\nreturns GPT_5_6_SOL profile\nsupportedEfforts: low/med/high/xhigh/max/ultra"]
    G --> H
    H --> I["coerceReasoningEffort()\n'max' in supportedEfforts → 'max'"]
    I --> J{"coercedEffort === 'ultra'?"}
    J -- yes --> K["wireEffort = 'max'"]
    J -- no --> L["wireEffort = coercedEffort"]
    K --> M["ReasoningConfig { effort: 'max' }"]
    L --> M
    style B fill:#e8f5e9
    style I fill:#e8f5e9
    style K fill:#fff9c4
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["user config: model = 'gpt-5.6-sol-max'"] --> B["getModelConfig()\nVARIANT_SUFFIX_PATTERN strips -max\n(?<!codex)-(max)"]
    B --> C["model key = 'gpt-5.6-sol'\neffort = 'max'"]
    C --> D["normalizeModel()\nresolveNormalizedModel()"]
    D --> E{In MODEL_MAP?}
    E -- yes --> F["'gpt-5.6-sol' (exact alias)"]
    E -- no --> G["resolveGpt56CatalogModel()\ntokens includes 'terra'? luna? default→sol"]
    F --> H["getModelProfile()\nreturns GPT_5_6_SOL profile\nsupportedEfforts: low/med/high/xhigh/max/ultra"]
    G --> H
    H --> I["coerceReasoningEffort()\n'max' in supportedEfforts → 'max'"]
    I --> J{"coercedEffort === 'ultra'?"}
    J -- yes --> K["wireEffort = 'max'"]
    J -- no --> L["wireEffort = coercedEffort"]
    K --> M["ReasoningConfig { effort: 'max' }"]
    L --> M
    style B fill:#e8f5e9
    style I fill:#e8f5e9
    style K fill:#fff9c4
```

</a>

<sub>Reviews (3): Last reviewed commit: ["test(models): derive the suffix-pattern ..."](https://github.com/ndycode/codex-multi-auth/commit/6cffc5764d33ca8445ca50e50db54ec6555e0a28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43156961)</sub>

<!-- /greptile_comment -->