### PR TITLE
fix(menu): label quota windows by duration, not position (#635)

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -68,6 +68,8 @@ export interface ExistingAccountInfo {
 	quota5hResetAtMs?: number;
 	quota7dLeftPercent?: number;
 	quota7dResetAtMs?: number;
+	quotaPrimaryWindowMinutes?: number;
+	quotaSecondaryWindowMinutes?: number;
 	quotaRateLimited?: boolean;
 	quotaExhausted?: boolean;
 	isCurrentAccount?: boolean;

--- a/lib/codex-manager/login-menu-data.ts
+++ b/lib/codex-manager/login-menu-data.ts
@@ -36,6 +36,7 @@ import {
 } from "../runtime/runtime-current-account.js";
 import { loadPersistedRuntimeObservabilitySnapshot } from "../runtime/runtime-observability.js";
 import type { AccountMetadataV3, AccountStorageV3 } from "../storage.js";
+import { resolveQuotaWindowLabel } from "../ui/auth-menu-builder.js";
 import { hasUsableAccessToken } from "./account-credentials.js";
 import {
 	formatAccountQuotaSummary,
@@ -290,7 +291,7 @@ function mapAccountStatus(
 
 function parseLeftPercentFromQuotaSummary(
 	summary: string | undefined,
-	windowLabel: "5h" | "7d",
+	windowLabel: string,
 ): number {
 	if (!summary) return -1;
 	const match = summary.match(
@@ -303,22 +304,32 @@ function parseLeftPercentFromQuotaSummary(
 
 function readQuotaLeftPercent(
 	account: ExistingAccountInfo,
-	windowLabel: "5h" | "7d",
+	window: "primary" | "secondary",
 ): number {
-	const direct =
-		windowLabel === "5h"
-			? account.quota5hLeftPercent
-			: account.quota7dLeftPercent;
+	const isPrimary = window === "primary";
+	const direct = isPrimary
+		? account.quota5hLeftPercent
+		: account.quota7dLeftPercent;
 	if (typeof direct === "number" && Number.isFinite(direct)) {
 		return Math.max(0, Math.min(100, Math.round(direct)));
 	}
-	return parseLeftPercentFromQuotaSummary(account.quotaSummary, windowLabel);
+	// The summary string is labelled by DURATION (formatAccountQuotaSummary), so a
+	// Codex Business row reads "30d 18%, ...". Searching it for the positional
+	// "5h"/"7d" finds nothing, scores the account -1, and sinks it to the bottom of
+	// a ready-first sort. Resolve the label from the window's real duration.
+	const label = resolveQuotaWindowLabel(
+		isPrimary
+			? account.quotaPrimaryWindowMinutes
+			: account.quotaSecondaryWindowMinutes,
+		isPrimary ? "5h" : "7d",
+	);
+	return parseLeftPercentFromQuotaSummary(account.quotaSummary, label);
 }
 
 function readQuotaFloorPercent(account: ExistingAccountInfo): number {
 	return Math.min(
-		readQuotaLeftPercent(account, "5h"),
-		readQuotaLeftPercent(account, "7d"),
+		readQuotaLeftPercent(account, "primary"),
+		readQuotaLeftPercent(account, "secondary"),
 	);
 }
 
@@ -362,12 +373,12 @@ function compareReadyFirstAccounts(
 	const rightFloor = readQuotaFloorPercent(right);
 	if (leftFloor !== rightFloor) return rightFloor - leftFloor;
 
-	const left5h = readQuotaLeftPercent(left, "5h");
-	const right5h = readQuotaLeftPercent(right, "5h");
+	const left5h = readQuotaLeftPercent(left, "primary");
+	const right5h = readQuotaLeftPercent(right, "primary");
 	if (left5h !== right5h) return right5h - left5h;
 
-	const left7d = readQuotaLeftPercent(left, "7d");
-	const right7d = readQuotaLeftPercent(right, "7d");
+	const left7d = readQuotaLeftPercent(left, "secondary");
+	const right7d = readQuotaLeftPercent(right, "secondary");
 	if (left7d !== right7d) return right7d - left7d;
 
 	const leftLastUsed = left.lastUsed ?? 0;

--- a/lib/codex-manager/login-menu-data.ts
+++ b/lib/codex-manager/login-menu-data.ts
@@ -465,6 +465,8 @@ export function toExistingAccountInfo(
 				entry?.secondary.usedPercent,
 			),
 			quota7dResetAtMs: entry?.secondary.resetAtMs,
+			quotaPrimaryWindowMinutes: entry?.primary.windowMinutes,
+			quotaSecondaryWindowMinutes: entry?.secondary.windowMinutes,
 			quotaRateLimited: entry?.status === 429,
 			quotaExhausted,
 			isCurrentAccount,

--- a/lib/ui/auth-menu-builder.ts
+++ b/lib/ui/auth-menu-builder.ts
@@ -27,10 +27,16 @@ export interface AccountInfo {
 	lastUsed?: number;
 	status?: AccountStatus;
 	quotaSummary?: string;
+	// `quota5h*`/`quota7d*` hold the primary/secondary quota windows by position;
+	// the names are retained for compatibility. The window's real duration lives in
+	// `quotaPrimaryWindowMinutes`/`quotaSecondaryWindowMinutes` so the label can be
+	// derived from data (e.g. a Codex Business monthly window renders "30d", not "5h").
 	quota5hLeftPercent?: number;
 	quota5hResetAtMs?: number;
 	quota7dLeftPercent?: number;
 	quota7dResetAtMs?: number;
+	quotaPrimaryWindowMinutes?: number;
+	quotaSecondaryWindowMinutes?: number;
 	quotaRateLimited?: boolean;
 	quotaExhausted?: boolean;
 	isCurrentAccount?: boolean;
@@ -320,8 +326,31 @@ function formatQuotaPercent(
 	return paintUiText(ui, percentText, tone);
 }
 
+/**
+ * Resolve a quota-window label from its duration in minutes, matching the
+ * data-driven labels used by the compact quota summary (`Nd`/`Nh`/`Nm`). Falls
+ * back to the positional label when the duration is unknown (e.g. quota entries
+ * cached before window durations were persisted), so Plus/Pro rows keep their
+ * familiar "5h"/"7d" labels while a Codex Business monthly window renders "30d".
+ */
+function resolveQuotaWindowLabel(
+	windowMinutes: number | undefined,
+	fallbackLabel: string,
+): string {
+	if (
+		typeof windowMinutes !== "number" ||
+		!Number.isFinite(windowMinutes) ||
+		windowMinutes <= 0
+	) {
+		return fallbackLabel;
+	}
+	if (windowMinutes % 1440 === 0) return `${windowMinutes / 1440}d`;
+	if (windowMinutes % 60 === 0) return `${windowMinutes / 60}h`;
+	return `${windowMinutes}m`;
+}
+
 function formatQuotaWindow(
-	label: "5h" | "7d",
+	label: string,
 	leftPercent: number | null,
 	resetAtMs: number | undefined,
 	showCooldown: boolean,
@@ -349,13 +378,15 @@ function formatQuotaSummary(account: AccountInfo, ui: ReturnType<typeof getUiRun
 	const showCooldown = account.showQuotaCooldown !== false;
 	const left5h = normalizeQuotaPercent(account.quota5hLeftPercent) ?? parseLeftPercentFromSummary(summary, "5h");
 	const left7d = normalizeQuotaPercent(account.quota7dLeftPercent) ?? parseLeftPercentFromSummary(summary, "7d");
+	const primaryLabel = resolveQuotaWindowLabel(account.quotaPrimaryWindowMinutes, "5h");
+	const secondaryLabel = resolveQuotaWindowLabel(account.quotaSecondaryWindowMinutes, "7d");
 	const segments: string[] = [];
 
 	if (left5h !== null || typeof account.quota5hResetAtMs === "number") {
-		segments.push(formatQuotaWindow("5h", left5h, account.quota5hResetAtMs, showCooldown, ui));
+		segments.push(formatQuotaWindow(primaryLabel, left5h, account.quota5hResetAtMs, showCooldown, ui));
 	}
 	if (left7d !== null || typeof account.quota7dResetAtMs === "number") {
-		segments.push(formatQuotaWindow("7d", left7d, account.quota7dResetAtMs, showCooldown, ui));
+		segments.push(formatQuotaWindow(secondaryLabel, left7d, account.quota7dResetAtMs, showCooldown, ui));
 	}
 	if (account.quotaRateLimited || summary.toLowerCase().includes("rate-limited")) {
 		segments.push(ui.v2Enabled ? paintUiText(ui, "rate-limited", "danger") : `${ANSI.red}rate-limited${ANSI.reset}`);

--- a/lib/ui/auth-menu-builder.ts
+++ b/lib/ui/auth-menu-builder.ts
@@ -246,7 +246,7 @@ function normalizeQuotaPercent(value: number | undefined): number | null {
 	return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-function parseLeftPercentFromSummary(summary: string, windowLabel: "5h" | "7d"): number | null {
+function parseLeftPercentFromSummary(summary: string, windowLabel: string): number | null {
 	const segments = summary.split("|");
 	for (const segment of segments) {
 		const trimmed = segment.trim().toLowerCase();
@@ -376,10 +376,14 @@ function formatQuotaWindow(
 function formatQuotaSummary(account: AccountInfo, ui: ReturnType<typeof getUiRuntimeOptions>): string {
 	const summary = account.quotaSummary ?? "";
 	const showCooldown = account.showQuotaCooldown !== false;
-	const left5h = normalizeQuotaPercent(account.quota5hLeftPercent) ?? parseLeftPercentFromSummary(summary, "5h");
-	const left7d = normalizeQuotaPercent(account.quota7dLeftPercent) ?? parseLeftPercentFromSummary(summary, "7d");
+	// Resolve the window labels before parsing the summary: the summary string is
+	// produced by `formatAccountQuotaSummary`, which already labels its segments by
+	// duration, so a Business row reads "30d 18%, ..." and never "5h ...". Searching
+	// it for a literal "5h"/"7d" would find nothing and silently drop the bar.
 	const primaryLabel = resolveQuotaWindowLabel(account.quotaPrimaryWindowMinutes, "5h");
 	const secondaryLabel = resolveQuotaWindowLabel(account.quotaSecondaryWindowMinutes, "7d");
+	const left5h = normalizeQuotaPercent(account.quota5hLeftPercent) ?? parseLeftPercentFromSummary(summary, primaryLabel);
+	const left7d = normalizeQuotaPercent(account.quota7dLeftPercent) ?? parseLeftPercentFromSummary(summary, secondaryLabel);
 	const segments: string[] = [];
 
 	if (left5h !== null || typeof account.quota5hResetAtMs === "number") {

--- a/lib/ui/auth-menu-builder.ts
+++ b/lib/ui/auth-menu-builder.ts
@@ -333,7 +333,7 @@ function formatQuotaPercent(
  * cached before window durations were persisted), so Plus/Pro rows keep their
  * familiar "5h"/"7d" labels while a Codex Business monthly window renders "30d".
  */
-function resolveQuotaWindowLabel(
+export function resolveQuotaWindowLabel(
 	windowMinutes: number | undefined,
 	fallbackLabel: string,
 ): string {

--- a/test/auth-menu-builder.test.ts
+++ b/test/auth-menu-builder.test.ts
@@ -307,6 +307,82 @@ describe("formatAccountHint", () => {
 		expect(hint).toContain("5h ");
 		expect(hint).toContain("7d ");
 	});
+
+	// Render a row carrying only the given quota window and read back the label the
+	// menu printed for it, so every branch of the duration->label rule is observed
+	// through the public formatter rather than the private helper.
+	function windowLabelFor(
+		windowMinutes: number | undefined,
+		position: "primary" | "secondary",
+	): string {
+		const hint = stripAnsi(
+			formatAccountHint(
+				account(
+					position === "primary"
+						? {
+							showLastUsed: false,
+							quota5hLeftPercent: 50,
+							quotaPrimaryWindowMinutes: windowMinutes,
+						}
+						: {
+							showLastUsed: false,
+							quota7dLeftPercent: 50,
+							quotaSecondaryWindowMinutes: windowMinutes,
+						},
+				),
+				ui,
+			),
+		);
+		return hint.replace(/^Limits: /, "").split(" ")[0] ?? "";
+	}
+
+	it.each([
+		[1_440, "1d"],
+		[43_200, "30d"],
+		[300, "5h"],
+		[720, "12h"],
+		[100, "100m"],
+		[90, "90m"],
+	] as const)("labels a %i-minute window as %s", (windowMinutes, expected) => {
+		expect(windowLabelFor(windowMinutes, "primary")).toBe(expected);
+	});
+
+	// An undefined duration is covered above; these are the durations a corrupt or
+	// hostile cache entry could carry, which must not produce labels like "0m" or
+	// "Infinityd".
+	it.each([
+		["zero", 0],
+		["negative", -1],
+		["NaN", Number.NaN],
+		["infinite", Number.POSITIVE_INFINITY],
+	] as const)(
+		"keeps the positional labels for a %s duration",
+		(_name, windowMinutes) => {
+			expect(windowLabelFor(windowMinutes, "primary")).toBe("5h");
+			expect(windowLabelFor(windowMinutes, "secondary")).toBe("7d");
+		},
+	);
+
+	// The percentage can also be recovered from the summary string when the typed
+	// field is absent. That string is labelled by duration too, so the lookup has to
+	// use the resolved label -- searching for a literal "5h" drops the whole segment.
+	it("recovers a percent from the summary using the resolved window label", () => {
+		const hint = stripAnsi(
+			formatAccountHint(
+				account({
+					showLastUsed: false,
+					quotaSummary: "30d 42%, resets in 12d | 7d 80%",
+					quotaPrimaryWindowMinutes: 30 * 24 * 60,
+					quotaSecondaryWindowMinutes: 7 * 24 * 60,
+				}),
+				ui,
+			),
+		);
+
+		expect(hint).toContain("30d ");
+		expect(hint).toContain("42%");
+		expect(hint).toContain("80%");
+	});
 });
 
 describe("legacy (v1) palette rendering", () => {

--- a/test/auth-menu-builder.test.ts
+++ b/test/auth-menu-builder.test.ts
@@ -265,6 +265,48 @@ describe("formatAccountHint", () => {
 			formatAccountHint(account({ showLastUsed: false }), ui),
 		).toBe("");
 	});
+
+	// Regression for issue #635: Codex Business accounts carry a 30d monthly
+	// primary window, but the account row hardcoded the positional "5h"/"7d"
+	// labels, so the monthly window rendered as "5h ... reset 28d 11h". The label
+	// must be derived from the window's real duration.
+	it("labels the primary window from its duration instead of the positional 5h default", () => {
+		const hint = stripAnsi(
+			formatAccountHint(
+				account({
+					lastUsed: NOW - 2 * DAY_MS,
+					// primary window is a 30d monthly quota (Codex Business), not 5h
+					quota5hLeftPercent: 18,
+					quota5hResetAtMs: NOW + 28 * DAY_MS,
+					quotaPrimaryWindowMinutes: 30 * 24 * 60,
+					// secondary window is the 7d weekly quota, fully available
+					quota7dLeftPercent: 100,
+					quotaSecondaryWindowMinutes: 7 * 24 * 60,
+				}),
+				ui,
+			),
+		);
+
+		expect(hint).toContain("30d ");
+		expect(hint).toContain("7d ");
+		expect(hint).not.toMatch(/\b5h\b/);
+	});
+
+	it("falls back to the positional 5h/7d labels when window durations are unknown", () => {
+		const hint = stripAnsi(
+			formatAccountHint(
+				account({
+					lastUsed: NOW,
+					quota5hLeftPercent: 50,
+					quota7dLeftPercent: 80,
+				}),
+				ui,
+			),
+		);
+
+		expect(hint).toContain("5h ");
+		expect(hint).toContain("7d ");
+	});
 });
 
 describe("legacy (v1) palette rendering", () => {

--- a/test/login-menu-data.test.ts
+++ b/test/login-menu-data.test.ts
@@ -347,6 +347,50 @@ describe("toExistingAccountInfo", () => {
 		expect(hint).not.toMatch(/\b5h\b/);
 	});
 
+	it("orders a monthly-window account by its real headroom", () => {
+		// The ready-first sort reads the primary/secondary windows positionally; a
+		// Codex Business row's primary window is 30d rather than 5h, and it must
+		// still be read as the primary window (regression guard for the sort helpers
+		// switching from positional "5h"/"7d" labels to primary/secondary).
+		const now = Date.now();
+		const storage = storageWith([account("plus"), account("business")]);
+		const cache: QuotaCacheData = {
+			byAccountId: {
+				acc_plus: cacheEntry(
+					{
+						primary: { usedPercent: 80, windowMinutes: 300, resetAtMs: now + 3_600_000 },
+						secondary: { usedPercent: 80, windowMinutes: 10_080, resetAtMs: now + 86_400_000 },
+					},
+					now,
+				),
+				acc_business: cacheEntry(
+					{
+						primary: { usedPercent: 10, windowMinutes: 43_200, resetAtMs: now + 28 * 86_400_000 },
+						secondary: { usedPercent: 10, windowMinutes: 10_080, resetAtMs: now + 86_400_000 },
+					},
+					now,
+				),
+			},
+			byEmail: {},
+		};
+
+		const rows = toExistingAccountInfo(
+			storage,
+			cache,
+			settings({
+				menuSortEnabled: true,
+				menuSortMode: "ready-first",
+				menuSortPinCurrent: false,
+			}),
+		);
+
+		// The monthly account has far more headroom, so it sorts first.
+		expect(rows.map((row) => row.accountId)).toEqual([
+			"acc_business",
+			"acc_plus",
+		]);
+	});
+
 	it("preserves storage order when sorting is disabled", () => {
 		const storage = storageWith([account("b"), account("a")]);
 

--- a/test/login-menu-data.test.ts
+++ b/test/login-menu-data.test.ts
@@ -5,6 +5,8 @@ import {
 } from "../lib/dashboard-settings.js";
 import type { QuotaCacheData, QuotaCacheEntry } from "../lib/quota-cache.js";
 import type { AccountMetadataV3, AccountStorageV3 } from "../lib/storage.js";
+import { formatAccountHint } from "../lib/ui/auth-menu-builder.js";
+import { getUiRuntimeOptions } from "../lib/ui/runtime.js";
 
 const {
 	loadCodexCliStateMock,
@@ -111,6 +113,11 @@ function cacheEntry(
 
 function emptyCache(): QuotaCacheData {
 	return { byAccountId: {}, byEmail: {} };
+}
+
+// The menu row is painted with ANSI in either UI mode; only the text is contract.
+function stripAnsi(value: string): string {
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 function settings(
@@ -300,6 +307,44 @@ describe("toExistingAccountInfo", () => {
 
 		expect(rows.map((row) => row.accountId)).toEqual(["acc_high", "acc_low"]);
 		expect(rows.map((row) => row.quickSwitchNumber)).toEqual([2, 1]);
+	});
+
+	// Regression for issue #635: the row label is derived from the cached window
+	// duration, so the mapping has to carry `windowMinutes` through to the row. A
+	// field-name drift here would silently restore the positional "5h" label with
+	// every auth-menu-builder test still green.
+	it("carries cached window durations onto rows so a monthly window renders 30d", () => {
+		const now = Date.now();
+		const storage = storageWith([account("business")]);
+		const cache: QuotaCacheData = {
+			byAccountId: {
+				acc_business: cacheEntry(
+					{
+						primary: {
+							usedPercent: 82,
+							windowMinutes: 43_200,
+							resetAtMs: now + 28 * 86_400_000,
+						},
+					},
+					now,
+				),
+			},
+			byEmail: {},
+		};
+
+		const rows = toExistingAccountInfo(
+			storage,
+			cache,
+			settings({ menuSortEnabled: false }),
+		);
+
+		expect(rows[0].quotaPrimaryWindowMinutes).toBe(43_200);
+		expect(rows[0].quotaSecondaryWindowMinutes).toBe(10_080);
+
+		const hint = stripAnsi(formatAccountHint(rows[0], getUiRuntimeOptions()));
+		expect(hint).toContain("30d ");
+		expect(hint).toContain("7d ");
+		expect(hint).not.toMatch(/\b5h\b/);
 	});
 
 	it("preserves storage order when sorting is disabled", () => {


### PR DESCRIPTION
Fixes #635.

## Problem

Codex Business accounts use a **30-day monthly** quota as their primary window. The account menu, however, hardcoded the positional labels `5h` (primary) and `7d` (secondary), so a monthly window rendered as:

```
Limits: 5h ##------- 18% reset 28d 11h | 7d ########## 100%
```

The `18%` and `reset 28d 11h` values were already correct — the `5h` **label** was the only thing wrong (a 5-hour window that resets in 28 days is the giveaway). The percent/reset data flows correctly; only the window's *identity* was mislabeled.

## Root cause

`quota-probe` already parses `windowMinutes` per window and the quota cache persists it. But `toExistingAccountInfo()` projected the parsed snapshot into the view model **by position** (`primary → quota5h*`, `secondary → quota7d*`) and dropped `windowMinutes`, and `auth-menu-builder`'s `formatQuotaSummary()` then hardcoded the `"5h"`/`"7d"` labels. The compact quota *summary string* (`formatAccountQuotaSummary`) already labels by duration, so the two surfaces disagreed.

## Fix

- Carry `windowMinutes` through the `ExistingAccountInfo` / `AccountInfo` view models as `quotaPrimaryWindowMinutes` / `quotaSecondaryWindowMinutes`.
- Populate them in `toExistingAccountInfo()` from the (already-cached) `entry.primary/secondary.windowMinutes`.
- Derive the displayed label from the duration in `auth-menu-builder`, matching the `Nd`/`Nh`/`Nm` scheme the summary string already uses. A 30d window now renders `30d`.
- **Fallback preserved:** when a window's duration is unknown (e.g. quota entries cached before durations were persisted), the label falls back to the positional `5h`/`7d`, so Plus/Pro rows are unchanged.

The existing `quota5h*`/`quota7d*` field names are kept (they've always meant primary/secondary by position) to keep the change surgical; a comment now documents that the duration lives in the new fields.

## Scope note

Sorting (`compareReadyFirstAccounts` et al.) keys off the primary/secondary **percent** fields, which are correct numbers independent of the label, so no sort changes were needed.

## Tests

- New regression tests in `auth-menu-builder.test.ts`: a 30d monthly primary window renders `30d` (and no longer `5h`), and the unknown-duration fallback still yields `5h`/`7d`.
- Full suite green: **5188 passed, 3 skipped**. Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes the mislabeled quota window for codex business accounts: a 30-day monthly primary window was displayed as "5h" because the menu hardcoded positional labels. the fix carries `windowMinutes` through the view model and derives the label from duration, with a positional fallback for old cache entries.

- adds `quotaPrimaryWindowMinutes` / `quotaSecondaryWindowMinutes` to `ExistingAccountInfo` and `AccountInfo`, populated in `toExistingAccountInfo()` from the already-cached `windowMinutes` fields.
- introduces `resolveQuotaWindowLabel()` in `auth-menu-builder.ts` (exported) to convert minutes → `Nd`/`Nh`/`Nm` labels, and applies it in both `formatQuotaSummary` and `readQuotaLeftPercent` (login-menu-data sort helpers) so the summary-string parse path uses the real label rather than the hardcoded positional one.
- regression tests cover all three label branches, invalid-duration fallbacks, summary-string recovery, and sort ordering for monthly-window accounts.

<h3>Confidence Score: 5/5</h3>

safe to merge — the change is additive and surgical, existing fields are untouched, and the fallback path preserves plus/pro behavior.

the fix correctly threads windowMinutes through the view model and resolves labels from real duration in both the display path and the sort/parse path. regression tests cover all three label branches, invalid-duration guards, summary-string recovery, and sort ordering. no data loss, no token handling changes, no concurrency surface touched.

no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/ui/auth-menu-builder.ts | adds resolveQuotaWindowLabel (exported), updates formatQuotaSummary to resolve labels before parsing, widens label param types from literal "5h"|"7d" to string — logic is correct and well-tested |
| lib/codex-manager/login-menu-data.ts | carries windowMinutes through toExistingAccountInfo, switches readQuotaLeftPercent to primary/secondary enum, imports resolveQuotaWindowLabel from the ui layer — creates a data→ui dependency that could be cleaner but is not a bug |
| lib/cli.ts | adds quotaPrimaryWindowMinutes and quotaSecondaryWindowMinutes optional fields to ExistingAccountInfo — additive, backward-compatible |
| test/auth-menu-builder.test.ts | new regression tests cover 30d label, fallback, all three resolveQuotaWindowLabel branches (d/h/m), invalid-duration guard, and summary-string recovery path — good coverage |
| test/login-menu-data.test.ts | adds integration tests asserting windowMinutes flows from cache to row fields and that sort order reflects real headroom for monthly-window accounts |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[quota-probe: windowMinutes cached per window] --> B[toExistingAccountInfo]
    B --> C[quotaPrimaryWindowMinutes\nquotaSecondaryWindowMinutes\nin ExistingAccountInfo / AccountInfo]

    C --> D[resolveQuotaWindowLabel]
    D --> E{windowMinutes valid?}
    E -- no --> F[fallback: '5h' or '7d']
    E -- yes --> G{divisible by 1440?}
    G -- yes --> H["Nd label (e.g. '30d')"]
    G -- no --> I{divisible by 60?}
    I -- yes --> J["Nh label (e.g. '5h')"]
    I -- no --> K["Nm label (e.g. '100m')"]

    H --> L[formatQuotaSummary / formatQuotaWindow]
    J --> L
    K --> L
    F --> L

    H --> M[parseLeftPercentFromSummary with resolved label]
    J --> M
    K --> M
    F --> M

    L --> N[menu row: '30d ##---- 18% reset 28d 11h']
    M --> N
```

<sub>Reviews (3): Last reviewed commit: ["fix(menu): rank rows by window duration ..."](https://github.com/ndycode/codex-multi-auth/commit/43e390b8173bbde93cae3aaf7ab4be19c7b835a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46762409)</sub>

<!-- /greptile_comment -->