### PR TITLE
Add MiniMax provider backend to local bridge

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -367,11 +367,11 @@ reports neutral account labels and does not expose raw account emails.
 
 ## Local bridge commands
 
-The optional local bridge exposes only `/health`, `/v1/models`, and
-`/v1/responses` on loopback. Forwarded bridge requests require a bearer token
-by default. When a runtime client API key is configured for the bridge, inbound
-auth must remain enabled (`requireAuth=true`); the bridge rewrites outbound
-auth for the rotation proxy and strips inbound cookies / proxy-auth headers.
+The optional local bridge exposes `/health`, `/v1/models`, and `/v1/responses`
+on loopback. A MiniMax backend also exposes `/anthropic/v1/messages` and
+`/anthropic/v1/messages/count_tokens`. Forwarded bridge requests require a
+local client token by default. Clients can send it as a bearer token or
+`x-api-key`; the bridge replaces inbound credentials before forwarding.
 
 ```bash
 codex-multi-auth bridge token create [--label <label>] [--json]
@@ -411,6 +411,20 @@ console.log(bridge.baseUrl); // e.g. http://127.0.0.1:43123
 // Clients: Authorization: Bearer <cma_local_...> from `bridge token create`
 ```
 
+For direct MiniMax access, select a regional backend instead of a runtime
+proxy. The provider key remains inside the host process, and local client auth
+must stay enabled:
+
+```ts
+const bridge = await startLocalBridge({
+  miniMax: {
+    apiKey: process.env.MINIMAX_API_KEY!,
+    region: "global", // or "cn"
+  },
+  requireAuth: true,
+});
+```
+
 Operator checklist:
 
 1. Ensure runtime rotation is available (`codex-multi-auth rotation status` / a wrapper session that owns a proxy).
@@ -420,7 +434,8 @@ Operator checklist:
 5. Generate glue with `codex-multi-auth integrations --kind python|curl|env|...`.
 
 Security invariants match the library: loopback-only bind, loopback-only
-`runtimeBaseUrl`, and `requireAuth=true` whenever a runtime client key is injected.
+`runtimeBaseUrl`, and `requireAuth=true` whenever a runtime or MiniMax key is
+injected.
 
 ---
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -126,9 +126,11 @@ These details are documented for operator expectations. Internal helper process 
 `startLocalBridge` (package root / public barrel) is the host API that opens the
 optional loopback bridge. There is no `bridge start` CLI daemon.
 
-- Bind host must be loopback; `runtimeBaseUrl` must also be loopback (the runtime rotation proxy).
-- Default `requireAuth=true`. Configuring `runtimeClientApiKey` **requires** `requireAuth=true`.
-- Surfaces: `/health`, `/v1/models`, `/v1/responses` only.
+- Bind host must be loopback; runtime mode also requires a loopback `runtimeBaseUrl`.
+- Default `requireAuth=true`. Configuring `runtimeClientApiKey` or `miniMax` **requires** `requireAuth=true`.
+- Runtime surfaces: `/health`, `/v1/models`, and `/v1/responses`.
+- MiniMax surfaces add `/anthropic/v1/messages` and `/anthropic/v1/messages/count_tokens` with Global or China endpoints.
+- Inbound bearer and `x-api-key` credentials are local client tokens; backend credentials replace them before egress.
 - Client tokens are managed with `codex-multi-auth bridge token ...` (hashes on disk).
 - Client snippets: `codex-multi-auth integrations ...`.
 

--- a/index.ts
+++ b/index.ts
@@ -4720,6 +4720,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 	};
 };
 
+export * from "./lib/local-bridge.js";
+export * from "./lib/providers/minimax.js";
+
 export const OpenAIAuthPlugin = OpenAIOAuthPlugin;
 
 export default OpenAIOAuthPlugin;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -48,5 +48,6 @@ export * from "./model-capability-matrix.js";
 export * from "./policy/runtime-policy.js";
 export * from "./local-bridge.js";
 export * from "./local-client-tokens.js";
+export * from "./providers/minimax.js";
 export * from "./integration-generators.js";
 export * from "./temp-path.js";

--- a/lib/local-bridge.ts
+++ b/lib/local-bridge.ts
@@ -3,6 +3,11 @@ import type { Socket } from "node:net";
 import { Hono } from "hono";
 import { fetch as undiciFetch } from "undici";
 import { verifyLocalClientBearerToken } from "./local-client-tokens.js";
+import {
+	createMiniMaxModelsResponse,
+	getMiniMaxEndpoints,
+	type MiniMaxRegion,
+} from "./providers/minimax.js";
 import { appendUsageLedgerRow } from "./usage/index.js";
 
 export interface LocalBridgeServer {
@@ -12,22 +17,32 @@ export interface LocalBridgeServer {
 	close: () => Promise<void>;
 }
 
-export interface LocalBridgeOptions {
+interface LocalBridgeCommonOptions {
 	host?: string;
 	port?: number;
-	runtimeBaseUrl: string;
 	fetchImpl?: typeof fetch;
 	requireAuth?: boolean;
 	verifyBearerToken?: typeof verifyLocalClientBearerToken;
-	/**
-	 * Client API key for an auth-enabled runtime proxy (runtime-proxy-03). When
-	 * set, the bridge replaces the inbound client's Authorization with this key on
-	 * the forwarded request, so it can talk to a runtime proxy that requires a
-	 * per-process client token. The inbound request is still authenticated by the
-	 * bridge's own verifyBearerToken check first.
-	 */
-	runtimeClientApiKey?: string;
 }
+
+export interface MiniMaxBridgeBackendOptions {
+	apiKey: string;
+	region?: MiniMaxRegion;
+}
+
+export type LocalBridgeOptions = LocalBridgeCommonOptions &
+	(
+		| {
+				runtimeBaseUrl: string;
+				runtimeClientApiKey?: string;
+				miniMax?: never;
+		  }
+		| {
+				miniMax: MiniMaxBridgeBackendOptions;
+				runtimeBaseUrl?: never;
+				runtimeClientApiKey?: never;
+		  }
+	);
 
 const DEFAULT_HOST = "127.0.0.1";
 const HOP_BY_HOP_HEADERS = new Set([
@@ -87,7 +102,7 @@ function responseHeadersForClient(headers: Headers): Headers {
 	return result;
 }
 
-function forwardHeaders(headers: Headers, runtimeClientApiKey?: string): Headers {
+function forwardHeaders(headers: Headers, outboundBearerToken?: string): Headers {
 	const result = new Headers(headers);
 	for (const key of HOP_BY_HOP_HEADERS) {
 		result.delete(key);
@@ -102,13 +117,10 @@ function forwardHeaders(headers: Headers, runtimeClientApiKey?: string): Headers
 	// alongside the managed token.
 	result.delete("cookie");
 	result.delete("proxy-authorization");
-	// runtime-proxy-03: present the runtime proxy's client token. We replace the
-	// inbound client's Authorization (already validated by the bridge) rather than
-	// forwarding it verbatim, so the bridge can authenticate to an auth-enabled
-	// runtime proxy. When no key is configured, strip any inbound Authorization to
-	// avoid leaking the caller's bridge token upstream (runtime-proxy-02).
-	if (runtimeClientApiKey && runtimeClientApiKey.trim().length > 0) {
-		result.set("authorization", `Bearer ${runtimeClientApiKey.trim()}`);
+	// Present only the configured backend credential. The inbound client's
+	// Authorization was already validated locally and must never cross this bridge.
+	if (outboundBearerToken && outboundBearerToken.trim().length > 0) {
+		result.set("authorization", `Bearer ${outboundBearerToken.trim()}`);
 	} else {
 		result.delete("authorization");
 	}
@@ -193,31 +205,51 @@ export async function startLocalBridge(
 	// "::1" produce an invalid "http://::1:port".
 	const bindHost = toBindHost(host);
 	const urlHost = toUrlHost(host);
-	const runtimeBaseUrl = options.runtimeBaseUrl.trim().replace(/\/+$/, "");
-	if (!runtimeBaseUrl) {
-		throw new Error("Local bridge requires a runtimeBaseUrl.");
-	}
-	// Egress guard (runtime-proxy-02): the bridge forwards the caller's bearer token
-	// to runtimeBaseUrl. That target must be the loopback runtime proxy, never an
-	// arbitrary remote host — otherwise a misconfigured base URL would exfiltrate the
-	// local client token (and, downstream, managed account material) off-box.
-	let runtimeHost: string;
-	try {
-		runtimeHost = new URL(runtimeBaseUrl).hostname;
-	} catch {
-		throw new Error(`Local bridge runtimeBaseUrl is not a valid URL: ${runtimeBaseUrl}`);
-	}
-	if (!isLoopbackHost(runtimeHost)) {
-		throw new Error(
-			`Local bridge refuses to forward to non-loopback runtimeBaseUrl host "${runtimeHost}". ` +
-				"It must target the loopback runtime proxy.",
-		);
-	}
 	const port = options.port ?? 0;
 	const fetchImpl = options.fetchImpl ?? (undiciFetch as typeof fetch);
 	const requireAuth = options.requireAuth ?? true;
 	const verifyBearerToken = options.verifyBearerToken ?? verifyLocalClientBearerToken;
+	const miniMax = options.miniMax;
+	const runtimeBaseUrl = options.runtimeBaseUrl?.trim().replace(/\/+$/, "") || null;
 	const runtimeClientApiKey = options.runtimeClientApiKey?.trim() || undefined;
+	const miniMaxRegion = miniMax?.region ?? "global";
+	if (miniMaxRegion !== "global" && miniMaxRegion !== "cn") {
+		throw new Error(`Local bridge received an unsupported MiniMax region: ${miniMaxRegion}`);
+	}
+	const miniMaxApiKey = miniMax?.apiKey.trim() || undefined;
+	const miniMaxEndpoints = miniMax ? getMiniMaxEndpoints(miniMaxRegion) : null;
+
+	if (miniMax) {
+		if (!miniMaxApiKey) {
+			throw new Error("Local bridge requires a MiniMax apiKey.");
+		}
+		if (!requireAuth) {
+			throw new Error(
+				"Local bridge requires requireAuth=true for a MiniMax backend.",
+			);
+		}
+	} else {
+		if (!runtimeBaseUrl) {
+			throw new Error("Local bridge requires a runtimeBaseUrl.");
+		}
+		// The runtime target must remain loopback-only. Allowing an arbitrary URL
+		// here would send local bridge credentials outside the trusted boundary.
+		let runtimeHost: string;
+		try {
+			runtimeHost = new URL(runtimeBaseUrl).hostname;
+		} catch {
+			throw new Error(
+				`Local bridge runtimeBaseUrl is not a valid URL: ${runtimeBaseUrl}`,
+			);
+		}
+		if (!isLoopbackHost(runtimeHost)) {
+			throw new Error(
+				`Local bridge refuses to forward to non-loopback runtimeBaseUrl host "${runtimeHost}". ` +
+					"It must target the loopback runtime proxy.",
+			);
+		}
+	}
+
 	if (runtimeClientApiKey && !requireAuth) {
 		// Security: forwarding a runtime client key while accepting unauthenticated
 		// inbound requests turns the bridge into an open local capability proxy —
@@ -231,45 +263,66 @@ export async function startLocalBridge(
 	}
 	const app = new Hono();
 
-	app.get("/health", (context) =>
-		context.json({
+	app.get("/health", (context) => {
+		if (miniMax) {
+			return context.json({
+				ok: true,
+				service: "codex-multi-auth-local-bridge",
+				backend: "MiniMax",
+				region: miniMaxRegion,
+			});
+		}
+		return context.json({
 			ok: true,
 			service: "codex-multi-auth-local-bridge",
 			runtimeBaseUrl,
-		}),
-	);
+		});
+	});
+
+	const authorize = async (
+		request: Request,
+		startedAt: number,
+	): Promise<Response | null> => {
+		if (!requireAuth) return null;
+		let token = await verifyBearerToken(
+			request.headers.get("authorization"),
+			startedAt,
+		);
+		if (!token) {
+			const apiKey = request.headers.get("x-api-key")?.trim();
+			if (apiKey) {
+				token = await verifyBearerToken(`Bearer ${apiKey}`, startedAt);
+			}
+		}
+		if (token) return null;
+		return new Response(
+			JSON.stringify({
+				error: {
+					message: "Local bridge rejected an unauthenticated request.",
+					code: "local_bridge_unauthorized",
+				},
+			}),
+			{
+				status: 401,
+				headers: { "content-type": "application/json; charset=utf-8" },
+			},
+		);
+	};
 
 	const forward = async (
 		request: Request,
-		targetPath: "/v1/models" | "/v1/responses",
+		targetUrl: string,
+		operation: "models" | "responses" | "messages",
+		outboundBearerToken?: string,
 	): Promise<Response> => {
 		const startedAt = Date.now();
-		if (requireAuth) {
-			const token = await verifyBearerToken(
-				request.headers.get("authorization"),
-				startedAt,
-			);
-			if (!token) {
-				return new Response(
-					JSON.stringify({
-						error: {
-							message: "Local bridge rejected an unauthenticated request.",
-							code: "local_bridge_unauthorized",
-						},
-					}),
-					{
-						status: 401,
-						headers: { "content-type": "application/json; charset=utf-8" },
-					},
-				);
-			}
-		}
-		const targetUrl = `${runtimeBaseUrl}${targetPath}`;
+		const unauthorized = await authorize(request, startedAt);
+		if (unauthorized) return unauthorized;
 		let upstream: Response;
 		try {
 			upstream = await fetchImpl(targetUrl, {
 				method: request.method,
-				headers: forwardHeaders(request.headers, runtimeClientApiKey),
+				headers: forwardHeaders(request.headers, outboundBearerToken),
 				body:
 					request.method === "GET" || request.method === "HEAD"
 						? undefined
@@ -278,7 +331,7 @@ export async function startLocalBridge(
 		} catch {
 			await appendUsageLedgerRow({
 				source: "local-bridge",
-				operation: targetPath === "/v1/models" ? "models" : "responses",
+				operation,
 				outcome: "failure",
 				statusCode: 502,
 				errorCode: "local_bridge_upstream_error",
@@ -287,7 +340,7 @@ export async function startLocalBridge(
 			return new Response(
 				JSON.stringify({
 					error: {
-						message: "Local bridge failed to reach the runtime proxy.",
+						message: "Local bridge failed to reach the configured backend.",
 						code: "local_bridge_upstream_error",
 					},
 				}),
@@ -299,7 +352,7 @@ export async function startLocalBridge(
 		}
 		await appendUsageLedgerRow({
 			source: "local-bridge",
-			operation: targetPath === "/v1/models" ? "models" : "responses",
+			operation,
 			outcome: upstream.ok ? "success" : "failure",
 			statusCode: upstream.status,
 			durationMs: Date.now() - startedAt,
@@ -311,13 +364,70 @@ export async function startLocalBridge(
 		});
 	};
 
-	app.get("/v1/models", (context) => forward(context.req.raw, "/v1/models"));
-	app.post("/v1/responses", (context) => forward(context.req.raw, "/v1/responses"));
+	if (miniMaxEndpoints && miniMaxApiKey) {
+		app.get("/v1/models", async (context) => {
+			const startedAt = Date.now();
+			const unauthorized = await authorize(context.req.raw, startedAt);
+			if (unauthorized) return unauthorized;
+			await appendUsageLedgerRow({
+				source: "local-bridge",
+				operation: "models",
+				outcome: "success",
+				statusCode: 200,
+				durationMs: Date.now() - startedAt,
+			}).catch(() => undefined);
+			return context.json(createMiniMaxModelsResponse());
+		});
+		app.post("/v1/responses", (context) =>
+			forward(
+				context.req.raw,
+				`${miniMaxEndpoints.responsesBaseUrl}/responses`,
+				"responses",
+				miniMaxApiKey,
+			),
+		);
+		app.post("/anthropic/v1/messages", (context) =>
+			forward(
+				context.req.raw,
+				`${miniMaxEndpoints.messagesBaseUrl}/v1/messages`,
+				"messages",
+				miniMaxApiKey,
+			),
+		);
+		app.post("/anthropic/v1/messages/count_tokens", (context) =>
+			forward(
+				context.req.raw,
+				`${miniMaxEndpoints.messagesBaseUrl}/v1/messages/count_tokens`,
+				"messages",
+				miniMaxApiKey,
+			),
+		);
+	} else if (runtimeBaseUrl) {
+		app.get("/v1/models", (context) =>
+			forward(
+				context.req.raw,
+				`${runtimeBaseUrl}/v1/models`,
+				"models",
+				runtimeClientApiKey,
+			),
+		);
+		app.post("/v1/responses", (context) =>
+			forward(
+				context.req.raw,
+				`${runtimeBaseUrl}/v1/responses`,
+				"responses",
+				runtimeClientApiKey,
+			),
+		);
+	}
+	const notFoundMessage = miniMax
+		? "Local bridge only accepts /health, /v1/models, /v1/responses, and MiniMax Messages API paths."
+		: "Local bridge only accepts /health, /v1/models, and /v1/responses.";
 	app.all("*", (context) =>
 		context.json(
 			{
 				error: {
-					message: "Local bridge only accepts /health, /v1/models, and /v1/responses.",
+					message: notFoundMessage,
 					code: "local_bridge_not_found",
 				},
 			},

--- a/lib/providers/minimax.ts
+++ b/lib/providers/minimax.ts
@@ -1,0 +1,103 @@
+export type MiniMaxRegion = "global" | "cn";
+
+export interface MiniMaxModelDefinition {
+	id: "MiniMax-M3" | "MiniMax-M2.7";
+	contextWindow: number;
+	inputModalities: readonly ("text" | "image" | "video")[];
+	thinking: readonly ("adaptive" | "disabled" | "always_on")[];
+	pricingUsdPerMillionTokens: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number | null;
+	};
+}
+
+export interface MiniMaxRegionalEndpoints {
+	responsesBaseUrl: string;
+	messagesBaseUrl: string;
+}
+
+export const MINIMAX_MODELS: readonly MiniMaxModelDefinition[] = [
+	{
+		id: "MiniMax-M3",
+		contextWindow: 1_000_000,
+		inputModalities: ["text", "image", "video"],
+		thinking: ["adaptive", "disabled"],
+		pricingUsdPerMillionTokens: {
+			input: 0.6,
+			output: 2.4,
+			cacheRead: 0.12,
+			cacheWrite: null,
+		},
+	},
+	{
+		id: "MiniMax-M2.7",
+		contextWindow: 204_800,
+		inputModalities: ["text"],
+		thinking: ["always_on"],
+		pricingUsdPerMillionTokens: {
+			input: 0.3,
+			output: 1.2,
+			cacheRead: 0.06,
+			cacheWrite: 0.375,
+		},
+	},
+] as const;
+
+export const MINIMAX_ENDPOINTS: Readonly<
+	Record<MiniMaxRegion, MiniMaxRegionalEndpoints>
+> = {
+	global: {
+		responsesBaseUrl: "https://api.minimax.io/v1",
+		messagesBaseUrl: "https://api.minimax.io/anthropic",
+	},
+	cn: {
+		responsesBaseUrl: "https://api.minimaxi.com/v1",
+		messagesBaseUrl: "https://api.minimaxi.com/anthropic",
+	},
+} as const;
+
+export function getMiniMaxEndpoints(
+	region: MiniMaxRegion = "global",
+): MiniMaxRegionalEndpoints {
+	return MINIMAX_ENDPOINTS[region];
+}
+
+export function createMiniMaxModelsResponse(): {
+	object: "list";
+	data: Array<{
+		id: MiniMaxModelDefinition["id"];
+		object: "model";
+		created: 0;
+		owned_by: "MiniMax";
+		context_window: number;
+		input_modalities: readonly ("text" | "image" | "video")[];
+		thinking: readonly ("adaptive" | "disabled" | "always_on")[];
+		pricing_usd_per_million_tokens: {
+			input: number;
+			output: number;
+			cache_read: number;
+			cache_write: number | null;
+		};
+	}>;
+} {
+	return {
+		object: "list",
+		data: MINIMAX_MODELS.map((model) => ({
+			id: model.id,
+			object: "model",
+			created: 0,
+			owned_by: "MiniMax",
+			context_window: model.contextWindow,
+			input_modalities: model.inputModalities,
+			thinking: model.thinking,
+			pricing_usd_per_million_tokens: {
+				input: model.pricingUsdPerMillionTokens.input,
+				output: model.pricingUsdPerMillionTokens.output,
+				cache_read: model.pricingUsdPerMillionTokens.cacheRead,
+				cache_write: model.pricingUsdPerMillionTokens.cacheWrite,
+			},
+		})),
+	};
+}

--- a/lib/usage/ledger.ts
+++ b/lib/usage/ledger.ts
@@ -39,6 +39,7 @@ const VALID_SOURCES = new Set<UsageLedgerSource>([
 ]);
 const VALID_OPERATIONS = new Set<UsageLedgerOperation>([
 	"responses",
+	"messages",
 	"models",
 	"thread-goal",
 	"auth-refresh",

--- a/lib/usage/redaction.ts
+++ b/lib/usage/redaction.ts
@@ -19,6 +19,7 @@ const VALID_SOURCES = new Set<UsageLedgerSource>([
 ]);
 const VALID_OPERATIONS = new Set<UsageLedgerOperation>([
 	"responses",
+	"messages",
 	"models",
 	"thread-goal",
 	"auth-refresh",
@@ -163,4 +164,3 @@ export function normalizeUsageLedgerRow(
 export function usageRowToJsonLine(row: UsageLedgerRow): string {
 	return `${JSON.stringify(row)}\n`;
 }
-

--- a/lib/usage/types.ts
+++ b/lib/usage/types.ts
@@ -7,6 +7,7 @@ export type UsageLedgerSource =
 
 export type UsageLedgerOperation =
 	| "responses"
+	| "messages"
 	| "models"
 	| "thread-goal"
 	| "auth-refresh"
@@ -118,4 +119,3 @@ export interface UsageLedgerPaths {
 	dir: string;
 	current: string;
 }
-

--- a/test/local-bridge.test.ts
+++ b/test/local-bridge.test.ts
@@ -334,4 +334,146 @@ describe("local bridge", () => {
 		expect(headers.get("cookie")).toBeNull();
 		expect(headers.get("proxy-authorization")).toBeNull();
 	});
+
+	it("serves the MiniMax catalog and forwards both compatible request paths", async () => {
+		const { calls, fetchImpl } = createFetch();
+		const verifyBearerToken = vi.fn(
+			async (authorization: string | null) =>
+				authorization
+					? {
+							id: "token-1",
+							label: "test",
+							prefix: "cma_local_test",
+							tokenHash: "hash",
+							createdAt: 1,
+							lastUsedAt: null,
+							revokedAt: null,
+						}
+					: null,
+		);
+		const server = await startLocalBridge({
+			miniMax: { apiKey: "mm-test", region: "global" },
+			fetchImpl,
+			verifyBearerToken,
+		});
+		openServers.push(server);
+
+		const bearerClientHeaders = {
+			authorization: "Bearer bearer-client",
+			"content-type": "application/json",
+			cookie: "local-cookie",
+		};
+		const anthropicClientHeaders = {
+			"content-type": "application/json",
+			"x-api-key": "anthropic-client",
+			cookie: "local-cookie",
+		};
+		const health = await fetch(`${server.baseUrl}/health`);
+		expect(await health.json()).toEqual({
+			ok: true,
+			service: "codex-multi-auth-local-bridge",
+			backend: "MiniMax",
+			region: "global",
+		});
+
+		const models = await fetch(`${server.baseUrl}/v1/models`, {
+			headers: bearerClientHeaders,
+		});
+		expect(models.status).toBe(200);
+		expect(await models.json()).toMatchObject({
+			object: "list",
+			data: [
+				{ id: "MiniMax-M3", context_window: 1_000_000 },
+				{ id: "MiniMax-M2.7", context_window: 204_800 },
+			],
+		});
+
+		for (const path of [
+			"/v1/responses",
+			"/anthropic/v1/messages",
+			"/anthropic/v1/messages/count_tokens",
+		]) {
+			const response = await fetch(`${server.baseUrl}${path}`, {
+				method: "POST",
+				headers: path.startsWith("/anthropic/")
+					? anthropicClientHeaders
+					: bearerClientHeaders,
+				body: JSON.stringify({ model: "MiniMax-M3", input: "hello" }),
+			});
+			expect(response.status).toBe(200);
+		}
+
+		expect(calls.map((call) => call.url)).toEqual([
+			"https://api.minimax.io/v1/responses",
+			"https://api.minimax.io/anthropic/v1/messages",
+			"https://api.minimax.io/anthropic/v1/messages/count_tokens",
+		]);
+		expect(
+			verifyBearerToken.mock.calls.map(([authorization]) => authorization),
+		).toEqual([
+			"Bearer bearer-client",
+			"Bearer bearer-client",
+			null,
+			"Bearer anthropic-client",
+			null,
+			"Bearer anthropic-client",
+		]);
+		for (const call of calls) {
+			const headers = new Headers(call.init?.headers as HeadersInit);
+			expect(headers.get("authorization")).toBe("Bearer mm-test");
+			expect(headers.get("x-api-key")).toBeNull();
+			expect(headers.get("cookie")).toBeNull();
+		}
+	});
+
+	it("selects the China MiniMax endpoints", async () => {
+		const { calls, fetchImpl } = createFetch();
+		const server = await startLocalBridge({
+			miniMax: { apiKey: "mm-test", region: "cn" },
+			fetchImpl,
+			verifyBearerToken: vi.fn().mockResolvedValue({
+				id: "token-1",
+				label: "test",
+				prefix: "cma_local_test",
+				tokenHash: "hash",
+				createdAt: 1,
+				lastUsedAt: null,
+				revokedAt: null,
+			}),
+		});
+		openServers.push(server);
+
+		for (const path of ["/v1/responses", "/anthropic/v1/messages"]) {
+			await fetch(`${server.baseUrl}${path}`, {
+				method: "POST",
+				headers: {
+					authorization: "Bearer local-client",
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({ model: "MiniMax-M2.7", input: "hello" }),
+			});
+		}
+
+		expect(calls.map((call) => call.url)).toEqual([
+			"https://api.minimaxi.com/v1/responses",
+			"https://api.minimaxi.com/anthropic/v1/messages",
+		]);
+	});
+
+	it("requires a provider key and local auth for MiniMax", async () => {
+		const { fetchImpl } = createFetch();
+		await expect(
+			startLocalBridge({
+				miniMax: { apiKey: "" },
+				fetchImpl,
+			}),
+		).rejects.toThrow(/requires a MiniMax apiKey/i);
+		await expect(
+			startLocalBridge({
+				miniMax: { apiKey: "mm-test" },
+				fetchImpl,
+				requireAuth: false,
+			}),
+		).rejects.toThrow(/requires requireAuth=true/i);
+	});
 });

--- a/test/minimax-provider.test.ts
+++ b/test/minimax-provider.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+	createMiniMaxModelsResponse,
+	getMiniMaxEndpoints,
+	MINIMAX_MODELS,
+} from "../lib/providers/minimax.js";
+
+describe("MiniMax provider catalog", () => {
+	it("defines the global and China regional endpoints", () => {
+		expect(getMiniMaxEndpoints("global")).toEqual({
+			responsesBaseUrl: "https://api.minimax.io/v1",
+			messagesBaseUrl: "https://api.minimax.io/anthropic",
+		});
+		expect(getMiniMaxEndpoints("cn")).toEqual({
+			responsesBaseUrl: "https://api.minimaxi.com/v1",
+			messagesBaseUrl: "https://api.minimaxi.com/anthropic",
+		});
+	});
+
+	it("publishes the current model capabilities and pricing", () => {
+		expect(MINIMAX_MODELS).toEqual([
+			{
+				id: "MiniMax-M3",
+				contextWindow: 1_000_000,
+				inputModalities: ["text", "image", "video"],
+				thinking: ["adaptive", "disabled"],
+				pricingUsdPerMillionTokens: {
+					input: 0.6,
+					output: 2.4,
+					cacheRead: 0.12,
+					cacheWrite: null,
+				},
+			},
+			{
+				id: "MiniMax-M2.7",
+				contextWindow: 204_800,
+				inputModalities: ["text"],
+				thinking: ["always_on"],
+				pricingUsdPerMillionTokens: {
+					input: 0.3,
+					output: 1.2,
+					cacheRead: 0.06,
+					cacheWrite: 0.375,
+				},
+			},
+		]);
+	});
+
+	it("renders an executable model-list response", () => {
+		expect(createMiniMaxModelsResponse()).toEqual({
+			object: "list",
+			data: [
+				expect.objectContaining({
+					id: "MiniMax-M3",
+					owned_by: "MiniMax",
+					context_window: 1_000_000,
+					input_modalities: ["text", "image", "video"],
+					thinking: ["adaptive", "disabled"],
+				}),
+				expect.objectContaining({
+					id: "MiniMax-M2.7",
+					context_window: 204_800,
+					input_modalities: ["text"],
+					thinking: ["always_on"],
+				}),
+			],
+		});
+	});
+});


### PR DESCRIPTION
Reason: Add MiniMax-M3 and MiniMax-M2.7 access through the Global and China Responses and Messages-compatible endpoints.

- Add an executable MiniMax model catalog with current capabilities, pricing, and regional endpoints.
- Extend the loopback bridge with direct Responses and Messages-compatible routes while preserving the existing runtime backend.
- Accept local bearer or `x-api-key` credentials and replace them with the configured provider credential before egress.
- Document the public host API and regional backend selection.

Checks:
- `npm test -- --run test/minimax-provider.test.ts test/local-bridge.test.ts test/usage-redaction.test.ts test/documentation.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run pack:check`
- Required diff secret scan

The full `npm test` run also reports existing platform-specific wrapper, path, backup, and timeout failures that reproduce from base commit `89ca969`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

adds direct minimax support to the loopback bridge.
- adds global and china responses and messages endpoints with backend credential replacement.
- publishes a minimax model and pricing catalog through the package barrels.
- extends usage operation types and documents the host api and authentication contract.
- adds vitest coverage for routing, credential stripping, catalog output, and configuration validation, but not minimax usage attribution or budget accounting.

<h3>Confidence Score: 4/5</h3>

the minimax usage-accounting defect should be fixed before merging because direct provider spend and tokens are omitted from governance reports and limits.

minimax forwarding and token replacement are covered, including concurrent ledger serialization and windows-safe filesystem locking, but every new billable request is persisted as unknown zero usage despite the provider catalog defining model pricing.

**Files Needing Attention:** lib/local-bridge.ts, lib/providers/minimax.ts, test/local-bridge.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/local-bridge.ts | adds authenticated minimax forwarding safely, but records direct provider traffic without model, token, or cost attribution. |
| lib/providers/minimax.ts | defines the regional endpoints and executable model capability and pricing catalog. |
| lib/usage/ledger.ts | accepts the new messages operation while preserving existing windows-aware locking and concurrent append serialization. |
| lib/usage/redaction.ts | recognizes messages, but correctly exposes that omitted minimax usage fields normalize to zero or null. |
| test/local-bridge.test.ts | covers endpoint selection and token safety, but lacks vitest assertions for minimax usage and budget accounting. |
| index.ts | exposes the local bridge and minimax catalog from the package root without an observed export collision. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Bridge as local bridge
  participant MiniMax
  participant Ledger as usage ledger
  Client->>Bridge: bearer or x-api-key request
  Bridge->>Bridge: verify local token
  Bridge->>MiniMax: replace credential and forward
  MiniMax-->>Bridge: response or stream
  Bridge->>Ledger: append outcome/status/duration
  Note over Ledger: model, tokens, and cost are omitted
  Bridge-->>Client: filtered response
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/local-bridge.ts`, line 353-359 ([link](https://github.com/ndycode/codex-multi-auth/blob/6ed031c632b4c7a4c83cf682639225383057a653/lib/local-bridge.ts#L353-L359)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **minimax usage is not attributed**

   when the bridge completes a minimax request, it records only the operation, outcome, status, and duration, causing the model to appear as `unknown` and its tokens and cost to count as zero in usage reports and budget limits.

   **Context Used:** lib/AGENTS.md ([source](https://github.com/ndycode/codex-multi-auth/blob/main/lib/AGENTS.md))
   
   **Knowledge Base Used:** [Quota, Usage, and Budget Tracking](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/quota-usage.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: lib/local-bridge.ts
   Line: 353-359
   
   Comment:
   **minimax usage is not attributed**
   
   when the bridge completes a minimax request, it records only the operation, outcome, status, and duration, causing the model to appear as `unknown` and its tokens and cost to count as zero in usage reports and budget limits.
   
   **Context Used:** lib/AGENTS.md ([source](https://github.com/ndycode/codex-multi-auth/blob/main/lib/AGENTS.md))
   
   **Knowledge Base Used:** [Quota, Usage, and Budget Tracking](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/quota-usage.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/local-bridge.ts:353-359
**minimax usage is not attributed**

when the bridge completes a minimax request, it records only the operation, outcome, status, and duration, causing the model to appear as `unknown` and its tokens and cost to count as zero in usage reports and budget limits.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add MiniMax provider bridge backend"](https://github.com/ndycode/codex-multi-auth/commit/6ed031c632b4c7a4c83cf682639225383057a653) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49026991)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - lib/AGENTS.md ([source](https://github.com/ndycode/codex-multi-auth/blob/main/lib/AGENTS.md))
- Knowledge Base — [Auth / OAuth login flow](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/auth-oauth-flow.md)
- Knowledge Base — [Quota, Usage, and Budget Tracking](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/quota-usage.md)
</details>


<!-- /greptile_comment -->