### PR TITLE
fix: bug sweep — 8 confirmed correctness bugs across refresh, quota, storage, request & budget

### DIFF
--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -5,6 +5,7 @@ import {
 	findQuotaCacheEntryForAccount,
 	isQuotaCacheEntryExhausted,
 	quotaLeftPercentFromUsed,
+	quotaUsedPercentIsExhausted,
 } from "./quota-readiness.js";
 import { getRateLimitResetTimeForFamily } from "./runtime/account-status.js";
 import type { AccountMetadataV3 } from "./storage.js";
@@ -327,6 +328,26 @@ export function evaluateForecastAccount(
 		waitMs = Math.max(waitMs, liveWait);
 		if (liveWait > 0 && availability === "ready") {
 			availability = "delayed";
+		}
+
+		// A live window at 100% used with NO resetAtMs has no known recovery time —
+		// the probe reports it fully consumed and cannot say when it refills. On a
+		// 200 probe getLiveQuotaWaitMs then yields 0 (no reset to wait on) and the
+		// 429 branch never fires, so without this the account would stay "ready" and
+		// be recommended as a healthy pick. Treat that case as exhausted and downgrade
+		// a "ready" account to "delayed". A window WITH a resetAtMs is only *delayed*,
+		// not exhausted: getLiveQuotaWaitMs already contributes its wait above, so a
+		// 429 with known reset times stays a recoverable "delayed" account rather than
+		// a blocked one. The raw-usedPercent test (not rounded left-percent) keeps
+		// 99.6% from being falsely benched.
+		const liveExhausted =
+			(quotaUsedPercentIsExhausted(quota.primary.usedPercent) &&
+				typeof quota.primary.resetAtMs !== "number") ||
+			(quotaUsedPercentIsExhausted(quota.secondary.usedPercent) &&
+				typeof quota.secondary.resetAtMs !== "number");
+		if (liveExhausted) {
+			exhausted = true;
+			if (availability === "ready") availability = "delayed";
 		}
 
 		const primaryUsage = describeQuotaUsage(

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -4,7 +4,6 @@ import type { QuotaCacheData } from "./quota-cache.js";
 import {
 	findQuotaCacheEntryForAccount,
 	isQuotaCacheEntryExhausted,
-	quotaLeftPercentFromUsed,
 	quotaUsedPercentIsExhausted,
 } from "./quota-readiness.js";
 import { getRateLimitResetTimeForFamily } from "./runtime/account-status.js";
@@ -249,10 +248,15 @@ export function evaluateForecastAccount(
 		input.allAccounts ?? [account],
 	);
 	if (isQuotaCacheEntryExhausted(quotaEntry, now)) {
+		// Only a window that is genuinely at/over 100% used should contribute its
+		// reset time. Testing the ROUNDED left-percent instead would treat a
+		// 99.6%-used sibling as at-limit and fold its (possibly far-future) reset
+		// into the Math.max below, overstating the wait for an account whose
+		// actually-exhausted window recovers much sooner.
 		const resetAts = [quotaEntry?.primary, quotaEntry?.secondary]
 			.filter(
 				(window) =>
-					quotaLeftPercentFromUsed(window?.usedPercent) === 0 &&
+					quotaUsedPercentIsExhausted(window?.usedPercent) &&
 					typeof window?.resetAtMs === "number" &&
 					Number.isFinite(window.resetAtMs) &&
 					window.resetAtMs > now,

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -141,8 +141,10 @@ function getLiveQuotaWaitMs(
 		// resets ~7d out; folding that in would overstate the wait by orders of
 		// magnitude and invert the account recommendation (stress audit H5). On a
 		// 429 we honor every future window, since the upstream said "slow down now"
-		// regardless of the usage gauge.
-		if (onlyExhausted && quotaLeftPercentFromUsed(window?.usedPercent) !== 0) {
+		// regardless of the usage gauge. The test is the RAW usedPercent, never the
+		// rounded left-percent: 100 - 99.6 rounds to 0 left, which would bench a
+		// window that still has quota and falsely mark the account "delayed".
+		if (onlyExhausted && !quotaUsedPercentIsExhausted(window?.usedPercent)) {
 			continue;
 		}
 		const resetAt = window?.resetAtMs;

--- a/lib/policy/runtime-policy.ts
+++ b/lib/policy/runtime-policy.ts
@@ -9,6 +9,7 @@ import {
 	evaluateBudgetGuard,
 	getBudgetWindowStart,
 	loadBudgetGuardStore,
+	normalizeBudgetKey,
 	type BudgetGuardEvaluation,
 	type BudgetGuardStore,
 } from "../budget-guard.js";
@@ -105,12 +106,19 @@ async function evaluateBudgets(input: {
 	now: number;
 }): Promise<BudgetGuardEvaluation[]> {
 	const keys = new Set<string>();
+	// `global` is already normalize-clean. Project/profile keys can carry uppercase
+	// or spaces, but budget-guard STORES limits only under normalizeBudgetKey (see
+	// upsertBudgetLimit and load-time normalizeStore). Look them up the same way, or
+	// a key like `project:MyApp` never matches its stored `project:myapp` and the
+	// budget is silently unenforced.
 	keys.add("global");
 	if (input.state.project.projectKey) {
-		keys.add(`project:${input.state.project.projectKey}`);
+		const projectKey = normalizeBudgetKey(`project:${input.state.project.projectKey}`);
+		if (projectKey) keys.add(projectKey);
 	}
 	if (input.state.project.profile?.budgetKey) {
-		keys.add(input.state.project.profile.budgetKey);
+		const budgetKey = normalizeBudgetKey(input.state.project.profile.budgetKey);
+		if (budgetKey) keys.add(budgetKey);
 	}
 	const evaluations: BudgetGuardEvaluation[] = [];
 	for (const key of keys) {

--- a/lib/quota-readiness.ts
+++ b/lib/quota-readiness.ts
@@ -74,6 +74,22 @@ export function quotaLeftPercentFromUsed(
 	return Math.max(0, Math.min(100, Math.round(100 - usedPercent)));
 }
 
+// A window is exhausted only when it is genuinely at/over 100% used. Base this on
+// the RAW usedPercent, never the rounded quotaLeftPercentFromUsed: rounding
+// 100 - 99.6 = 0.4 down to 0 left-percent would falsely bench a window that still
+// has ~0.4% quota (any usedPercent in (99.5, 100) rounds to 0 left). The header
+// parser preserves fractional used-percent, so this input is expected;
+// quotaLeftPercentFromUsed stays for DISPLAY only.
+export function quotaUsedPercentIsExhausted(
+	usedPercent: number | undefined,
+): boolean {
+	return (
+		typeof usedPercent === "number" &&
+		Number.isFinite(usedPercent) &&
+		usedPercent >= 100
+	);
+}
+
 function quotaWindowIsExhausted(
 	window: QuotaWindowLike | undefined,
 	now = Date.now(),
@@ -96,8 +112,7 @@ function quotaWindowIsExhausted(
 	) {
 		return false;
 	}
-	const leftPercent = quotaLeftPercentFromUsed(window?.usedPercent);
-	return typeof leftPercent === "number" && leftPercent <= 0;
+	return quotaUsedPercentIsExhausted(window?.usedPercent);
 }
 
 export function isQuotaCacheEntryExhausted(

--- a/lib/refresh-lease.ts
+++ b/lib/refresh-lease.ts
@@ -11,7 +11,9 @@ import { isRecord } from "./utils.js";
 const log = createLogger("refresh-lease");
 
 const DEFAULT_LEASE_TTL_MS = 30_000;
-const DEFAULT_WAIT_TIMEOUT_MS = 35_000;
+// Exported so the refresh queue can size its acquire-stage eviction threshold
+// above the maximum time a lease acquire() may legitimately block waiting.
+export const DEFAULT_WAIT_TIMEOUT_MS = 35_000;
 const DEFAULT_POLL_INTERVAL_MS = 150;
 const DEFAULT_RESULT_TTL_MS = 20_000;
 const RETRYABLE_IO_ERRORS = new Set(["EBUSY", "EPERM", "EMFILE", "ENFILE"]);
@@ -311,7 +313,14 @@ export class RefreshLeaseCoordinator {
 				if (released) return;
 				released = true;
 				try {
-					if (result) {
+					// Only ever cache a SUCCESSFUL refresh in the cross-process lease.
+					// A `failed` result carries no token material to share; caching it
+					// would make readFreshResult serve the failure verbatim to every
+					// follower for the whole result TTL (DEFAULT_RESULT_TTL_MS), blocking
+					// a real refresh and even escalating to cooldowns. On failure we skip
+					// the cache and still unlink the lock in `finally`, so the next caller
+					// becomes owner and retries immediately.
+					if (result?.type === "success") {
 						await this.writeResult(resultPath, tokenHash, result);
 					}
 				} finally {

--- a/lib/refresh-lease.ts
+++ b/lib/refresh-lease.ts
@@ -179,6 +179,20 @@ export class RefreshLeaseCoordinator {
 		this.fsOps = options.fsOps ?? fs;
 	}
 
+	/**
+	 * Resolved maximum time `acquire()` may block waiting for a lease.
+	 *
+	 * Exposed so the refresh queue can size its acquire-stage eviction threshold
+	 * against the budget this coordinator ACTUALLY uses. The budget is
+	 * configurable (constructor option / `CODEX_AUTH_REFRESH_LEASE_WAIT_MS`), so
+	 * sizing eviction off the static `DEFAULT_WAIT_TIMEOUT_MS` would evict an
+	 * acquire that is still legitimately waiting under a larger budget, spawning
+	 * the duplicate refresh (→ `invalid_grant`) the lease exists to prevent.
+	 */
+	get configuredWaitTimeoutMs(): number {
+		return this.waitTimeoutMs;
+	}
+
 	static fromEnvironment(): RefreshLeaseCoordinator {
 		const testMode = process.env.VITEST === "true" || process.env.NODE_ENV === "test";
 		const enabled =

--- a/lib/refresh-queue.ts
+++ b/lib/refresh-queue.ts
@@ -12,10 +12,18 @@ import { createHash } from "node:crypto";
 import { refreshAccessToken } from "./auth/auth.js";
 import type { TokenResult } from "./types.js";
 import { createLogger } from "./logger.js";
-import { RefreshLeaseCoordinator } from "./refresh-lease.js";
+import { RefreshLeaseCoordinator, DEFAULT_WAIT_TIMEOUT_MS } from "./refresh-lease.js";
 import { isAbortError } from "./utils.js";
 
 const log = createLogger("refresh-queue");
+
+/**
+ * Extra headroom beyond the lease wait budget before an acquire-stage entry is
+ * treated as genuinely stuck. A lease acquire() polls on an interval and does
+ * filesystem work, so it can overshoot its wait deadline slightly; this slack
+ * keeps cleanup from evicting an acquire that is still legitimately waiting.
+ */
+const ACQUIRE_EVICTION_SLACK_MS = 5_000;
 
 /**
  * Non-reversible correlation fingerprint for a token, for logs.
@@ -340,10 +348,21 @@ export class RefreshQueue {
    */
   private cleanup(): void {
     const now = Date.now();
+    // A lease acquire() can legitimately block up to the coordinator's wait
+    // budget (DEFAULT_WAIT_TIMEOUT_MS). Evicting an acquire-stage entry before
+    // that budget elapses would spawn a duplicate refresh whose refresh token
+    // OpenAI has already rotated on first use (invalid_grant). So an acquire-stage
+    // entry is only evicted once it exceeds BOTH the configured max age AND the
+    // lease wait budget plus slack — never merely maxEntryAgeMs, which can be
+    // shorter than the wait budget.
+    const acquireEvictionAgeMs = Math.max(
+      this.maxEntryAgeMs,
+      DEFAULT_WAIT_TIMEOUT_MS + ACQUIRE_EVICTION_SLACK_MS,
+    );
     for (const [token, entry] of this.pending.entries()) {
       const ageMs = now - entry.startedAt;
-      if (ageMs <= this.maxEntryAgeMs) continue;
       if (entry.stage === "acquire") {
+        if (ageMs <= acquireEvictionAgeMs) continue;
         log.warn("Evicting stale refresh entry during lease acquire stage", {
           tokenSuffix: tokenFingerprint(token),
           ageMs,
@@ -352,6 +371,7 @@ export class RefreshQueue {
         this.cleanupRotationMapping(token);
         continue;
       }
+      if (ageMs <= this.maxEntryAgeMs) continue;
       if (!entry.staleWarningLogged) {
         log.warn("Refresh entry exceeded stale warning threshold", {
           tokenSuffix: tokenFingerprint(token),

--- a/lib/refresh-queue.ts
+++ b/lib/refresh-queue.ts
@@ -349,15 +349,25 @@ export class RefreshQueue {
   private cleanup(): void {
     const now = Date.now();
     // A lease acquire() can legitimately block up to the coordinator's wait
-    // budget (DEFAULT_WAIT_TIMEOUT_MS). Evicting an acquire-stage entry before
-    // that budget elapses would spawn a duplicate refresh whose refresh token
-    // OpenAI has already rotated on first use (invalid_grant). So an acquire-stage
-    // entry is only evicted once it exceeds BOTH the configured max age AND the
-    // lease wait budget plus slack — never merely maxEntryAgeMs, which can be
-    // shorter than the wait budget.
+    // budget. Evicting an acquire-stage entry before that budget elapses would
+    // spawn a duplicate refresh whose refresh token OpenAI has already rotated on
+    // first use (invalid_grant). So an acquire-stage entry is only evicted once it
+    // exceeds BOTH the configured max age AND the lease wait budget plus slack —
+    // never merely maxEntryAgeMs, which can be shorter than the wait budget.
+    //
+    // Read the budget the coordinator was actually CONFIGURED with (constructor
+    // option / CODEX_AUTH_REFRESH_LEASE_WAIT_MS) rather than the static default:
+    // under a larger configured budget the default would evict too early. An
+    // injected test double may not expose the getter, so fall back to the default.
+    const configuredWaitTimeoutMs = this.leaseCoordinator.configuredWaitTimeoutMs;
+    const leaseWaitTimeoutMs =
+      typeof configuredWaitTimeoutMs === "number" &&
+      Number.isFinite(configuredWaitTimeoutMs)
+        ? configuredWaitTimeoutMs
+        : DEFAULT_WAIT_TIMEOUT_MS;
     const acquireEvictionAgeMs = Math.max(
       this.maxEntryAgeMs,
-      DEFAULT_WAIT_TIMEOUT_MS + ACQUIRE_EVICTION_SLACK_MS,
+      leaseWaitTimeoutMs + ACQUIRE_EVICTION_SLACK_MS,
     );
     for (const [token, entry] of this.pending.entries()) {
       const ageMs = now - entry.startedAt;

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -669,15 +669,15 @@ export function trimInputForFastSession(
 	if (input.length <= maxItems && excludedHeadIndexes.size === 0) return input;
 	if (trimmed.length <= safeMax) return trimmed;
 
-	// Kept head items sit before the tail window at the front of `trimmed`.
-	// Reserve budget for them so slicing the tail does not drop them.
-	let headKept = 0;
-	for (const index of keepIndexes) {
-		if (index < tailStart) headKept++;
-	}
-	const tailBudget = Math.max(1, safeMax - headKept);
+	// Kept head items are always the LOWEST kept indexes, so they occupy the first
+	// `keptHead` entries of `trimmed`. Reserve budget for exactly that many.
+	// Recounting the kept indexes below `tailStart` instead would miss a head
+	// instruction that ALSO falls inside the tail window (input.length only just
+	// over safeMax), and the tail slice would then drop it. The two slices cannot
+	// overlap here: keptHead + tailBudget === safeMax < trimmed.length.
+	const tailBudget = Math.max(1, safeMax - keptHead);
 	return [
-		...trimmed.slice(0, headKept),
+		...trimmed.slice(0, keptHead),
 		...trimmed.slice(trimmed.length - tailBudget),
 	];
 }

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -658,7 +658,8 @@ export function trimInputForFastSession(
 		break;
 	}
 
-	for (let i = Math.max(0, input.length - safeMax); i < input.length; i++) {
+	const tailStart = Math.max(0, input.length - safeMax);
+	for (let i = tailStart; i < input.length; i++) {
 		if (excludedHeadIndexes.has(i)) continue;
 		keepIndexes.add(i);
 	}
@@ -667,7 +668,18 @@ export function trimInputForFastSession(
 	if (trimmed.length === 0) return input;
 	if (input.length <= maxItems && excludedHeadIndexes.size === 0) return input;
 	if (trimmed.length <= safeMax) return trimmed;
-	return trimmed.slice(trimmed.length - safeMax);
+
+	// Kept head items sit before the tail window at the front of `trimmed`.
+	// Reserve budget for them so slicing the tail does not drop them.
+	let headKept = 0;
+	for (const index of keepIndexes) {
+		if (index < tailStart) headKept++;
+	}
+	const tailBudget = Math.max(1, safeMax - headKept);
+	return [
+		...trimmed.slice(0, headKept),
+		...trimmed.slice(trimmed.length - tailBudget),
+	];
 }
 
 export interface FastSessionInputTrimPlan {

--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -1027,7 +1027,19 @@ export function isEmptyResponse(body: unknown): boolean {
 	if (Object.keys(obj).length === 0) return true;
 
 	const hasOutput =
-		"output" in obj && obj.output !== null && obj.output !== undefined;
+		"output" in obj &&
+		obj.output !== null &&
+		obj.output !== undefined &&
+		(Array.isArray(obj.output)
+			? obj.output.some(
+					(o) =>
+						o !== null &&
+						o !== undefined &&
+						(typeof o !== "object" || Object.keys(o as object).length > 0),
+				)
+			: typeof obj.output === "string"
+				? obj.output.trim() !== ""
+				: true);
 	const hasChoices =
 		"choices" in obj &&
 		Array.isArray(obj.choices) &&

--- a/lib/rotation.ts
+++ b/lib/rotation.ts
@@ -198,7 +198,14 @@ export const DEFAULT_TOKEN_BUCKET_CONFIG: TokenBucketConfig = {
 	tokensPerMinute: 6,
 };
 
-const TOKEN_REFUND_WINDOW_MS = 30_000;
+// Must cover the full request lifetime so a token consumed at request start can
+// still be refunded when the request fails at the very end. The runtime proxy
+// refunds on network error / upstream timeout, and the default fetch timeout is
+// 60_000ms (config.ts fetchTimeoutMs) — measured AFTER token consumption and a
+// token refresh. 90_000ms = that 60s timeout plus slack for the refresh and
+// processing, so a genuinely timed-out request's token is reversed instead of
+// leaking (gradual token-bucket starvation -> spurious token-exhausted skips).
+const TOKEN_REFUND_WINDOW_MS = 90_000;
 
 interface TokenBucketEntry {
 	tokens: number;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -811,6 +811,7 @@ async function migrateLegacyProjectStorageIfNeeded(options?: {
 			targetStorage,
 			legacyStorage,
 			normalizeAccountStorage,
+			findMatchingAccountIndex,
 		);
 		const fallbackStorage = targetStorage ?? legacyStorage;
 
@@ -2203,6 +2204,7 @@ export async function importAccounts(
 		mergeImportedAccounts,
 		maxAccounts: ACCOUNT_LIMITS.MAX_ACCOUNTS,
 		deduplicateAccounts,
+		findMatchingAccountIndex,
 		logInfo: (message, details) => {
 			log.info(message, details);
 		},

--- a/lib/storage/account-port.ts
+++ b/lib/storage/account-port.ts
@@ -60,6 +60,10 @@ export async function importAccountsSnapshot(params: {
 		deduplicateAccounts: (
 			accounts: AccountStorageV3["accounts"],
 		) => AccountStorageV3["accounts"];
+		findMatchingAccountIndex: (
+			accounts: AccountStorageV3["accounts"],
+			candidate: AccountStorageV3["accounts"][number],
+		) => number | undefined;
 	}) => {
 		newStorage: AccountStorageV3;
 		imported: number;
@@ -70,6 +74,12 @@ export async function importAccountsSnapshot(params: {
 	deduplicateAccounts: (
 		accounts: AccountStorageV3["accounts"],
 	) => AccountStorageV3["accounts"];
+	// Forwarded to `mergeImportedAccounts` so it can re-resolve the manual pin by
+	// identity after dedupe reorders the merged account list.
+	findMatchingAccountIndex: (
+		accounts: AccountStorageV3["accounts"],
+		candidate: AccountStorageV3["accounts"][number],
+	) => number | undefined;
 	logInfo: (message: string, details: Record<string, unknown>) => void;
 }): Promise<{ imported: number; total: number; skipped: number }> {
 	const normalized = await params.readImportFile({
@@ -84,6 +94,7 @@ export async function importAccountsSnapshot(params: {
 				imported: normalized,
 				maxAccounts: params.maxAccounts,
 				deduplicateAccounts: params.deduplicateAccounts,
+				findMatchingAccountIndex: params.findMatchingAccountIndex,
 			});
 			await persist(merged.newStorage);
 			return {

--- a/lib/storage/import-export.ts
+++ b/lib/storage/import-export.ts
@@ -190,6 +190,18 @@ export function mergeImportedAccounts(params: {
 		activeIndex: existingActiveIndex,
 		activeIndexByFamily: params.existing?.activeIndexByFamily,
 	};
+	// Preserve the user's manual pin (#474) and affinity generation across import.
+	// Rebuilding storage from scratch here previously dropped a `switch <n>` pin
+	// and reset affinityGeneration to 0, which lets a running proxy holding a
+	// higher in-memory generation clobber a newer CLI pin. normalizeAccountStorage
+	// re-validates/clamps an out-of-range pin against the merged account list on
+	// the next load, so carrying the raw value forward is safe.
+	if (typeof params.existing?.pinnedAccountIndex === "number") {
+		newStorage.pinnedAccountIndex = params.existing.pinnedAccountIndex;
+	}
+	if (typeof params.existing?.affinityGeneration === "number") {
+		newStorage.affinityGeneration = params.existing.affinityGeneration;
+	}
 	const importedCount =
 		deduplicatedAccounts.length - deduplicatedExistingAccounts.length;
 	const skippedCount = params.imported.accounts.length - importedCount;

--- a/lib/storage/import-export.ts
+++ b/lib/storage/import-export.ts
@@ -162,6 +162,12 @@ export function mergeImportedAccounts(params: {
 	deduplicateAccounts: (
 		accounts: AccountStorageV3["accounts"],
 	) => AccountStorageV3["accounts"];
+	// Injected like `deduplicateAccounts` rather than imported from ../storage.js,
+	// which would put this leaf module in a dependency cycle with the storage barrel.
+	findMatchingAccountIndex: (
+		accounts: AccountStorageV3["accounts"],
+		candidate: AccountStorageV3["accounts"][number],
+	) => number | undefined;
 }): {
 	newStorage: AccountStorageV3;
 	imported: number;
@@ -170,6 +176,15 @@ export function mergeImportedAccounts(params: {
 } {
 	const existingAccounts = params.existing?.accounts ?? [];
 	const existingActiveIndex = params.existing?.activeIndex ?? 0;
+	// Resolve the pinned account by IDENTITY before merging. The merged list is
+	// deduplicated below, which can move accounts to different positions, so a raw
+	// positional pin can end up selecting a DIFFERENT account (in range, wrong
+	// account) instead of the one the user pinned.
+	const existingPinnedIndex = params.existing?.pinnedAccountIndex;
+	const pinnedAccount =
+		typeof existingPinnedIndex === "number"
+			? existingAccounts[existingPinnedIndex]
+			: undefined;
 	const merged = [...existingAccounts, ...params.imported.accounts];
 
 	if (merged.length > params.maxAccounts) {
@@ -193,11 +208,19 @@ export function mergeImportedAccounts(params: {
 	// Preserve the user's manual pin (#474) and affinity generation across import.
 	// Rebuilding storage from scratch here previously dropped a `switch <n>` pin
 	// and reset affinityGeneration to 0, which lets a running proxy holding a
-	// higher in-memory generation clobber a newer CLI pin. normalizeAccountStorage
-	// re-validates/clamps an out-of-range pin against the merged account list on
-	// the next load, so carrying the raw value forward is safe.
-	if (typeof params.existing?.pinnedAccountIndex === "number") {
-		newStorage.pinnedAccountIndex = params.existing.pinnedAccountIndex;
+	// higher in-memory generation clobber a newer CLI pin. The pin is re-resolved
+	// against the deduplicated list by identity — a range check alone would happily
+	// keep an in-range index that dedupe has repointed at another account. When the
+	// pinned account no longer resolves (removed or ambiguous) the pin is dropped
+	// rather than left pointing somewhere arbitrary.
+	if (pinnedAccount) {
+		const remappedPinnedIndex = params.findMatchingAccountIndex(
+			deduplicatedAccounts,
+			pinnedAccount,
+		);
+		if (remappedPinnedIndex !== undefined) {
+			newStorage.pinnedAccountIndex = remappedPinnedIndex;
+		}
 	}
 	if (typeof params.existing?.affinityGeneration === "number") {
 		newStorage.affinityGeneration = params.existing.affinityGeneration;

--- a/lib/storage/project-migration.ts
+++ b/lib/storage/project-migration.ts
@@ -46,6 +46,13 @@ export function mergeStorageForMigration(
 		activeIndex: current.activeIndex,
 		activeIndexByFamily: current.activeIndexByFamily,
 		accounts: [...current.accounts, ...incoming.accounts],
+		// Carry the manual pin (#474) and affinity generation from the current
+		// storage through legacy-project migration; normalizeAccountStorage
+		// validates/clamps them against the merged account list. Omitting them
+		// dropped the pin and reset affinityGeneration to 0, which let a running
+		// proxy clobber a newer CLI pin.
+		pinnedAccountIndex: current.pinnedAccountIndex,
+		affinityGeneration: current.affinityGeneration,
 	});
 	if (!merged) {
 		return current;

--- a/lib/storage/project-migration.ts
+++ b/lib/storage/project-migration.ts
@@ -36,10 +36,26 @@ export function mergeStorageForMigration(
 	current: AccountStorageV3 | null,
 	incoming: AccountStorageV3,
 	normalizeAccountStorage: (value: unknown) => AccountStorageV3 | null,
+	// Injected like `normalizeAccountStorage` rather than imported from
+	// ../storage.js, which would put this leaf module in a dependency cycle with
+	// the storage barrel.
+	findMatchingAccountIndex: (
+		accounts: AccountStorageV3["accounts"],
+		candidate: AccountStorageV3["accounts"][number],
+	) => number | undefined,
 ): AccountStorageV3 {
 	if (!current) {
 		return incoming;
 	}
+
+	// Resolve the pinned account by IDENTITY before merging. normalizeAccountStorage
+	// deduplicates the merged list but only RANGE-validates the pin, so a raw
+	// positional pin that survives the range check can still end up pointing at a
+	// different account once dedupe shifts positions.
+	const pinnedAccount =
+		typeof current.pinnedAccountIndex === "number"
+			? current.accounts[current.pinnedAccountIndex]
+			: undefined;
 
 	const merged = normalizeAccountStorage({
 		version: 3,
@@ -57,5 +73,13 @@ export function mergeStorageForMigration(
 	if (!merged) {
 		return current;
 	}
-	return merged;
+	if (!pinnedAccount) {
+		return merged;
+	}
+	// Re-point the pin at the account the user actually pinned; clear it when that
+	// account no longer resolves in the normalized list.
+	return {
+		...merged,
+		pinnedAccountIndex: findMatchingAccountIndex(merged.accounts, pinnedAccount),
+	};
 }

--- a/test/account-port.test.ts
+++ b/test/account-port.test.ts
@@ -137,6 +137,7 @@ describe("account port helpers", () => {
 			}),
 			maxAccounts: 10,
 			deduplicateAccounts: (accounts) => accounts,
+			findMatchingAccountIndex: () => undefined,
 			logInfo: vi.fn(),
 		});
 		expect(result).toEqual({ imported: 1, total: 1, skipped: 0 });

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -1085,4 +1085,43 @@ describe("forecast helpers", () => {
 		expect(results[1].waitMs).toBe(600_000);
 	});
 
+	it("flags a live 200 probe at 100% used with no resetAtMs as exhausted, not ready", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+		};
+		// The upstream reported the primary window 100% used but omitted resetAtMs.
+		// getLiveQuotaWaitMs yields 0 (nothing to wait on) and the 429 branch never
+		// fires on a 200, so before the fix this stayed "ready" and could be
+		// recommended as the best account despite being fully exhausted.
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			allAccounts: [account],
+			liveQuota: {
+				status: 200,
+				model: "gpt-5.3-codex",
+				primary: { usedPercent: 100, windowMinutes: 300 },
+				secondary: {
+					usedPercent: 20,
+					windowMinutes: 10080,
+					resetAtMs: now + 300_000,
+				},
+			},
+		});
+
+		expect(result.availability).not.toBe("ready");
+		expect(result.exhausted).toBe(true);
+
+		// The HIGH-severity concern: such an account must not be recommended as a
+		// healthy pick. As the only account it yields a null recommendation.
+		const recommendation = recommendForecastAccount([result]);
+		expect(recommendation.recommendedIndex).toBeNull();
+		expect(recommendation.reason).toContain("blocked or exhausted");
+	});
+
 });

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -154,6 +154,50 @@ describe("forecast helpers", () => {
 		);
 	});
 
+	it("ignores a 99.6%-used sibling window when computing the exhausted wait", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			email: "quota@example.com",
+			accountId: "acc_quota",
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+		};
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			allAccounts: [account],
+			quotaCache: {
+				version: 1,
+				updatedAt: now,
+				byAccountId: {
+					acc_quota: {
+						accountId: "acc_quota",
+						status: 200,
+						model: "gpt-5.3-codex",
+						updatedAt: now,
+						// Genuinely exhausted, and it recovers in a minute.
+						primary: { usedPercent: 100, resetAtMs: now + 60_000 },
+						// 100 - 99.6 ROUNDS to 0 left, but this window still has quota
+						// and its monthly reset is 28 days out. Selecting contributing
+						// windows by the rounded left-percent would fold that in and
+						// report a 28-day wait for an account that recovers in 60s.
+						secondary: {
+							usedPercent: 99.6,
+							resetAtMs: now + 28 * 86_400_000,
+						},
+					},
+				},
+				byEmail: {},
+			},
+		});
+
+		expect(result.availability).toBe("delayed");
+		expect(result.waitMs).toBe(60_000);
+	});
+
 	it("applies runtime overlay skip reasons to forecast availability", () => {
 		const now = 1_700_000_000_000;
 		const account = {

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -597,6 +597,42 @@ describe("forecast helpers", () => {
 		expect(result.waitMs).toBe(0);
 	});
 
+	it("does not delay a 99.6%-used live window whose reset is still in the future", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 2,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-99",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+			},
+			liveQuota: {
+				status: 200,
+				model: "gpt-5-codex",
+				// 100 - 99.6 ROUNDS to 0% left, but the window is not exhausted: it
+				// still has quota. The live-wait filter must test the raw usedPercent,
+				// otherwise this future reset is folded in as a wait and a usable
+				// account is pushed to "delayed".
+				primary: {
+					usedPercent: 99.6,
+					windowMinutes: 300,
+					resetAtMs: now + 600_000,
+				},
+				secondary: {
+					usedPercent: 10,
+					windowMinutes: 10080,
+					resetAtMs: now + 1_800_000,
+				},
+			},
+		});
+
+		expect(result.availability).toBe("ready");
+		expect(result.waitMs).toBe(0);
+		expect(result.exhausted).toBe(false);
+	});
+
 	it("prefers refresh failure reason code over raw message text", () => {
 		const now = 1_700_000_000_000;
 		const result = evaluateForecastAccount({

--- a/test/import-export.test.ts
+++ b/test/import-export.test.ts
@@ -7,6 +7,7 @@ import {
 	mergeImportedAccounts,
 	readImportFile,
 } from "../lib/storage/import-export.js";
+import { findMatchingAccountIndex } from "../lib/storage.js";
 import { removeWithRetry } from "./helpers/remove-with-retry.js";
 
 describe("import export helpers", () => {
@@ -31,6 +32,7 @@ describe("import export helpers", () => {
 			},
 			maxAccounts: 10,
 			deduplicateAccounts: (accounts) => accounts,
+			findMatchingAccountIndex,
 		});
 
 		expect(result.total).toBe(2);
@@ -56,6 +58,7 @@ describe("import export helpers", () => {
 				Array.from(
 					new Map(accounts.map((account) => [account.refreshToken, account])).values(),
 				),
+			findMatchingAccountIndex,
 		});
 
 		expect(result.total).toBe(2);
@@ -81,10 +84,82 @@ describe("import export helpers", () => {
 			},
 			maxAccounts: 10,
 			deduplicateAccounts: (accounts) => accounts,
+			findMatchingAccountIndex,
 		});
 
 		expect(result.newStorage.pinnedAccountIndex).toBe(1);
 		expect(result.newStorage.affinityGeneration).toBe(7);
+	});
+
+	it("remaps the pin by identity when dedupe shifts account positions", () => {
+		// Existing [a, a, b] pinned on `b` (index 2). Dedupe collapses the duplicate
+		// `a`, so raw index 2 now points at the IMPORTED account `c` — in range, but
+		// the wrong account. The pin must follow the identity it was set on.
+		const result = mergeImportedAccounts({
+			existing: {
+				version: 3,
+				accounts: [
+					{ refreshToken: "a" },
+					{ refreshToken: "a" },
+					{ refreshToken: "b" },
+				],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+				pinnedAccountIndex: 2,
+				affinityGeneration: 7,
+			},
+			imported: {
+				version: 3,
+				accounts: [{ refreshToken: "c" }],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+			},
+			maxAccounts: 10,
+			deduplicateAccounts: (accounts) =>
+				Array.from(
+					new Map(accounts.map((account) => [account.refreshToken, account])).values(),
+				),
+			findMatchingAccountIndex,
+		});
+
+		expect(result.newStorage.accounts.map((a) => a.refreshToken)).toEqual([
+			"a",
+			"b",
+			"c",
+		]);
+		expect(result.newStorage.pinnedAccountIndex).toBe(1);
+		expect(
+			result.newStorage.accounts[result.newStorage.pinnedAccountIndex ?? -1]
+				?.refreshToken,
+		).toBe("b");
+		expect(result.newStorage.affinityGeneration).toBe(7);
+	});
+
+	it("drops the pin when the pinned account no longer resolves after merge", () => {
+		const result = mergeImportedAccounts({
+			existing: {
+				version: 3,
+				accounts: [{ refreshToken: "a" }, { refreshToken: "b" }],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+				pinnedAccountIndex: 1,
+				affinityGeneration: 3,
+			},
+			imported: {
+				version: 3,
+				accounts: [{ refreshToken: "c" }],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+			},
+			maxAccounts: 10,
+			// Drops the pinned account entirely, so no identity match remains.
+			deduplicateAccounts: (accounts) =>
+				accounts.filter((account) => account.refreshToken !== "b"),
+			findMatchingAccountIndex,
+		});
+
+		expect(result.newStorage.pinnedAccountIndex).toBeUndefined();
+		expect(result.newStorage.affinityGeneration).toBe(3);
 	});
 
 	it("leaves pin and affinity generation unset when existing storage lacks them", () => {
@@ -103,6 +178,7 @@ describe("import export helpers", () => {
 			},
 			maxAccounts: 10,
 			deduplicateAccounts: (accounts) => accounts,
+			findMatchingAccountIndex,
 		});
 
 		expect(result.newStorage.pinnedAccountIndex).toBeUndefined();

--- a/test/import-export.test.ts
+++ b/test/import-export.test.ts
@@ -63,6 +63,52 @@ describe("import export helpers", () => {
 		expect(result.skipped).toBe(0);
 	});
 
+	it("preserves the manual pin and affinity generation across import (#474)", () => {
+		const result = mergeImportedAccounts({
+			existing: {
+				version: 3,
+				accounts: [{ refreshToken: "a" }, { refreshToken: "b" }],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+				pinnedAccountIndex: 1,
+				affinityGeneration: 7,
+			},
+			imported: {
+				version: 3,
+				accounts: [{ refreshToken: "c" }],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+			},
+			maxAccounts: 10,
+			deduplicateAccounts: (accounts) => accounts,
+		});
+
+		expect(result.newStorage.pinnedAccountIndex).toBe(1);
+		expect(result.newStorage.affinityGeneration).toBe(7);
+	});
+
+	it("leaves pin and affinity generation unset when existing storage lacks them", () => {
+		const result = mergeImportedAccounts({
+			existing: {
+				version: 3,
+				accounts: [{ refreshToken: "a" }],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+			},
+			imported: {
+				version: 3,
+				accounts: [{ refreshToken: "b" }],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+			},
+			maxAccounts: 10,
+			deduplicateAccounts: (accounts) => accounts,
+		});
+
+		expect(result.newStorage.pinnedAccountIndex).toBeUndefined();
+		expect(result.newStorage.affinityGeneration).toBeUndefined();
+	});
+
 	it("throws for invalid import payloads and empty exports", async () => {
 		await expect(
 			readImportFile({

--- a/test/project-migration.test.ts
+++ b/test/project-migration.test.ts
@@ -74,4 +74,32 @@ describe("project migration helpers", () => {
 		const fallback = mergeStorageForMigration(current, incoming, () => null);
 		expect(fallback).toBe(current);
 	});
+
+	it("carries the manual pin and affinity generation through migration (#474)", () => {
+		const current: AccountStorageV3 = {
+			version: 3,
+			accounts: [{ refreshToken: "a" }] as AccountStorageV3["accounts"],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+			pinnedAccountIndex: 0,
+			affinityGeneration: 5,
+		};
+		const incoming: AccountStorageV3 = {
+			version: 3,
+			accounts: [{ refreshToken: "b" }] as AccountStorageV3["accounts"],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		};
+
+		const normalize = vi.fn((value: unknown) => value as AccountStorageV3);
+		const merged = mergeStorageForMigration(current, incoming, normalize);
+
+		// The pin/gen must be forwarded into normalizeAccountStorage, which is where
+		// clamping/validation against the merged account list happens.
+		expect(normalize).toHaveBeenCalledWith(
+			expect.objectContaining({ pinnedAccountIndex: 0, affinityGeneration: 5 }),
+		);
+		expect(merged.pinnedAccountIndex).toBe(0);
+		expect(merged.affinityGeneration).toBe(5);
+	});
 });

--- a/test/project-migration.test.ts
+++ b/test/project-migration.test.ts
@@ -3,7 +3,10 @@ import {
 	loadNormalizedStorageFromPath,
 	mergeStorageForMigration,
 } from "../lib/storage/project-migration.js";
-import type { AccountStorageV3 } from "../lib/storage.js";
+import {
+	findMatchingAccountIndex,
+	type AccountStorageV3,
+} from "../lib/storage.js";
 
 describe("project migration helpers", () => {
 	it("loads normalized storage and reports schema warnings", async () => {
@@ -68,38 +71,125 @@ describe("project migration helpers", () => {
 		};
 
 		const normalize = vi.fn((value: unknown) => value as AccountStorageV3);
-		const merged = mergeStorageForMigration(current, incoming, normalize);
+		const merged = mergeStorageForMigration(
+			current,
+			incoming,
+			normalize,
+			findMatchingAccountIndex,
+		);
 		expect(merged.accounts).toHaveLength(2);
 
-		const fallback = mergeStorageForMigration(current, incoming, () => null);
+		const fallback = mergeStorageForMigration(
+			current,
+			incoming,
+			() => null,
+			findMatchingAccountIndex,
+		);
 		expect(fallback).toBe(current);
 	});
 
 	it("carries the manual pin and affinity generation through migration (#474)", () => {
+		// `current` holds a duplicate `a`, pinned on `b` at index 2. The normalize
+		// mock mirrors the real normalizeAccountStorage: it DEDUPLICATES the merged
+		// accounts and then only RANGE-validates the pin. An identity mock could not
+		// catch this — after dedupe, raw index 2 is in range but points at `c`.
 		const current: AccountStorageV3 = {
 			version: 3,
-			accounts: [{ refreshToken: "a" }] as AccountStorageV3["accounts"],
+			accounts: [
+				{ refreshToken: "a" },
+				{ refreshToken: "a" },
+				{ refreshToken: "b" },
+			] as AccountStorageV3["accounts"],
 			activeIndex: 0,
 			activeIndexByFamily: {},
-			pinnedAccountIndex: 0,
+			pinnedAccountIndex: 2,
 			affinityGeneration: 5,
 		};
 		const incoming: AccountStorageV3 = {
 			version: 3,
-			accounts: [{ refreshToken: "b" }] as AccountStorageV3["accounts"],
+			accounts: [{ refreshToken: "c" }] as AccountStorageV3["accounts"],
 			activeIndex: 0,
 			activeIndexByFamily: {},
 		};
 
-		const normalize = vi.fn((value: unknown) => value as AccountStorageV3);
-		const merged = mergeStorageForMigration(current, incoming, normalize);
-
-		// The pin/gen must be forwarded into normalizeAccountStorage, which is where
-		// clamping/validation against the merged account list happens.
-		expect(normalize).toHaveBeenCalledWith(
-			expect.objectContaining({ pinnedAccountIndex: 0, affinityGeneration: 5 }),
+		const normalize = vi.fn((value: unknown) => {
+			const storage = value as AccountStorageV3;
+			const accounts = Array.from(
+				new Map(
+					storage.accounts.map((account) => [account.refreshToken, account]),
+				).values(),
+			) as AccountStorageV3["accounts"];
+			const pinnedAccountIndex =
+				typeof storage.pinnedAccountIndex === "number" &&
+				storage.pinnedAccountIndex >= 0 &&
+				storage.pinnedAccountIndex < accounts.length
+					? storage.pinnedAccountIndex
+					: undefined;
+			return { ...storage, accounts, pinnedAccountIndex };
+		});
+		const merged = mergeStorageForMigration(
+			current,
+			incoming,
+			normalize,
+			findMatchingAccountIndex,
 		);
-		expect(merged.pinnedAccountIndex).toBe(0);
+
+		// The pin/gen must still be forwarded into normalizeAccountStorage, which is
+		// where clamping/validation against the merged account list happens.
+		expect(normalize).toHaveBeenCalledWith(
+			expect.objectContaining({ pinnedAccountIndex: 2, affinityGeneration: 5 }),
+		);
+		expect(merged.accounts.map((account) => account.refreshToken)).toEqual([
+			"a",
+			"b",
+			"c",
+		]);
+		// Dedupe moved `b` from index 2 to 1; carrying the raw index would have
+		// silently re-pinned onto `c`.
+		expect(merged.pinnedAccountIndex).toBe(1);
+		expect(merged.accounts[merged.pinnedAccountIndex ?? -1]?.refreshToken).toBe(
+			"b",
+		);
+		expect(merged.affinityGeneration).toBe(5);
+	});
+
+	it("clears the pin when the pinned account is gone after normalization", () => {
+		const current: AccountStorageV3 = {
+			version: 3,
+			accounts: [
+				{ refreshToken: "a" },
+				{ refreshToken: "b" },
+			] as AccountStorageV3["accounts"],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+			pinnedAccountIndex: 1,
+			affinityGeneration: 5,
+		};
+		const incoming: AccountStorageV3 = {
+			version: 3,
+			accounts: [{ refreshToken: "c" }] as AccountStorageV3["accounts"],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		};
+
+		// Normalization drops the pinned account (e.g. it failed validation).
+		const normalize = vi.fn((value: unknown) => {
+			const storage = value as AccountStorageV3;
+			return {
+				...storage,
+				accounts: storage.accounts.filter(
+					(account) => account.refreshToken !== "b",
+				),
+			};
+		});
+		const merged = mergeStorageForMigration(
+			current,
+			incoming,
+			normalize,
+			findMatchingAccountIndex,
+		);
+
+		expect(merged.pinnedAccountIndex).toBeUndefined();
 		expect(merged.affinityGeneration).toBe(5);
 	});
 });

--- a/test/quota-readiness.test.ts
+++ b/test/quota-readiness.test.ts
@@ -26,6 +26,25 @@ describe("quota readiness", () => {
 		).toBe(false);
 	});
 
+	// Exhaustion is decided on RAW usedPercent (>= 100), not the rounded
+	// left-percent: 100 - 99.6 = 0.4 rounds to 0 left-percent but 0.4% quota
+	// genuinely remains, so a fractional usedPercent in (99.5, 100) must NOT read
+	// as exhausted. usedPercent === 100 still exhausts.
+	it("does not bench a window with fractional quota just above 99.5% used", () => {
+		expect(
+			isQuotaCacheEntryExhausted({
+				primary: { usedPercent: 99.6, windowMinutes: 300 },
+				secondary: { usedPercent: 30, windowMinutes: 10080 },
+			}),
+		).toBe(false);
+		expect(
+			isQuotaCacheEntryExhausted({
+				primary: { usedPercent: 100, windowMinutes: 300 },
+				secondary: { usedPercent: 30, windowMinutes: 10080 },
+			}),
+		).toBe(true);
+	});
+
 	it("does not treat expired quota windows as exhausted", () => {
 		const now = 10_000;
 		expect(

--- a/test/refresh-lease.test.ts
+++ b/test/refresh-lease.test.ts
@@ -48,6 +48,44 @@ describe("RefreshLeaseCoordinator", () => {
     expect(follower.result).toEqual(sampleSuccessResult);
   });
 
+  it("does not cache a failed refresh result; only success is served to followers", async () => {
+    // Regression: a `failed` result carries no token material. If the owner cached
+    // it, readFreshResult would serve the failure to every follower for the whole
+    // result TTL, blocking a real refresh (and escalating to cooldowns). A failed
+    // release must leave NO result cache — the next caller becomes owner and
+    // retries — while a success is still shared with followers.
+    const coordinator = new RefreshLeaseCoordinator({
+      enabled: true,
+      leaseDir,
+      leaseTtlMs: 5_000,
+      waitTimeoutMs: 500,
+      pollIntervalMs: 25,
+      resultTtlMs: 5_000,
+    });
+
+    const failedResult = {
+      type: "failed" as const,
+      reason: "network_error" as const,
+      message: "boom",
+    };
+
+    const owner = await coordinator.acquire("token-fail");
+    expect(owner.role).toBe("owner");
+    await owner.release(failedResult);
+
+    // A failure was NOT cached: the next caller acquires as owner, not a follower
+    // holding the stale failure.
+    const afterFailure = await coordinator.acquire("token-fail");
+    expect(afterFailure.role).toBe("owner");
+    expect(afterFailure.result).toBeUndefined();
+    await afterFailure.release(sampleSuccessResult);
+
+    // Happy path intact: a success IS served to a subsequent follower.
+    const follower = await coordinator.acquire("token-fail");
+    expect(follower.role).toBe("follower");
+    expect(follower.result).toEqual(sampleSuccessResult);
+  });
+
   it("tightens an already-existing lease dir to 0o700 on POSIX (chmod after mkdir)", async () => {
     // Regression: mkdir(recursive, mode) does NOT re-apply mode to a dir that
     // already exists, so an upgrade over a looser (umask) dir kept its perms.

--- a/test/refresh-queue.test.ts
+++ b/test/refresh-queue.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { RefreshQueue, getRefreshQueue, resetRefreshQueue, queuedRefresh } from "../lib/refresh-queue.js";
 import * as authModule from "../lib/auth/auth.js";
-import { RefreshLeaseCoordinator } from "../lib/refresh-lease.js";
+import { RefreshLeaseCoordinator, DEFAULT_WAIT_TIMEOUT_MS } from "../lib/refresh-lease.js";
 
 const loggerMocks = vi.hoisted(() => ({
   info: vi.fn(),
@@ -270,12 +270,63 @@ describe("RefreshQueue", () => {
         await Promise.resolve();
         expect(queue.pendingCount).toBe(1);
 
-        await vi.advanceTimersByTimeAsync(1200);
+        // Acquire-stage entries are now held until they exceed the lease wait
+        // budget (35s) + slack (5s), so advance past that 40s threshold to force
+        // eviction of a genuinely stuck acquire.
+        await vi.advanceTimersByTimeAsync(41_000);
 
         const secondResult = await queue.refresh("stale-acquire-token");
         expect(secondResult).toEqual(successResult);
         expect(leaseAcquire).toHaveBeenCalledTimes(2);
         expect(queue.pendingCount).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not evict an acquire-stage entry younger than the lease wait budget", async () => {
+      vi.useFakeTimers();
+      try {
+        // Regression: a lease acquire() can legitimately block up to
+        // DEFAULT_WAIT_TIMEOUT_MS (35s), which is LONGER than the default
+        // maxEntryAgeMs (30s). Cleanup must not evict an acquire-stage entry that
+        // is still within that wait budget, or it spawns a duplicate refresh that
+        // hits invalid_grant on the already-rotated token.
+        const neverResolves = new Promise<
+          Awaited<ReturnType<RefreshLeaseCoordinator["acquire"]>>
+        >(() => {});
+        const leaseAcquire = vi.fn().mockReturnValue(neverResolves);
+        const leaseCoordinator = { acquire: leaseAcquire } as unknown as RefreshLeaseCoordinator;
+        vi.mocked(authModule.refreshAccessToken).mockResolvedValue({
+          type: "success",
+          access: "a",
+          refresh: "r",
+          expires: Date.now() + 3600_000,
+        });
+
+        const queue = new RefreshQueue(30_000, leaseCoordinator);
+        void queue.refresh("wait-budget-token");
+        await Promise.resolve();
+        expect(queue.pendingCount).toBe(1);
+        expect(leaseAcquire).toHaveBeenCalledTimes(1);
+
+        // Past maxEntryAgeMs (30s) but still within the lease wait budget: the
+        // acquire-stage entry must survive, so a concurrent refresh dedupes onto
+        // it instead of starting a duplicate acquire.
+        await vi.advanceTimersByTimeAsync(DEFAULT_WAIT_TIMEOUT_MS - 3_000);
+        void queue.refresh("wait-budget-token");
+        await Promise.resolve();
+        expect(queue.pendingCount).toBe(1);
+        expect(leaseAcquire).toHaveBeenCalledTimes(1);
+
+        // Past the wait budget + slack: now genuinely stuck, so cleanup evicts it
+        // and a fresh acquire is allowed.
+        await vi.advanceTimersByTimeAsync(11_000);
+        void queue.refresh("wait-budget-token");
+        await Promise.resolve();
+        expect(leaseAcquire).toHaveBeenCalledTimes(2);
+
+        queue.clear();
       } finally {
         vi.useRealTimers();
       }
@@ -315,7 +366,9 @@ describe("RefreshQueue", () => {
         await Promise.resolve();
         expect(queue.pendingCount).toBe(1);
 
-        await vi.advanceTimersByTimeAsync(1200);
+        // Past the acquire-stage eviction threshold (lease wait budget 35s + 5s
+        // slack) so the still-blocked first acquire is evicted and superseded.
+        await vi.advanceTimersByTimeAsync(41_000);
         const secondAttempt = queue.refresh("superseded-acquire-token");
         await Promise.resolve();
         expect(leaseAcquire).toHaveBeenCalledTimes(2);

--- a/test/refresh-queue.test.ts
+++ b/test/refresh-queue.test.ts
@@ -332,6 +332,66 @@ describe("RefreshQueue", () => {
       }
     });
 
+    it("sizes acquire eviction off the CONFIGURED lease wait budget, not the default", async () => {
+      vi.useFakeTimers();
+      try {
+        // The coordinator's wait budget is configurable (constructor option /
+        // CODEX_AUTH_REFRESH_LEASE_WAIT_MS). Sizing eviction off the static
+        // DEFAULT_WAIT_TIMEOUT_MS would evict an acquire that is still legitimately
+        // blocked under a larger budget, spawning the duplicate refresh (against an
+        // already-rotated token -> invalid_grant) the lease exists to prevent.
+        const configuredWaitMs = DEFAULT_WAIT_TIMEOUT_MS * 3;
+        const leaseCoordinator = new RefreshLeaseCoordinator({
+          enabled: true,
+          leaseDir: join(tmpdir(), "codex-refresh-lease-configured-wait"),
+          waitTimeoutMs: configuredWaitMs,
+        });
+        expect(leaseCoordinator.configuredWaitTimeoutMs).toBe(configuredWaitMs);
+
+        const leaseAcquire = vi
+          .spyOn(leaseCoordinator, "acquire")
+          .mockReturnValue(
+            new Promise<Awaited<ReturnType<RefreshLeaseCoordinator["acquire"]>>>(
+              () => {},
+            ),
+          );
+        vi.mocked(authModule.refreshAccessToken).mockResolvedValue({
+          type: "success",
+          access: "a",
+          refresh: "r",
+          expires: Date.now() + 3600_000,
+        });
+
+        const queue = new RefreshQueue(30_000, leaseCoordinator);
+        void queue.refresh("configured-wait-token");
+        await Promise.resolve();
+        expect(queue.pendingCount).toBe(1);
+        expect(leaseAcquire).toHaveBeenCalledTimes(1);
+
+        // 45s: past the DEFAULT budget + slack (40s) but well inside the CONFIGURED
+        // budget, so the acquire-stage entry must survive and a concurrent refresh
+        // must dedupe onto it.
+        await vi.advanceTimersByTimeAsync(DEFAULT_WAIT_TIMEOUT_MS + 10_000);
+        void queue.refresh("configured-wait-token");
+        await Promise.resolve();
+        expect(queue.pendingCount).toBe(1);
+        expect(leaseAcquire).toHaveBeenCalledTimes(1);
+
+        // 111s: past the CONFIGURED budget (105s) + slack (5s), so this acquire is
+        // genuinely stuck and cleanup evicts it.
+        await vi.advanceTimersByTimeAsync(
+          configuredWaitMs + 6_000 - (DEFAULT_WAIT_TIMEOUT_MS + 10_000),
+        );
+        void queue.refresh("configured-wait-token");
+        await Promise.resolve();
+        expect(leaseAcquire).toHaveBeenCalledTimes(2);
+
+        queue.clear();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("joins a superseding generation after stale acquire eviction", async () => {
       vi.useFakeTimers();
       try {

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -2829,9 +2829,47 @@ describe('Request Transformer Module', () => {
 				role: 'user',
 				content: 'msg-49',
 			});
-			// The total stays within the item budget.
-			expect(result.length).toBeLessThanOrEqual(maxItems);
-			expect(result.length).toBeGreaterThan(1);
+			// The total fills the item budget exactly — a degenerate implementation
+			// that returned a short slice would still satisfy `<= maxItems`.
+			expect(result.length).toBe(maxItems);
+		});
+
+		it('keeps every preserved head instruction when input only just exceeds the budget', () => {
+			// maxItems 10 => safeMax 10 and tailStart 1, so the SECOND head instruction
+			// also sits inside the tail window. Recounting reserved head slots as
+			// "kept indexes below tailStart" misses it, and the tail slice then drops
+			// a head instruction the head pass deliberately preserved.
+			const maxItems = 10;
+			const input: InputItem[] = [
+				{ type: 'message', role: 'developer', content: 'HEAD_ONE' },
+				{ type: 'message', role: 'system', content: 'HEAD_TWO' },
+			];
+			for (let i = 2; i <= maxItems; i++) {
+				input.push({ type: 'message', role: 'user', content: `msg-${i}` });
+			}
+			expect(input).toHaveLength(maxItems + 1);
+
+			const result = trimInputForFastSession(input, maxItems) as InputItem[];
+
+			// Both head instructions survive, in order, at the front.
+			expect(result[0]).toEqual({
+				type: 'message',
+				role: 'developer',
+				content: 'HEAD_ONE',
+			});
+			expect(result[1]).toEqual({
+				type: 'message',
+				role: 'system',
+				content: 'HEAD_TWO',
+			});
+			// The most recent item is still present.
+			expect(result[result.length - 1]).toEqual({
+				type: 'message',
+				role: 'user',
+				content: `msg-${maxItems}`,
+			});
+			// Exactly the budget: no dropped head, no duplicated head.
+			expect(result).toHaveLength(maxItems);
 		});
 	});
 });

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -9,6 +9,7 @@ import {
     filterHostSystemPromptsWithCachedPrompt,
     addCodexBridgeMessage,
     transformRequestBody,
+    trimInputForFastSession,
 } from '../lib/request/request-transformer.js';
 import * as loggerModule from '../lib/logger.js';
 import { TOOL_REMAP_MESSAGE } from '../lib/prompts/codex.js';
@@ -2801,6 +2802,36 @@ describe('Request Transformer Module', () => {
 					).rejects.toThrowError('transformRequestBody requires body');
 				});
 			});
+		});
+	});
+
+	describe('trimInputForFastSession', () => {
+		it('preserves a leading developer instruction that falls outside the tail window', () => {
+			const input: InputItem[] = [
+				{ type: 'message', role: 'developer', content: 'HEAD_INSTRUCTION' },
+			];
+			for (let i = 1; i < 50; i++) {
+				input.push({ type: 'message', role: 'user', content: `msg-${i}` });
+			}
+
+			const maxItems = 30;
+			const result = trimInputForFastSession(input, maxItems) as InputItem[];
+
+			// The kept head instruction survives even though it sits before the tail window.
+			expect(result[0]).toEqual({
+				type: 'message',
+				role: 'developer',
+				content: 'HEAD_INSTRUCTION',
+			});
+			// The most recent item is still present.
+			expect(result[result.length - 1]).toEqual({
+				type: 'message',
+				role: 'user',
+				content: 'msg-49',
+			});
+			// The total stays within the item budget.
+			expect(result.length).toBeLessThanOrEqual(maxItems);
+			expect(result.length).toBeGreaterThan(1);
 		});
 	});
 });

--- a/test/response-handler.test.ts
+++ b/test/response-handler.test.ts
@@ -818,6 +818,22 @@ data: {"type":"response.done","response":{"id":"resp_789"}}
 			expect(isEmptyResponse({ id: 'resp_123', output: undefined })).toBe(true);
 		});
 
+		it('should return true for response with empty output array', () => {
+			expect(
+				isEmptyResponse({
+					id: 'resp_123',
+					object: 'response',
+					model: 'gpt-5.2',
+					output: [],
+				}),
+			).toBe(true);
+		});
+
+		it('should return true for response whose output entries are all empty', () => {
+			expect(isEmptyResponse({ id: 'resp_123', output: [{}] })).toBe(true);
+			expect(isEmptyResponse({ id: 'resp_123', output: [{}, null] })).toBe(true);
+		});
+
 		it('should return true for response with empty choices array', () => {
 			expect(isEmptyResponse({ id: 'resp_123', choices: [] })).toBe(true);
 		});

--- a/test/response-handler.test.ts
+++ b/test/response-handler.test.ts
@@ -834,6 +834,11 @@ data: {"type":"response.done","response":{"id":"resp_789"}}
 			expect(isEmptyResponse({ id: 'resp_123', output: [{}, null] })).toBe(true);
 		});
 
+		it('should return true for response with empty or whitespace-only string output', () => {
+			expect(isEmptyResponse({ id: 'resp_123', output: '' })).toBe(true);
+			expect(isEmptyResponse({ id: 'resp_123', output: '   ' })).toBe(true);
+		});
+
 		it('should return true for response with empty choices array', () => {
 			expect(isEmptyResponse({ id: 'resp_123', choices: [] })).toBe(true);
 		});

--- a/test/rotation.test.ts
+++ b/test/rotation.test.ts
@@ -236,17 +236,34 @@ describe("TokenBucketTracker", () => {
 	});
 
 	describe("refundToken", () => {
-		it("refunds token consumed within 30s window", () => {
+		it("refunds token consumed within the refund window", () => {
 			tracker.tryConsume(0);
 			const result = tracker.refundToken(0);
 			expect(result).toBe(true);
 			expect(tracker.getTokens(0)).toBe(DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens);
 		});
 
-		it("rejects refund for token consumed over 30s ago", () => {
+		// The refund window (90s) must cover the full request lifetime so a token
+		// consumed at request start is still refundable when a request that ran up
+		// to the 60s default fetch timeout fails at the very end. A consumption aged
+		// past the 30s default fetch timeout but within the window is refundable.
+		// Uses tokensPerMinute:0 so refill can't mask the refund's restored token.
+		it("refunds a token consumed ~55s ago (within the request lifetime window)", () => {
+			const noRefill = new TokenBucketTracker({ tokensPerMinute: 0 });
+			noRefill.tryConsume(0);
+			const beforeRefund = noRefill.getTokens(0);
+
+			vi.advanceTimersByTime(55_000);
+
+			const result = noRefill.refundToken(0);
+			expect(result).toBe(true);
+			expect(noRefill.getTokens(0)).toBe(beforeRefund + 1);
+		});
+
+		it("rejects refund for a truly ancient consumption (over 90s ago)", () => {
 			tracker.tryConsume(0);
 
-			vi.advanceTimersByTime(30_001);
+			vi.advanceTimersByTime(90_001);
 
 			const result = tracker.refundToken(0);
 			expect(result).toBe(false);

--- a/test/rotation.test.ts
+++ b/test/rotation.test.ts
@@ -245,8 +245,9 @@ describe("TokenBucketTracker", () => {
 
 		// The refund window (90s) must cover the full request lifetime so a token
 		// consumed at request start is still refundable when a request that ran up
-		// to the 60s default fetch timeout fails at the very end. A consumption aged
-		// past the 30s default fetch timeout but within the window is refundable.
+		// to the 60s default fetch timeout (config.ts fetchTimeoutMs) fails at the
+		// very end. 55s is inside that fetch timeout and well inside the window, so
+		// it must still refund.
 		// Uses tokensPerMinute:0 so refill can't mask the refund's restored token.
 		it("refunds a token consumed ~55s ago (within the request lifetime window)", () => {
 			const noRefill = new TokenBucketTracker({ tokensPerMinute: 0 });
@@ -257,6 +258,20 @@ describe("TokenBucketTracker", () => {
 
 			const result = noRefill.refundToken(0);
 			expect(result).toBe(true);
+			expect(noRefill.getTokens(0)).toBe(beforeRefund + 1);
+		});
+
+		// The window cutoff is INCLUSIVE (`timestamp >= now - TOKEN_REFUND_WINDOW_MS`).
+		// Pin the exact boundary so an accidental flip to exclusive can't slip past
+		// the 55s / 90_001ms cases on either side of it.
+		it("refunds a consumption sitting exactly on the 90s window boundary", () => {
+			const noRefill = new TokenBucketTracker({ tokensPerMinute: 0 });
+			noRefill.tryConsume(0);
+			const beforeRefund = noRefill.getTokens(0);
+
+			vi.advanceTimersByTime(90_000);
+
+			expect(noRefill.refundToken(0)).toBe(true);
 			expect(noRefill.getTokens(0)).toBe(beforeRefund + 1);
 		});
 

--- a/test/runtime-policy.test.ts
+++ b/test/runtime-policy.test.ts
@@ -138,6 +138,91 @@ describe("runtime policy", () => {
 		expect(decision.errorCode).toBe("budget_blocked");
 	});
 
+	// budget-guard stores limits ONLY under normalizeBudgetKey (lowercased, spaces
+	// -> "-"), so a project key that carries uppercase/spaces at runtime must be
+	// normalized before lookup or the budget is silently unenforced. The limit here
+	// is stored under `project:myapp`, while the runtime state carries the raw
+	// `MyApp`; enforcement proves the lookup normalizes to match the stored key.
+	it("enforces a project budget stored under a normalized key when the runtime projectKey is un-normalized", async () => {
+		const policyState = state();
+		policyState.project.projectKey = "MyApp";
+		policyState.budgets.limits["project:myapp"] = {
+			key: "project:myapp",
+			window: "day",
+			maxRequests: 1,
+			updatedAt: 1,
+		};
+		await appendUsageLedgerRow({
+			createdAt: Date.UTC(2026, 3, 29, 1),
+			source: "runtime-proxy",
+			operation: "responses",
+			outcome: "success",
+			model: "gpt-5.3-codex",
+		});
+
+		const decision = await evaluateRuntimePolicy({
+			state: policyState,
+			accounts: [],
+			model: "gpt-5.3-codex",
+			now: Date.UTC(2026, 3, 29, 2),
+		});
+
+		expect(decision.allowed).toBe(false);
+		expect(decision.statusCode).toBe(429);
+		expect(decision.errorCode).toBe("budget_blocked");
+		expect(
+			decision.budgetEvaluations.some(
+				(evaluation) => evaluation.key === "project:myapp" && !evaluation.allowed,
+			),
+		).toBe(true);
+	});
+
+	// Same normalization gap on the routing profile's budgetKey: stored as
+	// `team-alpha`, carried at runtime as `Team Alpha`.
+	it("enforces a profile budget stored under a normalized key when the runtime budgetKey is un-normalized", async () => {
+		const policyState = state();
+		policyState.project.profile = {
+			projectKey: "project-a",
+			projectName: "Project A",
+			identityRoot: "/repo",
+			preferredTags: [],
+			avoidTags: [],
+			modelAllowlist: [],
+			modelDenylist: [],
+			accountWeightByKey: {},
+			budgetKey: "Team Alpha",
+			updatedAt: 1,
+		};
+		policyState.budgets.limits["team-alpha"] = {
+			key: "team-alpha",
+			window: "day",
+			maxRequests: 1,
+			updatedAt: 1,
+		};
+		await appendUsageLedgerRow({
+			createdAt: Date.UTC(2026, 3, 29, 1),
+			source: "runtime-proxy",
+			operation: "responses",
+			outcome: "success",
+			model: "gpt-5.3-codex",
+		});
+
+		const decision = await evaluateRuntimePolicy({
+			state: policyState,
+			accounts: [],
+			model: "gpt-5.3-codex",
+			now: Date.UTC(2026, 3, 29, 2),
+		});
+
+		expect(decision.allowed).toBe(false);
+		expect(decision.errorCode).toBe("budget_blocked");
+		expect(
+			decision.budgetEvaluations.some(
+				(evaluation) => evaluation.key === "team-alpha" && !evaluation.allowed,
+			),
+		).toBe(true);
+	});
+
 	it("records usage at most once", async () => {
 		const append = vi.fn<typeof appendUsageLedgerRow>().mockResolvedValue({
 			version: 1,


### PR DESCRIPTION
A repo-wide, evidence-driven bug hunt. Every finding below was independently verified (traced through callers + existing tests) before fixing, and each fix ships with a regression test. Full suite green: **5,199 passed, 3 skipped, 0 failed**; typecheck + lint clean.

Five atomic commits, one per subsystem.

## HIGH

**1. Failed refreshes poisoned the cross-process lease cache** (`refresh-lease`, `refresh-queue`)
`RefreshLeaseCoordinator.release` cached *any* result. A transient failed refresh (`executeRefresh` returns `{type:"failed"}` on network error/timeout — it doesn't throw) was written to the lease result file and served verbatim to every follower for the full result TTL (20s), blocking real refreshes — and a cached `failed{429}` could escalate to a multi-minute account cooldown. Now only `success` results (which carry token material) are cached; a failure releases the lock so the next caller retries.

**2. Live-probe exhaustion mis-classified** (`forecast`)
A live probe with a window 100% used and **no** `resetAtMs` stayed `ready` (because `getLiveQuotaWaitMs` returns 0 with no reset to wait on) and could be recommended as the best account. It's now flagged exhausted/delayed when there's no known recovery — while a 100%-used window *with* a `resetAtMs` correctly stays a recoverable `delayed` account (a 429 with known reset times must not read as blocked).

## MEDIUM

**3. Refresh queue evicted still-waiting lease acquires** (`refresh-queue`)
Acquire-stage entries were evicted at `maxEntryAgeMs` (30s), shorter than the lease wait budget (35s), so a legitimately-waiting acquire could be evicted and spawn a duplicate refresh that hits `invalid_grant` (OpenAI rotates the refresh token on first use). Eviction now waits for the lease budget + slack.

**4. Fractional usage falsely benched an account** (`quota-readiness`)
`quotaWindowIsExhausted` rounded `usedPercent` before the exhaustion test, so 99.6% used (0.4% left) rounded to 0-left and was treated as fully exhausted — benching an account (for a 30d Business window, the whole month) that still had quota. Exhaustion now tests the raw `usedPercent` (`>= 100`); rounding stays for display only.

**5. Manual pin & affinity generation lost on import / legacy migration** (`storage`)
`mergeImportedAccounts` and `mergeStorageForMigration` rebuilt storage from scratch, dropping `pinnedAccountIndex` and resetting `affinityGeneration` to 0 (the #474 lost-update fields). A reset generation lets a running proxy holding a higher in-memory generation clobber a newer CLI pin. Both paths now carry the fields forward (validated/clamped on load).

**6. Fast-session trim dropped the head instructions it tried to keep** (`request-transformer`)
`trimInputForFastSession` preserved up to two leading developer/system instructions, then final-sliced the last `safeMax` items — dropping exactly those head items whenever they sat outside the tail window (i.e. essentially always). It now reserves budget for the kept head and re-prepends it.

**7. Empty `output:[]` completions skipped the empty-response retry** (`response-handler`)
`isEmptyResponse` treated `output:[]` (or an array of empty objects) as non-empty, so a genuinely empty completion was returned to the client instead of retried. `hasOutput` is now shape-aware, mirroring the existing `hasChoices` check.

**8. Token-refund window shorter than the fetch timeout** (`rotation`) + **project/profile budgets silently unenforced** (`runtime-policy`)
- `TOKEN_REFUND_WINDOW_MS` (30s) < default `fetchTimeoutMs` (60s), so a timed-out request's token consumption had aged out of the refund window and could never be reversed → gradual token-bucket starvation and spurious `token-exhausted` skips. Widened to 90s.
- Budget limits are stored under `normalizeBudgetKey` but `evaluateBudgets` looked them up with raw keys, so any project/profile budget with uppercase/spaces (e.g. `project:MyApp`) was silently unenforced. The lookup now normalizes the keys.

## Verified but deliberately NOT changed
- **429 live-probe wait** overstates via `Math.max` over all windows — but a "fix" would break the deliberate both-healthy-429 semantics (a test encodes it) and could recommend an account that immediately 429s. Current behavior is conservative/safe; left as-is.
- **`withStreamingFailover` backpressure** — real but pre-existing and conditional (fast upstream + slow client); a ReadableStream backpressure change is easy to get wrong, so it's flagged for a dedicated task, not this sweep.

## Follow-ups (real bugs found, deferred to focused PRs — coordinated/larger changes unsafe to bundle here)
- **Cost/token budgets are inert** (HIGH): the usage ledger never records tokens/cost (every `record()` omits them), so `--cost`/`--tokens` caps never fire — only `--requests` works. Fixing it means parsing upstream (incl. streaming SSE) usage and threading it through the hot path, plus fixing a latent reasoning-token double-count in pricing.
- **Manual pin left stale on account removal** (HIGH): deleting or auto-removing (revoked-token) an account remaps `activeIndex` but not `pinnedAccountIndex`, so a pin can silently route to the wrong account or wedge the pool. Correct fix is a coordinated pin-integrity change (identity re-resolution at both removal sites + hot-path reader validation + affinity-generation bump).
- **Account-policy "unknown" identity collision** (MEDIUM): two accounts both lacking `accountId` and `email` share a policy key (pause/tag bleed). The correct refresh-token-fallback fix requires widening `RuntimePolicyAccount` to avoid a write/read key mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr is a targeted bug sweep across 8 correctness defects spanning the refresh lease/queue, quota readiness, storage migration, request trim, response detection, and budget enforcement subsystems. every fix is accompanied by a regression test and the test suite is reported green at 5,199 passing.

- **refresh/queue**: failed refreshes no longer poison the cross-process lease cache; acquire-stage eviction now respects the full lease wait budget (35s + 5s slack) rather than the shorter cleanup age; the `TOKEN_REFUND_WINDOW_MS` constant is widened to 90s to cover the 60s fetch timeout window, preventing token-bucket starvation.
- **quota/forecast**: exhaustion decisions now use the raw `usedPercent >= 100` predicate instead of the rounded `leftPercent === 0`, avoiding false benching at 99.6%; a live 200-probe at 100% with no `resetAtMs` is now correctly flagged exhausted instead of staying `ready`.
- **storage/budget**: `pinnedAccountIndex` and `affinityGeneration` are preserved through import and legacy migration by re-resolving the pin by account identity after dedupe reorders positions; project/profile budget keys are now normalized before lookup, making `project:MyApp` match its stored `project:myapp` counterpart.

<h3>Confidence Score: 5/5</h3>

all 8 fixes are narrowly scoped to their target subsystems, each paired with a regression test, and the full suite is green — safe to merge

each fix is grounded in a traced, reproduced defect with a corresponding regression test. the refresh-lease fix correctly guards on result?.type === 'success' without touching the lock-release path, so failures still release the lock atomically. the quota exhaustion predicate change is a pure arithmetic correction. the storage pin re-resolution is identity-based and falls back gracefully when the account is gone. the trim fix is structurally sound: keptHead + tailBudget = safeMax is invariant when safeMax >= 8 and keptHead <= 2, so the result never overflows the budget. no cross-subsystem regressions or concurrency hazards were identified.

no files require special attention; the one pre-existing note (secondary OR branch of liveExhausted in test/forecast.test.ts) was flagged in the previous review and does not affect correctness

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/refresh-lease.ts | only cache success results in cross-process lease; export DEFAULT_WAIT_TIMEOUT_MS and add configuredWaitTimeoutMs getter so the queue can size eviction correctly |
| lib/refresh-queue.ts | acquire-stage eviction threshold raised to max(maxEntryAgeMs, leaseWaitBudget+5s slack), preventing premature eviction and duplicate invalid_grant refreshes |
| lib/quota-readiness.ts | adds quotaUsedPercentIsExhausted (raw >= 100 test) and replaces rounded leftPercent check in quotaWindowIsExhausted; fixes false benching at 99.6% |
| lib/forecast.ts | switches all exhaustion tests to quotaUsedPercentIsExhausted; adds liveExhausted guard that flags a 200-probe at 100% with no resetAtMs as exhausted instead of ready |
| lib/policy/runtime-policy.ts | project and profile budget keys are now normalized via normalizeBudgetKey before lookup, making mixed-case/space keys match their stored normalized counterparts |
| lib/storage/import-export.ts | mergeImportedAccounts now accepts findMatchingAccountIndex and re-resolves the manual pin by account identity after dedupe, preserving affinityGeneration |
| lib/storage/project-migration.ts | mergeStorageForMigration passes pinnedAccountIndex/affinityGeneration into normalizeAccountStorage and re-resolves the pin by identity after normalization; drops pin gracefully when account is gone |
| lib/request/request-transformer.ts | trimInputForFastSession now re-prepends the kept head items separately from the tail slice, preventing the final slice from dropping head instructions that fall outside the tail window |
| lib/request/response-handler.ts | isEmptyResponse now treats output:[] and output:[{}] as empty, mirroring the existing hasChoices check; empty/whitespace string output also detected correctly |
| lib/rotation.ts | TOKEN_REFUND_WINDOW_MS widened from 30s to 90s, covering the full request lifetime (60s default fetch timeout + refresh slack) to prevent token-bucket starvation |
| lib/storage/account-port.ts | findMatchingAccountIndex threaded through importAccountsSnapshot parameter chain to mergeImportedAccounts |
| lib/storage.ts | passes findMatchingAccountIndex to mergeStorageForMigration and importAccounts call sites |
| test/refresh-lease.test.ts | regression test: failed release leaves no cached result; success is still shared with followers |
| test/refresh-queue.test.ts | advances fake timers to 41s (past 40s threshold) to test eviction; adds tests for configured vs default wait budget sizing |
| test/forecast.test.ts | three new cases: 99.6% sibling ignored for exhausted wait, 99.6% live window not delayed, 100% with no resetAtMs flagged exhausted; primary OR branch of liveExhausted covered — secondary branch still lacks a mirror test |
| test/import-export.test.ts | four new cases covering pin preservation, identity remap after dedupe shift, pin drop when account gone, and absent pin/generation |
| test/project-migration.test.ts | two new cases: pin + generation carried through migration with dedupe-shifted identity remap; pin cleared when account dropped by normalization |
| test/runtime-policy.test.ts | two new cases enforce project and profile budgets when runtime keys are un-normalized (MyApp vs project:myapp, Team Alpha vs team-alpha) |
| test/request-transformer.test.ts | two new cases verify head instructions outside and inside the tail window are preserved and that result length equals the budget exactly |
| test/rotation.test.ts | refund window tests updated to 90s boundary; adds 55s mid-window and exact-boundary cases |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller A (owner)
    participant C2 as Caller B (follower)
    participant L as RefreshLeaseCoordinator
    participant FS as Lease File (disk)
    participant Q as RefreshQueue cleanup

    Note over Q: acquire-stage eviction threshold = max(maxEntryAgeMs, leaseWaitBudget + slack)

    C->>L: acquire(token)
    L->>FS: write lock file
    L-->>C: "role=owner"

    alt success path
        C->>L: "release({type:success})"
        L->>FS: writeResult (cache success)
        L->>FS: unlink lock
        C2->>L: acquire(token)
        L->>FS: readFreshResult hit
        L-->>C2: "role=follower result=success"
    else failure path BEFORE fix
        C->>L: "release({type:failed})"
        L->>FS: writeResult cached failure BUG
        L->>FS: unlink lock
        C2->>L: acquire(token)
        L->>FS: readFreshResult stale failure served for full TTL
        L-->>C2: "role=follower result=failed wrong"
    else failure path AFTER fix
        C->>L: "release({type:failed})"
        Note over L: skip writeResult no token material to share
        L->>FS: unlink lock
        C2->>L: acquire(token)
        L->>FS: readFreshResult miss no cached result
        L-->>C2: "role=owner retries immediately"
    end
```

<sub>Reviews (3): Last reviewed commit: ["fix(forecast): pick the exhausted wait f..."](https://github.com/ndycode/codex-multi-auth/commit/001683e46321db75b2202d5088771746cb703a77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46778471)</sub>

<!-- /greptile_comment -->