### PR TITLE
fix(pin): keep a manual pin pointing at its account across account removal

### DIFF
--- a/lib/codex-manager/login-menu-actions.ts
+++ b/lib/codex-manager/login-menu-actions.ts
@@ -7,6 +7,7 @@ import {
 	type AccountStorageV3,
 	findMatchingAccountIndex,
 	loadAccounts,
+	reconcilePinnedAccountIndex,
 	type NamedBackupSummary,
 	setStoragePath,
 	withAccountStorageTransaction,
@@ -252,6 +253,9 @@ function replaceManageActionStorage(
 	target.activeIndexByFamily = {
 		...source.activeIndexByFamily,
 	};
+	// Keep the in-memory view's manual pin in sync with what was just persisted;
+	// the pin was re-resolved (or cleared) against the post-deletion account list.
+	target.pinnedAccountIndex = source.pinnedAccountIndex;
 }
 
 function resolveManageActionAccountIndex(
@@ -332,8 +336,20 @@ export async function handleManageAction(
 				if (!matchesManageActionAccount(selectedAccount, nextAccount)) {
 					return;
 				}
+				// Capture the pinned account BEFORE the splice so the manual pin can be
+				// followed by identity afterwards. resetManageActionSelection only remaps
+				// activeIndex; without this the pin keeps its raw slot and silently points
+				// at a different account (or wedges the pool). See #474.
+				const pinnedAccount =
+					typeof nextStorage.pinnedAccountIndex === "number"
+						? nextStorage.accounts[nextStorage.pinnedAccountIndex]
+						: undefined;
 				nextStorage.accounts.splice(nextIndex, 1);
 				resetManageActionSelection(nextStorage, nextIndex);
+				nextStorage.pinnedAccountIndex = reconcilePinnedAccountIndex(
+					pinnedAccount,
+					nextStorage.accounts,
+				);
 				await persist(nextStorage);
 				replaceManageActionStorage(storage, nextStorage);
 				deleted = true;

--- a/lib/runtime/account-check.ts
+++ b/lib/runtime/account-check.ts
@@ -2,7 +2,11 @@ import { maskEmail } from "../logger.js";
 import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../quota-probe.js";
 import { isCodexUnavailableError } from "../errors.js";
 import type { ModelFamily } from "../prompts/codex.js";
-import type { AccountStorageV3, FlaggedAccountMetadataV1 } from "../storage.js";
+import {
+	type AccountStorageV3,
+	type FlaggedAccountMetadataV1,
+	reconcilePinnedAccountIndex,
+} from "../storage.js";
 import type { AccountIdSource, TokenResult } from "../types.js";
 import type { AccountCheckWorkingState } from "./account-check-types.js";
 import type { CodexQuotaSnapshot } from "./quota-headers.js";
@@ -320,10 +324,21 @@ export async function runRuntimeAccountCheck(
 	}
 
 	if (state.removeFromActive.size > 0) {
+		// Follow the manual pin by identity across the removal: the filter can drop
+		// several accounts at once, so a raw index would point at the wrong account
+		// (or out of range, wedging the pool). See #474.
+		const pinnedAccount =
+			typeof workingStorage.pinnedAccountIndex === "number"
+				? workingStorage.accounts[workingStorage.pinnedAccountIndex]
+				: undefined;
 		workingStorage.accounts = workingStorage.accounts.filter(
 			(account) => !state.removeFromActive.has(account.refreshToken),
 		);
 		deps.clampRuntimeActiveIndices(workingStorage, deps.MODEL_FAMILIES);
+		workingStorage.pinnedAccountIndex = reconcilePinnedAccountIndex(
+			pinnedAccount,
+			workingStorage.accounts,
+		);
 		state.storageChanged = true;
 	}
 

--- a/lib/runtime/rotation-storage-meta.ts
+++ b/lib/runtime/rotation-storage-meta.ts
@@ -131,10 +131,16 @@ export function readStorageMetaFromDisk(
 			pinnedAccountIndex?: unknown;
 			affinityGeneration?: unknown;
 		};
+		// Validate exactly like readPinAndGenFromDisk / the loader / the zod schema:
+		// a non-integer or negative pin is rejected (null), never truncated. This is
+		// the value the proxy actually routes on, so a malformed disk pin must not
+		// slip past here and reach chooseAccount (a negative index wedges the pool).
 		const pinnedAccountIndex =
 			typeof parsed.pinnedAccountIndex === "number" &&
-			Number.isFinite(parsed.pinnedAccountIndex)
-				? Math.trunc(parsed.pinnedAccountIndex)
+			Number.isFinite(parsed.pinnedAccountIndex) &&
+			Number.isInteger(parsed.pinnedAccountIndex) &&
+			parsed.pinnedAccountIndex >= 0
+				? parsed.pinnedAccountIndex
 				: null;
 		const affinityGeneration =
 			typeof parsed.affinityGeneration === "number" &&

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1038,6 +1038,28 @@ export function findMatchingAccountIndex<
 	return findUniqueAccountIdMatchIndex(accounts, candidateRef, options);
 }
 
+/**
+ * Re-resolve a manual pin after the account list changes (deletion / auto-removal).
+ * `pinnedAccountIndex` is a POSITION, so once accounts are removed or reordered the
+ * raw index silently points at a DIFFERENT account — or out of range, which wedges
+ * the pool. Capture the pinned account BEFORE the change and pass it here to follow
+ * it by identity: returns its new index, or `undefined` when it is no longer present
+ * (the pin is cleared, never left dangling at a stale slot). See #474 — a manual pin
+ * must keep pointing at the account the user chose, or be dropped.
+ */
+export function reconcilePinnedAccountIndex(
+	pinnedAccount:
+		| Pick<AccountLike, "accountId" | "email" | "refreshToken">
+		| undefined,
+	nextAccounts: readonly Pick<
+		AccountLike,
+		"accountId" | "email" | "refreshToken"
+	>[],
+): number | undefined {
+	if (!pinnedAccount) return undefined;
+	return findMatchingAccountIndex(nextAccounts, pinnedAccount);
+}
+
 export function resolveAccountSelectionIndex<
 	T extends Pick<AccountLike, "accountId" | "email" | "refreshToken">,
 >(

--- a/test/issue-474-pin-safety.test.ts
+++ b/test/issue-474-pin-safety.test.ts
@@ -15,6 +15,7 @@ import {
 import { runStatusCommand } from "../lib/codex-manager/commands/status.js";
 import {
 	readPinAndGenFromDisk,
+	reconcilePinnedAccountIndex,
 	setStoragePathDirect,
 	type AccountStorageV3,
 } from "../lib/storage.js";
@@ -494,6 +495,67 @@ describe("issue #474 — pin-honored review feedback", () => {
 			const meta = readPinAndGenFromDisk(path);
 			expect(meta.pinnedAccountIndex).toBeUndefined();
 			expect(meta.affinityGeneration).toBe(0);
+		});
+	});
+
+	describe("readStorageMetaFromDisk pin validation", () => {
+		it("rejects a negative or non-integer pin, matching the other pin readers", () => {
+			// The hot-path reader governs routing, so a malformed pin must not slip
+			// past it into chooseAccount (a negative index wedges the pool).
+			const negativePath = makeTmpStoragePath();
+			writeFileSync(
+				negativePath,
+				JSON.stringify({ pinnedAccountIndex: -1, affinityGeneration: 3 }),
+				"utf8",
+			);
+			expect(readStorageMetaFromDisk(negativePath).pinnedAccountIndex).toBeNull();
+
+			const fractionalPath = makeTmpStoragePath();
+			writeFileSync(
+				fractionalPath,
+				JSON.stringify({ pinnedAccountIndex: 2.5, affinityGeneration: 3 }),
+				"utf8",
+			);
+			expect(
+				readStorageMetaFromDisk(fractionalPath).pinnedAccountIndex,
+			).toBeNull();
+
+			const validPath = makeTmpStoragePath();
+			writeFileSync(
+				validPath,
+				JSON.stringify({ pinnedAccountIndex: 2, affinityGeneration: 3 }),
+				"utf8",
+			);
+			expect(readStorageMetaFromDisk(validPath).pinnedAccountIndex).toBe(2);
+		});
+	});
+
+	describe("reconcilePinnedAccountIndex follows a pin across removal", () => {
+		const acc = (id: string) => ({
+			accountId: `acc_${id}`,
+			email: `${id}@example.com`,
+			refreshToken: `refresh-${id}`,
+		});
+
+		it("re-resolves the pinned account's new index after lower accounts are removed", () => {
+			const pinned = acc("d");
+			// one lower account removed → shifts down by one
+			expect(
+				reconcilePinnedAccountIndex(pinned, [acc("b"), acc("c"), pinned]),
+			).toBe(2);
+			// multiple lower accounts removed (the account-check filter path) → still
+			// lands on the same account by identity
+			expect(reconcilePinnedAccountIndex(pinned, [acc("c"), pinned])).toBe(1);
+		});
+
+		it("clears the pin when the pinned account is gone, and is undefined with no pin", () => {
+			const pinned = acc("b");
+			expect(
+				reconcilePinnedAccountIndex(pinned, [acc("a"), acc("c")]),
+			).toBeUndefined();
+			expect(
+				reconcilePinnedAccountIndex(undefined, [acc("a"), acc("b")]),
+			).toBeUndefined();
 		});
 	});
 });

--- a/test/login-menu-actions.test.ts
+++ b/test/login-menu-actions.test.ts
@@ -265,6 +265,48 @@ describe("handleManageAction delete", () => {
 		expect(saved.activeIndexByFamily["gpt-5-codex"]).toBe(0);
 		expect(saved.activeIndexByFamily.codex).toBe(0);
 	});
+
+	it("shifts the manual pin to follow its account when a lower-indexed account is deleted", async () => {
+		const storage = storageWith([account("a"), account("b"), account("c")]);
+		storage.pinnedAccountIndex = 2; // pinned to account c
+		loadedStorage = structuredClone(storage);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			deleteAccountIndex: 0,
+		} satisfies MenuResult);
+
+		const saved = persisted[0];
+		expect(saved.accounts.map((entry) => entry.accountId)).toEqual([
+			"acc_b",
+			"acc_c",
+		]);
+		// The pin must keep pointing at account c (now index 1), not whatever slot 2
+		// now holds — otherwise the pin silently routes to the wrong account (#474).
+		expect(saved.pinnedAccountIndex).toBe(1);
+		expect(storage.pinnedAccountIndex).toBe(1);
+	});
+
+	it("clears the manual pin when the pinned account itself is deleted", async () => {
+		const storage = storageWith([account("a"), account("b"), account("c")]);
+		storage.pinnedAccountIndex = 1; // pinned to account b
+		loadedStorage = structuredClone(storage);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			deleteAccountIndex: 1,
+		} satisfies MenuResult);
+
+		const saved = persisted[0];
+		expect(saved.accounts.map((entry) => entry.accountId)).toEqual([
+			"acc_a",
+			"acc_c",
+		]);
+		// The pinned account is gone; the pin must be cleared, never left dangling
+		// at a stale slot (which would wedge or mis-route the pool).
+		expect(saved.pinnedAccountIndex).toBeUndefined();
+		expect(storage.pinnedAccountIndex).toBeUndefined();
+	});
 });
 
 describe("handleManageAction toggle", () => {

--- a/test/runtime-account-check.test.ts
+++ b/test/runtime-account-check.test.ts
@@ -506,4 +506,56 @@ describe("runRuntimeAccountCheck", () => {
 		]);
 		expect(saved.pinnedAccountIndex).toBe(1);
 	});
+
+	it("clears a manual pin when the pinned account itself is auto-removed on deep probe", async () => {
+		const now = 10_000;
+		const saveAccounts = vi.fn(async () => {});
+		// The pinned account (index 2) is the one with no cached access whose
+		// refresh fails flaggably, so the deep-probe auto-removal drops it. The pin
+		// has nothing left to follow and must be cleared instead of dangling at a
+		// stale slot that now belongs to a different account (#474). This also pins
+		// the ordering in account-check.ts: the pinned account has to be captured
+		// BEFORE the filter runs, or it could never be resolved at all.
+		await runRuntimeAccountCheck(true, {
+			hydrateEmails: async (storage) => storage,
+			loadAccounts: async () => ({
+				version: 3,
+				pinnedAccountIndex: 2,
+				accounts: [
+					{ email: "a@example.com", accountId: "acc_a", refreshToken: "r0", accessToken: "a0", expiresAt: now + 3_600_000, addedAt: 1, lastUsed: 1 },
+					{ email: "b@example.com", accountId: "acc_b", refreshToken: "r1", accessToken: "a1", expiresAt: now + 3_600_000, addedAt: 1, lastUsed: 1 },
+					{ email: "c@example.com", accountId: "acc_c", refreshToken: "r2", accessToken: undefined, addedAt: 1, lastUsed: 1 },
+				],
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+			}),
+			createEmptyStorage: () => ({ version: 3, accounts: [], activeIndex: 0, activeIndexByFamily: {} }),
+			loadFlaggedAccounts: async () => ({ version: 1, accounts: [] }),
+			createAccountCheckWorkingState: (flaggedStorage) => ({ flaggedStorage, removeFromActive: new Set(), storageChanged: false, flaggedChanged: false, ok: 0, errors: 0, disabled: 0 }),
+			lookupCodexCliTokensByEmail: async () => null,
+			extractAccountId: () => undefined,
+			shouldUpdateAccountIdFromToken: () => false,
+			sanitizeEmail: (email) => email,
+			extractAccountEmail: () => undefined,
+			queuedRefresh: async () => ({ type: "failed" as const, reason: "invalid_grant", message: "token has been revoked" }),
+			isRuntimeFlaggableFailure: () => true,
+			fetchCodexQuotaSnapshot: async () => ({ remaining5h: 1, remaining7d: 2 } as never),
+			resolveRequestAccountId: () => "acct",
+			formatCodexQuotaLine: () => "quota ok",
+			clampRuntimeActiveIndices: vi.fn(),
+			MODEL_FAMILIES: ["codex"],
+			saveAccounts,
+			invalidateAccountManagerCache: vi.fn(),
+			saveFlaggedAccounts: vi.fn(async () => {}),
+			now: () => now,
+			showLine: vi.fn(),
+		});
+
+		const saved = saveAccounts.mock.calls[0]?.[0];
+		expect(saved.accounts.map((entry) => entry.refreshToken)).toEqual([
+			"r0",
+			"r1",
+		]);
+		expect(saved.pinnedAccountIndex).toBeUndefined();
+	});
 });

--- a/test/runtime-account-check.test.ts
+++ b/test/runtime-account-check.test.ts
@@ -456,4 +456,54 @@ describe("runRuntimeAccountCheck", () => {
 		// summary reflects the warning bucket
 		expect(lines.some((l) => /Results:.*1 warning/.test(l))).toBe(true);
 	});
+
+	it("re-resolves a manual pin when a lower account is auto-removed on deep probe", async () => {
+		const now = 10_000;
+		const saveAccounts = vi.fn(async () => {});
+		// Account 0 has no cached access and its refresh fails flaggably, so the
+		// deep-probe auto-removal drops it. The pin points at account 2 and must
+		// follow that account by identity (now index 1) rather than keep its stale
+		// slot — otherwise the pin silently routes to the wrong account (#474).
+		await runRuntimeAccountCheck(true, {
+			hydrateEmails: async (storage) => storage,
+			loadAccounts: async () => ({
+				version: 3,
+				pinnedAccountIndex: 2,
+				accounts: [
+					{ email: "a@example.com", accountId: "acc_a", refreshToken: "r0", accessToken: undefined, addedAt: 1, lastUsed: 1 },
+					{ email: "b@example.com", accountId: "acc_b", refreshToken: "r1", accessToken: "a1", expiresAt: now + 3_600_000, addedAt: 1, lastUsed: 1 },
+					{ email: "c@example.com", accountId: "acc_c", refreshToken: "r2", accessToken: "a2", expiresAt: now + 3_600_000, addedAt: 1, lastUsed: 1 },
+				],
+				activeIndex: 0,
+				activeIndexByFamily: { codex: 0 },
+			}),
+			createEmptyStorage: () => ({ version: 3, accounts: [], activeIndex: 0, activeIndexByFamily: {} }),
+			loadFlaggedAccounts: async () => ({ version: 1, accounts: [] }),
+			createAccountCheckWorkingState: (flaggedStorage) => ({ flaggedStorage, removeFromActive: new Set(), storageChanged: false, flaggedChanged: false, ok: 0, errors: 0, disabled: 0 }),
+			lookupCodexCliTokensByEmail: async () => null,
+			extractAccountId: () => undefined,
+			shouldUpdateAccountIdFromToken: () => false,
+			sanitizeEmail: (email) => email,
+			extractAccountEmail: () => undefined,
+			queuedRefresh: async () => ({ type: "failed" as const, reason: "invalid_grant", message: "token has been revoked" }),
+			isRuntimeFlaggableFailure: () => true,
+			fetchCodexQuotaSnapshot: async () => ({ remaining5h: 1, remaining7d: 2 } as never),
+			resolveRequestAccountId: () => "acct",
+			formatCodexQuotaLine: () => "quota ok",
+			clampRuntimeActiveIndices: vi.fn(),
+			MODEL_FAMILIES: ["codex"],
+			saveAccounts,
+			invalidateAccountManagerCache: vi.fn(),
+			saveFlaggedAccounts: vi.fn(async () => {}),
+			now: () => now,
+			showLine: vi.fn(),
+		});
+
+		const saved = saveAccounts.mock.calls[0]?.[0];
+		expect(saved.accounts.map((entry) => entry.refreshToken)).toEqual([
+			"r1",
+			"r2",
+		]);
+		expect(saved.pinnedAccountIndex).toBe(1);
+	});
 });


### PR DESCRIPTION
## HIGH — a manual pin silently routes to the wrong account after a removal

`chooseAccount` honors `pinnedAccountIndex` **by position**. But the two account-removal fixups remap `activeIndex`/`activeIndexByFamily` and **never touch `pinnedAccountIndex`**, and the loader only *range*-checks the pin (not identity). So once accounts shift, a stale in-range pin points at a **different** account — and an out-of-range pin returns `null` → the pinned-path suppresses stale-state recovery → the pool wedges with a 503.

The dangerous path is **automatic and silent**: the runtime account-check removes accounts whose refresh tokens were revoked, with no user action.

**Scenario A (silent mis-route):** pool `[A,B,C,D]`, user pins index 2 (`C`). `A`'s token is revoked → auto-removed → pool `[B,C,D]`, disk pin still `2`. On the next proxy load the pin (`2 < 3`, still "valid") routes **every** request to `D` — an account the user never pinned. No error surfaces, and it persists across reloads because the loader keeps a stale in-range pin.

**Scenario B (wedge):** pool `[A,B,C]`, pin=2 (`C`, last). Remove `B` → `[A,C]`, disk pin still `2` → `2 >= count` → `chooseAccount` returns `null`; because the pin is set, stale-state recovery is suppressed → 503 "pinned account unavailable" until the user manually unpins.

### Fix

Both removal sites now follow the pinned account by **identity** via a new `reconcilePinnedAccountIndex(pinnedAccount, nextAccounts)` helper — capture the pinned account before the change, then re-resolve its new index afterward (or **clear** the pin when the account is gone, never leave it dangling):

- `lib/codex-manager/login-menu-actions.ts` — interactive delete (single splice); the in-memory menu view is also kept in sync.
- `lib/runtime/account-check.ts` — the automatic revoked-token removal (multi-account filter). This path already invalidates the account-manager cache, so the reconciled pin is picked up on reload.

## MEDIUM — proxy hot-path pin reader accepted pins every other reader rejects

`readStorageMetaFromDisk` (`lib/runtime/rotation-storage-meta.ts`) truncated the pin with only a `Number.isFinite` check, omitting the `Number.isInteger` / `>= 0` validation that `readPinAndGenFromDisk`, the loader, and the zod schema all enforce — and it's the value the proxy actually routes on. A negative or non-integer disk pin slipped straight into `chooseAccount` and wedged the pool. It now rejects non-integer/negative pins to `null`, matching the other readers.

## Tests
- `test/login-menu-actions.test.ts`: deleting a lower-indexed account shifts the pin to keep pointing at the same account; deleting the pinned account clears the pin.
- `test/runtime-account-check.test.ts`: the silent deep-probe auto-removal re-resolves the pin by identity.
- `test/issue-474-pin-safety.test.ts`: `readStorageMetaFromDisk` rejects negative/non-integer pins; unit coverage for `reconcilePinnedAccountIndex` (including the multi-account-removal case).

Full suite green: **5,192 passed, 3 skipped, 0 failed**; typecheck + lint clean.

## Not included (residual, lower confidence)
The removal fixups do not bump `affinityGeneration`, so a *concurrently running* proxy's sticky **session affinity** isn't invalidated for the reshuffled pool (and restore-from-backup persists the backup's pin/gen verbatim). That interacts with the #474 compare-and-set and is a separate, lower-severity concern — deferred to avoid reintroducing the clobber bug that mechanism prevents. The pin **correctness** (the HIGH) is fully fixed here.

Context: found by a coverage-gap audit of the AccountManager selection path — the existing pin tests only ever *add* accounts, never delete below a pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes position-based pin drift — both removal sites (interactive delete in `login-menu-actions.ts` and auto-removal in `account-check.ts`) now capture the pinned account by identity before mutation and call `reconcilePinnedAccountIndex` after, so the pin follows its account or is cleared cleanly. a secondary fix aligns the proxy hot-path validator in `readStorageMetaFromDisk` with the other readers, rejecting negative/fractional disk pins instead of truncating them into `chooseAccount`.

- new `reconcilePinnedAccountIndex` helper in `storage.ts` wraps `findMatchingAccountIndex`; returns `undefined` (not a stale slot) when the pinned account is gone.
- `replaceManageActionStorage` now syncs `pinnedAccountIndex` to the in-memory view so the cli menu and disk stay in sync after a delete.
- test coverage closes both scenario a (shift) and scenario b (clear) for interactive delete, deep-probe auto-removal, the hot-path validator, and the reconcile helper directly.

<h3>Confidence Score: 5/5</h3>

safe to merge — the identity-capture + reconcile pattern is correct at both removal sites, pin is never left dangling, and the hot-path validator change is strictly more conservative

both removal sites correctly capture the pinned account before the list mutation and re-resolve by identity after; the reconcile helper delegates to the well-tested findMatchingAccountIndex with a clean undefined-clear path; the validator tightening in readStorageMetaFromDisk removes a pre-existing gap with no correctness regression on normal integer pins; tests cover shift, clear, and no-pin paths end-to-end including the previously flagged scenario b

no files require special attention; the acknowledged affinityGeneration/concurrency gap is pre-existing and correctly deferred

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage.ts | adds `reconcilePinnedAccountIndex` — a clean thin wrapper over `findMatchingAccountIndex` that follows a captured account by identity and returns `undefined` (clear) when the account is absent; type-safe, correctly thin |
| lib/codex-manager/login-menu-actions.ts | captures pinned account by identity before the splice inside `withAccountStorageTransaction`, reconciles after, and syncs the reconciled pin to the in-memory view via `replaceManageActionStorage`; ordering is correct |
| lib/runtime/account-check.ts | captures pinned account before the multi-account filter and reconciles after; `storageChanged = true` ensures `saveAccounts` is called so the pin hits disk; pre-existing concurrency/affinity-generation concern is acknowledged and deferred |
| lib/runtime/rotation-storage-meta.ts | replaces the `Math.trunc`+`isFinite` path with `Number.isInteger`+`>= 0`, matching `readPinAndGenFromDisk`; negative/fractional disk pins now return `null` instead of reaching `chooseAccount` |
| test/login-menu-actions.test.ts | adds shift and clear path tests for interactive delete; asserts both the persisted value and the in-memory `storage.pinnedAccountIndex` after `replaceManageActionStorage` |
| test/runtime-account-check.test.ts | adds two deep-probe tests: pin shift (lower account revoked) and pin clear (pinned account revoked); addresses the previously flagged missing scenario B coverage |
| test/issue-474-pin-safety.test.ts | adds unit tests for `readStorageMetaFromDisk` pin validation (negative/fractional rejection) and `reconcilePinnedAccountIndex` (shift, clear, no-op when pin undefined) |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant RemovalSite as login-menu-actions / account-check
    participant Storage as storage.ts
    participant Disk as openai-codex-accounts.json
    participant Proxy as rotation-storage-meta (hot path)

    Caller->>RemovalSite: delete account / auto-remove revoked token
    RemovalSite->>Storage: "read pinnedAccount = accounts[pinnedAccountIndex]"
    note over RemovalSite: capture by identity BEFORE mutation
    RemovalSite->>Storage: splice / filter accounts
    RemovalSite->>Storage: reconcilePinnedAccountIndex(pinnedAccount, nextAccounts)
    Storage-->>RemovalSite: new index (shifted) OR undefined (cleared)
    RemovalSite->>Disk: saveAccounts(workingStorage)
    RemovalSite->>RemovalSite: replaceManageActionStorage (in-memory sync)
    Proxy->>Disk: readStorageMetaFromDisk on next request
    note over Proxy: isInteger + >= 0 guard (fixed) negative/fractional to null
    Proxy-->>Caller: routes to correct account (or no pin)
```

<sub>Reviews (2): Last reviewed commit: ["test(pin): cover the pin-clear path when..."](https://github.com/ndycode/codex-multi-auth/commit/8ee0666867a59cbf07e6716726ac380d216a1623) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46783092)</sub>

<!-- /greptile_comment -->