### PR TITLE
docs: realign maintainer docs with the 2.8.0 architecture

### DIFF
--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -57,7 +57,8 @@ Runtime rotation enabled -> one of three transports
   |
   |- interactive TUI (no forwarded subcommand)
   |    canonical CODEX_HOME + ephemeral -c provider overrides
-  |    (no shadow copy, no config.toml rewrite, detach on exit)
+  |    (no shadow copy, no provider/transport rewrite of config.toml,
+  |     detach on exit; the auth-store reconcile above still applies)
   |
   |- codex app
   |    app runtime helper process + shadow CODEX_HOME
@@ -165,7 +166,7 @@ Policy evaluation (`lib/policy/runtime-policy.ts`) can block paused/drained acco
 
    | Branch | Predicate | Transport |
    | --- | --- | --- |
-   | Interactive TUI | `isCodexInteractiveTuiCommand` — no forwarded subcommand at all | App runtime helper with `useCanonicalHome: true` and `detachOnExit: true`. Runs against the **canonical** `CODEX_HOME`; the provider is passed as ephemeral `-c model_providers.*` overrides. No shadow copy, no state sync-back, and `config.toml` is never rewritten on this path. |
+   | Interactive TUI | `isCodexInteractiveTuiCommand` — no forwarded subcommand at all | App runtime helper with `useCanonicalHome: true` and `detachOnExit: true`. Runs against the **canonical** `CODEX_HOME`; the provider is passed as ephemeral `-c model_providers.*` overrides. No shadow copy and no state sync-back. Nothing **provider- or transport-related** is written into `config.toml` on this path — the only top-level key the wrapper still reconciles there is `cli_auth_credentials_store`, which is transport-independent (see step 4 note). |
    | `codex app` | `isCodexAppCommand` — forwarded command is `app` | App runtime helper process with a shadow `CODEX_HOME`. |
    | Everything else | request-bearing forwarded command | Shadow `CODEX_HOME` created inline by the wrapper process. |
 
@@ -177,7 +178,11 @@ Policy evaluation (`lib/policy/runtime-policy.ts`) can block paused/drained acco
 9. Usage ledger rows and runtime counters are persisted for status/report/usage/budget commands.
 10. On exit, shadow-home branches sync refreshed official state files back and remove the temporary directory. The canonical-home branch has nothing to sync — it read and wrote official state in place.
 
-Why the interactive branch is different: copying the Codex home into a shadow made the official CLI reindex its thread history and SQLite state on every TUI launch. Running interactive sessions against the canonical home keeps that state reusable. Because neither session copies nor syncs state, two interactive sessions can run concurrently against the same home — the same as running the official CLI twice — so no lock is taken. Regression coverage lives in `test/codex-bin-wrapper.test.ts`.
+Why the interactive branch is different: copying the Codex home into a shadow made the official CLI reindex its thread history and SQLite state on every TUI launch. Running interactive sessions against the canonical home keeps that state reusable.
+
+Two interactive sessions can therefore run concurrently against the same home — the same as running the official CLI twice — and **no lock is taken over session state**: neither session copies or syncs it, so there is nothing to clobber. Regression coverage lives in `test/codex-bin-wrapper.test.ts`.
+
+Scope that guarantee to session state only. It does **not** extend to `config.toml`: `ensureCodexCliFileAuthStore` (`lib/codex-cli/writer.ts`) still read-modify-writes the canonical file when the store is not already `"file"`, and the atomic write does not serialize cross-process writers. That is safe in practice rather than by locking — the operation is idempotent, converges on a single value, and lands via atomic rename, so concurrent invocations agree instead of interleaving. Anything added to that write path that is *not* idempotent would need a real lock.
 
 Internal env used by these branches (not operator-facing): `CODEX_MULTI_AUTH_APP_ROTATION_USE_CANONICAL_HOME`, `CODEX_MULTI_AUTH_APP_SERVER_CONFIG_ARGS_JSON`, `CODEX_MULTI_AUTH_APP_ROTATION_OWNER_PID`, `CODEX_MULTI_AUTH_REAL_CODEX_HOME`.
 

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -47,17 +47,25 @@ scripts/codex.js
   |- handles auth subcommands locally
   |- discovers official Codex binary
   |- injects file-backed auth store unless caller opted out
+  |- reconciles top-level cli_auth_credentials_store on startup
   |- resolves --account / FORCE_ACCOUNT to ephemeral pin
-  |- optionally creates shadow CODEX_HOME for runtime rotation
+  |- picks a runtime-rotation transport (see below)
   v
 Official Codex CLI
 
-Runtime rotation enabled
+Runtime rotation enabled -> one of three transports
   |
-  v
-shadow CODEX_HOME/config.toml
-  |- model_provider = "codex-multi-auth-runtime-proxy"
-  |- provider base_url = localhost proxy
+  |- interactive TUI (no forwarded subcommand)
+  |    canonical CODEX_HOME + ephemeral -c provider overrides
+  |    (no shadow copy, no config.toml rewrite, detach on exit)
+  |
+  |- codex app
+  |    app runtime helper process + shadow CODEX_HOME
+  |
+  |- every other request-bearing command
+  |    shadow CODEX_HOME/config.toml
+  |      |- model_provider = "codex-multi-auth-runtime-proxy"
+  |      |- provider base_url = localhost proxy
   v
 lib/runtime-rotation-proxy.ts
   |- validates local client token
@@ -103,7 +111,8 @@ Codex or ChatGPT-backed request flow
 | --- | --- | --- |
 | Standalone package CLI | `scripts/codex-multi-auth.js`, `scripts/codex-routing.js` | Primary account-manager entrypoint, bare-subcommand normalization, version surface |
 | Convenience launcher | `scripts/mcodex.js` | Cross-platform `mcodex` bin: forwards to the Codex wrapper; optional live monitor (`watch`) and tmux session helpers |
-| Optional forwarding wrapper | `scripts/codex.js`, `scripts/codex-routing.js`, `scripts/codex-bin-resolver.js` | Local auth routing, official Codex discovery, file-store forwarding, shadow-home setup, ephemeral `--account` pin |
+| Optional forwarding wrapper | `scripts/codex.js`, `scripts/codex-routing.js`, `scripts/codex-bin-resolver.js` | Local auth routing, official Codex discovery, file-store forwarding, canonical-home vs shadow-home transport selection, ephemeral `--account` pin |
+| Official Codex CLI state | `lib/codex-cli/` (`state.ts`, `writer.ts`, `sync.ts`, `observability.ts`) | Reads/writes the official `~/.codex` auth + accounts + `config.toml` surface, active-selection sync, and the `cli_auth_credentials_store = "file"` reconcile |
 | Auth flow | `lib/auth/auth.ts`, `lib/auth/server.ts`, `lib/auth/browser.ts` | PKCE OAuth flow, callback handling, browser/manual/device auth path |
 | Account manager | `lib/codex-manager.ts`, `lib/codex-manager/commands/`, `lib/accounts.ts` | Dashboard actions, account selection, health operations, repair commands |
 | Manager command surface | `lib/codex-manager/commands/*` | Focused modules: `account`, `best`, `bridge`, `budget`, `check`, `config-explain`, `debug-bundle`, `forecast`, `history`, `init-config`, `integrations`, `models`, `monitor`, `report`, `rotation`, `status`, `switch`, `uninstall`, `unpin`, `usage`, `verify`, `why-selected`, `workspace` (plus repair helpers in `repair-commands.ts`) |
@@ -152,14 +161,25 @@ Policy evaluation (`lib/policy/runtime-policy.ts`) can block paused/drained acco
 
 1. The wrapper checks `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY` and `codexRuntimeRotationProxy`.
 2. If disabled, the command forwards to the official Codex CLI unchanged except for normal wrapper compatibility settings.
-3. If enabled and the forwarded command is request-bearing, the wrapper starts `lib/runtime-rotation-proxy.ts` on `127.0.0.1` with a per-process client API key.
-4. The wrapper creates a temporary shadow `CODEX_HOME`, copies relevant official Codex state, and rewrites `config.toml` to select `codex-multi-auth-runtime-proxy`.
+3. If enabled, `createRuntimeRotationProxyContextIfEnabled` (`scripts/codex.js`) picks one of three transports from the forwarded argv:
+
+   | Branch | Predicate | Transport |
+   | --- | --- | --- |
+   | Interactive TUI | `isCodexInteractiveTuiCommand` — no forwarded subcommand at all | App runtime helper with `useCanonicalHome: true` and `detachOnExit: true`. Runs against the **canonical** `CODEX_HOME`; the provider is passed as ephemeral `-c model_providers.*` overrides. No shadow copy, no state sync-back, and `config.toml` is never rewritten on this path. |
+   | `codex app` | `isCodexAppCommand` — forwarded command is `app` | App runtime helper process with a shadow `CODEX_HOME`. |
+   | Everything else | request-bearing forwarded command | Shadow `CODEX_HOME` created inline by the wrapper process. |
+
+4. The wrapper starts `lib/runtime-rotation-proxy.ts` on `127.0.0.1` with a per-process client API key. Shadow-home branches copy relevant official Codex state and rewrite `config.toml` to select `codex-multi-auth-runtime-proxy`; the canonical-home branch instead injects the same provider through `-c` arguments and passes the client key via `OPENAI_API_KEY`.
 5. The official Codex CLI sends Responses/model traffic to the local provider.
 6. The proxy validates the client token, evaluates runtime policy, selects a managed account, refreshes tokens if needed, and forwards to the official backend.
 7. The proxy rotates to another account before streaming response bytes when it sees retryable auth refresh failures, 429s, 5xx responses, or network errors (subject to pin and min-rotation-interval throttling).
 8. Successful responses stream back to the local Codex client with hop-by-hop/private/stale decoded headers removed.
 9. Usage ledger rows and runtime counters are persisted for status/report/usage/budget commands.
-10. On exit, the wrapper syncs refreshed official state files back from the shadow home and cleans up the temporary directory.
+10. On exit, shadow-home branches sync refreshed official state files back and remove the temporary directory. The canonical-home branch has nothing to sync — it read and wrote official state in place.
+
+Why the interactive branch is different: copying the Codex home into a shadow made the official CLI reindex its thread history and SQLite state on every TUI launch. Running interactive sessions against the canonical home keeps that state reusable. Because neither session copies nor syncs state, two interactive sessions can run concurrently against the same home — the same as running the official CLI twice — so no lock is taken. Regression coverage lives in `test/codex-bin-wrapper.test.ts`.
+
+Internal env used by these branches (not operator-facing): `CODEX_MULTI_AUTH_APP_ROTATION_USE_CANONICAL_HOME`, `CODEX_MULTI_AUTH_APP_SERVER_CONFIG_ARGS_JSON`, `CODEX_MULTI_AUTH_APP_ROTATION_OWNER_PID`, `CODEX_MULTI_AUTH_REAL_CODEX_HOME`.
 
 * * *
 
@@ -197,11 +217,17 @@ High-level optional host flow:
 Package install scripts stay side-effect-free. On the first durable CLI invocation after install, `lib/runtime/first-run.ts`:
 
 - Claims a one-time marker at `~/.codex/multi-auth/first-run-setup.json` (exclusive create; concurrent claims race safely).
-- Best-effort self-heals packaged Codex app bind and user-level launcher routing when rotation is enabled and the environment is not CI/`npx`/project-local.
-- Records step outcomes (`completed` / `skipped` / `failed`) without secrets.
+- Runs three best-effort steps, each recording `completed` / `skipped` / `failed` without secrets:
+  1. **App bind** — packaged Codex app bind, when rotation is enabled and the environment is not CI/`npx`/project-local.
+  2. **Launcher** — user-level launcher routing, under the same gate.
+  3. **Auth store** — `ensureCodexCliFileAuthStore()` pins the top-level `cli_auth_credentials_store = "file"` in `~/.codex/config.toml` (`lib/codex-cli/writer.ts`).
 - Failures are debug-logged and never block the requested command.
 
-Explicit repair remains `codex-multi-auth rotation enable` / `bind-app` / launcher install helpers.
+The marker is versioned (`FIRST_RUN_MARKER_VERSION = 2`). Because `ensureFirstRunSetup` short-circuits on marker existence, a marker written before the auth-store step existed (`version: 1`, or any unreadable/truncated marker) is **migrated in place** on the next manager CLI run: only the auth-store step is replayed. App bind and launcher install are deliberately not rerun, so shortcuts the user removed stay removed. The migration takes no exclusive claim — both `ensureCodexCliFileAuthStore` and the atomic marker write are idempotent, so concurrent invocations converge instead of racing.
+
+A **failed** auth-store step deliberately records the pre-v2 version so the next run retries it; otherwise one transient Windows `EPERM`/`EBUSY` on a locked `config.toml` would strand the install on keychain mode permanently. A `skipped` result does advance the version, since that is the normal outcome both for a config already pinned to `"file"` and for an explicit `CODEX_MULTI_AUTH_ENFORCE_CLI_FILE_AUTH_STORE=0` opt-out.
+
+Explicit repair remains `codex-multi-auth rotation enable` / `bind-app` / launcher install helpers, plus `codex-multi-auth doctor --fix` for the auth-store pin.
 
 * * *
 
@@ -245,6 +271,8 @@ Official Codex-owned files remain under `~/.codex`, including `auth.json`, `acco
 7. **Ephemeral force-account pins** — `--account` / `CODEX_MULTI_AUTH_FORCE_ACCOUNT` never mutate the persisted switch pin and fail hard when the proxy is disabled or the target is unavailable.
 8. **Budget guards are soft under concurrency** — evaluations read a pre-request ledger snapshot; concurrent requests may briefly overshoot. This is intentional (best-effort, not a hard distributed quota).
 9. **First-run marker is not a secret** — it only records that durable-install self-heal ran; opt-out via env remains available.
+10. **The keychain is never touched** — the `cli_auth_credentials_store` reconcile only rewrites a top-level TOML assignment in `~/.codex/config.toml`. No keychain item and no `security` CLI is ever read or written, and credentials saved by an earlier official `codex login` are left in place (unread once the store is pinned to `"file"`). Opt out of the per-invocation `-c` override with `CODEX_MULTI_AUTH_FORCE_FILE_AUTH_STORE=0`, or of every persisted rewrite with `CODEX_MULTI_AUTH_ENFORCE_CLI_FILE_AUTH_STORE=0`.
+11. **Canonical-home overrides carry no secret on disk** — the interactive path passes provider config as `-c` arguments and the per-process client key through `OPENAI_API_KEY` in the child environment, so no credential is persisted into the user's `config.toml`.
 
 * * *
 
@@ -273,6 +301,9 @@ Official Codex-owned files remain under `~/.codex`, including `auth.json`, `acco
 11. Windows filesystem operations use retry helpers for transient `EBUSY`/`EPERM`/`ENOTEMPTY` behavior where lock-prone paths are touched.
 12. Account selection order remains pin → sequential|affinity → hybrid → scan unless a release intentionally changes that contract.
 13. `mcodex` is a convenience launcher only; it must not reimplement account-manager or Codex command logic.
+14. Interactive TUI sessions run against the canonical `CODEX_HOME`. They must not be moved back onto a shadow copy: doing so reintroduces per-launch thread-history reindexing, and the no-lock concurrency guarantee depends on neither session copying or syncing state.
+15. The rotation provider is never written into the real `~/.codex/config.toml` on the interactive path. The only top-level key this project reconciles there is `cli_auth_credentials_store`.
+16. The keychain is never read or written. Reading a keychain item would raise the prompt the auth-store pin exists to eliminate; a `[profiles.*]` credential-store value is left as authored.
 
 * * *
 

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -295,6 +295,65 @@ Cross-process refresh lease knobs: `CODEX_AUTH_REFRESH_LEASE`, `CODEX_AUTH_REFRE
 | `CODEX_MULTI_AUTH_PWSH_PROFILE_GUARD` | Install PowerShell profile guard when enabled |
 | `CODEX_MULTI_AUTH_OVERWRITE_CUSTOM_BATCH_SHIM` | Allow Windows shim guard to overwrite custom shims when set to `1` |
 
+### Official Codex CLI state paths
+
+These point the Codex-CLI state layer (`lib/codex-cli/state.ts`) at non-default files. Useful for sandboxes and tests; rarely set by operators.
+
+| Variable | Purpose |
+| --- | --- |
+| `CODEX_HOME` | Official Codex home. When set to a non-default path, multi-auth resolves strictly to `$CODEX_HOME/multi-auth` and does not scan `~/.codex/multi-auth` |
+| `CODEX_CLI_AUTH_PATH` | Override the official `auth.json` path |
+| `CODEX_CLI_ACCOUNTS_PATH` | Override the official `accounts.json` path |
+| `CODEX_CLI_CONFIG_PATH` | Override the official `config.toml` path |
+| `CODEX_AUTH_SYNC_CODEX_CLI` | Legacy alias for `CODEX_MULTI_AUTH_SYNC_CODEX_CLI`; read only when the canonical name is unset |
+
+### Runtime rotation transport internals
+
+Set by the wrapper for its own child processes. Not intended to be set by hand.
+
+| Variable | Purpose |
+| --- | --- |
+| `CODEX_MULTI_AUTH_APP_ROTATION_USE_CANONICAL_HOME` | `1` when the app runtime helper must run against the canonical `CODEX_HOME` (interactive TUI path) instead of a shadow home |
+| `CODEX_MULTI_AUTH_APP_SERVER_CONFIG_ARGS_JSON` | JSON array of `-c` provider overrides the app-server preload replays on the canonical-home path |
+| `CODEX_MULTI_AUTH_RUNTIME_SHADOW_COPY_GENERATED_DIRS` | `1`/`true`/`yes` allows copying generated runtime directories into a shadow `CODEX_HOME` when they cannot be linked. Off by default: the wrapper skips such a directory rather than duplicating active runtime data |
+| `CODEX_MULTI_AUTH_WRAPPER_IMPORT_ONLY` | Import `scripts/codex.js` without running its main entrypoint (used by the preload shim) |
+| `CODEX_MULTI_AUTH_CLI_VERSION` | Version string the manager publishes for the dashboard header |
+| `CODEX_MULTI_AUTH_UPDATE_NOTICE_STARTUP_BUDGET_MS` | Time budget for the best-effort daily update check during wrapper startup |
+
+### Auth flow
+
+Consumed by the OAuth login path (`lib/auth/`, `lib/runtime/manual-oauth-flow.ts`) in both the CLI and the plugin host.
+
+| Variable | Purpose |
+| --- | --- |
+| `CODEX_AUTH_ACCOUNT_ID` | Bind an OAuth login to an explicit ChatGPT account/workspace id. This is the override mechanism behind `codex-multi-auth login --org <org_id>`, which lets the same email register its personal and its business/team workspace as separate accounts |
+| `CODEX_AUTH_NO_BROWSER` | Force the manual callback flow instead of launching a browser |
+
+### Plugin-host request pipeline
+
+Consumed by the optional plugin-host runtime (`index.ts`) rather than the CLI.
+
+| Variable | Purpose |
+| --- | --- |
+| `CODEX_AUTH_FAILOVER_MODE` | `conservative`, `balanced` (default; also the fallback for any unrecognised value), or `aggressive`. Selects the per-mode defaults below. Same-account retries: conservative `2`, balanced `1`, aggressive `0`. Soft stall timeout: `20000` / `15000` / `10000` ms |
+| `CODEX_AUTH_STREAM_FAILOVER_MAX` | Maximum stream failover attempts; overrides the per-mode default (`2` / `2` / `1`). Always clamped to `0..1` by `capStreamFailoverMax`, so the effective value is at most one failover regardless of mode or override |
+| `CODEX_AUTH_STREAM_STALL_SOFT_TIMEOUT_MS` | Soft stream-stall threshold before failover is considered; overrides the per-mode default, floor `1000` ms |
+| `CODEX_AUTH_STREAM_STALL_HARD_TIMEOUT_MS` | Hard stream-stall threshold that aborts the stream; never lower than the soft threshold, and defaults to `streamStallTimeoutMs` |
+| `CODEX_AUTH_PREWARM` | Set `0` to disable connection prewarming |
+| `CODEX_COLLABORATION_MODE` | Collaboration-mode hint applied by the request transformer |
+| `CODEX_THREAD_ID` | Thread id used as the session-affinity key. Takes precedence over the host-supplied prompt cache key |
+| `CODEX_SKIP_EMAIL_HYDRATE` | Set `1` to skip best-effort account email hydration |
+| `CODEX_MULTI_AUTH_EXPOSE_ADMIN_TOOLS` | Set `1` to expose admin tools on the plugin-host tool surface |
+
+### Benchmark and matrix scripts
+
+Used only by `scripts/` tooling, not by the shipped runtime.
+
+| Variable | Purpose |
+| --- | --- |
+| `CODEX_MATRIX_TIMEOUT_MS` | Per-probe timeout for `npm run test:model-matrix` |
+| `CODEX_MODELS_TIMEOUT_MS` | Timeout for model listing in the edit-format benchmark harness |
+
 * * *
 
 ## Runtime Rotation Architecture Fields

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -336,7 +336,7 @@ Consumed by the optional plugin-host runtime (`index.ts`) rather than the CLI.
 | Variable | Purpose |
 | --- | --- |
 | `CODEX_AUTH_FAILOVER_MODE` | `conservative`, `balanced` (default; also the fallback for any unrecognised value), or `aggressive`. Selects the per-mode defaults below. Same-account retries: conservative `2`, balanced `1`, aggressive `0`. Soft stall timeout: `20000` / `15000` / `10000` ms |
-| `CODEX_AUTH_STREAM_FAILOVER_MAX` | Maximum stream failover attempts; overrides the per-mode default (`2` / `2` / `1`). Always clamped to `0..1` by `capStreamFailoverMax`, so the effective value is at most one failover regardless of mode or override |
+| `CODEX_AUTH_STREAM_FAILOVER_MAX` | Maximum stream failover attempts. The declared per-mode defaults are `2` / `2` / `1` (conservative / balanced / aggressive), but every value — default or override — passes through `capStreamFailoverMax`, which clamps to `0..1`. **Effective defaults are therefore `1` / `1` / `1`**, and the only override that changes behaviour is `0` (disable failover entirely); anything `>= 1` yields one failover |
 | `CODEX_AUTH_STREAM_STALL_SOFT_TIMEOUT_MS` | Soft stream-stall threshold before failover is considered; overrides the per-mode default, floor `1000` ms |
 | `CODEX_AUTH_STREAM_STALL_HARD_TIMEOUT_MS` | Hard stream-stall threshold that aborts the stream; never lower than the soft threshold, and defaults to `streamStallTimeoutMs` |
 | `CODEX_AUTH_PREWARM` | Set `0` to disable connection prewarming |

--- a/docs/development/CONFIG_FLOW.md
+++ b/docs/development/CONFIG_FLOW.md
@@ -73,7 +73,7 @@ For dashboard display values:
 2. If disabled or the forwarded command is help/non-requesting, forward directly to official Codex.
 3. If enabled, start a loopback Responses proxy with a per-process client token.
 4. Select a transport from the forwarded argv:
-   - **No forwarded subcommand (interactive TUI)** — keep the canonical `CODEX_HOME` and pass `codex-multi-auth-runtime-proxy` as ephemeral `-c model_providers.*` overrides. Nothing is copied, `config.toml` is not rewritten, and the helper detaches on exit.
+   - **No forwarded subcommand (interactive TUI)** — keep the canonical `CODEX_HOME` and pass `codex-multi-auth-runtime-proxy` as ephemeral `-c model_providers.*` overrides. Nothing is copied, no provider or transport config is written into `config.toml`, and the helper detaches on exit. The transport-independent `cli_auth_credentials_store` reconcile below still applies.
    - **`codex app`** — run the app runtime helper against a shadow `CODEX_HOME`.
    - **Any other request-bearing command** — create a temporary shadow `CODEX_HOME` and rewrite its `config.toml` to use `codex-multi-auth-runtime-proxy`.
 5. Forward official Codex with the selected home.

--- a/docs/development/CONFIG_FLOW.md
+++ b/docs/development/CONFIG_FLOW.md
@@ -72,10 +72,15 @@ For dashboard display values:
 1. Resolve `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY`; if unset, read `pluginConfig.codexRuntimeRotationProxy`, which defaults to enabled.
 2. If disabled or the forwarded command is help/non-requesting, forward directly to official Codex.
 3. If enabled, start a loopback Responses proxy with a per-process client token.
-4. Create a temporary shadow `CODEX_HOME` and rewrite `config.toml` to use `codex-multi-auth-runtime-proxy`.
-5. Forward official Codex with the shadow home.
-6. Proxy request handling selects/refreshed managed accounts and rotates on rate limit, auth, network, or server failure before streaming starts.
-7. On process exit, sync refreshed official Codex state files back and remove the shadow home.
+4. Select a transport from the forwarded argv:
+   - **No forwarded subcommand (interactive TUI)** — keep the canonical `CODEX_HOME` and pass `codex-multi-auth-runtime-proxy` as ephemeral `-c model_providers.*` overrides. Nothing is copied, `config.toml` is not rewritten, and the helper detaches on exit.
+   - **`codex app`** — run the app runtime helper against a shadow `CODEX_HOME`.
+   - **Any other request-bearing command** — create a temporary shadow `CODEX_HOME` and rewrite its `config.toml` to use `codex-multi-auth-runtime-proxy`.
+5. Forward official Codex with the selected home.
+6. Proxy request handling selects/refreshes managed accounts and rotates on rate limit, auth, network, or server failure before streaming starts.
+7. On process exit, shadow-home transports sync refreshed official Codex state files back and remove the shadow home. The canonical-home transport wrote state in place, so there is nothing to sync.
+
+Independently of the transport, the wrapper reconciles the top-level `cli_auth_credentials_store = "file"` assignment in the real `~/.codex/config.toml` at startup (idempotent; see `lib/codex-cli/writer.ts`). That is the only key this project persists into the official config.
 
 * * *
 

--- a/docs/development/REPOSITORY_SCOPE.md
+++ b/docs/development/REPOSITORY_SCOPE.md
@@ -16,6 +16,9 @@ Ownership map for source paths and documentation paths.
 | `config/` | Plugin-host config examples |
 | `vendor/` | Vendored codex-ai-plugin + codex-ai-sdk dist shims |
 | `assets/` | Static project assets |
+| `bench/` | Edit-format benchmark fixtures and prompts |
+| `skills/` | Packaged agent skill definitions |
+| `.codex-plugin/` | Plugin manifest consumed by the Codex plugin scanner |
 | `dist/` | Generated build output (do not edit directly) |
 
 * * *
@@ -26,8 +29,10 @@ Ownership map for source paths and documentation paths.
 | --- | --- |
 | CLI wrapper and forwarding | `scripts/codex.js`, `scripts/codex-routing.js`, `scripts/codex-bin-resolver.js` |
 | Convenience launcher | `scripts/mcodex.js` |
-| CLI auth manager | `lib/codex-manager.ts` |
+| CLI auth manager | `lib/codex-manager.ts` (`CLI_COMMAND_HANDLERS` dispatch) |
 | Manager command modules | `lib/codex-manager/commands/*` |
+| Manager command registry | `lib/codex-manager/account-manager-commands.ts`, `lib/codex-manager/help.ts` |
+| Official Codex CLI state | `lib/codex-cli/` (`state.ts`, `writer.ts`, `sync.ts`, `observability.ts`) |
 | Settings hub | `lib/codex-manager/settings-hub.ts`, `lib/codex-manager/settings-hub/` |
 | OAuth flow/server | `lib/auth/*` (`auth.ts`, `server.ts`, `browser.ts`, `device-auth.ts`) |
 | WSL / Windows host detection | `lib/wsl.ts` |

--- a/docs/development/RUNBOOK_ADD_AUTH_COMMAND.md
+++ b/docs/development/RUNBOOK_ADD_AUTH_COMMAND.md
@@ -17,18 +17,23 @@ Add one new command path while keeping:
 
 ## Primary Files
 
-- `lib/codex-manager.ts`
+- `lib/codex-manager/commands/<name>.ts` — command implementation
+- `lib/codex-manager.ts` — `CLI_COMMAND_HANDLERS` registration
+- `lib/codex-manager/account-manager-commands.ts` — `ACCOUNT_MANAGER_COMMANDS` registration (required for the bare `codex-multi-auth <name>` form)
+- `lib/codex-manager/help.ts` — `printUsage()` text
 - `docs/reference/commands.md`
 - `README.md` when user-visible workflow changes
 - `test/codex-manager-cli.test.ts`
 - `test/documentation.test.ts`
 
+For the full dispatch contract and the two-registry trap, see [RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md](RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md).
+
 * * *
 
 ## Implementation Steps
 
-1. Add the command logic in `lib/codex-manager.ts` or the current command handler module.
-2. Keep usage text literal and copy-pasteable.
+1. Add the command logic as a module under `lib/codex-manager/commands/`, then register it in both `CLI_COMMAND_HANDLERS` and `ACCOUNT_MANAGER_COMMANDS`.
+2. Keep usage text literal and copy-pasteable, and add the line to `printUsage()` in `lib/codex-manager/help.ts`.
 3. Reuse existing storage, refresh, and quota helpers instead of adding new command-local state.
 4. Add or extend CLI tests in `test/codex-manager-cli.test.ts` for:
    - success path

--- a/docs/development/RUNBOOK_ADD_AUTH_COMMAND.md
+++ b/docs/development/RUNBOOK_ADD_AUTH_COMMAND.md
@@ -25,6 +25,8 @@ Add one new command path while keeping:
 - `README.md` when user-visible workflow changes
 - `test/codex-manager-cli.test.ts`
 - `test/documentation.test.ts`
+- `docs/upgrade.md` when the command changes user-visible behavior or a documented workflow
+- `package.json` scripts, when the command adds or changes a build/test entrypoint referenced by docs
 
 For the full dispatch contract and the two-registry trap, see [RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md](RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md).
 

--- a/docs/development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md
+++ b/docs/development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md
@@ -36,7 +36,8 @@ Aliases point at the same handler (`status` and `list` share `runListOrStatusCom
 4. Take collaborators as an injected `deps` object rather than importing singletons directly — this is what keeps the command testable.
 5. Keep JSON output stable and explicit if the command has `--json`.
 6. Update `docs/reference/commands.md` in the same change.
-7. Add or extend `test/codex-manager-cli.test.ts` for the new path.
+7. Add or extend `test/codex-manager-cli.test.ts` with a case for **each dispatch form**: `codex-multi-auth auth <name>` *and* the bare `codex-multi-auth <name>`. Only the bare-form case catches a missing `ACCOUNT_MANAGER_COMMANDS` entry — a handler-only registration passes the `auth`-prefixed test and still ships broken.
+8. If the command exercises token refresh or storage writes, add deterministic coverage for the refresh race and for Windows `EBUSY`/`EPERM` cleanup rather than relying on timing.
 
 ## Compatibility Checks
 

--- a/docs/development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md
+++ b/docs/development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md
@@ -8,20 +8,35 @@ Add a command without breaking the existing CLI surface, help text, JSON mode, o
 
 ## Where to Change
 
-- `lib/codex-manager.ts` — command parsing and dispatch
-- `lib/codex-manager/` — extracted command/controller helpers when the command grows beyond trivial size
+- `lib/codex-manager/commands/<name>.ts` — the command implementation (one module per command)
+- `lib/codex-manager.ts` — register the handler in the `CLI_COMMAND_HANDLERS` map
+- `lib/codex-manager/account-manager-commands.ts` — add the name to `ACCOUNT_MANAGER_COMMANDS`
+- `lib/codex-manager/help.ts` — `printUsage()` text, plus any per-command usage/arg parser
 - `lib/cli.ts` — prompt-heavy shared CLI helpers when the command needs reusable interactive flows
 - `docs/reference/commands.md` — command reference
 - `test/codex-manager-cli.test.ts` — CLI behavior coverage
 - `test/documentation.test.ts` — docs parity when command text/help changes
 
+## How dispatch actually works
+
+`runCodexMultiAuthCli` (`lib/codex-manager.ts`) is a two-stage lookup, not an `if (command === …)` chain:
+
+1. **Bare-subcommand normalization.** If `argv[0]` is not `auth` but *is* a member of `ACCOUNT_MANAGER_COMMANDS`, the args are rewritten to `["auth", ...argv]`. Everything downstream assumes an `auth` root.
+2. **Handler lookup.** The command is looked up in `CLI_COMMAND_HANDLERS`, a `ReadonlyMap<string, CliCommandHandler>`. Keys are exact-match and unique, so lookup order cannot change semantics. Per-invocation dependency factories are called *inside* each handler so they are constructed at dispatch time.
+
+> **The trap:** the two registries are separate. Registering only in `CLI_COMMAND_HANDLERS` gives you a working `codex-multi-auth auth <name>` but a broken bare `codex-multi-auth <name>` — the bare form falls through to `printUsage()` and exits `1`. Add the name to both.
+
+Aliases point at the same handler (`status` and `list` share `runListOrStatusCommand`). Sub-dispatched commands (`config`, `debug`) branch on `rest[0]` inside their own handler and must print `Unknown … command:` and return `1` for an unrecognised subcommand.
+
 ## Safe Workflow
 
-1. Add the smallest possible parsing/dispatch change in `lib/codex-manager.ts`.
-2. If the command has more than one logical branch, extract a helper under `lib/codex-manager/` instead of growing the main file.
-3. Keep JSON output stable and explicit if the command already has `--json`.
-4. Update command help text and `docs/reference/commands.md` in the same change.
-5. Add or extend `test/codex-manager-cli.test.ts` for the new path.
+1. Implement the command as its own module under `lib/codex-manager/commands/`, exporting a `run<Name>Command(args, deps)` function that returns a `number` exit code.
+2. Register it in `CLI_COMMAND_HANDLERS` **and** `ACCOUNT_MANAGER_COMMANDS`.
+3. Add the command line to `printUsage()` in `lib/codex-manager/help.ts`, under the section that matches its role (Start here / Daily use / Repair / Diagnostics / Advanced).
+4. Take collaborators as an injected `deps` object rather than importing singletons directly — this is what keeps the command testable.
+5. Keep JSON output stable and explicit if the command has `--json`.
+6. Update `docs/reference/commands.md` in the same change.
+7. Add or extend `test/codex-manager-cli.test.ts` for the new path.
 
 ## Compatibility Checks
 
@@ -32,7 +47,7 @@ Add a command without breaking the existing CLI surface, help text, JSON mode, o
 ## QA
 
 - `npm run typecheck`
-- `npm run lint -- lib/codex-manager.ts test/codex-manager-cli.test.ts docs/reference/commands.md test/documentation.test.ts`
+- `npm run lint` (ESLint is configured for `.ts` plus `scripts/**/*.{js,mjs}` only — do not pass markdown paths to it)
 - `npm run test -- test/codex-manager-cli.test.ts test/documentation.test.ts`
 - For auth flows, never paste raw tokens/session headers in PRs, issues, or logs; redact sensitive output.
 - Run the real command or `--help` path in Bash and inspect output

--- a/docs/development/implementation-plans/decisions.md
+++ b/docs/development/implementation-plans/decisions.md
@@ -1,5 +1,13 @@
 # Local Governance Decisions
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../reference/commands.md](../../reference/commands.md),
+> [../../reference/settings.md](../../reference/settings.md), and [../ARCHITECTURE.md](../ARCHITECTURE.md).
+
 ## Accepted Ideas
 
 | Decision | Rationale |

--- a/docs/development/implementation-plans/local-governance-roadmap.md
+++ b/docs/development/implementation-plans/local-governance-roadmap.md
@@ -1,5 +1,13 @@
 # Local Governance Roadmap
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../reference/commands.md](../../reference/commands.md),
+> [../../reference/settings.md](../../reference/settings.md), and [../ARCHITECTURE.md](../ARCHITECTURE.md).
+
 Generated: 2026-04-29
 Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 Package version: `2.0.2`

--- a/docs/development/implementation-plans/open-issues.md
+++ b/docs/development/implementation-plans/open-issues.md
@@ -1,5 +1,13 @@
 # Local Governance Open Issues
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../reference/commands.md](../../reference/commands.md),
+> [../../reference/settings.md](../../reference/settings.md), and [../ARCHITECTURE.md](../ARCHITECTURE.md).
+
 This file records validation failures, design blockers, and follow-up decisions
 found while implementing the local governance roadmap.
 

--- a/docs/development/implementation-plans/pr-description-template.md
+++ b/docs/development/implementation-plans/pr-description-template.md
@@ -1,5 +1,13 @@
 # Local Governance PR Description Template
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../reference/commands.md](../../reference/commands.md),
+> [../../reference/settings.md](../../reference/settings.md), and [../ARCHITECTURE.md](../ARCHITECTURE.md).
+
 Use this template for each local governance PR.
 
 ```markdown

--- a/docs/development/implementation-plans/status.md
+++ b/docs/development/implementation-plans/status.md
@@ -1,5 +1,13 @@
 # Local Governance Status
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../reference/commands.md](../../reference/commands.md),
+> [../../reference/settings.md](../../reference/settings.md), and [../ARCHITECTURE.md](../ARCHITECTURE.md).
+
 Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 
 ## Baseline

--- a/docs/development/implementation-plans/subagent-handoffs/README.md
+++ b/docs/development/implementation-plans/subagent-handoffs/README.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Each roadmap PR must add or update a handoff file in this directory before
 handoff. The handoff should include branch, base, scope, files changed,

--- a/docs/development/implementation-plans/subagent-handoffs/README.md
+++ b/docs/development/implementation-plans/subagent-handoffs/README.md
@@ -1,5 +1,13 @@
 # Local Governance Handoffs
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Each roadmap PR must add or update a handoff file in this directory before
 handoff. The handoff should include branch, base, scope, files changed,
 validation, and known follow-ups.

--- a/docs/development/implementation-plans/subagent-handoffs/pr-01-roadmap-local-governance.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-01-roadmap-local-governance.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `chore/roadmap-local-governance`
 Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`

--- a/docs/development/implementation-plans/subagent-handoffs/pr-01-roadmap-local-governance.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-01-roadmap-local-governance.md
@@ -1,5 +1,13 @@
 # PR 01 Handoff: Local Governance Roadmap
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `chore/roadmap-local-governance`
 Base: `origin/main` at `4308b56a14c132c5df9584a7b611a02b64891b2c`
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md
@@ -1,5 +1,13 @@
 # PR 02 Handoff: Usage Ledger Core
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/usage-ledger-core`
 Base: `origin/main` after PR 01 merge
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-02-usage-ledger-core.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/usage-ledger-core`
 Base: `origin/main` after PR 01 merge

--- a/docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/usage-command`
 Base: `origin/main` after PR 02 merge

--- a/docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-03-usage-command.md
@@ -1,5 +1,13 @@
 # PR 03 Handoff: Usage Command
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/usage-command`
 Base: `origin/main` after PR 02 merge
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md
@@ -1,5 +1,13 @@
 # PR 04 Handoff: Account Policy Controls
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/account-policy-controls`
 Base: `origin/main` after PR 03 merge
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-04-account-policy-controls.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/account-policy-controls`
 Base: `origin/main` after PR 03 merge

--- a/docs/development/implementation-plans/subagent-handoffs/pr-05-routing-profiles-core.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-05-routing-profiles-core.md
@@ -1,5 +1,13 @@
 # PR 05 Handoff: Routing Profiles Core
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/routing-profiles-core`
 Base: `origin/main` after PR 04 merge
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-05-routing-profiles-core.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-05-routing-profiles-core.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/routing-profiles-core`
 Base: `origin/main` after PR 04 merge

--- a/docs/development/implementation-plans/subagent-handoffs/pr-06-budget-guard.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-06-budget-guard.md
@@ -1,5 +1,13 @@
 # PR 06 Handoff: Budget Guard
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/local-governance-review-stack`
 Base: `origin/main` with local governance review stack PR open
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-06-budget-guard.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-06-budget-guard.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/local-governance-review-stack`
 Base: `origin/main` with local governance review stack PR open

--- a/docs/development/implementation-plans/subagent-handoffs/pr-07-model-capability-matrix.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-07-model-capability-matrix.md
@@ -1,5 +1,13 @@
 # PR 07 Handoff: Model Capability Matrix
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/local-governance-review-stack`
 Base: `origin/main` with local governance review stack PR open
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-07-model-capability-matrix.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-07-model-capability-matrix.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/local-governance-review-stack`
 Base: `origin/main` with local governance review stack PR open

--- a/docs/development/implementation-plans/subagent-handoffs/pr-08-runtime-policy-integration.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-08-runtime-policy-integration.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR

--- a/docs/development/implementation-plans/subagent-handoffs/pr-08-runtime-policy-integration.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-08-runtime-policy-integration.md
@@ -1,5 +1,13 @@
 # PR 08 Handoff: Runtime Policy Integration
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-09-monitor-command.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-09-monitor-command.md
@@ -1,5 +1,13 @@
 # PR 09 Handoff: Monitor Command
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-09-monitor-command.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-09-monitor-command.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR

--- a/docs/development/implementation-plans/subagent-handoffs/pr-10-local-bridge-core.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-10-local-bridge-core.md
@@ -1,5 +1,13 @@
 # PR 10 Handoff: Local Bridge Core
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-10-local-bridge-core.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-10-local-bridge-core.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR

--- a/docs/development/implementation-plans/subagent-handoffs/pr-11-local-client-tokens.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-11-local-client-tokens.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR

--- a/docs/development/implementation-plans/subagent-handoffs/pr-11-local-client-tokens.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-11-local-client-tokens.md
@@ -1,5 +1,13 @@
 # PR 11 Handoff: Local Client Tokens
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-12-integration-generators.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-12-integration-generators.md
@@ -1,5 +1,13 @@
 # PR 12 Handoff: Integration Generators
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-12-integration-generators.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-12-integration-generators.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR

--- a/docs/development/implementation-plans/subagent-handoffs/pr-13-release-local-governance.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-13-release-local-governance.md
@@ -1,5 +1,13 @@
 # PR 13 Handoff: Release Local Governance Docs
 
+> **Historical record — completed work.** This document is a planning artifact from the
+> April 2026 local-governance effort. Every roadmap item below shipped in 2.1.0 and 2.2.0;
+> the package is now on the 2.x line well past those releases. Branch names, "Ready for
+> review" statuses, version stamps, and test counts are preserved as written at the time and
+> are **not** current repository state. For how these features behave today see
+> [../../../reference/commands.md](../../../reference/commands.md),
+> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR
 

--- a/docs/development/implementation-plans/subagent-handoffs/pr-13-release-local-governance.md
+++ b/docs/development/implementation-plans/subagent-handoffs/pr-13-release-local-governance.md
@@ -6,7 +6,7 @@
 > review" statuses, version stamps, and test counts are preserved as written at the time and
 > are **not** current repository state. For how these features behave today see
 > [../../../reference/commands.md](../../../reference/commands.md),
-> [../../../reference/settings.md](../../../reference/settings.md), and [../ARCHITECTURE.md](../../ARCHITECTURE.md).
+> [../../../reference/settings.md](../../../reference/settings.md), and [../../ARCHITECTURE.md](../../ARCHITECTURE.md).
 
 Branch: `feat/local-governance-review-stack`
 Base: open local governance review stack PR

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,6 +1,6 @@
 # Command Reference
 
-Complete command, flag, and hotkey reference for `codex-multi-auth` (package `2.6.1`).
+Complete command, flag, and hotkey reference for `codex-multi-auth` (package `2.8.0`).
 
 ---
 
@@ -134,7 +134,7 @@ Turning `showQuotaDetails` off reduces the line to a bare `live session OK`.
 | `codex-multi-auth monitor` | Aggregate runtime, usage, policy, quota, model, and project state |
 | `codex-multi-auth why-selected [--now|--last]` | Explain which account the selector picks now or via the last persisted runtime snapshot |
 | `codex-multi-auth history [list\|show <id>]` | List every local Codex session across all providers, bypassing the `model_provider` filtering that hides threads in `codex resume` while runtime rotation / app bind is active |
-| `codex-multi-auth rotation enable\|disable\|status\|bind-app\|unbind-app` | Manage the default-on runtime Responses proxy for live Codex account rotation |
+| `codex-multi-auth rotation enable\|disable\|status\|bind-app\|unbind-app\|reset-runtime` | Manage the default-on runtime Responses proxy for live Codex account rotation. `reset-runtime` clears volatile in-process rotation state and, when app-bind helpers are available, unbinds and rebinds the packaged Codex app so the router picks the reset state up |
 | `codex-multi-auth rotation reset-rate-limits [--all \| --account <idx>]` | Clear local rate-limit cooldowns for all accounts or one account |
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -544,7 +544,7 @@ Behavior:
 - `bind-app` repairs or installs the persistent packaged-app bind without changing the stored rotation setting.
 - `unbind-app` removes the persistent packaged-app bind and restores the backed-up Codex config.
 - `reset-rate-limits` clears local rate-limit cooldowns for every account (`--all`) or one 1-based account index (`--account`).
-- `reset-runtime` clears transient runtime observability counters used by status/report.
+- `reset-runtime` clears volatile rotation state and, when app-bind helpers are available, restarts the packaged app bind. Specifically it (1) unbinds and rebinds the packaged Codex app so the router picks up the reset state, (2) resets the process-global rotation trackers and circuit breakers, and (3) clears the persisted runtime-observability fields used by status/report — pool-exhaustion reason, per-account skip reasons, and policy-blocked entries — stamping a reset timestamp and reason. If the app-bind helpers are unavailable it still performs (2) and (3), and reports that new wrapper sessions will pick up the reset state. A failed bind restart exits non-zero.
 - `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` disables the proxy for the current process without changing settings.
 
 When enabled, the wrapper creates a temporary shadow `CODEX_HOME/config.toml` with a custom provider named `codex-multi-auth-runtime-proxy`, starts a `127.0.0.1` proxy on a random port, and forwards official Codex Responses traffic through that provider. This applies to CLI request commands plus `codex app-server` and `codex app` when they are launched through the wrapper. Existing behavior is unchanged while the setting and env override are off.

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -1,6 +1,6 @@
 # Public API Contract
 
-Public API contract for `codex-multi-auth` (package `2.6.1`).
+Public API contract for `codex-multi-auth` (package `2.8.0`).
 
 ---
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -2,7 +2,7 @@
 
 Reference for dashboard display settings and runtime `pluginConfig` values available from `codex-multi-auth login` -> `Settings`.
 
-`pluginConfig` is the persisted compatibility name for runtime settings. It covers wrapper/runtime rotation behavior and optional plugin-host behavior. Defaults below match `DEFAULT_PLUGIN_CONFIG` in `lib/config.ts` (package `2.6.1`).
+`pluginConfig` is the persisted compatibility name for runtime settings. It covers wrapper/runtime rotation behavior and optional plugin-host behavior. Defaults below match `DEFAULT_PLUGIN_CONFIG` in `lib/config.ts` (package `2.8.0`).
 
 ---
 
@@ -203,6 +203,7 @@ These fields live in `pluginConfig` and are commonly overridden via environment 
 | `unsupportedCodexPolicy` | `strict` | How unsupported Codex model requests are handled |
 | `fallbackOnUnsupportedCodexModel` | `false` | Whether to fall back when a Codex model is unsupported |
 | `fallbackToGpt52OnUnsupportedGpt53` | `true` | Compatibility fallback for unsupported gpt-5.3-class requests |
+| `unsupportedCodexFallbackChain` | `{}` | Per-model ordered fallback chain consulted before the generic unsupported-model policy. Empty by default; keys are model ids, values are ordered candidate lists |
 | `rateLimitToastDebounceMs` | `60000` | Debounce window for rate-limit toast spam |
 | `toastDurationMs` | `5000` | Dashboard toast display duration |
 

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -4,8 +4,9 @@ Generated: 2026-07-29
 Commit: 78aa9b5 (2.8.0)
 
 ## OVERVIEW
+
 Vitest suites for OAuth flow, request transforms, response handling, rotation logic, storage, CLI management, repo hygiene, and more.
-**5274 tests** across **336 test files** with 80%+ coverage threshold (2.8.0; 6 tests and 2 files skipped by default).
+**5277 tests** across **336 test files** with 80%+ coverage threshold (2.8.0; 6 tests and 2 files skipped by default).
 
 ## STRUCTURE
 ```

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,11 +1,11 @@
 # TEST KNOWLEDGE BASE
 
-Generated: 2026-05-02
-Commit: b0ef65d
+Generated: 2026-07-29
+Commit: 78aa9b5 (2.8.0)
 
 ## OVERVIEW
 Vitest suites for OAuth flow, request transforms, response handling, rotation logic, storage, CLI management, repo hygiene, and more.
-**4909 tests** across **317 test files** with 80%+ coverage threshold.
+**5274 tests** across **336 test files** with 80%+ coverage threshold (2.8.0; 6 tests and 2 files skipped by default).
 
 ## STRUCTURE
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the test suite for the OpenAI Codex OAuth plugin.
 
-**Stats**: 4909 tests across 317 test files with 80%+ coverage threshold.
+**Stats**: 5274 tests across 336 test files with 80%+ coverage threshold (2.8.0; 6 tests and 2 files skipped by default).
 
 ## Test Structure
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the test suite for the OpenAI Codex OAuth plugin.
 
-**Stats**: 5274 tests across 336 test files with 80%+ coverage threshold (2.8.0; 6 tests and 2 files skipped by default).
+**Stats**: 5277 tests across 336 test files with 80%+ coverage threshold (2.8.0; 6 tests and 2 files skipped by default).
 
 ## Test Structure
 

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -243,6 +243,32 @@ describe("Documentation Integrity", () => {
 		expect(agents).toContain(`Package version: ${packageVersion}`);
 	});
 
+	it("keeps reference-doc package-version stamps in sync with package.json", () => {
+		// These three headers silently drifted from 2.6.1 through the 2.7.0,
+		// 2.7.1, and 2.8.0 releases because nothing pinned them to the manifest.
+		// Same failure class as the AGENTS.md header above, so pin them too.
+		const stampedReferenceDocs = [
+			"docs/reference/commands.md",
+			"docs/reference/public-api.md",
+			"docs/reference/settings.md",
+		];
+		for (const docPath of stampedReferenceDocs) {
+			const contents = read(docPath);
+			const stamps = [...contents.matchAll(/\(package `([^`]+)`\)/g)].map(
+				(match) => match[1],
+			);
+			expect(
+				stamps.length,
+				`${docPath} must carry a (package \`x.y.z\`) version stamp`,
+			).toBeGreaterThan(0);
+			for (const stamp of stamps) {
+				expect(stamp, `${docPath} version stamp is stale`).toBe(
+					packageVersion,
+				);
+			}
+		}
+	});
+
 	it("uses codex-multi-auth as canonical package name", () => {
 		const canonicalPackageDocs = [
 			"README.md",

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -151,6 +151,59 @@ function listMarkdownFiles(rootDir: string): string[] {
 	return markdownFiles.sort((left, right) => left.localeCompare(right));
 }
 
+function listSourceFiles(rootDir: string): string[] {
+	let entries: ReturnType<typeof readdirSync>;
+	try {
+		entries = readdirSync(rootDir, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	const sourceFiles: string[] = [];
+	for (const entry of entries) {
+		const absolutePath = join(rootDir, entry.name);
+		if (entry.isDirectory()) {
+			sourceFiles.push(...listSourceFiles(absolutePath));
+			continue;
+		}
+		if (entry.isFile() && /\.(ts|js|mjs)$/.test(entry.name)) {
+			sourceFiles.push(absolutePath);
+		}
+	}
+	return sourceFiles;
+}
+
+let cachedSourceBlob: string | null = null;
+
+/**
+ * All shipped source concatenated, for presence checks on env-var names.
+ *
+ * Deliberately a substring search rather than a pattern over access forms.
+ * This codebase reads env through at least three shapes — `process.env.NAME`,
+ * a string literal handed to a resolver that does `process.env[envName]`
+ * (`resolveBooleanSetting("CODEX_MODE", …)`), and `env.NAME` off a passed-in
+ * env object. Enumerating those forms is what makes this check wrong: each
+ * omission reports live variables as deleted. The question worth asking is
+ * simply "does this name appear in shipped code at all", so ask that.
+ */
+function readSourceBlob(): string {
+	if (cachedSourceBlob !== null) return cachedSourceBlob;
+	const files = [
+		...listSourceFiles(join(projectRoot, "lib")),
+		...listSourceFiles(join(projectRoot, "scripts")),
+		join(projectRoot, "index.ts"),
+	];
+	const parts: string[] = [];
+	for (const filePath of files) {
+		try {
+			parts.push(readFileSync(filePath, "utf-8"));
+		} catch {
+			// Unreadable file cannot disprove a name; skip it.
+		}
+	}
+	cachedSourceBlob = parts.join("\n");
+	return cachedSourceBlob;
+}
+
 function isExternalOrUriSchemeLink(linkPath: string): boolean {
 	return /^[a-z][a-z0-9+.-]*:/i.test(linkPath) || linkPath.startsWith("//");
 }
@@ -266,6 +319,72 @@ describe("Documentation Integrity", () => {
 					packageVersion,
 				);
 			}
+		}
+	});
+
+	it("keeps every documented env-var name backed by shipped code", () => {
+		// CONFIG_FIELDS.md bills itself as the full inventory, so a documented
+		// name that no longer exists is a silent lie to operators. Guards the
+		// state-path group (CODEX_CLI_AUTH_PATH / _ACCOUNTS_PATH / _CONFIG_PATH,
+		// CODEX_AUTH_SYNC_CODEX_CLI) and everything else the references promise.
+		const sourceBlob = readSourceBlob();
+		const inventoryDocs = [
+			"docs/development/CONFIG_FIELDS.md",
+			"docs/reference/settings.md",
+		];
+		const unbacked: string[] = [];
+		for (const docPath of inventoryDocs) {
+			const documented = new Set(
+				[...read(docPath).matchAll(/`((?:CODEX|MCODEX|OC)_[A-Z0-9_]{3,})`/g)].map(
+					(match) => match[1],
+				),
+			);
+			for (const name of documented) {
+				if (!sourceBlob.includes(name)) unbacked.push(`${docPath}: ${name}`);
+			}
+		}
+		expect(
+			unbacked,
+			"documented env vars with no reference in lib/, scripts/, or index.ts",
+		).toEqual([]);
+	});
+
+	it("keeps the state-path and legacy-alias env names documented", () => {
+		// These four were undocumented until the 2.8.0 docs pass; pin them so a
+		// future edit cannot quietly drop them back out of the inventory.
+		const configFields = read("docs/development/CONFIG_FIELDS.md");
+		for (const name of [
+			"CODEX_CLI_AUTH_PATH",
+			"CODEX_CLI_ACCOUNTS_PATH",
+			"CODEX_CLI_CONFIG_PATH",
+			"CODEX_AUTH_SYNC_CODEX_CLI",
+		]) {
+			expect(configFields, `${name} must stay documented`).toContain(name);
+		}
+	});
+
+	it("keeps both rotation reset-runtime descriptions consistent", () => {
+		// The summary table and the rotation section drifted apart: one listed the
+		// app-bind restart, the other only the observability reset. Both must
+		// mention the bind restart so operators know the command touches it.
+		const commands = read("docs/reference/commands.md");
+		// Behavioral lines only: the bare usage block and the --json surface note
+		// mention reset-runtime without describing what it does.
+		const resetRuntimeLines = commands
+			.split(/\r?\n/)
+			.filter(
+				(line) =>
+					line.includes("reset-runtime") && /\bclears\b|\bresets\b/i.test(line),
+			);
+		expect(
+			resetRuntimeLines.length,
+			"expected reset-runtime to be described in commands.md",
+		).toBeGreaterThan(0);
+		for (const line of resetRuntimeLines) {
+			expect(
+				/bind/i.test(line),
+				`reset-runtime description omits the app-bind restart: ${line.trim().slice(0, 120)}`,
+			).toBe(true);
 		}
 	});
 


### PR DESCRIPTION
Audit of every markdown file in the repo against the v2.8.0 source, then a rewrite of what had gone stale.

## What was already correct

Worth stating up front, because it bounds the problem. Machine-checked against the code and found clean:

- **Internal links** — 0 broken across all 151 tracked markdown files
- **`npm run` references** — every one resolves to a real script
- **Repo path references** — every backticked `lib/…`, `scripts/…`, `test/…` path exists
- **All 54 `pluginConfig` defaults** in `settings.md` — byte-match `DEFAULT_PLUGIN_CONFIG`
- **Error-contract codes** — exactly the three the proxy emits
- **Documented env vars** — all 62 still exist in shipped code

The docs are partly guarded by `test/documentation.test.ts`, which is why the structural surface held up. The drift was semantic, in maintainer docs, and dated to 2.7.1/2.8.0 landing after those files were last touched.

## What was stale

**Runtime rotation described a flow that no longer exists.** `ARCHITECTURE.md` and `CONFIG_FLOW.md` both said the wrapper always creates a shadow `CODEX_HOME` and rewrites `config.toml`. Since #639 there are three transports selected in `createRuntimeRotationProxyContextIfEnabled`:

| Branch | Predicate | Transport |
| --- | --- | --- |
| Interactive TUI | no forwarded subcommand | **canonical** `CODEX_HOME` + ephemeral `-c` overrides; no shadow, no sync-back, `config.toml` untouched |
| `codex app` | forwarded command is `app` | app runtime helper + shadow home |
| Everything else | request-bearing command | shadow home + `config.toml` rewrite |

Documented all three, plus why the interactive branch can safely skip locking.

**First-run setup was missing its third step.** Docs listed app bind + launcher. 2.8.0 added the `cli_auth_credentials_store` pin, marker versioning (`FIRST_RUN_MARKER_VERSION = 2`), and in-place v1 migration — including why a *failed* auth-store step deliberately records the pre-v2 version so it retries.

**`CONFIG_FIELDS.md` claimed a complete inventory but omitted 21 real env vars.** Added in five verified groups. Three of my first-pass descriptions were wrong when checked against source and were corrected: `RUNTIME_SHADOW_COPY_GENERATED_DIRS` is a boolean (not a dir list), `CODEX_THREAD_ID` *takes precedence over* the prompt cache key, and `STREAM_FAILOVER_MAX` is clamped to a **ceiling** of 1.

**Three reference docs were stamped `2.6.1`** through 2.7.0, 2.7.1, and 2.8.0. Corrected and pinned to `package.json` by a new `documentation.test.ts` case — same failure class the existing `AGENTS.md` check guards. Confirmed the new guard fails when a stamp is wrong.

## Also

- `unsupportedCodexFallbackChain` and `rotation reset-runtime` were undocumented
- `lib/codex-cli/` was absent from both ownership maps despite being the published `./cli` export and the home of the 2.8.0 change
- Both command runbooks were rewritten around the `CLI_COMMAND_HANDLERS` dispatcher, documenting the **two-registry trap**: registering a command without adding it to `ACCOUNT_MANAGER_COMMANDS` silently breaks the bare `codex-multi-auth <name>` form
- Test counts corrected from `4909/317` to the measured **5274 across 336 files**
- The 14 April-2026 local-governance planning docs read as live status for work shipped in 2.1.0/2.2.0; marked historical rather than deleted — removal is a maintainer call

## Judgment calls

- `docs/release-local-governance` in two planning tables is a **git branch name**, not a path. Left alone.
- Planning docs archived in place, not deleted.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- Full suite — **5268 passed, 6 skipped** (336 files)
- `test/documentation.test.ts` — 29/29
- 0 broken internal links

Docs and one test file only; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaAqj4XiyF9WUFXCQn7oiQ

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr realigns maintainer documentation with the 2.8.0 architecture.
- documents canonical-home and shadow-home runtime rotation transports.
- documents first-run auth-store migration, command registration, configuration fields, and repository ownership.
- archives completed governance plans and updates reference versions and test counts.
- adds vitest guards for package-version stamps, environment-variable references, and reset-runtime documentation.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/development/ARCHITECTURE.md | documents the three runtime transports, first-run migration, token safety, windows filesystem handling, and explicit concurrency boundaries. |
| docs/development/CONFIG_FIELDS.md | expands the environment-variable inventory and clarifies effective defaults and precedence. |
| docs/development/CONFIG_FLOW.md | updates configuration flow for canonical-home and shadow-home runtime rotation. |
| docs/development/RUNBOOK_ADD_AUTH_COMMAND.md | documents both command registries and the required dispatch coverage. |
| docs/development/RUNBOOK_ADD_AUTH_MANAGER_COMMAND.md | explains the two-registry dispatch contract and bare-command failure mode. |
| docs/reference/commands.md | updates the package stamp and documents current command behavior. |
| docs/reference/settings.md | updates the package stamp and aligns configuration references with current defaults. |
| test/documentation.test.ts | adds vitest coverage for reference-version stamps, environment names, and reset-runtime documentation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[forwarded codex invocation] --> B{runtime rotation enabled?}
  B -- no --> C[official codex cli]
  B -- yes --> D{forwarded command}
  D -- interactive tui --> E[canonical CODEX_HOME plus ephemeral overrides]
  D -- codex app --> F[app helper plus shadow CODEX_HOME]
  D -- other request command --> G[inline shadow CODEX_HOME]
  E --> H[loopback rotation proxy]
  F --> H
  G --> H
  H --> I[official codex backend]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: address review findings on the 2.8..."](https://github.com/ndycode/codex-multi-auth/commit/a33e25d687322204bc2da49b3008e98fe95e3380) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48275286)</sub>

<!-- /greptile_comment -->