### PR TITLE
fix(auth): make WSL logins work and surface Windows/WSL callback-port contention (#630)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ codex-multi-auth login
 - Requests fail fast after repeated upstream 5xx errors: inspect `codex-multi-auth report --json` for runtime traffic and cooldown details
 - Storage cleanup fails with `EBUSY` / `EPERM` (Windows): run `codex-multi-auth doctor --fix` to retry, or manually remove `~/.codex/multi-auth/<project-key>/` and re-login
 - OAuth callback on port `1455` fails: free the port and re-run `codex-multi-auth login`
+- Login hangs in WSL, or installing in WSL breaks a working Windows install: Windows and WSL contend for callback port `1455`, and the browser opens on the Windows host either way — see [Windows and WSL side by side](docs/troubleshooting.md#windows-and-wsl-side-by-side), or use `codex-multi-auth login --device-auth`, which needs no callback port
 - Browser launch is blocked or you are in a headless shell: prefer `codex-multi-auth login --device-auth`; use `codex-multi-auth login --manual` or `CODEX_AUTH_NO_BROWSER=1` only when you need the callback-paste fallback
 - `missing field id_token` / `token_expired` / `refresh_token_reused`: re-login affected account
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,8 +71,10 @@ side is holding that port — an in-progress login, a leftover callback server, 
 running proxy — it will receive the redirect that the WSL listener is waiting for.
 
 The failure is silent from inside the distro: the WSL listener binds cleanly and
-simply never sees the callback, so login appears to hang. `codex-multi-auth` now
-detects this and prints the conflict instead of stalling.
+simply never sees the callback, so login appears to hang. It is waiting — the
+callback poll runs for five minutes before giving up, and `codex-multi-auth` then
+explains the likely conflict and drops you into the manual-paste fallback. If you
+would rather not wait it out, press Ctrl+C and use `--device-auth` below.
 
 To find the listener, check **both** sides:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,6 +56,46 @@ The package does not publish a global `codex` binary. `codex-multi-auth ...` is 
 | `missing field id_token` | Stale or malformed auth payload | Re-login the affected account |
 | `refresh_token_reused` | The token pair rotated in another context | Re-login the affected account |
 | `token_expired` | The refresh token is no longer valid | Re-login the affected account |
+| Login hangs in WSL, or breaks after installing on both Windows and WSL | Windows and WSL contend for callback port `1455` | See [Windows And WSL Side By Side](#windows-and-wsl-side-by-side) |
+
+### Windows And WSL Side By Side
+
+Installing `codex-multi-auth` on a Windows host **and** inside WSL is supported, but
+only one of them can run a browser login at a time.
+
+The OAuth redirect URI is registered with the provider as
+`http://localhost:1455/auth/callback`, so the callback port is fixed and cannot be
+changed. A browser launched from WSL still runs on the Windows host, and Windows
+resolves `localhost:1455` against its own loopback first. If anything on the Windows
+side is holding that port — an in-progress login, a leftover callback server, a
+running proxy — it will receive the redirect that the WSL listener is waiting for.
+
+The failure is silent from inside the distro: the WSL listener binds cleanly and
+simply never sees the callback, so login appears to hang. `codex-multi-auth` now
+detects this and prints the conflict instead of stalling.
+
+To find the listener, check **both** sides:
+
+```powershell
+# Windows (PowerShell)
+Get-NetTCPConnection -LocalPort 1455
+```
+
+```bash
+# WSL
+ss -lptn 'sport = :1455'
+```
+
+Close the login or proxy on the other side, then retry. If you need both environments
+signed in without coordinating the port, use the device-code flow, which never binds
+a callback port:
+
+```bash
+codex-multi-auth login --device-auth
+```
+
+Accounts are stored per environment: the Windows and WSL installs keep separate state
+directories and do not share saved accounts. Sign in to each one independently.
 
 ---
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -26,7 +26,11 @@
 	"ignoreBinaries": [
 		"powershell.exe",
 		"pbcopy",
-		"where"
+		"where",
+		// WSL host bridges: spawned only when running inside WSL, where the
+		// browser and clipboard belong to the Windows host.
+		"wslview",
+		"clip.exe"
 	],
 	"ignoreDependencies": [
 		// Editor-only LSP tooling; never imported.

--- a/lib/auth/browser.ts
+++ b/lib/auth/browser.ts
@@ -124,6 +124,9 @@ function spawnPowerShell(command: string, stdinText?: string): boolean {
 	);
 	child.on("error", () => {});
 	if (stdinText !== undefined) {
+		// A child that dies before draining stdin emits EPIPE on the stream, not
+		// on the child. Unhandled, that is an async throw no try/catch can catch.
+		child.stdin?.on("error", () => {});
 		child.stdin?.end(stdinText);
 	}
 	return true;
@@ -216,6 +219,7 @@ export function copyTextToClipboard(text: string): boolean {
 					shell: false,
 				});
 				child.on("error", () => {});
+				child.stdin?.on("error", () => {});
 				child.stdin?.end(text);
 				return true;
 			}
@@ -234,6 +238,7 @@ export function copyTextToClipboard(text: string): boolean {
 				shell: false,
 			});
 			child.on("error", () => {});
+			child.stdin?.on("error", () => {});
 			child.stdin?.end(text);
 			return true;
 		}
@@ -250,6 +255,7 @@ export function copyTextToClipboard(text: string): boolean {
 				shell: false,
 			});
 			child.on("error", () => {});
+			child.stdin?.on("error", () => {});
 			child.stdin?.end(text);
 			return true;
 		}

--- a/lib/auth/browser.ts
+++ b/lib/auth/browser.ts
@@ -7,6 +7,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { PLATFORM_OPENERS } from "../constants.js";
+import { isWsl } from "../wsl.js";
 
 const BROWSER_DISABLED_VALUES = new Set(["0", "false", "no", "off", "none"]);
 const NO_BROWSER_TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
@@ -92,6 +93,43 @@ function commandExists(command: string): boolean {
 }
 
 /**
+ * Escape a value for safe interpolation into a double-quoted PowerShell string.
+ *
+ * Neutralizes backticks, `$` sub-expression injection, and embedded double quotes.
+ */
+function escapeForPowerShell(value: string): string {
+	return value.replace(/`/g, "``").replace(/\$/g, "`$").replace(/"/g, '""');
+}
+
+/**
+ * Run a PowerShell command, fire-and-forget.
+ *
+ * Reachable from Windows and from WSL, where `powershell.exe` resolves through
+ * Windows/Linux PATH interop.
+ *
+ * @param command - A PowerShell command string; interpolated values must already be escaped.
+ * @param stdinText - Optional text piped to the command's stdin.
+ * @returns `true` if the spawn was attempted, `false` if PowerShell is unavailable.
+ */
+function spawnPowerShell(command: string, stdinText?: string): boolean {
+	if (!commandExists("powershell.exe")) {
+		return false;
+	}
+	const child = spawn(
+		"powershell.exe",
+		["-NoLogo", "-NoProfile", "-Command", command],
+		{
+			stdio: stdinText === undefined ? "ignore" : ["pipe", "ignore", "ignore"],
+		},
+	);
+	child.on("error", () => {});
+	if (stdinText !== undefined) {
+		child.stdin?.end(stdinText);
+	}
+	return true;
+}
+
+/**
  * Launches the user's default browser to open the provided URL using a platform-appropriate command.
  *
  * This is a best-effort, fire-and-forget launcher: it attempts a platform-specific spawn and ignores
@@ -99,6 +137,10 @@ function commandExists(command: string): boolean {
  * escaping to reduce shell/filesystem quirks. Callers must redact any sensitive tokens (for example,
  * OAuth codes) from `url` before calling. Invocations are not atomic—concurrent calls may race but are
  * safe to perform.
+ *
+ * Under WSL the browser lives on the Windows host, so `xdg-open` is the wrong tool and is usually not
+ * even installed. Prefer `wslview` (wslu), then Windows PowerShell via interop, before falling back to
+ * the Linux opener.
  *
  * @param url - The URL to open; redact sensitive tokens (e.g., OAuth codes) before passing.
  * @returns `true` if a browser launch was attempted, `false` if no suitable opener was available or an exception occurred.
@@ -111,23 +153,24 @@ export function openBrowserUrl(url: string): boolean {
 
 		// Windows: use PowerShell Start-Process to avoid cmd/start quirks with URLs containing '&' or ':'
 		if (process.platform === "win32") {
-			if (!commandExists("powershell.exe")) {
-				return false;
-			}
-			// Escape PowerShell special characters: backticks, double quotes, and $ (sub-expression injection)
-			const psUrl = url
-				.replace(/`/g, "``")
-				.replace(/\$/g, "`$")
-				.replace(/"/g, '""');
-			const child = spawn(
-				"powershell.exe",
-				["-NoLogo", "-NoProfile", "-Command", `Start-Process "${psUrl}"`],
-				{ stdio: "ignore" },
-			);
-			child.on("error", () => {});
-			return true;
+			return spawnPowerShell(`Start-Process "${escapeForPowerShell(url)}"`);
 		}
 
+		if (isWsl()) {
+			// wslu's browser shim: hands the URL to the Windows default browser.
+			if (commandExists("wslview")) {
+				const child = spawn("wslview", [url], {
+					stdio: "ignore",
+					shell: false,
+				});
+				child.on("error", () => {});
+				return true;
+			}
+			if (spawnPowerShell(`Start-Process "${escapeForPowerShell(url)}"`)) {
+				return true;
+			}
+			// Fall through: an X/Wayland browser inside the distro is still possible.
+		}
 
 		const opener = getBrowserOpener();
 		if (!commandExists(opener)) {
@@ -160,20 +203,28 @@ export function copyTextToClipboard(text: string): boolean {
 		if (!text) return false;
 
 		if (process.platform === "win32") {
-			if (!commandExists("powershell.exe")) {
-				return false;
-			}
-			const psText = text
-				.replace(/`/g, "``")
-				.replace(/\$/g, "`$")
-				.replace(/"/g, '""');
-			const child = spawn(
-				"powershell.exe",
-				["-NoLogo", "-NoProfile", "-Command", `Set-Clipboard -Value "${psText}"`],
-				{ stdio: "ignore" },
+			return spawnPowerShell(
+				`Set-Clipboard -Value "${escapeForPowerShell(text)}"`,
 			);
-			child.on("error", () => {});
-			return true;
+		}
+
+		if (isWsl()) {
+			// The clipboard the user pastes from is the Windows one, not the distro's.
+			if (commandExists("clip.exe")) {
+				const child = spawn("clip.exe", [], {
+					stdio: ["pipe", "ignore", "ignore"],
+					shell: false,
+				});
+				child.on("error", () => {});
+				child.stdin?.end(text);
+				return true;
+			}
+			if (
+				spawnPowerShell(`Set-Clipboard -Value "${escapeForPowerShell(text)}"`)
+			) {
+				return true;
+			}
+			// Fall through to the Linux clipboard tools.
 		}
 
 		if (process.platform === "darwin") {

--- a/lib/auth/callback-guidance.ts
+++ b/lib/auth/callback-guidance.ts
@@ -3,7 +3,7 @@
  *
  * The redirect URI is registered with the provider, so the port cannot be
  * negotiated away when it is contended. The best the CLI can do is name the
- * conflict and point at a flow that does not need the port at all.
+ * likely conflict and point at a flow that does not need the port at all.
  *
  * Windows and WSL contend for that port as far as a browser running on the
  * Windows host is concerned, so a listener on either side can swallow a callback
@@ -29,16 +29,55 @@ export type CallbackFailureContext = {
 };
 
 const INSPECT_WINDOWS = `  Windows (PowerShell):  Get-NetTCPConnection -LocalPort ${AUTH_REDIRECT.port}`;
-const INSPECT_LINUX = `  WSL / Linux:           ss -lptn 'sport = :${AUTH_REDIRECT.port}'`;
+const INSPECT_LINUX = `  Linux / WSL:           ss -lptn 'sport = :${AUTH_REDIRECT.port}'`;
+const INSPECT_DARWIN = `  macOS:                 lsof -nP -iTCP:${AUTH_REDIRECT.port} -sTCP:LISTEN`;
 const USE_DEVICE_AUTH =
 	"  Or sign in without the callback port: codex-multi-auth login --device-auth";
 
 /**
+ * The commands that would reveal a listener on the callback port here.
+ *
+ * Inside WSL both sides of the boundary are worth checking, because the
+ * offending listener is usually the one on the Windows host.
+ */
+function inspectCommands(): string[] {
+	if (isWsl()) return [INSPECT_WINDOWS, INSPECT_LINUX];
+	if (process.platform === "win32") return [INSPECT_WINDOWS];
+	if (process.platform === "darwin") return [INSPECT_DARWIN];
+	return [INSPECT_LINUX];
+}
+
+/**
+ * Why a listener on the other side of the Windows/WSL boundary may be at fault.
+ *
+ * @returns Explanatory lines, or an empty array when no WSL boundary is in play.
+ */
+function crossBoundaryNote(): string[] {
+	if (isWsl()) {
+		const distro = getWslDistroName();
+		const where = distro ? `WSL (${distro})` : "WSL";
+		return [
+			`You are running inside ${where}, but the browser opens on the Windows host.`,
+			`Windows and ${where} contend for localhost:${AUTH_REDIRECT.port}, so a codex-multi-auth`,
+			"or Codex login or proxy on the Windows side can take the callback meant for this one.",
+		];
+	}
+	if (process.platform === "win32") {
+		return [
+			`A codex-multi-auth login or proxy running inside WSL can also hold port ${AUTH_REDIRECT.port}.`,
+		];
+	}
+	return [];
+}
+
+/**
  * Build the lines shown to the user when a browser OAuth callback fails.
  *
- * Port contention is only asserted when it is actually observed (`EADDRINUSE`)
- * or when the callback never arrived despite a clean bind — the shape of a
- * cross-boundary Windows/WSL hijack.
+ * Contention is only *asserted* when it was actually observed — that is, the
+ * listen failed with `EADDRINUSE`. A callback that never arrives is far more
+ * often a cancelled or abandoned sign-in than a stolen redirect, so that case
+ * is phrased as a conditional ("if you completed sign-in and still landed
+ * here") rather than a diagnosis.
  *
  * @param reason - Which half of the callback flow broke.
  * @param context - Extra detail from the failed bind, when available.
@@ -49,60 +88,44 @@ export function describeCallbackFailure(
 	context: CallbackFailureContext = {},
 ): string[] {
 	const port = AUTH_REDIRECT.port;
-	const portIsContended =
-		reason === "callback-timeout" || context.bindErrorCode === "EADDRINUSE";
-	const lines: string[] = [];
 
 	if (reason === "bind-failed") {
-		lines.push(
-			portIsContended
-				? `Could not listen on port ${port} for the OAuth callback — something else already holds it.`
-				: `Could not listen on port ${port} for the OAuth callback${
-						context.bindErrorCode ? ` (${context.bindErrorCode})` : ""
-					}.`,
-		);
-	} else {
-		lines.push(
-			`No OAuth callback arrived on port ${port} before the sign-in window closed.`,
-		);
-	}
+		// A failed listen is hard evidence: something is on the port right now.
+		if (context.bindErrorCode === "EADDRINUSE") {
+			return [
+				`Could not listen on port ${port} for the OAuth callback — another process already holds it.`,
+				...crossBoundaryNote(),
+				"",
+				`Find the listener:`,
+				...inspectCommands(),
+				"",
+				"Close it, then retry.",
+				USE_DEVICE_AUTH,
+			];
+		}
 
-	if (!portIsContended) {
-		lines.push(
+		return [
+			`Could not listen on port ${port} for the OAuth callback${
+				context.bindErrorCode ? ` (${context.bindErrorCode})` : ""
+			}.`,
 			"",
-			`The callback port is fixed by the provider and cannot be changed.`,
+			"The callback port is fixed by the provider and cannot be changed.",
 			USE_DEVICE_AUTH,
-		);
-		return lines;
+		];
 	}
 
-	if (isWsl()) {
-		const distro = getWslDistroName();
-		const where = distro ? `WSL (${distro})` : "WSL";
-		lines.push(
-			`You are running inside ${where}, but the browser opens on the Windows host.`,
-			`Windows and ${where} contend for localhost:${port}, so a codex-multi-auth or Codex`,
-			"login or proxy running on the Windows side can take the callback meant for this one.",
-			"From in here that is indistinguishable from a broken login.",
-			"",
-			`Check both sides for a listener on port ${port}:`,
-			INSPECT_WINDOWS,
-			INSPECT_LINUX,
-			"",
-			"Close the Windows-side login or proxy, then retry.",
-			USE_DEVICE_AUTH,
-		);
-		return lines;
-	}
-
-	lines.push(
+	// The listener bound cleanly and nothing arrived. Usually the sign-in was
+	// simply cancelled or abandoned — say so first, and do not misdiagnose it.
+	return [
+		`No OAuth callback arrived on port ${port} before the sign-in window closed.`,
 		"",
-		`Check for another process holding port ${port}:`,
-		process.platform === "win32" ? INSPECT_WINDOWS : INSPECT_LINUX,
+		"If you closed or cancelled the browser sign-in, just run login again.",
 		"",
-		"On a Windows host, a codex-multi-auth login or proxy running inside WSL can also hold it.",
-		"Close the other listener, then retry.",
+		"If you completed sign-in in the browser and still landed here, something else",
+		`may have taken the callback on port ${port}:`,
+		...crossBoundaryNote(),
+		...inspectCommands(),
+		"",
 		USE_DEVICE_AUTH,
-	);
-	return lines;
+	];
 }

--- a/lib/auth/callback-guidance.ts
+++ b/lib/auth/callback-guidance.ts
@@ -1,0 +1,108 @@
+/**
+ * Operator-facing guidance for OAuth callback failures on the fixed callback port.
+ *
+ * The redirect URI is registered with the provider, so the port cannot be
+ * negotiated away when it is contended. The best the CLI can do is name the
+ * conflict and point at a flow that does not need the port at all.
+ *
+ * Windows and WSL contend for that port as far as a browser running on the
+ * Windows host is concerned, so a listener on either side can swallow a callback
+ * intended for the other. From inside the distro this is invisible: the WSL
+ * listener binds cleanly and simply never receives the redirect.
+ */
+
+import { AUTH_REDIRECT } from "./auth.js";
+import { getWslDistroName, isWsl } from "../wsl.js";
+
+/**
+ * Why the browser callback did not produce an authorization code.
+ *
+ * - `bind-failed`: the local listener could not take the callback port at all.
+ * - `callback-timeout`: the listener bound, but no redirect ever arrived.
+ */
+export type CallbackFailureReason = "bind-failed" | "callback-timeout";
+
+/** @internal */
+export type CallbackFailureContext = {
+	/** `errno` code from a failed listen, when one is known. */
+	bindErrorCode?: string;
+};
+
+const INSPECT_WINDOWS = `  Windows (PowerShell):  Get-NetTCPConnection -LocalPort ${AUTH_REDIRECT.port}`;
+const INSPECT_LINUX = `  WSL / Linux:           ss -lptn 'sport = :${AUTH_REDIRECT.port}'`;
+const USE_DEVICE_AUTH =
+	"  Or sign in without the callback port: codex-multi-auth login --device-auth";
+
+/**
+ * Build the lines shown to the user when a browser OAuth callback fails.
+ *
+ * Port contention is only asserted when it is actually observed (`EADDRINUSE`)
+ * or when the callback never arrived despite a clean bind — the shape of a
+ * cross-boundary Windows/WSL hijack.
+ *
+ * @param reason - Which half of the callback flow broke.
+ * @param context - Extra detail from the failed bind, when available.
+ * @returns Guidance lines. Empty strings are intentional blank separators.
+ */
+export function describeCallbackFailure(
+	reason: CallbackFailureReason,
+	context: CallbackFailureContext = {},
+): string[] {
+	const port = AUTH_REDIRECT.port;
+	const portIsContended =
+		reason === "callback-timeout" || context.bindErrorCode === "EADDRINUSE";
+	const lines: string[] = [];
+
+	if (reason === "bind-failed") {
+		lines.push(
+			portIsContended
+				? `Could not listen on port ${port} for the OAuth callback — something else already holds it.`
+				: `Could not listen on port ${port} for the OAuth callback${
+						context.bindErrorCode ? ` (${context.bindErrorCode})` : ""
+					}.`,
+		);
+	} else {
+		lines.push(
+			`No OAuth callback arrived on port ${port} before the sign-in window closed.`,
+		);
+	}
+
+	if (!portIsContended) {
+		lines.push(
+			"",
+			`The callback port is fixed by the provider and cannot be changed.`,
+			USE_DEVICE_AUTH,
+		);
+		return lines;
+	}
+
+	if (isWsl()) {
+		const distro = getWslDistroName();
+		const where = distro ? `WSL (${distro})` : "WSL";
+		lines.push(
+			`You are running inside ${where}, but the browser opens on the Windows host.`,
+			`Windows and ${where} contend for localhost:${port}, so a codex-multi-auth or Codex`,
+			"login or proxy running on the Windows side can take the callback meant for this one.",
+			"From in here that is indistinguishable from a broken login.",
+			"",
+			`Check both sides for a listener on port ${port}:`,
+			INSPECT_WINDOWS,
+			INSPECT_LINUX,
+			"",
+			"Close the Windows-side login or proxy, then retry.",
+			USE_DEVICE_AUTH,
+		);
+		return lines;
+	}
+
+	lines.push(
+		"",
+		`Check for another process holding port ${port}:`,
+		process.platform === "win32" ? INSPECT_WINDOWS : INSPECT_LINUX,
+		"",
+		"On a Windows host, a codex-multi-auth login or proxy running inside WSL can also hold it.",
+		"Close the other listener, then retry.",
+		USE_DEVICE_AUTH,
+	);
+	return lines;
+}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -134,6 +134,7 @@ export function startLocalOAuthServer({
 				resolve({
 					port: AUTH_REDIRECT.port,
 					ready: false,
+					bindErrorCode: err?.code,
 					close: () => {
 						pollAborted = true;
 						try {

--- a/lib/codex-manager/login-oauth.ts
+++ b/lib/codex-manager/login-oauth.ts
@@ -22,6 +22,7 @@ import {
 import { runDeviceAuthFlow } from "../auth/device-auth.js";
 import { resolveOrgOverride } from "../auth/org-override.js";
 import { startLocalOAuthServer } from "../auth/server.js";
+import { describeCallbackFailure } from "../auth/callback-guidance.js";
 import { setCodexCliActiveSelection } from "../codex-cli/writer.js";
 import { createLogger } from "../logger.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
@@ -344,6 +345,20 @@ export async function runOAuthFlow(
 					"warning",
 				),
 			);
+
+			// Explain *why* the callback failed before dropping the user into the
+			// manual-paste prompt. A contended port 1455 — most often a Windows
+			// listener shadowing a WSL one, or vice versa — otherwise presents as
+			// an unexplained broken login.
+			if (signInMode === "browser") {
+				const failureLines = describeCallbackFailure(
+					waitingForCallback ? "callback-timeout" : "bind-failed",
+					{ bindErrorCode: oauthServer?.bindErrorCode },
+				);
+				for (const line of failureLines) {
+					console.log(line.length > 0 ? stylePromptText(line, "muted") : "");
+				}
+			}
 			const manualResult = await promptManualCallback(state, {
 				allowNonTty: signInMode === "manual",
 			});

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -139,6 +139,12 @@ export type TextFormatConfig =
 export interface OAuthServerInfo {
 	port: number;
 	ready: boolean;
+	/**
+	 * The `errno` code from a failed listen (for example `EADDRINUSE`) when
+	 * `ready` is `false`. Lets callers distinguish a contended callback port
+	 * from other bind failures. Absent when `ready` is `true`.
+	 */
+	bindErrorCode?: string;
 	close: () => void;
 	waitForCode: (state: string) => Promise<{ code: string } | null>;
 }

--- a/lib/wsl.ts
+++ b/lib/wsl.ts
@@ -1,0 +1,64 @@
+/**
+ * WSL (Windows Subsystem for Linux) detection.
+ *
+ * WSL reports `process.platform === "linux"`, so every platform switch in this
+ * package treats it as a native Linux host. That is wrong for anything crossing
+ * the Windows boundary: the default browser, the clipboard, and the loopback
+ * interface that receives the OAuth callback all belong to the Windows host
+ * rather than to the distro.
+ */
+
+import fs from "node:fs";
+
+let cachedIsWsl: boolean | undefined;
+
+function detectWsl(): boolean {
+	if (process.platform !== "linux") return false;
+
+	// Set by WSL itself; present in every interop-enabled distro shell.
+	if (
+		(process.env.WSL_DISTRO_NAME ?? "").length > 0 ||
+		(process.env.WSL_INTEROP ?? "").length > 0
+	) {
+		return true;
+	}
+
+	// Fallback for shells that strip the environment (systemd units, cron).
+	try {
+		return /microsoft|wsl/i.test(fs.readFileSync("/proc/version", "utf-8"));
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Whether the current process is running inside WSL.
+ *
+ * The result is cached because it cannot change within a process lifetime.
+ */
+export function isWsl(): boolean {
+	if (cachedIsWsl === undefined) {
+		cachedIsWsl = detectWsl();
+	}
+	return cachedIsWsl;
+}
+
+/**
+ * The WSL distro name (for example `Debian`), when WSL exposes it.
+ *
+ * @returns The distro name, or `undefined` outside WSL or when unset.
+ */
+export function getWslDistroName(): string | undefined {
+	if (!isWsl()) return undefined;
+	const name = (process.env.WSL_DISTRO_NAME ?? "").trim();
+	return name.length > 0 ? name : undefined;
+}
+
+/**
+ * Clear the memoized {@link isWsl} result.
+ *
+ * @internal Test seam — production code must not call this.
+ */
+export function resetWslDetectionCache(): void {
+	cachedIsWsl = undefined;
+}

--- a/lib/wsl.ts
+++ b/lib/wsl.ts
@@ -59,6 +59,6 @@ export function getWslDistroName(): string | undefined {
  *
  * @internal Test seam — production code must not call this.
  */
-export function resetWslDetectionCache(): void {
+export function resetWslDetectionCacheForTests(): void {
 	cachedIsWsl = undefined;
 }

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -8,23 +8,35 @@ import {
 	copyTextToClipboard,
 } from "../lib/auth/browser.js";
 import { PLATFORM_OPENERS } from "../lib/constants.js";
-import { resetWslDetectionCache } from "../lib/wsl.js";
+import { resetWslDetectionCacheForTests } from "../lib/wsl.js";
 
 vi.mock("node:child_process", () => ({
 	spawn: vi.fn(() => ({
 		on: vi.fn(),
-		stdin: { end: vi.fn() },
+		stdin: { end: vi.fn(), on: vi.fn() },
 	})),
 }));
 
-vi.mock("node:fs", () => ({
-	default: {
+// readFileSync is stubbed to throw so that isWsl()'s /proc/version fallback
+// resolves to false explicitly. Without it, these native-host assertions would
+// depend on readFileSync being absent from the mock and the resulting TypeError
+// being swallowed — which would silently break for anyone running the suite
+// from inside WSL.
+vi.mock("node:fs", () => {
+	const readFileSync = vi.fn(() => {
+		throw new Error("ENOENT");
+	});
+	return {
+		default: {
+			existsSync: vi.fn(),
+			statSync: vi.fn(),
+			readFileSync,
+		},
 		existsSync: vi.fn(),
 		statSync: vi.fn(),
-	},
-	existsSync: vi.fn(),
-	statSync: vi.fn(),
-}));
+		readFileSync,
+	};
+});
 
 const mockedSpawn = vi.mocked(spawn);
 const mockedExistsSync = vi.mocked(fs.existsSync);
@@ -50,7 +62,7 @@ describe("auth browser utilities", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		resetWslDetectionCache();
+		resetWslDetectionCacheForTests();
 		// These assertions describe a native host. Running the suite from inside
 		// WSL must not silently reroute them through the Windows interop paths.
 		delete process.env.WSL_DISTRO_NAME;
@@ -63,7 +75,7 @@ describe("auth browser utilities", () => {
 	});
 
 	afterEach(() => {
-		resetWslDetectionCache();
+		resetWslDetectionCacheForTests();
 		Object.defineProperty(process, "platform", { value: originalPlatform });
 		if (originalDistro === undefined) delete process.env.WSL_DISTRO_NAME;
 		else process.env.WSL_DISTRO_NAME = originalDistro;
@@ -394,7 +406,7 @@ describe("auth browser utilities under WSL", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		resetWslDetectionCache();
+		resetWslDetectionCacheForTests();
 		// WSL reports itself as linux; the distro env var is what gives it away.
 		Object.defineProperty(process, "platform", { value: "linux" });
 		process.env.PATH = "/usr/bin";
@@ -404,7 +416,7 @@ describe("auth browser utilities under WSL", () => {
 	});
 
 	afterEach(() => {
-		resetWslDetectionCache();
+		resetWslDetectionCacheForTests();
 		Object.defineProperty(process, "platform", { value: originalPlatform });
 		if (originalPath === undefined) delete process.env.PATH;
 		else process.env.PATH = originalPath;

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -8,6 +8,7 @@ import {
 	copyTextToClipboard,
 } from "../lib/auth/browser.js";
 import { PLATFORM_OPENERS } from "../lib/constants.js";
+import { resetWslDetectionCache } from "../lib/wsl.js";
 
 vi.mock("node:child_process", () => ({
 	spawn: vi.fn(() => ({
@@ -44,9 +45,16 @@ describe("auth browser utilities", () => {
 	const originalPathExt = process.env.PATHEXT;
 	const originalNoBrowser = process.env.CODEX_AUTH_NO_BROWSER;
 	const originalBrowser = process.env.BROWSER;
+	const originalDistro = process.env.WSL_DISTRO_NAME;
+	const originalInterop = process.env.WSL_INTEROP;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		resetWslDetectionCache();
+		// These assertions describe a native host. Running the suite from inside
+		// WSL must not silently reroute them through the Windows interop paths.
+		delete process.env.WSL_DISTRO_NAME;
+		delete process.env.WSL_INTEROP;
 		mockedExistsSync.mockReturnValue(false);
 		mockedStatSync.mockReturnValue({
 			isFile: () => true,
@@ -55,7 +63,12 @@ describe("auth browser utilities", () => {
 	});
 
 	afterEach(() => {
+		resetWslDetectionCache();
 		Object.defineProperty(process, "platform", { value: originalPlatform });
+		if (originalDistro === undefined) delete process.env.WSL_DISTRO_NAME;
+		else process.env.WSL_DISTRO_NAME = originalDistro;
+		if (originalInterop === undefined) delete process.env.WSL_INTEROP;
+		else process.env.WSL_INTEROP = originalInterop;
 		if (originalPath === undefined) delete process.env.PATH;
 		else process.env.PATH = originalPath;
 		if (originalPathExt === undefined) delete process.env.PATHEXT;
@@ -357,5 +370,130 @@ describe("auth browser utilities", () => {
 
 			expect(copyTextToClipboard("hello")).toBe(false);
 		});
+	});
+});
+
+describe("auth browser utilities under WSL", () => {
+	const url = "https://auth.openai.com/oauth/authorize";
+	const originalPlatform = process.platform;
+	const originalPath = process.env.PATH;
+	const originalDistro = process.env.WSL_DISTRO_NAME;
+	const originalNoBrowser = process.env.CODEX_AUTH_NO_BROWSER;
+	const originalBrowser = process.env.BROWSER;
+
+	/** Make only the named executables resolvable on PATH. */
+	function onlyOnPath(...names: string[]): void {
+		mockedStatSync.mockImplementation(((candidate: unknown) => {
+			const resolved = String(candidate);
+			if (names.some((name) => resolved.endsWith(name))) {
+				return { isFile: () => true, mode: 0o755 };
+			}
+			throw new Error("ENOENT");
+		}) as unknown as typeof fs.statSync);
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetWslDetectionCache();
+		// WSL reports itself as linux; the distro env var is what gives it away.
+		Object.defineProperty(process, "platform", { value: "linux" });
+		process.env.PATH = "/usr/bin";
+		process.env.WSL_DISTRO_NAME = "Debian";
+		delete process.env.CODEX_AUTH_NO_BROWSER;
+		delete process.env.BROWSER;
+	});
+
+	afterEach(() => {
+		resetWslDetectionCache();
+		Object.defineProperty(process, "platform", { value: originalPlatform });
+		if (originalPath === undefined) delete process.env.PATH;
+		else process.env.PATH = originalPath;
+		if (originalDistro === undefined) delete process.env.WSL_DISTRO_NAME;
+		else process.env.WSL_DISTRO_NAME = originalDistro;
+		if (originalNoBrowser === undefined)
+			delete process.env.CODEX_AUTH_NO_BROWSER;
+		else process.env.CODEX_AUTH_NO_BROWSER = originalNoBrowser;
+		if (originalBrowser === undefined) delete process.env.BROWSER;
+		else process.env.BROWSER = originalBrowser;
+	});
+
+	it("opens the Windows browser through wslview when it is available", () => {
+		onlyOnPath("wslview");
+
+		expect(openBrowserUrl(url)).toBe(true);
+		expect(mockedSpawn).toHaveBeenCalledWith("wslview", [url], {
+			stdio: "ignore",
+			shell: false,
+		});
+	});
+
+	it("falls back to Windows PowerShell interop when wslview is missing", () => {
+		onlyOnPath("powershell.exe");
+
+		expect(openBrowserUrl(url)).toBe(true);
+		expect(mockedSpawn).toHaveBeenCalledWith(
+			"powershell.exe",
+			["-NoLogo", "-NoProfile", "-Command", `Start-Process "${url}"`],
+			{ stdio: "ignore" },
+		);
+	});
+
+	it("falls back to the linux opener when no Windows bridge is present", () => {
+		onlyOnPath(PLATFORM_OPENERS.linux);
+
+		expect(openBrowserUrl(url)).toBe(true);
+		expect(mockedSpawn).toHaveBeenCalledWith(PLATFORM_OPENERS.linux, [url], {
+			stdio: "ignore",
+			shell: false,
+		});
+	});
+
+	it("reports failure when neither a Windows bridge nor xdg-open exists", () => {
+		// The pre-fix behaviour on a stock WSL Debian: xdg-open is not installed,
+		// so no browser ever opened and login appeared to hang.
+		onlyOnPath("nothing-resolvable");
+
+		expect(openBrowserUrl(url)).toBe(false);
+		expect(mockedSpawn).not.toHaveBeenCalled();
+	});
+
+	it("still honours browser suppression inside WSL", () => {
+		process.env.CODEX_AUTH_NO_BROWSER = "1";
+		onlyOnPath("wslview");
+
+		expect(openBrowserUrl(url)).toBe(false);
+		expect(mockedSpawn).not.toHaveBeenCalled();
+	});
+
+	it("copies to the Windows clipboard through clip.exe", () => {
+		onlyOnPath("clip.exe");
+
+		expect(copyTextToClipboard(url)).toBe(true);
+		expect(mockedSpawn).toHaveBeenCalledWith("clip.exe", [], {
+			stdio: ["pipe", "ignore", "ignore"],
+			shell: false,
+		});
+		expectLastSpawnStdinEndWith(url);
+	});
+
+	it("falls back to PowerShell Set-Clipboard when clip.exe is missing", () => {
+		onlyOnPath("powershell.exe");
+
+		expect(copyTextToClipboard(url)).toBe(true);
+		expect(mockedSpawn).toHaveBeenCalledWith(
+			"powershell.exe",
+			["-NoLogo", "-NoProfile", "-Command", `Set-Clipboard -Value "${url}"`],
+			{ stdio: "ignore" },
+		);
+	});
+
+	it("escapes PowerShell metacharacters in the interop command", () => {
+		onlyOnPath("powershell.exe");
+
+		expect(openBrowserUrl('https://example.com/?a=$x&b=`y"z')).toBe(true);
+		const command = mockedSpawn.mock.calls.at(-1)?.[1] as string[];
+		expect(command[3]).toBe(
+			'Start-Process "https://example.com/?a=`$x&b=``y""z"',
+		);
 	});
 });

--- a/test/callback-guidance.test.ts
+++ b/test/callback-guidance.test.ts
@@ -22,6 +22,7 @@ describe("describeCallbackFailure", () => {
 		vi.clearAllMocks();
 		mockedIsWsl.mockReturnValue(false);
 		mockedDistro.mockReturnValue(undefined);
+		Object.defineProperty(process, "platform", { value: "linux" });
 	});
 
 	afterEach(() => {
@@ -36,64 +37,98 @@ describe("describeCallbackFailure", () => {
 		}
 	});
 
-	it("names port contention when the bind actually failed with EADDRINUSE", () => {
-		const text = asText(
-			describeCallbackFailure("bind-failed", { bindErrorCode: "EADDRINUSE" }),
-		);
+	describe("contention is only asserted when it was actually observed", () => {
+		it("asserts contention on EADDRINUSE, which is hard evidence", () => {
+			const text = asText(
+				describeCallbackFailure("bind-failed", { bindErrorCode: "EADDRINUSE" }),
+			);
 
-		expect(text).toContain(`port ${AUTH_REDIRECT.port}`);
-		expect(text).toContain("already holds it");
+			expect(text).toContain("another process already holds it");
+			expect(text).toContain(`port ${AUTH_REDIRECT.port}`);
+		});
+
+		it("does not claim contention for unrelated bind errors", () => {
+			const text = asText(
+				describeCallbackFailure("bind-failed", { bindErrorCode: "EACCES" }),
+			);
+
+			expect(text).toContain("EACCES");
+			expect(text).not.toContain("already holds it");
+			expect(text).not.toContain("ss -lptn");
+		});
+
+		it("does not diagnose a cancelled or abandoned sign-in as port contention", () => {
+			// A clean bind with no redirect is far more often a closed browser tab
+			// than a stolen callback. Leading with a confident contention story
+			// would misdiagnose the common case.
+			const text = asText(describeCallbackFailure("callback-timeout"));
+
+			expect(text).toContain("If you closed or cancelled the browser sign-in");
+			expect(text).not.toContain("another process already holds it");
+			// The contention explanation is offered conditionally, not asserted.
+			expect(text).toContain("If you completed sign-in in the browser");
+		});
 	});
 
-	it("does not claim contention for unrelated bind errors", () => {
-		const text = asText(
-			describeCallbackFailure("bind-failed", { bindErrorCode: "EACCES" }),
-		);
+	describe("platform-appropriate inspection commands", () => {
+		it("gives macOS lsof, never the Linux-only ss", () => {
+			Object.defineProperty(process, "platform", { value: "darwin" });
 
-		expect(text).toContain("EACCES");
-		expect(text).not.toContain("already holds it");
-		expect(text).not.toContain("Get-NetTCPConnection");
+			const text = asText(describeCallbackFailure("callback-timeout"));
+
+			expect(text).toContain("lsof -nP -iTCP:1455");
+			expect(text).not.toContain("ss -lptn");
+			expect(text).not.toContain("Get-NetTCPConnection");
+		});
+
+		it("gives native Linux ss, and no WSL narrative", () => {
+			const text = asText(describeCallbackFailure("callback-timeout"));
+
+			expect(text).toContain("ss -lptn");
+			expect(text).not.toContain("Get-NetTCPConnection");
+			// The `ss` line is labelled "Linux / WSL", so assert the absence of the
+			// explanatory narrative rather than of the substring "WSL".
+			expect(text).not.toContain("the browser opens on the Windows host");
+			expect(text).not.toContain("can also hold port");
+		});
+
+		it("tells a Windows host that a WSL-side listener can also hold the port", () => {
+			Object.defineProperty(process, "platform", { value: "win32" });
+
+			const text = asText(
+				describeCallbackFailure("bind-failed", { bindErrorCode: "EADDRINUSE" }),
+			);
+
+			expect(text).toContain("Get-NetTCPConnection");
+			expect(text).toContain("inside WSL can also hold port");
+			expect(text).not.toContain("lsof");
+		});
 	});
 
-	it("treats a silent callback timeout as contention", () => {
-		// A clean bind that never receives a redirect is the exact signature of a
-		// listener on the other side of the Windows/WSL boundary taking the callback.
-		const text = asText(describeCallbackFailure("callback-timeout"));
+	describe("inside WSL", () => {
+		beforeEach(() => {
+			mockedIsWsl.mockReturnValue(true);
+			mockedDistro.mockReturnValue("Debian");
+		});
 
-		expect(text).toContain("No OAuth callback arrived");
-		expect(text).toContain(`port ${AUTH_REDIRECT.port}`);
-	});
+		it("explains the Windows/WSL split and offers both inspection commands", () => {
+			const text = asText(describeCallbackFailure("callback-timeout"));
 
-	it("explains the Windows/WSL split and names the distro when inside WSL", () => {
-		mockedIsWsl.mockReturnValue(true);
-		mockedDistro.mockReturnValue("Debian");
+			expect(text).toContain("WSL (Debian)");
+			expect(text).toContain("the browser opens on the Windows host");
+			// The offending listener is usually on the other side of the boundary,
+			// so both sides are worth checking.
+			expect(text).toContain("Get-NetTCPConnection");
+			expect(text).toContain("ss -lptn");
+		});
 
-		const text = asText(describeCallbackFailure("callback-timeout"));
+		it("still explains the split when the distro name is unknown", () => {
+			mockedDistro.mockReturnValue(undefined);
 
-		expect(text).toContain("WSL (Debian)");
-		expect(text).toContain("the browser opens on the Windows host");
-		// Both sides are worth inspecting, so both commands are offered.
-		expect(text).toContain("Get-NetTCPConnection");
-		expect(text).toContain("ss -lptn");
-	});
+			const text = asText(describeCallbackFailure("callback-timeout"));
 
-	it("still explains the split inside WSL when the distro name is unknown", () => {
-		mockedIsWsl.mockReturnValue(true);
-
-		const text = asText(describeCallbackFailure("callback-timeout"));
-
-		expect(text).toContain("WSL");
-		expect(text).not.toContain("WSL ()");
-	});
-
-	it("points a Windows host at the reciprocal WSL conflict", () => {
-		Object.defineProperty(process, "platform", { value: "win32" });
-
-		const text = asText(
-			describeCallbackFailure("bind-failed", { bindErrorCode: "EADDRINUSE" }),
-		);
-
-		expect(text).toContain("Get-NetTCPConnection");
-		expect(text).toContain("inside WSL can also hold it");
+			expect(text).toContain("WSL");
+			expect(text).not.toContain("WSL ()");
+		});
 	});
 });

--- a/test/callback-guidance.test.ts
+++ b/test/callback-guidance.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describeCallbackFailure } from "../lib/auth/callback-guidance.js";
+import { AUTH_REDIRECT } from "../lib/auth/auth.js";
+import { getWslDistroName, isWsl } from "../lib/wsl.js";
+
+vi.mock("../lib/wsl.js", () => ({
+	isWsl: vi.fn(() => false),
+	getWslDistroName: vi.fn(() => undefined),
+}));
+
+const mockedIsWsl = vi.mocked(isWsl);
+const mockedDistro = vi.mocked(getWslDistroName);
+
+function asText(lines: string[]): string {
+	return lines.join("\n");
+}
+
+describe("describeCallbackFailure", () => {
+	const originalPlatform = process.platform;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockedIsWsl.mockReturnValue(false);
+		mockedDistro.mockReturnValue(undefined);
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: originalPlatform });
+	});
+
+	it("always offers the device-code flow, which needs no callback port", () => {
+		for (const reason of ["bind-failed", "callback-timeout"] as const) {
+			expect(asText(describeCallbackFailure(reason))).toContain(
+				"--device-auth",
+			);
+		}
+	});
+
+	it("names port contention when the bind actually failed with EADDRINUSE", () => {
+		const text = asText(
+			describeCallbackFailure("bind-failed", { bindErrorCode: "EADDRINUSE" }),
+		);
+
+		expect(text).toContain(`port ${AUTH_REDIRECT.port}`);
+		expect(text).toContain("already holds it");
+	});
+
+	it("does not claim contention for unrelated bind errors", () => {
+		const text = asText(
+			describeCallbackFailure("bind-failed", { bindErrorCode: "EACCES" }),
+		);
+
+		expect(text).toContain("EACCES");
+		expect(text).not.toContain("already holds it");
+		expect(text).not.toContain("Get-NetTCPConnection");
+	});
+
+	it("treats a silent callback timeout as contention", () => {
+		// A clean bind that never receives a redirect is the exact signature of a
+		// listener on the other side of the Windows/WSL boundary taking the callback.
+		const text = asText(describeCallbackFailure("callback-timeout"));
+
+		expect(text).toContain("No OAuth callback arrived");
+		expect(text).toContain(`port ${AUTH_REDIRECT.port}`);
+	});
+
+	it("explains the Windows/WSL split and names the distro when inside WSL", () => {
+		mockedIsWsl.mockReturnValue(true);
+		mockedDistro.mockReturnValue("Debian");
+
+		const text = asText(describeCallbackFailure("callback-timeout"));
+
+		expect(text).toContain("WSL (Debian)");
+		expect(text).toContain("the browser opens on the Windows host");
+		// Both sides are worth inspecting, so both commands are offered.
+		expect(text).toContain("Get-NetTCPConnection");
+		expect(text).toContain("ss -lptn");
+	});
+
+	it("still explains the split inside WSL when the distro name is unknown", () => {
+		mockedIsWsl.mockReturnValue(true);
+
+		const text = asText(describeCallbackFailure("callback-timeout"));
+
+		expect(text).toContain("WSL");
+		expect(text).not.toContain("WSL ()");
+	});
+
+	it("points a Windows host at the reciprocal WSL conflict", () => {
+		Object.defineProperty(process, "platform", { value: "win32" });
+
+		const text = asText(
+			describeCallbackFailure("bind-failed", { bindErrorCode: "EADDRINUSE" }),
+		);
+
+		expect(text).toContain("Get-NetTCPConnection");
+		expect(text).toContain("inside WSL can also hold it");
+	});
+});

--- a/test/login-oauth-callback-guidance.test.ts
+++ b/test/login-oauth-callback-guidance.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Pins the wiring between the OAuth callback server and the failure guidance
+ * (issue #630). `describeCallbackFailure` and `startLocalOAuthServer` are each
+ * covered on their own; this asserts the seam in `runOAuthFlow` that picks the
+ * failure reason and forwards the bind error, which is what actually makes the
+ * Windows/WSL conflict legible to the user.
+ *
+ * Under vitest neither stdin nor stdout is a TTY, so the manual-paste prompt
+ * short-circuits to `cancelled` in browser mode and the flow returns without
+ * blocking on input.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { hooks } = vi.hoisted(() => ({
+	hooks: {
+		serverInfo: null as unknown,
+		guidanceLines: [] as string[],
+	},
+}));
+
+vi.mock("../lib/auth/auth.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/auth/auth.js")>();
+	return {
+		...actual,
+		createAuthorizationFlow: vi.fn(async () => ({
+			pkce: { challenge: "challenge", verifier: "verifier" },
+			state: "test-state",
+			url: "https://auth.openai.com/oauth/authorize?state=test-state",
+		})),
+	};
+});
+
+vi.mock("../lib/auth/server.js", () => ({
+	startLocalOAuthServer: vi.fn(async () => hooks.serverInfo),
+}));
+
+vi.mock("../lib/auth/browser.js", () => ({
+	openBrowserUrl: vi.fn(() => true),
+	copyTextToClipboard: vi.fn(() => true),
+	isBrowserLaunchSuppressed: vi.fn(() => false),
+	getBrowserOpener: vi.fn(() => "xdg-open"),
+}));
+
+vi.mock("../lib/auth/callback-guidance.js", () => ({
+	describeCallbackFailure: vi.fn(() => hooks.guidanceLines),
+}));
+
+const { describeCallbackFailure } = await import(
+	"../lib/auth/callback-guidance.js"
+);
+const { runOAuthFlow } = await import("../lib/codex-manager/login-oauth.js");
+
+const mockedGuidance = vi.mocked(describeCallbackFailure);
+
+/** A callback server that bound cleanly but never received a redirect. */
+function serverThatTimesOut() {
+	return {
+		port: 1455,
+		ready: true,
+		close: vi.fn(),
+		waitForCode: vi.fn(async () => null),
+	};
+}
+
+/** A callback server that could not take the port at all. */
+function serverThatFailedToBind(bindErrorCode?: string) {
+	return {
+		port: 1455,
+		ready: false,
+		bindErrorCode,
+		close: vi.fn(),
+		waitForCode: vi.fn(async () => null),
+	};
+}
+
+describe("runOAuthFlow callback-failure guidance", () => {
+	let logged: string[];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logged = [];
+		hooks.guidanceLines = ["GUIDANCE LINE ONE", "", "GUIDANCE LINE TWO"];
+		vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			logged.push(args.map(String).join(" "));
+		});
+	});
+
+	it("reports bind-failed with the bind error when the port could not be taken", async () => {
+		hooks.serverInfo = serverThatFailedToBind("EADDRINUSE");
+
+		await runOAuthFlow(false, "browser");
+
+		expect(mockedGuidance).toHaveBeenCalledWith("bind-failed", {
+			bindErrorCode: "EADDRINUSE",
+		});
+	});
+
+	it("reports callback-timeout when the server bound but no redirect arrived", async () => {
+		// The Windows/WSL hijack: a clean bind, and nothing ever comes back.
+		hooks.serverInfo = serverThatTimesOut();
+
+		await runOAuthFlow(false, "browser");
+
+		expect(mockedGuidance).toHaveBeenCalledWith("callback-timeout", {
+			bindErrorCode: undefined,
+		});
+	});
+
+	it("prints every guidance line, preserving blank separators", async () => {
+		hooks.serverInfo = serverThatTimesOut();
+
+		await runOAuthFlow(false, "browser");
+
+		expect(logged).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("GUIDANCE LINE ONE"),
+				expect.stringContaining("GUIDANCE LINE TWO"),
+			]),
+		);
+		// Blank separators are emitted unstyled rather than dropped.
+		expect(logged).toContain("");
+	});
+
+	// Manual mode is not exercised here: it sets `allowNonTty`, so the prompt
+	// blocks reading stdin rather than short-circuiting, and faking that stream
+	// would test the harness more than the code. The guidance is gated on
+	// `signInMode === "browser"` in one place, and the three cases above pin the
+	// branch that actually selects the reason.
+});

--- a/test/oauth-server-port-conflict.test.ts
+++ b/test/oauth-server-port-conflict.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Integration coverage for the contended-callback-port path (issue #630).
+ *
+ * Binds the real callback port first, then asks the OAuth server to take it.
+ * This is the half of the Windows/WSL conflict that can be reproduced on a
+ * single host: whoever holds port 1455 wins, and the loser must be able to say
+ * so rather than silently degrading.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import net from "node:net";
+import { startLocalOAuthServer } from "../lib/auth/server.js";
+import { AUTH_REDIRECT } from "../lib/auth/auth.js";
+import { describeCallbackFailure } from "../lib/auth/callback-guidance.js";
+
+const squatters: net.Server[] = [];
+
+/** Occupy the OAuth callback port, standing in for the other environment. */
+async function squatOnCallbackPort(): Promise<void> {
+	const server = net.createServer();
+	squatters.push(server);
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(AUTH_REDIRECT.port, AUTH_REDIRECT.host, resolve);
+	});
+}
+
+afterEach(async () => {
+	await Promise.all(
+		squatters.splice(0).map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+				}),
+		),
+	);
+});
+
+describe("OAuth callback server under port contention", () => {
+	it("reports EADDRINUSE instead of pretending to be ready", async () => {
+		await squatOnCallbackPort();
+
+		const info = await startLocalOAuthServer({ state: "test-state" });
+
+		expect(info.ready).toBe(false);
+		expect(info.bindErrorCode).toBe("EADDRINUSE");
+		expect(info.port).toBe(AUTH_REDIRECT.port);
+		// A server that never bound must not strand the caller waiting for a code.
+		await expect(info.waitForCode("test-state")).resolves.toBeNull();
+		info.close();
+	});
+
+	it("feeds the bind error into guidance that names the conflict", async () => {
+		await squatOnCallbackPort();
+
+		const info = await startLocalOAuthServer({ state: "test-state" });
+		// This is the exact wiring lib/codex-manager/login-oauth.ts performs.
+		const guidance = describeCallbackFailure("bind-failed", {
+			bindErrorCode: info.bindErrorCode,
+		}).join("\n");
+
+		expect(guidance).toContain("another process already holds it");
+		expect(guidance).toContain(String(AUTH_REDIRECT.port));
+		expect(guidance).toContain("--device-auth");
+		info.close();
+	});
+
+	it("binds cleanly and exposes no bind error when the port is free", async () => {
+		const info = await startLocalOAuthServer({ state: "test-state" });
+
+		expect(info.ready).toBe(true);
+		expect(info.bindErrorCode).toBeUndefined();
+		info.close();
+	});
+});

--- a/test/wsl.test.ts
+++ b/test/wsl.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import {
+	getWslDistroName,
+	isWsl,
+	resetWslDetectionCache,
+} from "../lib/wsl.js";
+
+vi.mock("node:fs", () => ({
+	default: { readFileSync: vi.fn() },
+	readFileSync: vi.fn(),
+}));
+
+const mockedReadFileSync = vi.mocked(fs.readFileSync);
+
+describe("wsl detection", () => {
+	const originalPlatform = process.platform;
+	const originalDistro = process.env.WSL_DISTRO_NAME;
+	const originalInterop = process.env.WSL_INTEROP;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetWslDetectionCache();
+		delete process.env.WSL_DISTRO_NAME;
+		delete process.env.WSL_INTEROP;
+		mockedReadFileSync.mockImplementation(() => {
+			throw new Error("ENOENT");
+		});
+	});
+
+	afterEach(() => {
+		resetWslDetectionCache();
+		Object.defineProperty(process, "platform", { value: originalPlatform });
+		if (originalDistro === undefined) delete process.env.WSL_DISTRO_NAME;
+		else process.env.WSL_DISTRO_NAME = originalDistro;
+		if (originalInterop === undefined) delete process.env.WSL_INTEROP;
+		else process.env.WSL_INTEROP = originalInterop;
+	});
+
+	it("is false on win32 even when WSL env vars leak in", () => {
+		Object.defineProperty(process, "platform", { value: "win32" });
+		process.env.WSL_DISTRO_NAME = "Debian";
+
+		expect(isWsl()).toBe(false);
+		expect(getWslDistroName()).toBeUndefined();
+	});
+
+	it("is false on darwin", () => {
+		Object.defineProperty(process, "platform", { value: "darwin" });
+
+		expect(isWsl()).toBe(false);
+	});
+
+	it("detects WSL from WSL_DISTRO_NAME without touching /proc", () => {
+		Object.defineProperty(process, "platform", { value: "linux" });
+		process.env.WSL_DISTRO_NAME = "Debian";
+
+		expect(isWsl()).toBe(true);
+		expect(getWslDistroName()).toBe("Debian");
+		expect(mockedReadFileSync).not.toHaveBeenCalled();
+	});
+
+	it("detects WSL from WSL_INTEROP", () => {
+		Object.defineProperty(process, "platform", { value: "linux" });
+		process.env.WSL_INTEROP = "/run/WSL/8_interop";
+
+		expect(isWsl()).toBe(true);
+		// No distro name is exported in this shell.
+		expect(getWslDistroName()).toBeUndefined();
+	});
+
+	it("falls back to /proc/version when the environment is stripped", () => {
+		Object.defineProperty(process, "platform", { value: "linux" });
+		mockedReadFileSync.mockReturnValue(
+			"Linux version 5.15.167.4-microsoft-standard-WSL2",
+		);
+
+		expect(isWsl()).toBe(true);
+	});
+
+	it("is false on a native linux host", () => {
+		Object.defineProperty(process, "platform", { value: "linux" });
+		mockedReadFileSync.mockReturnValue(
+			"Linux version 6.8.0-45-generic (buildd@lcy02)",
+		);
+
+		expect(isWsl()).toBe(false);
+	});
+
+	it("is false when /proc/version is unreadable", () => {
+		Object.defineProperty(process, "platform", { value: "linux" });
+
+		expect(isWsl()).toBe(false);
+	});
+
+	it("memoizes the result", () => {
+		Object.defineProperty(process, "platform", { value: "linux" });
+		mockedReadFileSync.mockReturnValue("microsoft-standard-WSL2");
+
+		expect(isWsl()).toBe(true);
+		expect(isWsl()).toBe(true);
+		expect(mockedReadFileSync).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/wsl.test.ts
+++ b/test/wsl.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import {
 	getWslDistroName,
 	isWsl,
-	resetWslDetectionCache,
+	resetWslDetectionCacheForTests,
 } from "../lib/wsl.js";
 
 vi.mock("node:fs", () => ({
@@ -20,7 +20,7 @@ describe("wsl detection", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		resetWslDetectionCache();
+		resetWslDetectionCacheForTests();
 		delete process.env.WSL_DISTRO_NAME;
 		delete process.env.WSL_INTEROP;
 		mockedReadFileSync.mockImplementation(() => {
@@ -29,7 +29,7 @@ describe("wsl detection", () => {
 	});
 
 	afterEach(() => {
-		resetWslDetectionCache();
+		resetWslDetectionCacheForTests();
 		Object.defineProperty(process, "platform", { value: originalPlatform });
 		if (originalDistro === undefined) delete process.env.WSL_DISTRO_NAME;
 		else process.env.WSL_DISTRO_NAME = originalDistro;


### PR DESCRIPTION
## Summary

- Fixes #630 — installing on both Windows and WSL broke OAuth login in both, and uninstalling the Windows side "fixed" WSL.
- Two compounding causes: WSL reports `process.platform === "linux"` and the package had **zero** WSL awareness, so login shelled out to `xdg-open` (not installed on stock WSL Debian) and no browser ever opened; and the callback port is **fixed** at 1455 by the provider-registered redirect URI, so a Windows-side listener silently swallows the redirect a WSL listener is waiting for.
- The port cannot be renegotiated, so this PR makes WSL login actually work, and makes the remaining conflict *legible* instead of a silent hang.

## What Changed

- **`lib/wsl.ts`** (new) — `isWsl()` / `getWslDistroName()`. Env-first (`WSL_DISTRO_NAME`, `WSL_INTEROP`) with a `/proc/version` fallback for shells that strip the environment. Memoized; short-circuits on `platform !== "linux"` so Windows and macOS can never enter a WSL branch even with leaked env vars.
- **`lib/auth/browser.ts`** — under WSL, open the *Windows* browser: `wslview` → `powershell.exe` interop → `xdg-open` as a last resort. Clipboard likewise routes through `clip.exe` → PowerShell `Set-Clipboard`, since the manual-paste fallback is exactly where WSL users were landing. Native Windows/macOS/Linux paths are unchanged. Also adds a `child.stdin` `error` handler — a child that dies before draining stdin emits `EPIPE` on the *stream*, which the surrounding `try/catch` cannot catch (this also hardens the pre-existing `pbcopy`/`xclip`/`xsel` paths).
- **`lib/auth/callback-guidance.ts`** (new) — explains the conflict at login time instead of silently degrading to manual paste, and points at `login --device-auth`, which needs no callback port. Contention is only **asserted** when observed (`EADDRINUSE`); a clean bind that received nothing leads with "if you closed or cancelled the browser sign-in, just run login again" and offers the contention explanation conditionally. Inspection commands are platform-correct (`lsof` on macOS, `ss` on Linux, `Get-NetTCPConnection` on Windows; both sides inside WSL).
- **`lib/auth/server.ts` / `lib/types.ts`** — surface `bindErrorCode` on `OAuthServerInfo` so callers can distinguish a contended port from any other bind failure.
- **Docs** — new "Windows And WSL Side By Side" section in `docs/troubleshooting.md`, linked from the README troubleshooting list.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 5,170 passed, 3 skipped, 0 failures (335 files)
- [x] `npm test -- test/documentation.test.ts` — 26 passed
- [x] `npm run build`

28 new tests: `test/wsl.test.ts` (8), `test/callback-guidance.test.ts` (9), `test/oauth-server-port-conflict.test.ts` (3), and a WSL block in `test/browser.test.ts` (8). They cover detection, opener fallback ordering, PowerShell metacharacter escaping, clipboard routing, the "no bridge and no `xdg-open`" case that reproduced the original hang, and — by squatting on port 1455 with a bare `net.createServer` — the real `EADDRINUSE` path end to end.

`test/browser.test.ts` now explicitly clears `WSL_DISTRO_NAME`/`WSL_INTEROP` and stubs `readFileSync`. Without that, its native-host assertions would have rerouted through the Windows interop paths for anyone running the suite *from inside* WSL.

## Docs and Governance Checklist

- [x] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (onboarding flow unchanged)
- [ ] `docs/features.md` updated (no new capability surface)
- [ ] relevant `docs/reference/*` pages updated (no command/setting/path changes; `--device-auth` already documented)
- [ ] `docs/upgrade.md` updated (no migration behavior change)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- **Risk level: low.** All new behavior is gated behind `isWsl()`, which is `false` on every non-WSL host. The `win32` branch returns before `isWsl()` is ever consulted; native Linux falls through to the existing `xdg-open` path when no Windows bridge resolves. The only unconditional changes are additive: an optional `bindErrorCode` field, extra `child.stdin` error handlers, and guidance text printed on a path that previously printed a bare warning.
- **Rollback:** revert the PR. No state format, config, or on-disk layout changes; nothing to migrate.

## Additional Notes

- **The callback port genuinely cannot be changed** — it is baked into the provider-registered redirect URI (`http://localhost:1455/auth/callback`), which is why this is *detect and explain* rather than *avoid*. `--device-auth` remains the only way to have both environments signed in without coordinating the port.
- Windows and WSL keep **separate state directories**, so accounts are not shared between them; each environment must be signed in independently. Now documented rather than left to be discovered.
- The WSL-side conflict still costs a 5-minute callback poll before the guidance prints (`server.ts` `TIMEOUT_MS`). A follow-up could emit the hint early (~30s) while continuing to wait, converting this from a post-mortem into something actionable mid-flow. Deliberately out of scope here.
- **Not fixed, and worth a maintainer's call:** the reporter's claim that the WSL install broke their *already-working Windows* install. Everything above explains why the WSL side failed and why removing the Windows install healed it, but nothing here reproduces damage inflicted on the Windows install. It may simply have been the same contention in the other direction. If you can get `codex-multi-auth report --json` from both sides, that would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes two compounding wsl oauth issues: `xdg-open` was the only browser opener tried on what node.js sees as linux, and the fixed callback port 1455 means a windows-side listener silently swallows the redirect a wsl listener is waiting for. the fix adds proper wsl detection and makes the port contention legible rather than a silent hang.

- **`lib/wsl.ts`** — new memoized detection module (env-first, `/proc/version` fallback, hard no-op on win32/darwin) with the required `reset*ForTests` seam; `lib/auth/browser.ts` adds `wslview` → `powershell.exe` interop → `xdg-open` fallback for both browser launch and clipboard, and hardens existing paths with `EPIPE` guards on `child.stdin`.
- **`lib/auth/callback-guidance.ts` + `lib/auth/server.ts` + `lib/types.ts`** — surfaces `bindErrorCode` from `EADDRINUSE` through to a new guidance layer that asserts contention only when it was actually observed, and gives platform-correct inspection commands; the wiring in `login-oauth.ts` is now pinned by `test/login-oauth-callback-guidance.test.ts`.
- **28 new tests** cover detection, opener fallback ordering, PowerShell metacharacter escaping, clipboard routing, the no-bridge hang that triggered the original report, and a real `EADDRINUSE` path via a squatter server on port 1455.

<h3>Confidence Score: 5/5</h3>

safe to merge — all new behavior is gated behind isWsl(), the fixed callback port is only detected and explained, and no state format or storage layout changes.

every new branch is additive and isolated: wsl detection hard-returns false on win32/darwin so existing windows and macos paths are untouched, the bindErrorCode field is optional so existing callers see no change, and the guidance layer only runs on a path that previously printed a bare warning. 28 new tests cover detection, opener fallback ordering, metacharacter escaping, clipboard routing, and the real eaddrinuse path end-to-end.

lib/auth/browser.ts — the stdinText parameter in spawnPowerShell is dead code and can be trimmed, but it has no impact on correctness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/wsl.ts | New WSL detection module: env-first (WSL_DISTRO_NAME / WSL_INTEROP), /proc/version fallback, memoized; short-circuits on non-linux so Windows/macOS are never affected. Exports test-reset helper per lib convention. |
| lib/auth/browser.ts | Adds WSL-aware browser and clipboard routing (wslview → powershell.exe interop → xdg-open fallback); extracts escapeForPowerShell and spawnPowerShell helpers; adds EPIPE guards on child.stdin. The stdinText parameter of spawnPowerShell is dead code — wired up but never passed at any call site. |
| lib/auth/callback-guidance.ts | New module that builds platform-appropriate failure guidance; contention only asserted on EADDRINUSE; timeout path leads with cancelled-browser-tab framing. Logic, escaping, and platform branches all look correct. |
| lib/auth/server.ts | Minimal additive change: surfaces bindErrorCode from the listen error onto OAuthServerInfo so callers can distinguish EADDRINUSE from other failures. |
| lib/codex-manager/login-oauth.ts | Wires describeCallbackFailure into the browser-mode fallback path; correctly uses waitingForCallback to pick the failure reason and forwards oauthServer?.bindErrorCode. |
| lib/types.ts | Adds optional bindErrorCode field to OAuthServerInfo interface with clear JSDoc; backward compatible. |
| test/login-oauth-callback-guidance.test.ts | New test file covering the wiring seam in runOAuthFlow that picks the failure reason and forwards bindErrorCode; directly addresses the gap noted in a prior review thread. |
| test/wsl.test.ts | 8 cases covering WSL detection across env vars, /proc/version, non-linux short-circuit, memoization, and the leaked-env-var guard on win32/darwin. |
| test/browser.test.ts | Existing suite updated to clear WSL env vars / reset detection cache in beforeEach/afterEach; new WSL describe block with 8 cases covering opener fallback ordering, clipboard routing, PowerShell escaping, and the no-bridge failure path. |
| test/oauth-server-port-conflict.test.ts | Integration tests that squat on port 1455 with a real net.Server to exercise the EADDRINUSE path end-to-end; correctly cleans up squatters in afterEach. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (WSL)
    participant CLI as codex-multi-auth
    participant WSL as lib/wsl.ts
    participant Browser as lib/auth/browser.ts
    participant Server as lib/auth/server.ts
    participant Win as Windows Host

    U->>CLI: login --browser
    CLI->>Server: startLocalOAuthServer()
    alt Port 1455 free
        Server-->>CLI: ready true port 1455
    else EADDRINUSE
        Server-->>CLI: ready false bindErrorCode EADDRINUSE
    end

    CLI->>WSL: isWsl()
    WSL-->>CLI: true via WSL_DISTRO_NAME or /proc/version

    CLI->>Browser: openBrowserUrl(url)
    alt wslview present
        Browser->>Win: wslview https://...
    else powershell.exe present
        Browser->>Win: powershell.exe Start-Process
    else fallback
        Browser->>U: xdg-open may fail on stock WSL
    end

    Win->>Server: "GET /auth/callback?code=..."
    alt Callback received
        Server-->>CLI: code returned
        CLI-->>U: Login successful
    else Timeout 5 min
        Server-->>CLI: null
        CLI->>CLI: describeCallbackFailure callback-timeout
        CLI-->>U: Guidance and manual paste prompt
    end

    note over Win,Server: If Windows also holds port 1455 the callback goes to Win listener and WSL server times out silently
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (WSL)
    participant CLI as codex-multi-auth
    participant WSL as lib/wsl.ts
    participant Browser as lib/auth/browser.ts
    participant Server as lib/auth/server.ts
    participant Win as Windows Host

    U->>CLI: login --browser
    CLI->>Server: startLocalOAuthServer()
    alt Port 1455 free
        Server-->>CLI: ready true port 1455
    else EADDRINUSE
        Server-->>CLI: ready false bindErrorCode EADDRINUSE
    end

    CLI->>WSL: isWsl()
    WSL-->>CLI: true via WSL_DISTRO_NAME or /proc/version

    CLI->>Browser: openBrowserUrl(url)
    alt wslview present
        Browser->>Win: wslview https://...
    else powershell.exe present
        Browser->>Win: powershell.exe Start-Process
    else fallback
        Browser->>U: xdg-open may fail on stock WSL
    end

    Win->>Server: "GET /auth/callback?code=..."
    alt Callback received
        Server-->>CLI: code returned
        CLI-->>U: Login successful
    else Timeout 5 min
        Server-->>CLI: null
        CLI->>CLI: describeCallbackFailure callback-timeout
        CLI-->>U: Guidance and manual paste prompt
    end

    note over Win,Server: If Windows also holds port 1455 the callback goes to Win listener and WSL server times out silently
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test(auth): pin the runOAuthFlow guidanc..."](https://github.com/ndycode/codex-multi-auth/commit/5f781773ac8dde415e4c953e526cf59c9719ffbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44087729)</sub>

<!-- /greptile_comment -->