### PR TITLE
fix(codex): route resume/fork through the canonical home and bound helper shutdown (#647)

### DIFF
--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -167,6 +167,7 @@ Policy evaluation (`lib/policy/runtime-policy.ts`) can block paused/drained acco
    | Branch | Predicate | Transport |
    | --- | --- | --- |
    | Interactive TUI | `isCodexInteractiveTuiCommand` — no forwarded subcommand at all | App runtime helper with `useCanonicalHome: true` and `detachOnExit: true`. Runs against the **canonical** `CODEX_HOME`; the provider is passed as ephemeral `-c model_providers.*` overrides. No shadow copy and no state sync-back. Nothing **provider- or transport-related** is written into `config.toml` on this path — the only top-level key the wrapper still reconciles there is `cli_auth_credentials_store`, which is transport-independent (see step 4 note). |
+   | Interactive `resume` / `fork` | `isCodexInteractiveResumeCommand` — forwarded command is `resume` or `fork` | Same transport and options as the interactive TUI above. These open a TUI against an existing thread, so they must see the canonical thread index. |
    | `codex app` | `isCodexAppCommand` — forwarded command is `app` | App runtime helper process with a shadow `CODEX_HOME`. |
    | Everything else | request-bearing forwarded command | Shadow `CODEX_HOME` created inline by the wrapper process. |
 
@@ -179,6 +180,10 @@ Policy evaluation (`lib/policy/runtime-policy.ts`) can block paused/drained acco
 10. On exit, shadow-home branches sync refreshed official state files back and remove the temporary directory. The canonical-home branch has nothing to sync — it read and wrote official state in place.
 
 Why the interactive branch is different: copying the Codex home into a shadow made the official CLI reindex its thread history and SQLite state on every TUI launch. Running interactive sessions against the canonical home keeps that state reusable.
+
+`resume` and `fork` belong to that same branch for a stronger reason. The shadow mirror deliberately omits the runtime SQLite state (`isRuntimeRotationShadowHomeOmittedEntry`), so a shadow home only ever holds a partial thread index rebuilt from the linked `sessions` directory. Resuming a thread that the shadow index does not contain left the TUI on a blank screen forever, while the same command worked under the official CLI and with the proxy disabled. Routing both commands to the canonical home is what makes the thread visible (#647).
+
+Helper shutdown is bounded rather than best-effort. `stopRuntimeRotationAppHelper` sends `SIGTERM`, waits out the graceful window, escalates to `SIGKILL` if the helper is still running, and then unconditionally destroys the helper's stdio streams and unrefs the child. That last step is the load-bearing one: the helper is spawned with piped stdio, so a helper that outlives the window — or any process that inherited those pipes — keeps the wrapper's event loop referenced and the shell prompt never returns. On Windows the signals are emulated as unconditional termination, so the stream teardown is the only part that reliably frees the wrapper there.
 
 Two interactive sessions can therefore run concurrently against the same home — the same as running the official CLI twice — and **no lock is taken over session state**: neither session copies or syncs it, so there is nothing to clobber. Regression coverage lives in `test/codex-bin-wrapper.test.ts`.
 

--- a/docs/development/CONFIG_FLOW.md
+++ b/docs/development/CONFIG_FLOW.md
@@ -74,6 +74,7 @@ For dashboard display values:
 3. If enabled, start a loopback Responses proxy with a per-process client token.
 4. Select a transport from the forwarded argv:
    - **No forwarded subcommand (interactive TUI)** — keep the canonical `CODEX_HOME` and pass `codex-multi-auth-runtime-proxy` as ephemeral `-c model_providers.*` overrides. Nothing is copied, no provider or transport config is written into `config.toml`, and the helper detaches on exit. The transport-independent `cli_auth_credentials_store` reconcile below still applies.
+   - **`resume` / `fork`** — the same canonical-home transport as the interactive TUI. These resume an existing thread, and the shadow home omits the runtime SQLite state, so the shadow transport could not see the requested thread (#647).
    - **`codex app`** — run the app runtime helper against a shadow `CODEX_HOME`.
    - **Any other request-bearing command** — create a temporary shadow `CODEX_HOME` and rewrite its `config.toml` to use `codex-multi-auth-runtime-proxy`.
 5. Forward official Codex with the selected home.

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -4439,6 +4439,10 @@ function shouldUseRuntimeRoutingForForwardedArgs(rawArgs) {
 	}
 
 	const requestCommands = new Set(["exec", "review", "resume", "fork", "app"]);
+	// Request commands whose `--help`/`-h` form is routed straight to the official
+	// CLI. Scoped to the commands that spawn a detached helper, since that is the
+	// transport where a wasted launch outlives the wrapper.
+	const HELP_ONLY_REQUEST_COMMANDS = new Set(["app", "resume", "fork"]);
 	const nonRequestCommands = new Set([
 		"help",
 		"completion",
@@ -4464,7 +4468,15 @@ function shouldUseRuntimeRoutingForForwardedArgs(rawArgs) {
 		);
 	}
 
-	if (command.command === "app" && hasHelpFlagAfterCommand(rawArgs, command.index)) {
+	// These are request commands, but printing their help makes no model requests.
+	// Short-circuit the whole transport so help never pays for a proxy, a shadow
+	// home, or a detached helper — the interactive branch detaches its helper on a
+	// clean exit, so `resume --help` would otherwise leave one running until its
+	// idle timeout (#647).
+	if (
+		HELP_ONLY_REQUEST_COMMANDS.has(command.command) &&
+		hasHelpFlagAfterCommand(rawArgs, command.index)
+	) {
 		return false;
 	}
 	if (requestCommands.has(command.command)) {

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -4439,10 +4439,6 @@ function shouldUseRuntimeRoutingForForwardedArgs(rawArgs) {
 	}
 
 	const requestCommands = new Set(["exec", "review", "resume", "fork", "app"]);
-	// Request commands whose `--help`/`-h` form is routed straight to the official
-	// CLI. Scoped to the commands that spawn a detached helper, since that is the
-	// transport where a wasted launch outlives the wrapper.
-	const HELP_ONLY_REQUEST_COMMANDS = new Set(["app", "resume", "fork"]);
 	const nonRequestCommands = new Set([
 		"help",
 		"completion",
@@ -4468,13 +4464,15 @@ function shouldUseRuntimeRoutingForForwardedArgs(rawArgs) {
 		);
 	}
 
-	// These are request commands, but printing their help makes no model requests.
-	// Short-circuit the whole transport so help never pays for a proxy, a shadow
-	// home, or a detached helper — the interactive branch detaches its helper on a
-	// clean exit, so `resume --help` would otherwise leave one running until its
-	// idle timeout (#647).
+	// Request commands still print their help without making a single model
+	// request, so the help form skips the transport entirely: no proxy, no shadow
+	// home, no detached helper. This matters most for the interactive commands,
+	// which detach their helper on a clean exit — help always exits clean, so
+	// `resume --help` would otherwise strand a helper until its idle timeout. It is
+	// keyed off the help flag rather than the command, so a real run still routes
+	// through rotation, and it matches how `app-server` help is handled above (#647).
 	if (
-		HELP_ONLY_REQUEST_COMMANDS.has(command.command) &&
+		requestCommands.has(command.command) &&
 		hasHelpFlagAfterCommand(rawArgs, command.index)
 	) {
 		return false;

--- a/scripts/codex.js
+++ b/scripts/codex.js
@@ -4003,6 +4003,9 @@ function waitForRuntimeRotationAppHelperExit(helper, timeoutMs = 2_000) {
 			if (settled) return;
 			settled = true;
 			if (timer) clearTimeout(timer);
+			// Drop the listener when the timeout wins, so a helper that outlives the
+			// graceful window does not keep a live reference back into this process.
+			helper.off?.("close", finish);
 			resolve();
 		};
 		timer = setTimeout(finish, timeoutMs);
@@ -4010,16 +4013,49 @@ function waitForRuntimeRotationAppHelperExit(helper, timeoutMs = 2_000) {
 	});
 }
 
-function stopRuntimeRotationAppHelper(helper) {
-	if (!helper || helper.killed) {
-		return Promise.resolve();
-	}
+function hasRuntimeRotationAppHelperExited(helper) {
+	return helper.exitCode !== null || helper.signalCode !== null;
+}
+
+// Releases every handle the helper still holds in this process. The helper is
+// spawned with piped stdio, so those pipes keep the parent event loop alive on
+// their own — destroying and unref-ing them is what actually lets `mcodex` return
+// to the shell when the child ignores or outlives SIGTERM (#647).
+function releaseRuntimeRotationAppHelperResources(helper) {
+	helper.stdout?.destroy();
+	helper.stderr?.destroy();
 	try {
-		helper.kill("SIGTERM");
+		helper.unref();
 	} catch {
-		return Promise.resolve();
+		// Best-effort only.
 	}
-	return waitForRuntimeRotationAppHelperExit(helper);
+}
+
+async function stopRuntimeRotationAppHelper(helper) {
+	if (!helper) {
+		return;
+	}
+	if (hasRuntimeRotationAppHelperExited(helper)) {
+		releaseRuntimeRotationAppHelperResources(helper);
+		return;
+	}
+	if (!helper.killed) {
+		try {
+			helper.kill("SIGTERM");
+		} catch {
+			releaseRuntimeRotationAppHelperResources(helper);
+			return;
+		}
+	}
+	await waitForRuntimeRotationAppHelperExit(helper);
+	if (!hasRuntimeRotationAppHelperExited(helper)) {
+		try {
+			helper.kill("SIGKILL");
+		} catch {
+			// Best-effort force-stop once the graceful shutdown window has elapsed.
+		}
+	}
+	releaseRuntimeRotationAppHelperResources(helper);
 }
 
 function startRuntimeRotationAppHelper(baseContext, options = {}) {
@@ -4171,7 +4207,10 @@ async function createRuntimeRotationProxyContextIfEnabled(
 	if (isCodexAppCommand(rawArgs)) {
 		return createRuntimeRotationAppHelperContext(baseContext, configTomlModule);
 	}
-	if (isCodexInteractiveTuiCommand(rawArgs)) {
+	if (
+		isCodexInteractiveTuiCommand(rawArgs) ||
+		isCodexInteractiveResumeCommand(rawArgs)
+	) {
 		return createRuntimeRotationAppHelperContext(baseContext, configTomlModule, {
 			detachOnExit: true,
 			useCanonicalHome: true,
@@ -4373,6 +4412,17 @@ function isCodexAppServerCommand(rawArgs) {
 
 function isCodexInteractiveTuiCommand(rawArgs) {
 	return findForwardedCommand(rawArgs) === null;
+}
+
+// `resume` and `fork` are interactive TUI entry points that happen to carry a
+// forwarded subcommand, so the bare-invocation predicate above misses them. They
+// must not take the shadow-home transport: the shadow mirror deliberately omits the
+// runtime SQLite state (`isRuntimeRotationShadowHomeOmittedEntry`), so the requested
+// thread is absent from the shadow session index and the resumed TUI hangs on a
+// blank screen (#647).
+function isCodexInteractiveResumeCommand(rawArgs) {
+	const command = findForwardedCommand(rawArgs)?.command;
+	return command === "resume" || command === "fork";
 }
 
 function shouldUseRuntimeRoutingForForwardedArgs(rawArgs) {

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -308,6 +308,7 @@ function createRuntimeRotationProxyFixtureModule(fixtureRoot: string): string {
 	writeFileSync(
 		modulePath,
 		[
+			'import { spawn } from "node:child_process";',
 			'import { appendFileSync, mkdirSync } from "node:fs";',
 			'import { dirname } from "node:path";',
 			"",
@@ -356,12 +357,43 @@ function createRuntimeRotationProxyFixtureModule(fixtureRoot: string): string {
 			"    appendMarker(`codex-home-env:${process.env.CODEX_HOME ?? ''}`);",
 			"    appendMarker(`real-home-env:${process.env.CODEX_MULTI_AUTH_REAL_CODEX_HOME ?? ''}`);",
 			"  }",
+			// Opt-in (#647): the real proxy owns a listening socket, so the helper stays
+			// alive until it is closed. This fake has no such handle and would otherwise
+			// let the helper exit on its own the moment its status timer is cleared —
+			// which would silently defeat a test about helpers that refuse to stop. Hold
+			// a ref'd handle so the helper's lifetime is governed by the signal path.
+			"  const closeHangs = (process.env.CODEX_MULTI_AUTH_TEST_PROXY_CLOSE_HANG ?? '').trim() === '1';",
+			"  if (closeHangs) {",
+			"    setInterval(() => {}, 1000);",
+			"  }",
+			// Opt-in (#647): leak a detached grandchild that inherits this helper's stdio.
+			// It keeps the write end of the launcher's pipes open after the helper is
+			// gone, so the launcher never sees `close` and must release the handles
+			// itself. This reproduces the stranded-wrapper failure on every platform,
+			// including Windows, where `kill()` is always a hard terminate.
+			"  const pipeHolderMs = readOptionalNumberEnv('CODEX_MULTI_AUTH_TEST_PROXY_PIPE_HOLDER_MS');",
+			"  if (pipeHolderMs !== null) {",
+			"    const holder = spawn(process.execPath, ['-e', `setTimeout(() => {}, ${pipeHolderMs})`], {",
+			"      stdio: ['ignore', 'inherit', 'inherit'],",
+			"      detached: true,",
+			"    });",
+			"    holder.unref();",
+			"  }",
 			"  appendMarker((process.env.CODEX_MULTI_AUTH_TEST_PROXY_MARKER_PID ?? '').trim() === '1' ? `start:${baseUrl}:pid=${process.pid}` : `start:${baseUrl}`);",
 			"  return {",
 			"    host: '127.0.0.1',",
 			"    port: 4567,",
 			"    baseUrl,",
-			"    close: async () => appendMarker('close'),",
+			// Opt-in (#647): stall `close()` forever so the helper's SIGTERM handler
+			// never reaches `process.exit`. Paired with the ref'd handle installed
+			// above, this reproduces a helper that survives the graceful window and can
+			// only be stopped by force.
+			"    close: async () => {",
+			"      appendMarker('close');",
+			"      if (closeHangs) {",
+			"        await new Promise(() => {});",
+			"      }",
+			"    },",
 			"    getStatus: () => buildStatus(),",
 			"  };",
 			"}",
@@ -2894,6 +2926,223 @@ describe("codex bin wrapper", () => {
 			"start:http://127.0.0.1:4567\nclose\n",
 		);
 	});
+
+	// `resume`/`fork` are interactive TUI entry points, but they carry a forwarded
+	// subcommand, so they used to fall through to the shadow-home transport. The
+	// shadow mirror omits the runtime SQLite state, so the requested thread was
+	// missing from the shadow session index and the resumed TUI hung on a blank
+	// screen (#647). Both must now reach the canonical home like the bare TUI.
+	for (const command of ["resume", "fork"] as const) {
+		it(`uses the canonical Codex home for \`${command}\` runtime routing (#647)`, async () => {
+			const fixtureRoot = createWrapperFixture();
+			createRuntimeRotationProxyFixtureModule(fixtureRoot);
+			const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+				"#!/usr/bin/env node",
+				'const fs = require("node:fs");',
+				'const path = require("node:path");',
+				"const args = process.argv.slice(2);",
+				'if (args[0] === "app-server") {',
+				'  console.log(`APP_SERVER_FORWARDED:${args.join(" ")}`);',
+				"  process.exit(0);",
+				"}",
+				"console.log(`RESUME_HOME_IS_ORIGINAL:${process.env.CODEX_HOME === process.env.ORIGINAL_CODEX_HOME}`);",
+				// The thread index only exists in the canonical home; the shadow mirror
+				// omits it, which is precisely what made resume hang.
+				'const statePath = path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite");',
+				"console.log(`RESUME_SEES_THREAD_INDEX:${fs.existsSync(statePath)}`);",
+				'console.log(`RESUME_COMMAND:${args[0]}`);',
+				'console.log(`RESUME_SESSION_ID:${args[1]}`);',
+				'console.log(`RESUME_HAS_BASE_URL_OVERRIDE:${args.some((arg) => arg.includes("model_providers.codex-multi-auth-runtime-proxy.base_url="))}`);',
+				"console.log(`RESUME_CLI_PATH_IS_SHIM:${(process.env.CODEX_CLI_PATH ?? \"\").includes(\"app-server-shims\")}`);",
+				"process.exit(0);",
+			]);
+			const originalHome = join(fixtureRoot, "codex-home");
+			const markerPath = join(fixtureRoot, "proxy-marker.txt");
+			const sessionId = "019ddf47-2c01-7c73-9f81-ab0cd9c1d5b7";
+			mkdirSync(originalHome, { recursive: true });
+			writeFileSync(
+				join(originalHome, "config.toml"),
+				'model_provider = "openai"\n',
+				"utf8",
+			);
+			writeFileSync(
+				join(originalHome, "state_5.sqlite"),
+				"canonical-thread-index\n",
+				"utf8",
+			);
+
+			const result = runWrapper(fixtureRoot, [command, sessionId], {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				ORIGINAL_CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "200",
+				CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+				OPENAI_API_KEY: undefined,
+			});
+
+			const output = combinedOutput(result);
+			if (result.status !== 0) {
+				throw new Error(output);
+			}
+			expect(output).toContain("RESUME_HOME_IS_ORIGINAL:true");
+			expect(output).toContain("RESUME_SEES_THREAD_INDEX:true");
+			expect(output).toContain(`RESUME_COMMAND:${command}`);
+			expect(output).toContain(`RESUME_SESSION_ID:${sessionId}`);
+			// Rotation is still active: the proxy overrides ride along as `-c` args.
+			expect(output).toContain("RESUME_HAS_BASE_URL_OVERRIDE:true");
+			expect(output).toContain("RESUME_CLI_PATH_IS_SHIM:true");
+			// The canonical home is never rewritten on disk.
+			expect(readFileSync(join(originalHome, "config.toml"), "utf8")).toBe(
+				'model_provider = "openai"\n',
+			);
+			await waitForFileText(markerPath, "start:http://127.0.0.1:4567\nclose\n");
+		});
+	}
+
+	// Guards the other half of the split: non-interactive request commands must keep
+	// using the isolated shadow home, so widening the interactive classification
+	// cannot silently move `exec`/`review` onto the canonical home.
+	for (const command of ["exec", "review"] as const) {
+		it(`keeps \`${command}\` on the shadow Codex home (#647)`, () => {
+			const fixtureRoot = createWrapperFixture();
+			createRuntimeRotationProxyFixtureModule(fixtureRoot);
+			const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+				"#!/usr/bin/env node",
+				"console.log(`SHADOW_HOME_IS_ORIGINAL:${process.env.CODEX_HOME === process.env.ORIGINAL_CODEX_HOME}`);",
+				"process.exit(0);",
+			]);
+			const originalHome = join(fixtureRoot, "codex-home");
+			const markerPath = join(fixtureRoot, "proxy-marker.txt");
+			mkdirSync(originalHome, { recursive: true });
+			writeFileSync(
+				join(originalHome, "config.toml"),
+				'model_provider = "openai"\n',
+				"utf8",
+			);
+
+			const result = runWrapper(fixtureRoot, [command, "do something"], {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				ORIGINAL_CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+				OPENAI_API_KEY: undefined,
+			});
+
+			const output = combinedOutput(result);
+			if (result.status !== 0) {
+				throw new Error(output);
+			}
+			expect(output).toContain("SHADOW_HOME_IS_ORIGINAL:false");
+		});
+	}
+
+	// The launcher only waits two seconds for the detached helper to stop, and it
+	// reads the helper over piped stdio. When those pipes stay open past the window
+	// the wrapper's event loop never drains and the shell prompt never comes back.
+	// Here a leaked grandchild holds the write end, so `close` never fires and the
+	// launcher must destroy and unref the handles itself (#647).
+	it("returns to the shell when the app helper's stdio outlives its shutdown window (#647)", async () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			"const args = process.argv.slice(2);",
+			'if (args[0] === "app-server") {',
+			"  process.exit(0);",
+			"}",
+			// A nonzero Codex exit forces the launcher down the stop-the-helper path
+			// rather than the detach-on-clean-exit path.
+			"process.exit(3);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const markerPath = join(fixtureRoot, "proxy-marker.txt");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			'model_provider = "openai"\n',
+			"utf8",
+		);
+
+		const pipeHolderMs = 25_000;
+		const startedAt = Date.now();
+		const result = runWrapper(fixtureRoot, [], {
+			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+			CODEX_HOME: originalHome,
+			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+			CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "60000",
+			CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+			CODEX_MULTI_AUTH_TEST_PROXY_PIPE_HOLDER_MS: String(pipeHolderMs),
+			OPENAI_API_KEY: undefined,
+		});
+		const elapsedMs = Date.now() - startedAt;
+
+		// The wrapper came back at all, and it did so on the 2s graceful window rather
+		// than waiting out the process still holding its pipes.
+		expect(result.status).toBe(3);
+		expect(elapsedMs).toBeLessThan(pipeHolderMs / 2);
+	});
+
+	// POSIX only: the launcher must escalate to SIGKILL when the helper ignores the
+	// graceful SIGTERM. On Windows `kill()` is always an unconditional terminate, so
+	// a helper cannot ignore it and this escalation cannot be exercised there.
+	it.skipIf(process.platform === "win32")(
+		"force-stops an app helper that ignores SIGTERM (#647)",
+		async () => {
+			const fixtureRoot = createWrapperFixture();
+			createRuntimeRotationProxyFixtureModule(fixtureRoot);
+			const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+				"#!/usr/bin/env node",
+				"const args = process.argv.slice(2);",
+				'if (args[0] === "app-server") {',
+				"  process.exit(0);",
+				"}",
+				// A nonzero Codex exit forces the launcher down the stop-the-helper path
+				// rather than the detach-on-clean-exit path.
+				"process.exit(3);",
+			]);
+			const originalHome = join(fixtureRoot, "codex-home");
+			const markerPath = join(fixtureRoot, "proxy-marker.txt");
+			mkdirSync(originalHome, { recursive: true });
+			writeFileSync(
+				join(originalHome, "config.toml"),
+				'model_provider = "openai"\n',
+				"utf8",
+			);
+
+			const startedAt = Date.now();
+			const result = runWrapper(fixtureRoot, [], {
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "60000",
+				CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+				CODEX_MULTI_AUTH_TEST_PROXY_MARKER_PID: "1",
+				// The helper's SIGTERM handler awaits `close()`, which never resolves
+				// here, so only the force-kill fallback can stop it.
+				CODEX_MULTI_AUTH_TEST_PROXY_CLOSE_HANG: "1",
+				OPENAI_API_KEY: undefined,
+			});
+			const elapsedMs = Date.now() - startedAt;
+
+			// The wrapper returned at all: before the fix this call never came back.
+			expect(result.status).toBe(3);
+			expect(elapsedMs).toBeLessThan(30_000);
+
+			const pidMatch = readFileSync(markerPath, "utf8").match(
+				/^start:[^\n]*:pid=(\d+)$/m,
+			);
+			expect(pidMatch?.[1]).toBeTruthy();
+			const helperPid = Number(pidMatch?.[1]);
+
+			// SIGKILL is asynchronous; give the OS a moment to reap the helper.
+			for (let attempt = 0; attempt < 40 && isProcessAlive(helperPid); attempt += 1) {
+				await sleep(100);
+			}
+			expect(isProcessAlive(helperPid)).toBe(false);
+		},
+	);
 
 	// Canonical-home routing drops the per-session shadow copy, so two concurrent
 	// interactive sessions now share the real Codex home. That is how the stock

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -3000,6 +3000,93 @@ describe("codex bin wrapper", () => {
 		});
 	}
 
+	// Printing help makes no model requests, so it must not pay for the rotation
+	// transport at all. This matters more since resume/fork became interactive: that
+	// branch detaches its helper on a clean exit, so a helper started for `--help`
+	// would outlive the wrapper and idle for its full timeout (#647).
+	for (const command of ["resume", "fork"] as const) {
+		for (const helpFlag of ["--help", "-h"] as const) {
+			it(`forwards \`${command} ${helpFlag}\` without starting the rotation transport (#647)`, () => {
+				const fixtureRoot = createWrapperFixture();
+				createRuntimeRotationProxyFixtureModule(fixtureRoot);
+				const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+					"#!/usr/bin/env node",
+					'console.log(`FORWARDED:${process.argv.slice(2).join(" ")}`);',
+					"console.log(`HELP_HOME_IS_ORIGINAL:${process.env.CODEX_HOME === process.env.ORIGINAL_CODEX_HOME}`);",
+					"process.exit(0);",
+				]);
+				const originalHome = join(fixtureRoot, "codex-home");
+				const markerPath = join(fixtureRoot, "proxy-marker.txt");
+				mkdirSync(originalHome, { recursive: true });
+				writeFileSync(
+					join(originalHome, "config.toml"),
+					'model_provider = "openai"\n',
+					"utf8",
+				);
+
+				const result = runWrapper(fixtureRoot, [command, helpFlag], {
+					CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+					CODEX_HOME: originalHome,
+					ORIGINAL_CODEX_HOME: originalHome,
+					CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+					CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+					OPENAI_API_KEY: undefined,
+				});
+
+				const output = combinedOutput(result);
+				if (result.status !== 0) {
+					throw new Error(output);
+				}
+				// No proxy was ever started, on either transport: the marker is the
+				// fixture proxy's only side effect and it is written at startup.
+				expect(existsSync(markerPath)).toBe(false);
+				expect(output).toContain("HELP_HOME_IS_ORIGINAL:true");
+				// Help reaches Codex verbatim, with no injected provider overrides.
+				expect(output).toContain(`FORWARDED:${command} ${helpFlag}`);
+				expect(output).not.toContain("model_provider=");
+			});
+		}
+	}
+
+	// The help short-circuit keys off a help flag, not the command, so a real
+	// resume must still take the rotation transport.
+	it("still routes `resume` with a session id through rotation (#647)", () => {
+		const fixtureRoot = createWrapperFixture();
+		createRuntimeRotationProxyFixtureModule(fixtureRoot);
+		const fakeBin = createCustomFakeCodexBin(fixtureRoot, [
+			"#!/usr/bin/env node",
+			"const args = process.argv.slice(2);",
+			'if (args[0] === "app-server") process.exit(0);',
+			"process.exit(0);",
+		]);
+		const originalHome = join(fixtureRoot, "codex-home");
+		const markerPath = join(fixtureRoot, "proxy-marker.txt");
+		mkdirSync(originalHome, { recursive: true });
+		writeFileSync(
+			join(originalHome, "config.toml"),
+			'model_provider = "openai"\n',
+			"utf8",
+		);
+
+		const result = runWrapper(
+			fixtureRoot,
+			["resume", "019ddf47-2c01-7c73-9f81-ab0cd9c1d5b7"],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "200",
+				CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+				OPENAI_API_KEY: undefined,
+			},
+		);
+
+		if (result.status !== 0) {
+			throw new Error(combinedOutput(result));
+		}
+		expect(existsSync(markerPath)).toBe(true);
+	});
+
 	// Guards the other half of the split: non-interactive request commands must keep
 	// using the isolated shadow home, so widening the interactive classification
 	// cannot silently move `exec`/`review` onto the canonical home.

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -645,6 +645,7 @@ function runWrapper(
 	fixtureRoot: string,
 	args: string[],
 	extraEnv: NodeJS.ProcessEnv = {},
+	options: { timeoutMs?: number } = {},
 ): SpawnSyncReturns<string> {
 	return spawnSync(
 		process.execPath,
@@ -652,8 +653,30 @@ function runWrapper(
 		{
 			encoding: "utf8",
 			env: buildWrapperEnv(extraEnv),
+			// Opt-in hard bound for the tests that deliberately stress the wrapper's
+			// shutdown path. `spawnSync` blocks the worker thread, so Vitest's
+			// `testTimeout` cannot interrupt it: without this, a shutdown regression
+			// hangs the whole run instead of failing an assertion. On timeout
+			// `result.error` is set, which those tests assert on.
+			...(options.timeoutMs === undefined
+				? {}
+				: { timeout: options.timeoutMs, killSignal: "SIGKILL" as const }),
 		},
 	);
+}
+
+// Generous next to the wrapper's 2s graceful-shutdown window, but far below the
+// time a stuck wrapper would otherwise block for.
+const WRAPPER_SHUTDOWN_TIMEOUT_MS = 12_000;
+
+function expectWrapperReturned(
+	result: SpawnSyncReturns<string>,
+	what: string,
+): void {
+	expect(
+		result.error,
+		`wrapper never returned within ${WRAPPER_SHUTDOWN_TIMEOUT_MS}ms: ${what}`,
+	).toBeUndefined();
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -3152,23 +3175,31 @@ describe("codex bin wrapper", () => {
 			"utf8",
 		);
 
+		// Comfortably longer than the bounded shutdown, and longer than the spawn
+		// timeout, so a regression trips the timeout rather than racing it.
 		const pipeHolderMs = 25_000;
 		const startedAt = Date.now();
-		const result = runWrapper(fixtureRoot, [], {
-			CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
-			CODEX_HOME: originalHome,
-			CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
-			CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "60000",
-			CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
-			CODEX_MULTI_AUTH_TEST_PROXY_PIPE_HOLDER_MS: String(pipeHolderMs),
-			OPENAI_API_KEY: undefined,
-		});
+		const result = runWrapper(
+			fixtureRoot,
+			[],
+			{
+				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+				CODEX_HOME: originalHome,
+				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+				CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "60000",
+				CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+				CODEX_MULTI_AUTH_TEST_PROXY_PIPE_HOLDER_MS: String(pipeHolderMs),
+				OPENAI_API_KEY: undefined,
+			},
+			{ timeoutMs: WRAPPER_SHUTDOWN_TIMEOUT_MS },
+		);
 		const elapsedMs = Date.now() - startedAt;
 
 		// The wrapper came back at all, and it did so on the 2s graceful window rather
 		// than waiting out the process still holding its pipes.
+		expectWrapperReturned(result, "a leaked grandchild still holds its stdio");
 		expect(result.status).toBe(3);
-		expect(elapsedMs).toBeLessThan(pipeHolderMs / 2);
+		expect(elapsedMs).toBeLessThan(WRAPPER_SHUTDOWN_TIMEOUT_MS);
 	});
 
 	// POSIX only: the launcher must escalate to SIGKILL when the helper ignores the
@@ -3199,23 +3230,29 @@ describe("codex bin wrapper", () => {
 			);
 
 			const startedAt = Date.now();
-			const result = runWrapper(fixtureRoot, [], {
-				CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
-				CODEX_HOME: originalHome,
-				CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
-				CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "60000",
-				CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
-				CODEX_MULTI_AUTH_TEST_PROXY_MARKER_PID: "1",
-				// The helper's SIGTERM handler awaits `close()`, which never resolves
-				// here, so only the force-kill fallback can stop it.
-				CODEX_MULTI_AUTH_TEST_PROXY_CLOSE_HANG: "1",
-				OPENAI_API_KEY: undefined,
-			});
+			const result = runWrapper(
+				fixtureRoot,
+				[],
+				{
+					CODEX_MULTI_AUTH_REAL_CODEX_BIN: fakeBin,
+					CODEX_HOME: originalHome,
+					CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY: "1",
+					CODEX_MULTI_AUTH_APP_ROTATION_IDLE_MS: "60000",
+					CODEX_MULTI_AUTH_TEST_PROXY_MARKER: markerPath,
+					CODEX_MULTI_AUTH_TEST_PROXY_MARKER_PID: "1",
+					// The helper's SIGTERM handler awaits `close()`, which never resolves
+					// here, so only the force-kill fallback can stop it.
+					CODEX_MULTI_AUTH_TEST_PROXY_CLOSE_HANG: "1",
+					OPENAI_API_KEY: undefined,
+				},
+				{ timeoutMs: WRAPPER_SHUTDOWN_TIMEOUT_MS },
+			);
 			const elapsedMs = Date.now() - startedAt;
 
 			// The wrapper returned at all: before the fix this call never came back.
+			expectWrapperReturned(result, "the helper ignored SIGTERM");
 			expect(result.status).toBe(3);
-			expect(elapsedMs).toBeLessThan(30_000);
+			expect(elapsedMs).toBeLessThan(WRAPPER_SHUTDOWN_TIMEOUT_MS);
 
 			const pidMatch = readFileSync(markerPath, "utf8").match(
 				/^start:[^\n]*:pid=(\d+)$/m,

--- a/test/codex-bin-wrapper.test.ts
+++ b/test/codex-bin-wrapper.test.ts
@@ -3024,10 +3024,12 @@ describe("codex bin wrapper", () => {
 	}
 
 	// Printing help makes no model requests, so it must not pay for the rotation
-	// transport at all. This matters more since resume/fork became interactive: that
-	// branch detaches its helper on a clean exit, so a helper started for `--help`
-	// would outlive the wrapper and idle for its full timeout (#647).
-	for (const command of ["resume", "fork"] as const) {
+	// transport at all. This matters most for resume/fork now that they are
+	// interactive: that branch detaches its helper on a clean exit, so a helper
+	// started for `--help` would outlive the wrapper and idle for its full timeout.
+	// `exec`/`review` never stranded anything, but they did build a whole shadow
+	// home just to print help, so every request command is covered (#647).
+	for (const command of ["resume", "fork", "exec", "review"] as const) {
 		for (const helpFlag of ["--help", "-h"] as const) {
 			it(`forwards \`${command} ${helpFlag}\` without starting the rotation transport (#647)`, () => {
 				const fixtureRoot = createWrapperFixture();


### PR DESCRIPTION
## Summary

- Fixes `mcodex resume` / `mcodex fork` hanging on a blank TUI when runtime rotation is enabled, by routing both through the canonical-home app-helper transport instead of the ephemeral shadow home.
- Makes detached app-helper shutdown bounded, so the wrapper always returns to the shell after an interrupted or nonzero Codex exit.
- Forwards every request command's `--help` straight to the official CLI, so help never starts a proxy, a shadow home, or a helper.
- Closes #647.

## What Changed

**Routing (`scripts/codex.js`).** `resume` and `fork` are interactive TUI entry points, but they carry a forwarded subcommand, so `isCodexInteractiveTuiCommand` — which only matches a bare invocation — missed them and they fell through to the shadow-home proxy path. The shadow mirror deliberately omits the runtime SQLite state (`isRuntimeRotationShadowHomeOmittedEntry`), so a shadow home only ever holds a partial thread index rebuilt from the linked `sessions` directory, and the requested thread was simply absent. That matches the reporter's evidence exactly: canonical `state_5.sqlite` held 257 threads including the target, while the two shadow databases held 126 and 128 and did not.

A dedicated predicate `isCodexInteractiveResumeCommand` now classifies them, and `createRuntimeRotationProxyContextIfEnabled` routes them to `createRuntimeRotationAppHelperContext` with the same `{ detachOnExit: true, useCanonicalHome: true }` the bare TUI already uses. `isCodexInteractiveTuiCommand` keeps its exact meaning, and `shouldUseRuntimeRoutingForForwardedArgs` is untouched — `resume`/`fork` stay in `requestCommands`, so account rotation stays enabled. This is the transport change only; nothing is dropped by leaving the shadow path, since `proxyAppServerAccountRead` is only set for `app-server`, which these are not.

**Shutdown (`scripts/codex.js`).** `stopRuntimeRotationAppHelper` sent `SIGTERM`, stopped waiting after the 2s graceful window, and returned with the helper and its piped stdio still referenced. Because the helper is spawned `stdio: ["ignore", "pipe", "pipe"]`, those pipes keep the wrapper's event loop alive on their own — the wrapper sets `process.exitCode` and relies on the loop draining, so it never exited. Shutdown now escalates to `SIGKILL` past the graceful window and then unconditionally destroys and unrefs the helper's streams. The stream teardown is the load-bearing part on Windows, where the signals are emulated as unconditional termination. `waitForRuntimeRotationAppHelperExit` also removes its own `close` listener when the timeout wins, and an already-exited helper now short-circuits instead of waiting out the full window.

**Help short-circuit (`scripts/codex.js`).** Moving these commands to the interactive branch had a side effect: that branch passes `detachOnExit: true`, and help always exits 0, so `resume --help` would spawn a detached helper and leave it idling for its full timeout. Before this PR the same invocation built a shadow home and a proxy, but both were torn down when the wrapper exited — so this was a new leak, not a pre-existing cost. `shouldUseRuntimeRoutingForForwardedArgs` now short-circuits the whole transport for the help form of any request command, matching the `app --help` and `app-server --help` precedent already in that function. Raised by Greptile in review, then extended from `app`/`resume`/`fork` to `exec`/`review` for consistency: those never stranded a helper, but they did mirror an entire shadow Codex home just to print help. The rule is now one sentence — a request command that is only printing help makes no model requests, so it needs no transport — and it is keyed off the help flag rather than the command, so real runs are untouched.

**Docs.** `docs/development/ARCHITECTURE.md` transport table and `docs/development/CONFIG_FLOW.md` §6 list `resume`/`fork` under the canonical-home path, with the reasoning and the bounded-shutdown contract recorded.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck` (plus `npm run typecheck:scripts`)
- [x] `npm test`
- [x] `npm test -- test/documentation.test.ts` (32/32)
- [x] `npm run build`

Fifteen regression tests were added, and each was confirmed to **fail against the unfixed wrapper** rather than merely pass against the fixed one:

| Test | Pre-fix behavior |
| --- | --- |
| canonical home for `resume` | `RESUME_HOME_IS_ORIGINAL:false` — took the shadow path |
| canonical home for `fork` | `RESUME_HOME_IS_ORIGINAL:false` — took the shadow path |
| `exec` stays on shadow home | passes before and after (guards against over-widening) |
| `review` stays on shadow home | passes before and after (guards against over-widening) |
| wrapper returns when helper stdio outlives the window | hung 25.1s until the process holding the pipes exited |
| force-stops a helper that ignores `SIGTERM` (POSIX only) | run never completed; had to be killed |
| `resume --help` / `resume -h` start no transport | started a helper that idled on after exit |
| `fork --help` / `fork -h` start no transport | started a helper that idled on after exit |
| `exec --help` / `exec -h` start no transport | built a shadow home and started a proxy |
| `review --help` / `review -h` start no transport | built a shadow home and started a proxy |
| `resume <session-id>` still starts the proxy | passes before and after (guards the short-circuit from over-matching) |

Full suite, both platforms:

- Windows: 5288 passed, 4 skipped, 0 failed.
- Linux (node:24 container): 5267 passed, 19 failed. The unmodified `origin/main` tree scores 5252 passed, **the same 19 failed** in that container, so those are pre-existing environment failures (platform-specific and root-user tests), not regressions. The delta is exactly +15 tests, all passing.

Both shutdown tests bound their `spawnSync` call (`runWrapper`'s opt-in `timeoutMs`) and assert the wrapper actually returned. `spawnSync` blocks the worker thread, so Vitest's `testTimeout` cannot interrupt it — without the bound, a shutdown regression hangs the whole run instead of failing. Against the unfixed wrapper both now fail in ~12s naming the cause. Only these two tests opt in, so the rest of the file is unchanged.

The `SIGTERM`-escalation test is skipped on `win32`: `child.kill()` there is always an unconditional terminate, so a helper cannot ignore it and the escalation is unreachable. The cross-platform stdio test covers the same failure on Windows. Both were verified on real Linux, not just reasoned about.

## Docs and Governance Checklist

- [ ] README updated (if user-visible behavior changed)
- [ ] `docs/getting-started.md` updated (if onboarding flow changed)
- [ ] `docs/features.md` updated (if capability surface changed)
- [x] relevant `docs/reference/*` pages updated — maintainer docs `ARCHITECTURE.md` and `CONFIG_FLOW.md` updated; no user-facing command, setting, or path changed
- [ ] `docs/upgrade.md` updated (if migration behavior changed)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

No CHANGELOG entry: this repo's changelog is written by `chore(release)` commits, matching #639, the PR that introduced this canonical-home path.

## Risk and Rollback

- **Risk level: low-to-moderate.** The transport for two commands changes. `resume`/`fork` now read and write the real `CODEX_HOME` in place rather than a per-session copy, so a crash mid-session can no longer be discarded with the shadow directory. That is how the stock CLI already behaves, and how the bare interactive TUI has behaved since #639.
- **Concurrency, called out deliberately:** the detached helper and the resumed session both run against the canonical home. This is not new — the interactive TUI branch has done exactly this since #639, and `test/codex-bin-wrapper.test.ts` already proves two overlapping canonical sessions each keep their state. This PR widens that existing exposure to two more commands rather than introducing it.
- **Rollback:** revert the commit. The change is self-contained in `scripts/codex.js`; no persisted state, config schema, or on-disk format changes, so no migration is involved.

## Additional Notes

The issue reporter diagnosed this correctly and their patch shape is what landed, with two deliberate differences. First, the routing uses a separate predicate rather than widening `isCodexInteractiveTuiCommand`, so that function's name stays accurate and the new branch is independently testable. Second, the stream teardown is unconditional and an already-exited helper short-circuits the wait, which avoids charging a 2s delay on the common path.

One thing worth flagging for reviewers: the original proposed patch guarded on `helper.killed` and returned early, which would skip teardown entirely on a second stop call. The version here keys off `exitCode`/`signalCode` instead, so a helper that is `killed` but still alive continues to escalation.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

the pr routes interactive `resume` and `fork` commands through the canonical codex home and makes helper shutdown bounded, including windows stream cleanup. it also fixes the prior help-only helper leak without changing real request routing; concurrent canonical-home sessions remain explicitly supported.

- adds canonical-home routing for `resume` and `fork`.
- escalates stalled helper shutdown and releases piped stdio.
- bypasses runtime transport for request-command help forms.
- adds vitest coverage for routing, help forwarding, shutdown bounds, and concurrent behavior.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

the prior help-only helper leak is fixed by bypassing runtime transport for help forms, while real resume, fork, exec, and review invocations retain their intended routing; no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/codex.js | routes interactive resume and fork through the canonical home, safely short-circuits help, and bounds helper shutdown with cross-platform stream release. |
| test/codex-bin-wrapper.test.ts | adds focused vitest coverage for canonical versus shadow routing, help forwarding, posix escalation, windows-compatible stdio release, and bounded wrapper return. |
| docs/development/ARCHITECTURE.md | documents canonical-home routing, bounded shutdown, windows behavior, and the concurrency contract. |
| docs/development/CONFIG_FLOW.md | updates the runtime transport selection flow for resume and fork. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  args[forwarded codex arguments] --> help{help-only request command?}
  help -->|yes| direct[official cli without runtime transport]
  help -->|no| interactive{bare tui, resume, or fork?}
  interactive -->|yes| canonical[canonical home app helper]
  interactive -->|no| shadow[shadow home runtime proxy]
  canonical --> exit{clean cli exit?}
  exit -->|yes| detach[detach helper]
  exit -->|no| stop[sigterm, bounded wait, sigkill, release streams]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(codex): skip the rotation transport ..."](https://github.com/ndycode/codex-multi-auth/commit/afeb42721a47dcde8f81187d5940825ed5bcd2df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49391700)</sub>

**Context used:**

- Knowledge Base — [Build and Packaging](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/build-and-packaging.md)

<!-- /greptile_comment -->