### PR TITLE
fix(quota-display): hide unlabeled full quota window with no reset data

### DIFF
--- a/lib/codex-manager/formatters/quota-formatters.ts
+++ b/lib/codex-manager/formatters/quota-formatters.ts
@@ -67,7 +67,8 @@ export function formatQuotaSnapshotForDashboard(
 	now = Date.now(),
 ): string {
 	if (!settings.showQuotaDetails) return "live session OK";
-	return `live session OK (${formatCompactQuotaSnapshot(snapshot, now, { showReset: true })})`;
+	const summary = formatCompactQuotaSnapshot(snapshot, now, { showReset: true });
+	return summary ? `live session OK (${summary})` : "live session OK";
 }
 
 export function quotaCacheEntryToSnapshot(
@@ -99,6 +100,23 @@ function formatCompactQuotaWindowLabel(
 	if (windowMinutes % 1440 === 0) return `${windowMinutes / 1440}d`;
 	if (windowMinutes % 60 === 0) return `${windowMinutes / 60}h`;
 	return `${windowMinutes}m`;
+}
+
+function isUninformativeFullQuotaWindow(
+	windowMinutes: number | undefined,
+	usedPercent: number | undefined,
+	resetAtMs: number | undefined,
+	now: number,
+): boolean {
+	if (formatCompactQuotaWindowLabel(windowMinutes) !== "quota") return false;
+	if (typeof usedPercent !== "number" || !Number.isFinite(usedPercent)) {
+		return false;
+	}
+	const left = quotaLeftPercentFromUsed(usedPercent);
+	return (
+		!formatQuotaResetAt(resetAtMs, now) &&
+		(left === undefined || left >= 100)
+	);
 }
 
 /**
@@ -133,7 +151,7 @@ function formatCompactQuotaPart(
 	// 2026-07/08 upstream limit changes it renders as a permanent "quota 100%"
 	// on every account. Hide exactly that shape: the segment reappears as soon
 	// as the window reports a duration, any depletion, or a reset time.
-	if (label === "quota" && !reset && (left === undefined || left >= 100)) {
+	if (!reset && label === "quota" && (left === undefined || left >= 100)) {
 		return null;
 	}
 	const part = `${label} ${left}%`;
@@ -174,6 +192,22 @@ export function formatCompactQuotaSnapshot(
 	if (parts.length > 0) {
 		return parts.join(" | ");
 	}
+	if (
+		isUninformativeFullQuotaWindow(
+			snapshot.primary.windowMinutes,
+			snapshot.primary.usedPercent,
+			snapshot.primary.resetAtMs,
+			now,
+		) ||
+		isUninformativeFullQuotaWindow(
+			snapshot.secondary.windowMinutes,
+			snapshot.secondary.usedPercent,
+			snapshot.secondary.resetAtMs,
+			now,
+		)
+	) {
+		return "";
+	}
 	return formatQuotaSnapshotLine(snapshot);
 }
 
@@ -208,6 +242,22 @@ export function formatAccountQuotaSummary(
 	}
 	if (parts.length > 0) {
 		return parts.join(" | ");
+	}
+	if (
+		isUninformativeFullQuotaWindow(
+			entry.primary.windowMinutes,
+			entry.primary.usedPercent,
+			entry.primary.resetAtMs,
+			now,
+		) ||
+		isUninformativeFullQuotaWindow(
+			entry.secondary.windowMinutes,
+			entry.secondary.usedPercent,
+			entry.secondary.resetAtMs,
+			now,
+		)
+	) {
+		return "";
 	}
 	return formatQuotaSnapshotLine(quotaCacheEntryToSnapshot(entry));
 }

--- a/lib/codex-manager/formatters/quota-formatters.ts
+++ b/lib/codex-manager/formatters/quota-formatters.ts
@@ -124,10 +124,21 @@ function formatCompactQuotaPart(
 		return null;
 	}
 	const left = quotaLeftPercentFromUsed(usedPercent);
+	// The reset validity is computed regardless of showReset: it also feeds the
+	// uninformative-window check below, so hiding stays consistent across the
+	// compact (no-reset) and check (with-reset) surfaces.
+	const reset = formatQuotaResetAt(resetAtMs, now);
+	// An unlabeled window ("quota" — upstream reported no duration) that sits at
+	// 100% left with no reset timestamp carries no actionable signal; since the
+	// 2026-07/08 upstream limit changes it renders as a permanent "quota 100%"
+	// on every account. Hide exactly that shape: the segment reappears as soon
+	// as the window reports a duration, any depletion, or a reset time.
+	if (label === "quota" && !reset && (left === undefined || left >= 100)) {
+		return null;
+	}
 	const part = `${label} ${left}%`;
 	if (!options.showReset) return part;
 	// A missing or malformed reset timestamp must never drop the percentage.
-	const reset = formatQuotaResetAt(resetAtMs, now);
 	return reset ? `${part}, resets ${reset}` : part;
 }
 

--- a/test/codex-manager-formatters.test.ts
+++ b/test/codex-manager-formatters.test.ts
@@ -291,6 +291,28 @@ describe("compact quota reset timestamps", () => {
 		);
 	});
 
+	it("does not restore quota text when both windows are uninformative", () => {
+		const allHidden = {
+			status: 200,
+			planType: "plus",
+			model: "gpt-5.3-codex",
+			primary: { usedPercent: 0 },
+			secondary: { usedPercent: 0 },
+		} satisfies CodexQuotaSnapshot;
+
+		expect(formatCompactQuotaSnapshot(allHidden, NOW)).toBe("");
+		expect(
+			formatCompactQuotaSnapshot(allHidden, NOW, { showReset: true }),
+		).toBe("");
+		expect(
+			formatQuotaSnapshotForDashboard(
+				allHidden,
+				{ showQuotaDetails: true } as DashboardDisplaySettings,
+				NOW,
+			),
+		).toBe("live session OK");
+	});
+
 	it("formatQuotaSnapshotForDashboard is the check line and shows resets", () => {
 		const display = {
 			showQuotaDetails: true,

--- a/test/codex-manager-formatters.test.ts
+++ b/test/codex-manager-formatters.test.ts
@@ -252,16 +252,12 @@ describe("compact quota reset timestamps", () => {
 
 	it("hides an unlabeled full quota window with no reset data", () => {
 		const unlabeledFull = {
-			status: "ok",
+			status: 200,
 			planType: "plus",
 			model: "gpt-5.3-codex",
 			primary: { usedPercent: 65, windowMinutes: 10080, resetAtMs: SAME_DAY },
-			secondary: {
-				usedPercent: 0,
-				windowMinutes: undefined,
-				resetAtMs: undefined,
-			},
-		} as unknown as CodexQuotaSnapshot;
+			secondary: { usedPercent: 0 },
+		} satisfies CodexQuotaSnapshot;
 		expect(
 			formatCompactQuotaSnapshot(unlabeledFull, NOW, { showReset: true }),
 		).toBe(`7d 35%, resets ${formatQuotaResetAt(SAME_DAY, NOW)}`);
@@ -270,29 +266,21 @@ describe("compact quota reset timestamps", () => {
 
 	it("keeps an unlabeled window once it reports depletion or a reset", () => {
 		const depleted = {
-			status: "ok",
+			status: 200,
 			planType: "plus",
 			model: "gpt-5.3-codex",
-			primary: { usedPercent: 65, windowMinutes: 10080, resetAtMs: undefined },
-			secondary: {
-				usedPercent: 12,
-				windowMinutes: undefined,
-				resetAtMs: undefined,
-			},
-		} as unknown as CodexQuotaSnapshot;
+			primary: { usedPercent: 65, windowMinutes: 10080 },
+			secondary: { usedPercent: 12 },
+		} satisfies CodexQuotaSnapshot;
 		expect(formatCompactQuotaSnapshot(depleted, NOW)).toBe("7d 35% | quota 88%");
 
 		const fullWithReset = {
-			status: "ok",
+			status: 200,
 			planType: "plus",
 			model: "gpt-5.3-codex",
-			primary: { usedPercent: 65, windowMinutes: 10080, resetAtMs: undefined },
-			secondary: {
-				usedPercent: 0,
-				windowMinutes: undefined,
-				resetAtMs: SAME_DAY,
-			},
-		} as unknown as CodexQuotaSnapshot;
+			primary: { usedPercent: 65, windowMinutes: 10080 },
+			secondary: { usedPercent: 0, resetAtMs: SAME_DAY },
+		} satisfies CodexQuotaSnapshot;
 		expect(formatCompactQuotaSnapshot(fullWithReset, NOW)).toBe(
 			"7d 35% | quota 100%",
 		);

--- a/test/codex-manager-formatters.test.ts
+++ b/test/codex-manager-formatters.test.ts
@@ -250,6 +250,59 @@ describe("compact quota reset timestamps", () => {
 		);
 	});
 
+	it("hides an unlabeled full quota window with no reset data", () => {
+		const unlabeledFull = {
+			status: "ok",
+			planType: "plus",
+			model: "gpt-5.3-codex",
+			primary: { usedPercent: 65, windowMinutes: 10080, resetAtMs: SAME_DAY },
+			secondary: {
+				usedPercent: 0,
+				windowMinutes: undefined,
+				resetAtMs: undefined,
+			},
+		} as unknown as CodexQuotaSnapshot;
+		expect(
+			formatCompactQuotaSnapshot(unlabeledFull, NOW, { showReset: true }),
+		).toBe(`7d 35%, resets ${formatQuotaResetAt(SAME_DAY, NOW)}`);
+		expect(formatCompactQuotaSnapshot(unlabeledFull, NOW)).toBe("7d 35%");
+	});
+
+	it("keeps an unlabeled window once it reports depletion or a reset", () => {
+		const depleted = {
+			status: "ok",
+			planType: "plus",
+			model: "gpt-5.3-codex",
+			primary: { usedPercent: 65, windowMinutes: 10080, resetAtMs: undefined },
+			secondary: {
+				usedPercent: 12,
+				windowMinutes: undefined,
+				resetAtMs: undefined,
+			},
+		} as unknown as CodexQuotaSnapshot;
+		expect(formatCompactQuotaSnapshot(depleted, NOW)).toBe("7d 35% | quota 88%");
+
+		const fullWithReset = {
+			status: "ok",
+			planType: "plus",
+			model: "gpt-5.3-codex",
+			primary: { usedPercent: 65, windowMinutes: 10080, resetAtMs: undefined },
+			secondary: {
+				usedPercent: 0,
+				windowMinutes: undefined,
+				resetAtMs: SAME_DAY,
+			},
+		} as unknown as CodexQuotaSnapshot;
+		expect(formatCompactQuotaSnapshot(fullWithReset, NOW)).toBe(
+			"7d 35% | quota 100%",
+		);
+		expect(
+			formatCompactQuotaSnapshot(fullWithReset, NOW, { showReset: true }),
+		).toBe(
+			`7d 35% | quota 100%, resets ${formatQuotaResetAt(SAME_DAY, NOW)}`,
+		);
+	});
+
 	it("formatQuotaSnapshotForDashboard is the check line and shows resets", () => {
 		const display = {
 			showQuotaDetails: true,


### PR DESCRIPTION
## Summary

- Hide the uninformative unlabeled quota window segment — the permanent `| quota 100%` with no duration and no reset data — from the compact quota summaries used by `check`, dashboard rows, and the account menu. The segment reappears the moment the window reports a duration, any depletion, or a reset time.

## What Changed

- `lib/codex-manager/formatters/quota-formatters.ts` — `formatCompactQuotaPart` now returns `null` for exactly one shape: label fell back to `"quota"` (no reported duration) AND left% is 100 (or not computable) AND there is no valid reset timestamp. Reset validity is computed regardless of `showReset` so the hide decision is consistent between the compact (no-reset) and `check` (with-reset) surfaces. Labeled windows (`5h`, `7d`, monthly) and any window showing depletion or a reset render exactly as before; `rate-limited` / `quota-exhausted` markers are unaffected.
- `test/codex-manager-formatters.test.ts` — two new cases: the hidden shape, and the keep-when-informative shapes (depleted unlabeled window; full unlabeled window carrying a reset).

Motivation: since the July 2026 provider limit changes (5h window temporarily lifted Jul 12, restored ~Jul 30), some accounts report the short window with no duration and no reset timestamp (account-side phenomenon also reported in openai/codex#32791). On those accounts every `check`/list line renders a permanent `quota 100%` that never moves and carries nothing actionable:

```
before: live session OK (7d 35%, resets 12:45 | quota 100%)
after:  live session OK (7d 35%, resets 12:45)
```

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 28 failed | 5260 passed | 6 skipped (5294). The 28 failures are pre-existing host-environment failures on this machine (macOS + Node 26.4: `/var` → `/private/var` symlink canonicalization in the named-backup/storage tests, Windows-platform mocking in paths/runtime-paths/resolver tests, Homebrew `libnode` dyld in the app-server shim fixtures) — the identical set fails on the untouched v2.8.1 baseline (28 failed | 5258 passed | 5292 total), i.e. before/after parity with the only delta being the two new passing tests. Expecting your Linux/Windows CI to be green.
- [x] `npm test -- test/documentation.test.ts` — 32 passed
- [x] `npm run build`

## Docs and Governance Checklist

- [ ] README updated — not applicable (no command/setting/path surface changed; display-only refinement of an existing summary line)
- [ ] `docs/getting-started.md` — not applicable
- [ ] `docs/features.md` — not applicable
- [ ] `docs/reference/*` — not applicable (no reference page documents the unlabeled-window segment; `test/documentation.test.ts` passes unchanged)
- [ ] `docs/upgrade.md` — not applicable (no migration behavior)
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

## Risk and Rollback

- Risk level: low — pure display change scoped to one exact uninformative shape; any real quota signal re-surfaces the segment automatically.
- Rollback plan: revert this single commit.

## Additional Notes

- Complements the diagnostics reports I filed separately (#654, #655, #656) from operating a 3-account pool through the runtime rotation proxy.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

the follow-up fixes the empty-parts fallback so fully hidden quota summaries remain hidden, including on dashboard and account-menu surfaces.
- adds a shared uninformative-window classification for fallback handling
- removes empty dashboard parentheses
- adds vitest coverage for the previous regression and informative-window cases

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/codex-manager/formatters/quota-formatters.ts | the previous fallback defect is fixed, and no eligible blocking issue remains. |
| test/codex-manager-formatters.test.ts | vitest coverage now exercises the prior all-hidden regression, dashboard output, and informative exceptions. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(quota-display): cover all-hidden fal..."](https://github.com/ndycode/codex-multi-auth/commit/8a96b8b191dbaefa4cd9c2c64d49ee4c6abbef7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51385462)</sub>

<!-- /greptile_comment -->