### PR TITLE
chore(release): 2.8.1

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-multi-auth",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Install and operate codex-multi-auth for the official @openai/codex CLI with multi-account OAuth rotation, switching, health checks, and recovery tools.",
   "interface": {
     "composerIcon": "./assets/codex-multi-auth-icon.svg"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Generated: 2026-04-25
 Commit: a87e005
 Validated: 2026-06-10 against commit 98d9819 (repo audit; claims re-checked against the tree, content not regenerated)
 Branch: main
-Package version: 2.8.0
+Package version: 2.8.1
 
 ## OVERVIEW
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ This repository's current stable release line is `2.x`.
 Current stable release notes live in `docs/releases/`.
 This top-level changelog preserves the foundational `0.x` milestones and points older iteration history to `docs/releases/legacy-pre-0.1-history.md`.
 
+## [2.8.1] - 2026-08-02
+
+A corrective release with no new features and no configuration changes. `mcodex resume` hung on a blank screen whenever runtime rotation was enabled, the wrapper could fail to return to the shell after an interrupted exit, and four high-severity dependency advisories are cleared.
+Closes [#647](https://github.com/ndycode/codex-multi-auth/issues/647). Landed as [#648](https://github.com/ndycode/codex-multi-auth/pull/648), [#649](https://github.com/ndycode/codex-multi-auth/pull/649), and [#650](https://github.com/ndycode/codex-multi-auth/pull/650). See [docs/releases/v2.8.1.md](docs/releases/v2.8.1.md) for full details.
+
+### Fixed
+
+- **`mcodex resume` and `mcodex fork` hung on a blank TUI with runtime rotation enabled.** Both are interactive TUI entry points, but they carry a forwarded subcommand, so the interactive classification added in 2.8.0 — which matched only an invocation with no subcommand — missed them and left them on the ephemeral shadow home. The shadow mirror deliberately omits the runtime SQLite state, so its session index only ever held a partial thread list rebuilt from the linked `sessions` directory and frequently did not contain the requested thread. Both commands now use the same canonical-home transport as the bare interactive TUI, so they see the real thread index, and account rotation stays enabled ([#647](https://github.com/ndycode/codex-multi-auth/issues/647), [#648](https://github.com/ndycode/codex-multi-auth/pull/648))
+- **The shell prompt did not always return after an interrupted or non-zero Codex exit.** The detached rotation helper runs with piped stdio; shutdown sent `SIGTERM`, stopped waiting after two seconds, and left the helper and its pipes referenced, which kept the wrapper's event loop alive indefinitely. Shutdown now escalates to `SIGKILL` past the graceful window and unconditionally destroys and unrefs the helper's streams — the part that actually frees the wrapper on Windows, where the signals are emulated as an unconditional terminate ([#648](https://github.com/ndycode/codex-multi-auth/pull/648))
+- **`--help` started a rotation proxy for every request command.** `exec`, `review`, `resume`, `fork`, and `app` now forward their help form straight to the official CLI with no proxy, no shadow home, and no helper, matching how `app-server --help` already behaved. This mattered most for `resume`/`fork`: once interactive, their helper detached on the clean exit help always produces and idled on after the wrapper had exited ([#648](https://github.com/ndycode/codex-multi-auth/pull/648))
+- **`npm run audit:ci` was failing, so the CI security gate could not pass.** `hono` 4.12.21 → 4.12.33 and `undici` 6.25.0 → 6.28.0 clear four high-severity advisories reaching the published runtime; `brace-expansion` and `postcss` are pinned through `overrides` for the dev graph. `undici` stays on `6.x` because `7.x` would raise the runtime floor to Node 20 ([#650](https://github.com/ndycode/codex-multi-auth/pull/650))
+
+### Changed
+
+- Regression coverage for both shutdown paths now bounds its own subprocess and carries a per-test timeout longer than that bound. `vitest.config.ts` sets no `testTimeout`, so these tests ran under the 5s default — shorter than the 12s bound they set for themselves, which made them flake as a non-root user on Linux and prevented the bound from ever reporting its diagnostic ([#649](https://github.com/ndycode/codex-multi-auth/pull/649))
+
 ## [2.8.0] - 2026-07-28
 
 Two fixes that change where the official Codex CLI keeps its state, plus a diagnostic that can now repair the first one instead of only reporting it. A minor rather than a patch release because behaviour changes: the wrapper now writes `cli_auth_credentials_store` into `~/.codex/config.toml` at first run and on wrapper startup, where before it only did so during an account switch, login, health check, or repair. Both opt-outs are documented.

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ codex-multi-auth doctor --json
 
 ## Release Notes
 
-- Current stable: [docs/releases/v2.8.0.md](docs/releases/v2.8.0.md) — install via `npm i -g codex-multi-auth`
+- Current stable: [docs/releases/v2.8.1.md](docs/releases/v2.8.1.md) — install via `npm i -g codex-multi-auth`
 - Previous stable: [docs/releases/v2.7.1.md](docs/releases/v2.7.1.md)
 - Previous stable: [docs/releases/v2.7.0.md](docs/releases/v2.7.0.md)
 - Previous stable: [docs/releases/v2.6.0.md](docs/releases/v2.6.0.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,8 @@ Public documentation for the `codex-multi-auth` Codex CLI multi-account OAuth ma
 
 | Document | Focus |
 | --- | --- |
-| [releases/v2.8.0.md](releases/v2.8.0.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
+| [releases/v2.8.1.md](releases/v2.8.1.md) | Current stable release notes (install via `npm i -g codex-multi-auth`) |
+| [releases/v2.8.0.md](releases/v2.8.0.md) | Prior stable release notes |
 | [releases/v2.7.1.md](releases/v2.7.1.md) | Prior stable release notes |
 | [releases/v2.7.0.md](releases/v2.7.0.md) | Prior stable release notes |
 | [releases/v2.6.1.md](releases/v2.6.1.md) | Prior stable release notes |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,6 +1,6 @@
 # Command Reference
 
-Complete command, flag, and hotkey reference for `codex-multi-auth` (package `2.8.0`).
+Complete command, flag, and hotkey reference for `codex-multi-auth` (package `2.8.1`).
 
 ---
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -1,6 +1,6 @@
 # Public API Contract
 
-Public API contract for `codex-multi-auth` (package `2.8.0`).
+Public API contract for `codex-multi-auth` (package `2.8.1`).
 
 ---
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -2,7 +2,7 @@
 
 Reference for dashboard display settings and runtime `pluginConfig` values available from `codex-multi-auth login` -> `Settings`.
 
-`pluginConfig` is the persisted compatibility name for runtime settings. It covers wrapper/runtime rotation behavior and optional plugin-host behavior. Defaults below match `DEFAULT_PLUGIN_CONFIG` in `lib/config.ts` (package `2.8.0`).
+`pluginConfig` is the persisted compatibility name for runtime settings. It covers wrapper/runtime rotation behavior and optional plugin-host behavior. Defaults below match `DEFAULT_PLUGIN_CONFIG` in `lib/config.ts` (package `2.8.1`).
 
 ---
 

--- a/docs/releases/v2.8.1.md
+++ b/docs/releases/v2.8.1.md
@@ -49,8 +49,28 @@ Two dev-only advisories (`brace-expansion`, `postcss`) are pinned through `overr
 
 ## Upgrade notes
 
-Nothing to do.
+No migration is required — but you do need to install the release to get the fixes:
 
-If you had been running `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` to make `resume` work, you can drop it — that was the workaround for this bug, and keeping it set leaves account rotation switched off.
+```bash
+npm i -g codex-multi-auth
+codex-multi-auth --version
+```
+
+That should report `2.8.1`. Then confirm the fix on a real session:
+
+```bash
+mcodex resume <session-id>
+```
+
+It should open the resumed TUI instead of a blank screen, and `/exit` should return you to your shell prompt.
+
+If you had been running `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` to make `resume` work, drop it — that was the workaround for this bug, and keeping it set leaves account rotation switched off:
+
+```bash
+unset CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY
+codex-multi-auth rotation status
+```
+
+That should report the runtime rotation proxy as enabled.
 
 Everything else is unchanged: no settings were added, renamed, or repurposed, and nothing new is written to disk.

--- a/docs/releases/v2.8.1.md
+++ b/docs/releases/v2.8.1.md
@@ -1,0 +1,56 @@
+# v2.8.1
+
+A corrective release. No new features and no configuration changes.
+
+The headline is `mcodex resume` hanging on a blank screen whenever runtime rotation was enabled — the command opened, printed the multi-auth status line, and then never became usable, while the official `codex resume` worked fine. The same release also makes the wrapper always give you your shell prompt back, and clears four high-severity dependency advisories.
+
+Closes [#647](https://github.com/ndycode/codex-multi-auth/issues/647). Landed as [#648](https://github.com/ndycode/codex-multi-auth/pull/648), [#649](https://github.com/ndycode/codex-multi-auth/pull/649), and [#650](https://github.com/ndycode/codex-multi-auth/pull/650).
+
+## Interactive sessions
+
+### `resume` and `fork` hung on a blank screen
+
+With runtime rotation enabled, `mcodex resume <session-id>` printed its status line and then sat on an empty TUI forever. `codex resume` worked, and so did `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0 mcodex resume` — but that second workaround buys a working resume by turning off account rotation, which is not a trade anyone should have to make.
+
+v2.8.0 moved interactive sessions onto the canonical `CODEX_HOME`, but it recognised "interactive" as *an invocation with no subcommand at all*. `resume` and `fork` are interactive TUI entry points that happen to carry a subcommand, so they missed that classification and kept using the ephemeral shadow home.
+
+That is fatal specifically for resuming, because the shadow home deliberately omits the runtime SQLite state. A shadow home only ever holds a partial thread index rebuilt from the linked `sessions` directory — so the thread you asked for was frequently just absent, and the TUI waited on a session that, as far as it could tell, did not exist. The reporter's numbers show it exactly: the canonical `state_5.sqlite` held 257 threads including the requested one, while the two shadow databases created by the failed launches held 126 and 128 and contained neither.
+
+Both commands now take the same canonical-home transport the bare interactive TUI already uses, so they see the real thread index. Account rotation stays on: it travels as `-c` overrides exactly as it does for a normal interactive session.
+
+As with the bare TUI, this means a resumed session shares the canonical home rather than a private copy — the same as running the official CLI twice. That was already true for interactive sessions since v2.8.0; this release widens it to two more commands ([#648](https://github.com/ndycode/codex-multi-auth/pull/648)).
+
+### The shell prompt did not always come back
+
+After an interrupted or non-zero Codex exit, the wrapper could print Codex's final "To continue this session..." message and then simply never return. `Ctrl+Z` showed it parked as a stopped job.
+
+The rotation helper runs detached with piped stdio. Shutdown sent `SIGTERM` and stopped waiting after two seconds, but if the helper had not actually exited by then it was left referenced — and because the wrapper finishes by setting an exit code and letting the event loop drain, those still-open pipes kept the process alive indefinitely.
+
+Shutdown is now bounded. It escalates to `SIGKILL` once the graceful window elapses, and then unconditionally destroys the helper's streams and unrefs the child. The stream teardown is the part that actually frees the wrapper on Windows, where both signals are emulated as an unconditional terminate. A helper that has already exited short-circuits instead of waiting out the full window ([#648](https://github.com/ndycode/codex-multi-auth/pull/648)).
+
+### `--help` no longer starts a proxy
+
+`resume --help` and friends print help and make no model requests, but they were still paying for the rotation transport — and once `resume` became interactive, its helper detached on the clean exit that help always produces, leaving a process idling in the background after you had already got your output.
+
+The help form of every request command — `exec`, `review`, `resume`, `fork`, `app` — now forwards straight to the official CLI with no proxy, no shadow home, and no helper. This matches how `app-server --help` has always behaved. It keys off the help flag rather than the command, so a real `resume <session-id>` is unaffected ([#648](https://github.com/ndycode/codex-multi-auth/pull/648)).
+
+## Dependencies
+
+Four high-severity advisories are cleared. Two reach the published runtime:
+
+| Package | From | To | Cleared |
+| --- | --- | --- | --- |
+| `hono` | 4.12.21 | 4.12.33 | JSX context not isolated per request; XSS via the `cx()` escaping bypass |
+| `undici` | 6.25.0 | 6.28.0 | Set-Cookie header injection; WebSocket fragment DoS; keep-alive response-queue poisoning; SameSite downgrade |
+
+`undici` stays on the `6.x` line deliberately. It is the only runtime HTTP dependency and it drives the published `engines.node >=18.17.0` floor; `7.x` would raise that floor to Node 20. `6.28.0` is the first `6.x` release clear of all four of its advisories.
+
+Two dev-only advisories (`brace-expansion`, `postcss`) are pinned through `overrides`, the mechanism this project already uses for transitive dev pins. `SECURITY.md` records the rationale for each pin ([#650](https://github.com/ndycode/codex-multi-auth/pull/650)).
+
+## Upgrade notes
+
+Nothing to do.
+
+If you had been running `CODEX_MULTI_AUTH_RUNTIME_ROTATION_PROXY=0` to make `resume` work, you can drop it — that was the workaround for this bug, and keeping it set leaves account rotation switched off.
+
+Everything else is unchanged: no settings were added, renamed, or repurposed, and nothing new is written to disk.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codex-multi-auth",
-			"version": "2.8.0",
+			"version": "2.8.1",
 			"bundleDependencies": [
 				"@codex-ai/plugin",
 				"@codex-ai/sdk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codex-multi-auth",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"description": "Codex CLI multi-account OAuth manager with account switching, health checks, runtime rotation, diagnostics, and recovery tools for @openai/codex",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -6,7 +6,7 @@ Commit: 78aa9b5 (2.8.0)
 ## OVERVIEW
 
 Vitest suites for OAuth flow, request transforms, response handling, rotation logic, storage, CLI management, repo hygiene, and more.
-**5277 tests** across **336 test files** with 80%+ coverage threshold (2.8.0; 6 tests and 2 files skipped by default).
+**5292 tests** across **336 test files** with 80%+ coverage threshold (2.8.1; 6 tests and 2 files skipped by default).
 
 ## STRUCTURE
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the test suite for the OpenAI Codex OAuth plugin.
 
-**Stats**: 5277 tests across 336 test files with 80%+ coverage threshold (2.8.0; 6 tests and 2 files skipped by default).
+**Stats**: 5292 tests across 336 test files with 80%+ coverage threshold (2.8.1; 6 tests and 2 files skipped by default).
 
 ## Test Structure
 


### PR DESCRIPTION
## Summary

Release commit for **2.8.1**, already published to npm (`npm view codex-multi-auth version` → `2.8.1`).

A corrective release: no new features, no configuration changes, nothing new written to disk.

Closes #647. Landed as #648, #649, and #650.

## What Changed

**Version stamps** — `package.json`, `package-lock.json`, `.codex-plugin/plugin.json`, `AGENTS.md`, and the three `docs/reference/*.md` `(package \`x.y.z\`)` stamps. Test-count stats in `test/AGENTS.md` and `test/README.md` refreshed to 5292 while they were being touched (they had been stale since 2.8.0).

**Release notes** — new `docs/releases/v2.8.1.md`, a `CHANGELOG.md` entry, and both README pointers moved to it. `docs/README.md` keeps `v2.8.0.md` in the archive list, since the docs portal is required to link every release note.

## Why patch, not minor

2.8.0 was minor because it changed *where the official CLI keeps its state* — it began writing `cli_auth_credentials_store` into `~/.codex/config.toml` proactively. 2.8.1 only corrects behaviour that was already meant to work, adds no settings, and changes no on-disk formats. That is the same shape as 2.7.1, which was also a patch.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 5288 passed, 4 skipped, 0 failed
- [x] `npm test -- test/documentation.test.ts` — 32/32
- [x] `npm run build`
- [x] `npm run audit:ci` — exits 0
- [x] `npm run pack:check` — 799 kB across 920 files

## Additional Notes

The version bump and the release notes cannot be separated in this repo: `test/documentation.test.ts` requires `docs/releases/v<version>.md` to exist and be linked from both READMEs, so a bump on its own fails five documentation checks. Worth knowing for any future release that wants to stage the two.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this release commit stamps version 2.8.1 and publishes release notes for fixes already landed in earlier pull requests.
- synchronizes package, plugin, reference, and test-suite version metadata.
- adds the 2.8.1 changelog and release-note links.
- refreshes documented vitest totals to 5,292.

<h3>Confidence Score: 5/5</h3>

the release-only changes appear safe to merge.

no blocking failure remains in the eligible follow-up scope.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | updates the npm package version to 2.8.1 without changing runtime dependencies or package behavior. |
| package-lock.json | synchronizes the root package version; no dependency resolution changes are introduced. |
| docs/releases/v2.8.1.md | documents the corrective release, including prior wrapper, windows shutdown, and dependency fixes. |
| CHANGELOG.md | adds the 2.8.1 release entry and links the pull requests where the behavioral changes landed. |
| test/AGENTS.md | refreshes the documented vitest count and release version without changing coverage. |
| test/README.md | refreshes the documented vitest count and release version without changing coverage. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(release): give 2.8.1 notes a runnab..."](https://github.com/ndycode/codex-multi-auth/commit/d97a2905c1446596631a9f1b54f0ddb55628f460) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49454469)</sub>

**Context used:**

- Knowledge Base — [Build and Packaging](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/build-and-packaging.md)

<!-- /greptile_comment -->