### PR TITLE
chore(deps): clear the high-severity advisories blocking audit:ci

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,12 +79,14 @@ The following are not treated as vulnerabilities in this repository:
 
 Security override rationale (`package.json` -> `overrides`):
 
-- `hono`: pinned to `4.12.21` to keep builds out of the vulnerable `<4.12.21` range reported in `GHSA-3hrh-pfw6-9m5x`, `GHSA-2gcr-mfcq-wcc3`, `GHSA-xrhx-7g5j-rcj5`, and `GHSA-f577-qrjj-4474` (Set-Cookie injection, `app.mount()` path-decoding, IPv6 IP-restriction bypass, and JWT scheme-acceptance advisories).
+- `hono`: pinned to `4.12.33` to keep builds out of the vulnerable `<4.12.33` range. This covers the earlier `GHSA-3hrh-pfw6-9m5x`, `GHSA-2gcr-mfcq-wcc3`, `GHSA-xrhx-7g5j-rcj5`, and `GHSA-f577-qrjj-4474` advisories (Set-Cookie injection, `app.mount()` path-decoding, IPv6 IP-restriction bypass, and JWT scheme-acceptance) plus `GHSA-hvrm-45r6-mjfj` and `GHSA-w62v-xxxg-mg59` (JSX per-request context disclosure and XSS via the `cx()` escaping bypass), both of which reach `<=4.12.26`.
 - `rollup`: pinned to `^4.59.0` to keep the Vite and Vitest transitive graph above the vulnerable `<4.59.0` range surfaced by `npm audit`.
+- `brace-expansion`: pinned to `5.0.9` to lift the dev graph above the ReDoS ranges `>=2.0.0 <2.1.3` and `>=4.0.0 <5.0.8`. Transitive dev-only, so the pin is the practical fix rather than waiting on each consumer to bump.
+- `postcss`: pinned to `8.5.25` to clear the `<=8.5.17` advisory reaching the dev graph through the Vite toolchain.
 
 Runtime dependency pin rationale (`package.json` -> `dependencies`):
 
-- `undici`: pinned exactly to `6.25.0`. It is the only runtime HTTP dependency (proxy `ProxyAgent` dispatch and the fetch fallback in the local bridge), it drives the published `engines.node >=18.17.0` floor, and its dispatcher behavior is part of the rotation proxy's tested surface — so version movement is taken deliberately via an explicit bump, never silently through a range. Moving to the undici `7.x` line is deferred until Node 18 support is dropped, since `7.x` raises the runtime floor to Node 20.
+- `undici`: pinned exactly to `6.28.0`. It is the only runtime HTTP dependency (proxy `ProxyAgent` dispatch and the fetch fallback in the local bridge), it drives the published `engines.node >=18.17.0` floor, and its dispatcher behavior is part of the rotation proxy's tested surface — so version movement is taken deliberately via an explicit bump, never silently through a range. `6.28.0` is the first `6.x` release clear of `GHSA-p88m-4jfj-68fv`, `GHSA-vxpw-j846-p89q`, `GHSA-35p6-xmwp-9g52`, and `GHSA-g8m3-5g58-fq7m` (Set-Cookie header injection, WebSocket fragment DoS, keep-alive response-queue poisoning, and SameSite downgrade), all of which reach `<=6.26.0`. Moving to the undici `7.x` line is deferred until Node 18 support is dropped, since `7.x` raises the runtime floor to Node 20.
 
 Before release and after dependency changes:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
 				"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 				"@codex-ai/sdk": "file:vendor/codex-ai-sdk",
 				"@openauthjs/openauth": "^0.4.3",
-				"hono": "4.12.21",
-				"undici": "6.25.0",
+				"hono": "4.12.33",
+				"undici": "6.28.0",
 				"zod": "4.4.3"
 			},
 			"bin": {
@@ -1458,23 +1458,6 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
 			"version": "9.0.9",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -2152,16 +2135,16 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -2869,9 +2852,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.21",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-			"integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+			"version": "4.12.33",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+			"integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -3277,9 +3260,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -3456,9 +3439,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.25",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+			"integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3476,7 +3459,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -3951,9 +3934,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-			"integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+			"version": "6.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+			"integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -175,12 +175,12 @@
 		"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 		"@codex-ai/sdk": "file:vendor/codex-ai-sdk",
 		"@openauthjs/openauth": "^0.4.3",
-		"hono": "4.12.21",
-		"undici": "6.25.0",
+		"hono": "4.12.33",
+		"undici": "6.28.0",
 		"zod": "4.4.3"
 	},
 	"overrides": {
-		"hono": "4.12.21",
+		"hono": "4.12.33",
 		"flatted": "3.4.2",
 		"minimatch": "10.2.4",
 		"picomatch": "4.0.4",
@@ -191,6 +191,8 @@
 		},
 		"@typescript-eslint/typescript-estree": {
 			"minimatch": "9.0.9"
-		}
+		},
+		"brace-expansion": "5.0.9",
+		"postcss": "8.5.25"
 	}
 }


### PR DESCRIPTION
## Summary

- `npm run audit:ci` — a CI gate — has been failing. This clears it.
- Two production dependencies and two transitive dev dependencies carried high-severity advisories.

## What Changed

**Production:**

| Package | From | To | Cleared |
| --- | --- | --- | --- |
| `hono` | 4.12.21 | 4.12.33 | `GHSA-hvrm-45r6-mjfj` (JSX context not isolated per request), `GHSA-w62v-xxxg-mg59` (XSS via `cx()` escaping bypass) — both reach `<=4.12.26` |
| `undici` | 6.25.0 | 6.28.0 | `GHSA-p88m-4jfj-68fv`, `GHSA-vxpw-j846-p89q`, `GHSA-35p6-xmwp-9g52`, `GHSA-g8m3-5g58-fq7m` (Set-Cookie header injection, WebSocket fragment DoS, keep-alive response-queue poisoning, SameSite downgrade) — all reach `<=6.26.0` |

`hono` is bumped in both `dependencies` and `overrides`; the override is what `@openauthjs/openauth` resolves through, and npm rejects the install if the two disagree.

`undici` deliberately stays on the `6.x` line. `7.x` raises the runtime floor to Node 20 and this package still publishes `engines.node >=18.17.0` — `6.28.0` is the first `6.x` release clear of all four advisories.

**Dev-only**, pinned via `overrides` in the style already used for `rollup` and `minimatch`, since both are transitive:

- `brace-expansion` → `5.0.9` (ReDoS in `>=2.0.0 <2.1.3` and `>=4.0.0 <5.0.8`)
- `postcss` → `8.5.25` (`<=8.5.17`, reaching the dev graph through Vite)

**`SECURITY.md`** documents each pin's rationale and is machine-checked against `package.json` by `test/documentation.test.ts` — that test caught the drift, so the doc is updated in the same commit.

## Validation

- [x] `npm run audit:ci` → exits 0 (was exiting 1)
- [x] `npm audit --omit=dev --audit-level=high` → `found 0 vulnerabilities`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 5288 passed, 4 skipped, 0 failed
- [x] `npm run build`
- [x] `npm test -- test/lockfile-version-floor.test.ts`

## Risk and Rollback

- **Risk: low-to-moderate.** `undici` is the only runtime HTTP dependency and backs the rotation proxy's dispatch path, so it is the one to watch; it stays within `6.x` and the full suite passes. The other three are a patch bump and two dev-only pins.
- **Rollback:** revert the commit and reinstall. No code, config schema, or on-disk format changes.

## Additional Notes

Worth knowing separately: this repo's GitHub Actions have never actually executed — `ci.yml` has zero runs and recent workflow runs sit queued for days — so `audit:ci` failing had never surfaced anywhere. The gate is only meaningful once Actions runs.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr updates production and development dependency pins to clear high-severity audit findings while preserving node 18 production support.
- bumps hono to 4.12.33 and undici to 6.28.0.
- overrides brace-expansion 5.0.9 and postcss 8.5.25 in the development graph.
- updates the lockfile and security rationale to match the new versions.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge, with no concrete changed-code failure identified.

the runtime packages remain within compatible major versions, the development overrides resolve the current toolchain, and the lockfile and security documentation remain synchronized.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | updates runtime dependencies and adds development-only security overrides; no concrete compatibility failure was found. |
| package-lock.json | resolves the requested secure versions consistently, including the documented node engine metadata. |
| SECURITY.md | keeps dependency-pin rationale synchronized with the manifest changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): clear the high-severity adv..."](https://github.com/ndycode/codex-multi-auth/commit/8f01870d6b46f372d6d2085719fef89166509573) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49451285)</sub>

**Context used:**

- Knowledge Base — [Build and Packaging](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/build-and-packaging.md)

<!-- /greptile_comment -->