### PR TITLE
fix(auth): remove deprecated OpenAuth dependency

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -1,5 +1,4 @@
-import { generatePKCE } from "@openauthjs/openauth/pkce";
-import { randomBytes } from "node:crypto";
+import { randomBytes, webcrypto } from "node:crypto";
 import type {
 	PKCEPair,
 	AuthorizationFlow,
@@ -410,6 +409,16 @@ export interface AuthorizationFlowOptions {
 	forceNewLogin?: boolean;
 }
 
+async function generatePKCE(): Promise<PKCEPair> {
+	const verifier = randomBytes(64).toString("base64url");
+	const digest = await webcrypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(verifier),
+	);
+	const challenge = Buffer.from(digest).toString("base64url");
+	return { verifier, challenge };
+}
+
 /**
  * Create OAuth authorization flow
  * @param options - Optional configuration for the flow
@@ -418,7 +427,7 @@ export interface AuthorizationFlowOptions {
 export async function createAuthorizationFlow(
 	options?: AuthorizationFlowOptions,
 ): Promise<AuthorizationFlow> {
-	const pkce = (await generatePKCE()) as PKCEPair;
+	const pkce = await generatePKCE();
 	const state = createState();
 
 	const url = new URL(AUTHORIZE_URL);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
 			"dependencies": {
 				"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 				"@codex-ai/sdk": "file:vendor/codex-ai-sdk",
-				"@openauthjs/openauth": "^0.4.3",
 				"hono": "4.12.33",
 				"undici": "6.28.0",
 				"zod": "4.4.3"
@@ -784,72 +783,6 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
-		"node_modules/@openauthjs/openauth": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@openauthjs/openauth/-/openauth-0.4.3.tgz",
-			"integrity": "sha512-RlnjqvHzqcbFVymEwhlUEuac4utA5h4nhSK/i2szZuQmxTIqbGUxZ+nM+avM+VV4Ing+/ZaNLKILoXS3yrkOOw==",
-			"dependencies": {
-				"@standard-schema/spec": "1.0.0-beta.3",
-				"aws4fetch": "1.0.20",
-				"jose": "5.9.6"
-			},
-			"peerDependencies": {
-				"arctic": "^2.2.2",
-				"hono": "^4.0.0"
-			}
-		},
-		"node_modules/@oslojs/asn1": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
-			"integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@oslojs/binary": "1.0.0"
-			}
-		},
-		"node_modules/@oslojs/binary": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
-			"integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@oslojs/crypto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
-			"integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@oslojs/asn1": "1.0.0",
-				"@oslojs/binary": "1.0.0"
-			}
-		},
-		"node_modules/@oslojs/encoding": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
-			"integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@oslojs/jwt": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
-			"integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@oslojs/encoding": "0.4.1"
-			}
-		},
-		"node_modules/@oslojs/jwt/node_modules/@oslojs/encoding": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
-			"integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@package-json/types": {
 			"version": "0.0.12",
 			"resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
@@ -1213,12 +1146,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/@standard-schema/spec": {
-			"version": "1.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0-beta.3.tgz",
-			"integrity": "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw==",
-			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.2",
@@ -2084,18 +2011,6 @@
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
-		"node_modules/arctic": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/arctic/-/arctic-2.3.4.tgz",
-			"integrity": "sha512-+p30BOWsctZp+CVYCt7oAean/hWGW42sH5LAcRQX56ttEkFJWbzXBhmSpibbzwSJkRrotmsA+oAoJoVsU0f5xA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@oslojs/crypto": "1.0.1",
-				"@oslojs/encoding": "1.1.0",
-				"@oslojs/jwt": "0.2.0"
-			}
-		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2117,12 +2032,6 @@
 				"estree-walker": "^3.0.3",
 				"js-tokens": "^10.0.0"
 			}
-		},
-		"node_modules/aws4fetch": {
-			"version": "1.0.20",
-			"resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
-			"integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
-			"license": "MIT"
 		},
 		"node_modules/balanced-match": {
 			"version": "4.0.3",
@@ -3006,15 +2915,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/jose": {
-			"version": "5.9.6",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
-			"integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
 	"dependencies": {
 		"@codex-ai/plugin": "file:vendor/codex-ai-plugin",
 		"@codex-ai/sdk": "file:vendor/codex-ai-sdk",
-		"@openauthjs/openauth": "^0.4.3",
 		"hono": "4.12.33",
 		"undici": "6.28.0",
 		"zod": "4.4.3"

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -217,6 +217,7 @@ describe("Auth Module", () => {
 			expect(flow.pkce).toHaveProperty("verifier");
 			expect(flow.pkce.verifier.length).toBeGreaterThanOrEqual(43);
 			expect(flow.pkce.verifier.length).toBeLessThanOrEqual(128);
+			expect(flow.pkce.verifier).toMatch(/^[A-Za-z0-9_-]+$/);
 			expect(flow.pkce.challenge).toBe(
 				createHash("sha256")
 					.update(flow.pkce.verifier)

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { createHash } from "node:crypto";
 import {
 	createState,
 	parseAuthorizationInput,
@@ -214,6 +215,13 @@ describe("Auth Module", () => {
 
 			expect(flow.pkce).toHaveProperty("challenge");
 			expect(flow.pkce).toHaveProperty("verifier");
+			expect(flow.pkce.verifier.length).toBeGreaterThanOrEqual(43);
+			expect(flow.pkce.verifier.length).toBeLessThanOrEqual(128);
+			expect(flow.pkce.challenge).toBe(
+				createHash("sha256")
+					.update(flow.pkce.verifier)
+					.digest("base64url"),
+			);
 			expect(flow.state).toMatch(/^[a-f0-9]{32}$/);
 		});
 


### PR DESCRIPTION
## Summary

- replace the sole `@openauthjs/openauth/pkce` usage with Node's built-in crypto APIs
- remove OpenAuth and its deprecated Arctic/Oslo dependency chain
- verify the RFC 7636 verifier constraints and S256 challenge derivation

## Motivation

`@openauthjs/openauth@0.4.3` declares `arctic ^2.2.2` as a peer
dependency. npm therefore installs deprecated versions of `arctic` and
`@oslojs/*` for every installation of codex-multi-auth.

codex-multi-auth uses OpenAuth only for `generatePKCE`. Since the package
already requires Node >=18.17, the same operation can be implemented directly
with `node:crypto` without carrying the additional dependency chain.

The implementation preserves the existing behavior:

- 64 cryptographically random bytes
- base64url-encoded verifier
- SHA-256 S256 challenge
- unchanged asynchronous authorization-flow API

## Verification

- `npm ci` — clean install without Arctic/Oslo deprecation warnings
- `npm test -- test/auth.test.ts` — 64 tests passed
- `npm run lint`
- `npm run typecheck`
- `npx --yes npm@11.6.2 run pack:check` — 811,749 bytes across 920 files

The full suite was also attempted locally on macOS with Node 24.17:
5,326 tests passed and 28 unrelated existing platform/wrapper/storage tests
failed. None of the failing files overlap this change.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

the pr replaces the deprecated openauth pkce helper with node’s built-in cryptographic apis and removes the obsolete dependency chain.

- generates an rfc 7636 verifier from 64 random bytes and derives its s256 challenge.
- removes openauth, arctic, oslo, and associated transitive packages.
- adds focused vitest coverage for verifier constraints and challenge derivation.
- no concurrency behavior, token persistence, or windows filesystem paths are changed.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/auth/auth.ts | replaces the external pkce helper with a node-compatible implementation that preserves the authorization-flow contract. |
| test/auth.test.ts | directly verifies verifier length, character constraints, and s256 challenge derivation; no relevant vitest coverage gap remains. |
| package.json | removes the sole direct openauth dependency without affecting package exports or runtime requirements. |
| package-lock.json | removes openauth and its deprecated transitive chain while remaining synchronized with the root manifest. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(auth): assert PKCE verifier alphabe..."](https://github.com/ndycode/codex-multi-auth/commit/388419dbe8424dee11a5f46f805a516c7da75b5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52113559)</sub>

**Context used:**

- Knowledge Base — [Auth / OAuth login flow](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/auth-oauth-flow.md)
- Knowledge Base — [Build and Packaging](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/build-and-packaging.md)

<!-- /greptile_comment -->