### PR TITLE
fix(forecast,runtime): review fixes for #670 and #671 — keep the default forecast on codex, harden the pinned-503 reset

### DIFF
--- a/docs/reference/error-contracts.md
+++ b/docs/reference/error-contracts.md
@@ -120,10 +120,20 @@ The default-on localhost Responses proxy returns JSON error payloads with a stab
 | `runtime_rotation_proxy_unauthorized` | `401` | Local request did not include the per-process proxy client key |
 | `runtime_rotation_proxy_payload_too_large` | `413` | Request body exceeded the proxy safety cap |
 | `codex_runtime_rotation_pool_exhausted` | `429` or `503` | No managed account can currently service the runtime request |
-| `codex_pinned_account_unavailable` | `503` | A manual pin is set (via `codex-multi-auth switch`) but the pinned account is rate-limited, cooling down, disabled, or blocked by policy. Run `codex-multi-auth status` for details, or `codex-multi-auth unpin` to allow rotation |
+| `codex_pinned_account_unavailable` | `503` | A pin is in force — either a manual pin (`codex-multi-auth switch`) or a forced per-invocation pin (`--account` / `CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX`) — but the pinned account is rate-limited, cooling down, disabled, or blocked by policy. The remedy depends on `pin_source` (see below) |
 | `codex_runtime_rotation_proxy_error` | `500` | Proxy failed before forwarding the request |
 
 Pool exhaustion includes a `reason`, `retry_after_ms`, and a hint to run `codex-multi-auth rotation status`. Pinned-account-unavailable responses include a `pinnedAccountIndex` field identifying the pinned account, a structured `reason` field carrying the runtime skip reason (for example `rate-limited`, `cooling-down:auth-failure`, `circuit-open`, `disabled`, `workspace-disabled`, `policy-blocked`, `missing`, `already-attempted`) or `null` when no reason was recorded, and an `account_skip_reasons` map keyed by account index that mirrors the pool-exhausted response shape. The human-readable `message` appends the same reason in parentheses when present (see issue #486).
+
+Pinned-account-unavailable responses also carry:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `pin_source` | `"forced"`, `"manual"`, or `null` | `"forced"` when the pin came from `--account` / `CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX`, `"manual"` when it came from `codex-multi-auth switch`. `unpin` clears only a manual pin, so the `message` tells a forced-pin caller to relaunch instead |
+| `reset_at` | ISO-8601 string or `null` | When the blocking state ends — the latest of the gating rate-limit record, the account cooldown, and the circuit-breaker deadline. `null` under a permanent blocker (`disabled`, `workspace-disabled`, `policy-blocked`, `missing`, invalidated auth) or when nothing bounds recovery |
+| `retry_after_ms` | number or `null` | `reset_at` expressed as a delay from the moment the response was built; `null` whenever `reset_at` is `null` |
+
+When `reset_at` is present the `message` appends `; the recorded limit resets at <ISO>`.
 
 Account policy pause/drain is enforced through runtime policy evaluation and contributes to selection skip reasons such as `policy-blocked`.
 

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1294,6 +1294,22 @@ export class AccountManager {
 		return getCircuitBreaker(getAccountCircuitKey(account)).isAvailable();
 	}
 
+	/**
+	 * When the account's circuit breaker will admit an attempt again, as an
+	 * epoch-ms deadline — null when it already would. Lets the pinned-503
+	 * recovery metadata cover circuit-open skips, whose deadline lives in the
+	 * breaker rather than the persisted account record.
+	 */
+	getCircuitRecoveryTime(
+		account: ManagedAccount,
+		now = Date.now(),
+	): number | null {
+		const waitMs = getCircuitBreaker(
+			getAccountCircuitKey(account),
+		).getTimeUntilAvailable(now);
+		return waitMs > 0 ? now + waitMs : null;
+	}
+
 	incrementAuthFailures(account: ManagedAccount): number {
 		account.consecutiveAuthFailures =
 			(account.consecutiveAuthFailures ?? 0) + 1;

--- a/lib/codex-manager/commands/best.ts
+++ b/lib/codex-manager/commands/best.ts
@@ -287,14 +287,24 @@ export async function runBestCommand(
 		}
 	}
 
+	// Resolved once, not once per account. Only an EXPLICIT `--model` may move
+	// the availability family: DEFAULT_LIVE_PROBE_MODEL is `gpt-5.6-sol`, whose
+	// prompt family is `gpt-5.2`, so deriving it unconditionally would let a bare
+	// `best` recommend an account that is rate-limited on the codex family the
+	// wrapper actually routes — and every Codex request would then 503 off the
+	// pin that recommendation produced.
+	const forecastFamily = options.modelProvided
+		? getModelProfile(probeModel).promptFamily
+		: undefined;
+	const forecastActiveIndex = deps.resolveActiveIndex(storage, "codex");
 	const forecastInputs = storage.accounts.map((account, index) => ({
 		index,
 		account,
-		isCurrent: index === deps.resolveActiveIndex(storage, "codex"),
+		isCurrent: index === forecastActiveIndex,
 		now,
 		refreshFailure: refreshFailures.get(index),
 		liveQuota: liveQuotaByIndex.get(index),
-		family: getModelProfile(probeModel).promptFamily,
+		family: forecastFamily,
 	}));
 	const forecastResults = deps.evaluateForecastAccounts(forecastInputs);
 	const recommendation = deps.recommendForecastAccount(forecastResults);

--- a/lib/codex-manager/commands/best.ts
+++ b/lib/codex-manager/commands/best.ts
@@ -1,6 +1,9 @@
 import type { ForecastAccountResult } from "../../forecast.js";
 import { type CodexQuotaSnapshot, describeCodexProbeFailure } from "../../quota-probe.js";
-import { resolveNormalizedModel } from "../../request/helpers/model-map.js";
+import {
+	getModelProfile,
+	resolveNormalizedModel,
+} from "../../request/helpers/model-map.js";
 import type { AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 import { DEFAULT_LIVE_PROBE_MODEL } from "../quota-cache-helpers.js";
@@ -289,6 +292,7 @@ export async function runBestCommand(
 		now,
 		refreshFailure: refreshFailures.get(index),
 		liveQuota: liveQuotaByIndex.get(index),
+		family: getModelProfile(probeModel).promptFamily,
 	}));
 	const forecastResults = deps.evaluateForecastAccounts(forecastInputs);
 	const recommendation = deps.recommendForecastAccount(forecastResults);

--- a/lib/codex-manager/commands/best.ts
+++ b/lib/codex-manager/commands/best.ts
@@ -2,6 +2,7 @@ import type { ForecastAccountResult } from "../../forecast.js";
 import { type CodexQuotaSnapshot, describeCodexProbeFailure } from "../../quota-probe.js";
 import {
 	getModelProfile,
+	type ModelFamily,
 	resolveNormalizedModel,
 } from "../../request/helpers/model-map.js";
 import type { AccountStorageV3 } from "../../storage.js";
@@ -126,6 +127,7 @@ export interface BestCommandDeps {
 			now: number;
 			refreshFailure?: TokenFailure;
 			liveQuota?: CodexQuotaSnapshot;
+			family?: ModelFamily;
 		}>,
 	) => ForecastAccountResult[];
 	recommendForecastAccount: (results: ForecastAccountResult[]) => {

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -28,6 +28,14 @@ interface ForecastCliOptions {
 	json: boolean;
 	explain: boolean;
 	model: string;
+	/**
+	 * True only when the invocation actually carried `--model`. `model` always
+	 * holds a value (it falls back to DEFAULT_PROBE_MODEL so the probe and the
+	 * header have something to name), so it cannot distinguish an explicit
+	 * request from the default — and the availability family must never follow a
+	 * default the user did not ask for.
+	 */
+	modelProvided: boolean;
 	runtimeOverlay: boolean;
 }
 
@@ -156,6 +164,7 @@ function parseForecastArgs(
 		json: false,
 		explain: false,
 		model: DEFAULT_PROBE_MODEL,
+		modelProvided: false,
 		runtimeOverlay: true,
 	};
 
@@ -184,6 +193,7 @@ function parseForecastArgs(
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
+			options.modelProvided = true;
 			i += 1;
 			continue;
 		}
@@ -193,6 +203,7 @@ function parseForecastArgs(
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
+			options.modelProvided = true;
 			continue;
 		}
 		return { ok: false, message: `Unknown option: ${arg}` };
@@ -223,6 +234,18 @@ export async function runForecastCommand(
 	const options = parsedArgs.options;
 	const requestedModel = options.model?.trim() || DEFAULT_PROBE_MODEL;
 	const probeModel = resolveNormalizedModel(requestedModel);
+	// Resolved once, not once per account: getModelProfile re-parses and
+	// re-resolves the model string on every call.
+	//
+	// Only an EXPLICIT `--model` may move the availability family. The default
+	// probe model is `gpt-5.6-sol`, whose prompt family is `gpt-5.2`, so
+	// deriving the family unconditionally would flip a bare `forecast` off the
+	// codex family and report a codex-rate-limited account as `ready` — the
+	// exact forecast/runtime desync this threading exists to remove, aimed at
+	// the default invocation instead.
+	const forecastFamily = options.modelProvided
+		? getModelProfile(requestedModel).promptFamily
+		: undefined;
 	const display = deps.loadDashboardDisplaySettings
 		? (await deps.loadDashboardDisplaySettings().catch(() => null)) ??
 			deps.defaultDisplay
@@ -374,7 +397,7 @@ export async function runForecastCommand(
 		quotaCache,
 		allAccounts: storage.accounts,
 		runtimeOverlay,
-		family: getModelProfile(requestedModel).promptFamily,
+		family: forecastFamily,
 	}));
 	const forecastResults = deps.evaluateForecastAccounts(forecastInputs);
 	const summary = deps.summarizeForecast(forecastResults);

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -17,6 +17,7 @@ import { type CodexQuotaSnapshot, describeCodexProbeFailure } from "../../quota-
 import {
 	DEFAULT_PROBE_MODEL,
 	getModelProfile,
+	type ModelFamily,
 	resolveNormalizedModel,
 } from "../../request/helpers/model-map.js";
 import { type AccountMetadataV3, type AccountStorageV3 } from "../../storage.js";
@@ -89,6 +90,7 @@ export interface ForecastCommandDeps {
 			quotaCache?: QuotaCacheData | null;
 			allAccounts?: readonly AccountMetadataV3[];
 			runtimeOverlay?: RuntimeForecastOverlay | null;
+			family?: ModelFamily;
 		}>,
 	) => ForecastAccountResult[];
 	summarizeForecast: (results: ForecastAccountResult[]) => {

--- a/lib/codex-manager/commands/forecast.ts
+++ b/lib/codex-manager/commands/forecast.ts
@@ -14,7 +14,11 @@ import {
 } from "../forecast-report-shared.js";
 import type { QuotaCacheData } from "../../quota-cache.js";
 import { type CodexQuotaSnapshot, describeCodexProbeFailure } from "../../quota-probe.js";
-import { DEFAULT_PROBE_MODEL, resolveNormalizedModel } from "../../request/helpers/model-map.js";
+import {
+	DEFAULT_PROBE_MODEL,
+	getModelProfile,
+	resolveNormalizedModel,
+} from "../../request/helpers/model-map.js";
 import { type AccountMetadataV3, type AccountStorageV3 } from "../../storage.js";
 import type { TokenFailure, TokenResult } from "../../types.js";
 
@@ -368,6 +372,7 @@ export async function runForecastCommand(
 		quotaCache,
 		allAccounts: storage.accounts,
 		runtimeOverlay,
+		family: getModelProfile(requestedModel).promptFamily,
 	}));
 	const forecastResults = deps.evaluateForecastAccounts(forecastInputs);
 	const summary = deps.summarizeForecast(forecastResults);

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -46,6 +46,14 @@ interface ReportCliOptions {
 	json: boolean;
 	explain: boolean;
 	model: string;
+	/**
+	 * True only when the invocation actually carried `--model`. `model` always
+	 * holds a value (it falls back to DEFAULT_PROBE_MODEL for the probe and the
+	 * `modelSelection` block), so it cannot distinguish an explicit request from
+	 * the default — and the availability family must never follow a default the
+	 * user did not ask for.
+	 */
+	modelProvided: boolean;
 	maxAccounts?: number;
 	maxProbes?: number;
 	cachedOnly: boolean;
@@ -144,6 +152,7 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 		json: false,
 		explain: false,
 		model: DEFAULT_PROBE_MODEL,
+		modelProvided: false,
 		cachedOnly: false,
 	};
 
@@ -172,6 +181,7 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
+			options.modelProvided = true;
 			i += 1;
 			continue;
 		}
@@ -181,6 +191,7 @@ function parseReportArgs(args: string[]): ParsedArgsResult<ReportCliOptions> {
 				return { ok: false, message: "Missing value for --model" };
 			}
 			options.model = value;
+			options.modelProvided = true;
 			continue;
 		}
 		if (arg === "--max-accounts") {
@@ -462,6 +473,16 @@ export async function runReportCommand(
 		}
 	}
 
+	// `inspectRequestedModel` already resolved the profile, so reuse its
+	// `promptFamily` instead of re-resolving the model once per account.
+	//
+	// Only an EXPLICIT `--model` may move the availability family: the default
+	// probe model is `gpt-5.6-sol`, whose prompt family is `gpt-5.2`, so
+	// deriving it unconditionally would make a bare `report` describe gpt-5.2
+	// availability while the wrapper routes codex-family traffic.
+	const forecastFamily = options.modelProvided
+		? modelInspection.promptFamily
+		: undefined;
 	const forecastResults = storage
 		? evaluateForecastAccounts(
 				storage.accounts.map((account, index) => ({
@@ -474,7 +495,7 @@ export async function runReportCommand(
 					quotaCache,
 					allAccounts: storage.accounts,
 					runtimeOverlay: runtimeSnapshot,
-					family: getModelProfile(modelInspection.normalized).promptFamily,
+					family: forecastFamily,
 				})),
 			)
 		: [];

--- a/lib/codex-manager/commands/report.ts
+++ b/lib/codex-manager/commands/report.ts
@@ -474,6 +474,7 @@ export async function runReportCommand(
 					quotaCache,
 					allAccounts: storage.accounts,
 					runtimeOverlay: runtimeSnapshot,
+					family: getModelProfile(modelInspection.normalized).promptFamily,
 				})),
 			)
 		: [];

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -10,6 +10,7 @@ import {
 	isQuotaCacheEntryExhausted,
 	quotaUsedPercentIsExhausted,
 } from "./quota-readiness.js";
+import type { ModelFamily } from "./request/helpers/model-map.js";
 import { getRateLimitResetTimeForFamily } from "./runtime/account-status.js";
 import type { AccountMetadataV3 } from "./storage.js";
 import type { TokenFailure } from "./types.js";
@@ -27,6 +28,12 @@ export interface ForecastAccountInput {
 	quotaCache?: QuotaCacheData | null;
 	allAccounts?: readonly AccountMetadataV3[];
 	runtimeOverlay?: RuntimeForecastOverlay | null;
+	/**
+	 * Prompt family whose per-family rate-limit records gate this forecast.
+	 * Callers with a model in hand resolve it via getModelProfile; the codex
+	 * default preserves the historical behavior for model-less surfaces.
+	 */
+	family?: ModelFamily;
 }
 
 export interface RuntimeForecastOverlay {
@@ -245,7 +252,7 @@ export function evaluateForecastAccount(
 	const rateLimitResetAt = getRateLimitResetTimeForFamily(
 		account,
 		now,
-		"codex",
+		input.family ?? "codex",
 	);
 	if (typeof rateLimitResetAt === "number") {
 		const remaining = Math.max(0, rateLimitResetAt - now);
@@ -298,7 +305,10 @@ export function evaluateForecastAccount(
 	// drop the overlay reason when the condition it describes is no longer
 	// active. Each reason validates only against its own backing disk state
 	// ("rate-limited" -> rateLimitResetTimes, "cooling-down" -> coolingDownUntil)
-	// so we never substitute a misleading reason string. Non-time-bounded
+	// so we never substitute a misleading reason string. The rate-limited
+	// cross-check is family-aware through rateLimitResetAt above: a record for
+	// the forecast's own family keeps the reason, while a record for another
+	// family neither sustains it nor gates this model's availability. Non-time-bounded
 	// reasons ("circuit-open", "token-exhausted", "policy-blocked") have no disk
 	// expiry to check and are always applied.
 	const coolingDownActive =

--- a/lib/request/rate-limit-decision.ts
+++ b/lib/request/rate-limit-decision.ts
@@ -185,12 +185,31 @@ export interface PinnedUnavailableErrorBody {
 	code: "codex_pinned_account_unavailable";
 	pinnedAccountIndex: number | null;
 	reason: string | null;
+	/** How the pin was set; forced pins are not cleared by `unpin`. */
+	pin_source: "forced" | "manual" | null;
+	/** When the blocking record ends, when the skip reason is time-bounded. */
+	reset_at: string | null;
+	retry_after_ms: number | null;
 	account_skip_reasons: Record<string, string>;
+}
+
+export interface PinnedUnavailableContext {
+	/**
+	 * "forced" when the pin came from the wrapper's forced-account mode
+	 * (`--account` / CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX), "manual" when it
+	 * came from `switch`. `unpin` clears only the manual kind, so the remedy
+	 * line must not suggest it for a forced pin.
+	 */
+	pinSource?: "forced" | "manual" | null;
+	/** Epoch ms when the blocking record ends (rate limit or cooldown). */
+	resetAtMs?: number | null;
+	now?: number;
 }
 
 export function buildPinnedUnavailableErrorBody(
 	pinnedIndex: number | null | undefined,
 	accountSkipReasons: ReadonlyMap<number, string>,
+	context?: PinnedUnavailableContext,
 ): PinnedUnavailableErrorBody {
 	const normalizedPinnedIndex =
 		typeof pinnedIndex === "number" ? pinnedIndex : null;
@@ -205,11 +224,32 @@ export function buildPinnedUnavailableErrorBody(
 		normalizedPinnedIndex === null
 			? "The pinned account"
 			: `Pinned account ${normalizedPinnedIndex + 1}`;
+	const pinSource = context?.pinSource ?? null;
+	const resetAtMs =
+		typeof context?.resetAtMs === "number" &&
+		Number.isFinite(context.resetAtMs) &&
+		context.resetAtMs > 0
+			? context.resetAtMs
+			: null;
+	const now = context?.now ?? Date.now();
+	const retryAfterMs = resetAtMs !== null ? Math.max(0, resetAtMs - now) : null;
+	const resetAt = resetAtMs !== null ? new Date(resetAtMs).toISOString() : null;
+	const waitSuffix =
+		resetAt !== null ? `; the recorded limit resets at ${resetAt}` : "";
+	// A forced pin belongs to the launching process, not to ndy's persisted
+	// pin state, so `unpin` would clear nothing — say what actually helps.
+	const remedy =
+		pinSource === "forced"
+			? "the pin was set by this session's launcher, so relaunch to select a different account"
+			: "run `codex-multi-auth status` for details, or `codex-multi-auth unpin` to allow rotation";
 	return {
-		message: `${accountPhrase} is currently unavailable${reasonSuffix}; run \`codex-multi-auth status\` for details, or \`codex-multi-auth unpin\` to allow rotation.`,
+		message: `${accountPhrase} is currently unavailable${reasonSuffix}${waitSuffix}; ${remedy}.`,
 		code: "codex_pinned_account_unavailable",
 		pinnedAccountIndex: normalizedPinnedIndex,
 		reason: skipReason,
+		pin_source: pinSource,
+		reset_at: resetAt,
+		retry_after_ms: retryAfterMs,
 		account_skip_reasons: Object.fromEntries(
 			[...accountSkipReasons.entries()].map(([index, reason]) => [
 				String(index),

--- a/lib/request/rate-limit-decision.ts
+++ b/lib/request/rate-limit-decision.ts
@@ -193,6 +193,9 @@ export interface PinnedUnavailableErrorBody {
 	account_skip_reasons: Record<string, string>;
 }
 
+/** Largest epoch-ms a `Date` can represent; beyond it `toISOString()` throws. */
+const MAX_ECMASCRIPT_TIME_MS = 8.64e15;
+
 export interface PinnedUnavailableContext {
 	/**
 	 * "forced" when the pin came from the wrapper's forced-account mode
@@ -228,7 +231,14 @@ export function buildPinnedUnavailableErrorBody(
 	const resetAtMs =
 		typeof context?.resetAtMs === "number" &&
 		Number.isFinite(context.resetAtMs) &&
-		context.resetAtMs > 0
+		context.resetAtMs > 0 &&
+		// `new Date(x).toISOString()` throws RangeError past the ECMAScript time
+		// range. The deadline is read from persisted account state
+		// (`rateLimitResetTimes`, `coolingDownUntil`) which a corrupted or
+		// hand-edited storage file can carry out of range, and this builder runs
+		// on the 503 path: a throw here would drop the pin diagnostics entirely
+		// and surface the proxy's generic 500 instead.
+		context.resetAtMs <= MAX_ECMASCRIPT_TIME_MS
 			? context.resetAtMs
 			: null;
 	const now = context?.now ?? Date.now();
@@ -236,8 +246,8 @@ export function buildPinnedUnavailableErrorBody(
 	const resetAt = resetAtMs !== null ? new Date(resetAtMs).toISOString() : null;
 	const waitSuffix =
 		resetAt !== null ? `; the recorded limit resets at ${resetAt}` : "";
-	// A forced pin belongs to the launching process, not to ndy's persisted
-	// pin state, so `unpin` would clear nothing — say what actually helps.
+	// A forced pin belongs to the launching process, not to the persisted pin
+	// state, so `unpin` would clear nothing — say what actually helps.
 	const remedy =
 		pinSource === "forced"
 			? "the pin was set by this session's launcher, so relaunch to select a different account"

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1592,6 +1592,7 @@ async function handleRequestInner(
 							pinnedAccount,
 							state.now(),
 							context.family,
+							context.model,
 						);
 			// An open circuit outlives the short failure cooldowns that tripped
 			// it; its deadline lives in the breaker, not the account record.

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { Socket } from "node:net";
 import {
 	AccountManager,
+	AUTH_INVALIDATION_MARKER,
 	extractAccountId,
 	type ManagedAccount,
 } from "./accounts.js";
@@ -166,6 +167,19 @@ function toUrlHost(host: string): string {
 // failures surfaced only as a last-write-wins status.lastError string. Logs are
 // level-gated and carry the per-request correlation id set in handleRequest.
 const proxyLog = createLogger("runtime-proxy");
+
+/**
+ * Pinned skip reasons that no timer clears: the account stays unselectable
+ * after any concurrent rate-limit record or cooldown expires, so the pinned
+ * 503 must not advertise that record's expiry as a recovery time.
+ */
+const PINNED_PERMANENT_SKIP_REASONS: ReadonlySet<string> = new Set([
+	"missing",
+	"disabled",
+	"workspace-disabled",
+	"policy-blocked",
+	AUTH_INVALIDATION_MARKER,
+]);
 const DEFAULT_QUOTA_REMAINING_THRESHOLD = 10;
 
 /** @internal Stable identity key for in-memory quota snapshots across reloads. */
@@ -1578,7 +1592,19 @@ async function handleRequestInner(
 				typeof pinnedIndex === "number"
 					? accountManager.getAccountByIndex(pinnedIndex)
 					: null;
-			// Recovery comes from the pinned account's persisted state, not the
+			const pinnedSkipReason =
+				typeof pinnedIndex === "number"
+					? accountSkipReasons.get(pinnedIndex) ?? null
+					: null;
+			// A permanent blocker (disabled, no enabled workspace, invalidated
+			// auth, policy block, out-of-range pin) outlives every timed record,
+			// so advertising a record's expiry would invite a retry into another
+			// 503. Selection rejects such an account before any attempt, so the
+			// recorded skip reason is the permanent one in exactly these cases.
+			const pinnedBlockedPermanently =
+				pinnedSkipReason !== null &&
+				PINNED_PERMANENT_SKIP_REASONS.has(pinnedSkipReason);
+			// Otherwise recovery comes from the pinned account's persisted state, not the
 			// recorded skip reason: a direct 429/cooldown on the pinned account
 			// reaches this 503 as "already-attempted" (the retry loop's selection
 			// verdict) while the record it just wrote is what actually bounds
@@ -1601,7 +1627,8 @@ async function handleRequestInner(
 					? null
 					: accountManager.getCircuitRecoveryTime(pinnedAccount, state.now());
 			const pinnedResetAtMs =
-				pinnedStateRecoveryAtMs === null && pinnedCircuitRecoveryAtMs === null
+				pinnedBlockedPermanently ||
+				(pinnedStateRecoveryAtMs === null && pinnedCircuitRecoveryAtMs === null)
 					? null
 					: Math.max(
 							pinnedStateRecoveryAtMs ?? 0,

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -72,7 +72,7 @@ import {
 	responseHeadersForClient,
 	withTimeout,
 } from "./request/stream-failover-runtime.js";
-import { getRateLimitResetTimeForFamily } from "./runtime/account-status.js";
+import { getAccountRecoveryTimeForFamily } from "./runtime/account-status.js";
 import { chooseAccount } from "./runtime/rotation-account-selection.js";
 import {
 	createRotationProxyState,
@@ -1578,26 +1578,21 @@ async function handleRequestInner(
 				typeof pinnedIndex === "number"
 					? accountManager.getAccountByIndex(pinnedIndex)
 					: null;
-			const pinnedSkipReason =
-				typeof pinnedIndex === "number"
-					? accountSkipReasons.get(pinnedIndex) ?? null
-					: null;
-			// A rate-limited skip is bounded by the family record and a cooldown
-			// by coolingDownUntil; anything else has no known recovery moment.
+			// Recovery comes from the pinned account's persisted state, not the
+			// recorded skip reason: a direct 429/cooldown on the pinned account
+			// reaches this 503 as "already-attempted" (the retry loop's selection
+			// verdict) while the record it just wrote is what actually bounds
+			// recovery — and with several overlapping records the account stays
+			// skipped until the LAST one expires, so the latest bound is the one
+			// worth advertising.
 			const pinnedResetAtMs =
-				pinnedAccount === null || pinnedSkipReason === null
+				pinnedAccount === null
 					? null
-					: pinnedSkipReason === "rate-limited"
-						? getRateLimitResetTimeForFamily(
-								pinnedAccount,
-								state.now(),
-								context.family,
-							)
-						: pinnedSkipReason.startsWith("cooling-down") &&
-								typeof pinnedAccount.coolingDownUntil === "number" &&
-								pinnedAccount.coolingDownUntil > state.now()
-							? pinnedAccount.coolingDownUntil
-							: null;
+					: getAccountRecoveryTimeForFamily(
+							pinnedAccount,
+							state.now(),
+							context.family,
+						);
 			const errorBody = buildPinnedUnavailableErrorBody(
 				pinnedIndex,
 				accountSkipReasons,

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -72,6 +72,7 @@ import {
 	responseHeadersForClient,
 	withTimeout,
 } from "./request/stream-failover-runtime.js";
+import { getRateLimitResetTimeForFamily } from "./runtime/account-status.js";
 import { chooseAccount } from "./runtime/rotation-account-selection.js";
 import {
 	createRotationProxyState,
@@ -1573,9 +1574,40 @@ async function handleRequestInner(
 		// null reason indicates a forecast/runtime state desync (the pinned
 		// account was selected but no skip reason was recorded) — see #486.
 		if (isPinned) {
+			const pinnedAccount =
+				typeof pinnedIndex === "number"
+					? accountManager.getAccountByIndex(pinnedIndex)
+					: null;
+			const pinnedSkipReason =
+				typeof pinnedIndex === "number"
+					? accountSkipReasons.get(pinnedIndex) ?? null
+					: null;
+			// A rate-limited skip is bounded by the family record and a cooldown
+			// by coolingDownUntil; anything else has no known recovery moment.
+			const pinnedResetAtMs =
+				pinnedAccount === null || pinnedSkipReason === null
+					? null
+					: pinnedSkipReason === "rate-limited"
+						? getRateLimitResetTimeForFamily(
+								pinnedAccount,
+								state.now(),
+								context.family,
+							)
+						: pinnedSkipReason.startsWith("cooling-down") &&
+								typeof pinnedAccount.coolingDownUntil === "number" &&
+								pinnedAccount.coolingDownUntil > state.now()
+							? pinnedAccount.coolingDownUntil
+							: null;
 			const errorBody = buildPinnedUnavailableErrorBody(
 				pinnedIndex,
 				accountSkipReasons,
+				{
+					// typeof check so a forced index of 0 still reads as forced.
+					pinSource:
+						typeof state.forcedAccountIndex === "number" ? "forced" : "manual",
+					resetAtMs: pinnedResetAtMs,
+					now: state.now(),
+				},
 			);
 			if (errorBody.reason === null) {
 				state.status.lastError = `pinned-503 missing skip reason (pinnedIndex=${pinnedIndex})`;

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1585,13 +1585,26 @@ async function handleRequestInner(
 			// recovery — and with several overlapping records the account stays
 			// skipped until the LAST one expires, so the latest bound is the one
 			// worth advertising.
-			const pinnedResetAtMs =
+			const pinnedStateRecoveryAtMs =
 				pinnedAccount === null
 					? null
 					: getAccountRecoveryTimeForFamily(
 							pinnedAccount,
 							state.now(),
 							context.family,
+						);
+			// An open circuit outlives the short failure cooldowns that tripped
+			// it; its deadline lives in the breaker, not the account record.
+			const pinnedCircuitRecoveryAtMs =
+				pinnedAccount === null
+					? null
+					: accountManager.getCircuitRecoveryTime(pinnedAccount, state.now());
+			const pinnedResetAtMs =
+				pinnedStateRecoveryAtMs === null && pinnedCircuitRecoveryAtMs === null
+					? null
+					: Math.max(
+							pinnedStateRecoveryAtMs ?? 0,
+							pinnedCircuitRecoveryAtMs ?? 0,
 						);
 			const errorBody = buildPinnedUnavailableErrorBody(
 				pinnedIndex,

--- a/lib/runtime/account-status.ts
+++ b/lib/runtime/account-status.ts
@@ -1,3 +1,4 @@
+import { getQuotaKey } from "../accounts/rate-limits.js";
 import type { ModelFamily } from "../prompts/codex.js";
 
 export function resolveActiveIndex(
@@ -67,8 +68,8 @@ export function getAccountRecoveryTimeForFamily(
 	};
 	const times = account.rateLimitResetTimes;
 	if (times) {
-		consider(times[family]);
-		if (model) consider(times[`${family}:${model}`]);
+		consider(times[getQuotaKey(family)]);
+		if (model) consider(times[getQuotaKey(family, model)]);
 	}
 	consider(account.coolingDownUntil);
 	return latest;

--- a/lib/runtime/account-status.ts
+++ b/lib/runtime/account-status.ts
@@ -38,6 +38,40 @@ export function getRateLimitResetTimeForFamily(
 	return minReset;
 }
 
+/**
+ * The moment the account becomes usable again for `family`: the LATEST
+ * matching rate-limit record plus any active cooldown. Distinct from
+ * getRateLimitResetTimeForFamily, whose earliest-reset answer feeds wait
+ * displays: the account stays skipped while ANY matching record is active,
+ * so a retry hint built from the earliest reset would send clients back
+ * into a 503. Null when nothing bounds recovery.
+ */
+export function getAccountRecoveryTimeForFamily(
+	account: {
+		rateLimitResetTimes?: Record<string, number | undefined>;
+		coolingDownUntil?: number;
+	},
+	now: number,
+	family: ModelFamily,
+): number | null {
+	let latest: number | null = null;
+	const consider = (value: number | undefined): void => {
+		if (typeof value !== "number" || !Number.isFinite(value)) return;
+		if (value <= now) return;
+		if (latest === null || value > latest) latest = value;
+	};
+	const times = account.rateLimitResetTimes;
+	if (times) {
+		const prefix = `${family}:`;
+		for (const [key, value] of Object.entries(times)) {
+			if (key !== family && !key.startsWith(prefix)) continue;
+			consider(value);
+		}
+	}
+	consider(account.coolingDownUntil);
+	return latest;
+}
+
 export function formatRateLimitEntry(
 	account: { rateLimitResetTimes?: Record<string, number | undefined> },
 	now: number,

--- a/lib/runtime/account-status.ts
+++ b/lib/runtime/account-status.ts
@@ -39,12 +39,16 @@ export function getRateLimitResetTimeForFamily(
 }
 
 /**
- * The moment the account becomes usable again for `family`: the LATEST
- * matching rate-limit record plus any active cooldown. Distinct from
+ * The moment the account becomes usable again for a `family`/`model`
+ * request: the LATEST bound among the records that actually gate that
+ * request plus any active cooldown. Two deliberate differences from
  * getRateLimitResetTimeForFamily, whose earliest-reset answer feeds wait
- * displays: the account stays skipped while ANY matching record is active,
- * so a retry hint built from the earliest reset would send clients back
- * into a 503. Null when nothing bounds recovery.
+ * displays: the account stays skipped while ANY gating record is active,
+ * so the earliest reset would send clients back into a 503 — and only the
+ * keys selection consults (`family`, plus `family:<model>` when a model is
+ * known; see isRateLimitedForFamily) may contribute, because another
+ * model's record does not block this request and would overstate its
+ * recovery. Null when nothing bounds recovery.
  */
 export function getAccountRecoveryTimeForFamily(
 	account: {
@@ -53,6 +57,7 @@ export function getAccountRecoveryTimeForFamily(
 	},
 	now: number,
 	family: ModelFamily,
+	model?: string | null,
 ): number | null {
 	let latest: number | null = null;
 	const consider = (value: number | undefined): void => {
@@ -62,11 +67,8 @@ export function getAccountRecoveryTimeForFamily(
 	};
 	const times = account.rateLimitResetTimes;
 	if (times) {
-		const prefix = `${family}:`;
-		for (const [key, value] of Object.entries(times)) {
-			if (key !== family && !key.startsWith(prefix)) continue;
-			consider(value);
-		}
+		consider(times[family]);
+		if (model) consider(times[`${family}:${model}`]);
 	}
 	consider(account.coolingDownUntil);
 	return latest;

--- a/test/account-status.test.ts
+++ b/test/account-status.test.ts
@@ -104,17 +104,50 @@ describe("account status helpers", () => {
 });
 
 describe("getAccountRecoveryTimeForFamily", () => {
-	it("returns the LATEST matching reset so a retry lands after real recovery", () => {
-		// Two overlapping records for the family: the account stays skipped
-		// until the last one expires, so the earliest reset would send a
-		// client straight back into a 503.
+	it("returns the LATEST gating reset so a retry lands after real recovery", () => {
+		// Family-wide and requested-model records overlap: the account stays
+		// skipped until the later one expires, so the earliest reset would
+		// send a client straight back into a 503.
 		expect(
 			getAccountRecoveryTimeForFamily(
-				{ rateLimitResetTimes: { codex: 3_000, "codex:5h": 9_000 } },
+				{
+					rateLimitResetTimes: {
+						codex: 3_000,
+						"codex:gpt-5-codex": 9_000,
+					},
+				},
+				1_000,
+				"codex",
+				"gpt-5-codex",
+			),
+		).toBe(9_000);
+	});
+
+	it("ignores records that do not gate the request", () => {
+		// Another model's record in the same family does not block this
+		// request (selection checks only the family key and the requested
+		// model's key), so it must not inflate the advertised recovery.
+		expect(
+			getAccountRecoveryTimeForFamily(
+				{
+					rateLimitResetTimes: {
+						codex: 3_000,
+						"codex:gpt-5.3-codex": 9_000,
+					},
+				},
+				1_000,
+				"codex",
+				"gpt-5-codex",
+			),
+		).toBe(3_000);
+		// Without a model only the family-wide key gates.
+		expect(
+			getAccountRecoveryTimeForFamily(
+				{ rateLimitResetTimes: { "codex:gpt-5-codex": 9_000 } },
 				1_000,
 				"codex",
 			),
-		).toBe(9_000);
+		).toBeNull();
 	});
 
 	it("ignores other families and expired records", () => {

--- a/test/account-status.test.ts
+++ b/test/account-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	formatRateLimitEntry,
+	getAccountRecoveryTimeForFamily,
 	getRateLimitResetTimeForFamily,
 	resolveActiveIndex,
 } from "../lib/runtime/account-status.js";
@@ -99,5 +100,58 @@ describe("account status helpers", () => {
 				"codex",
 			),
 		).toBe("resets in 4000ms");
+	});
+});
+
+describe("getAccountRecoveryTimeForFamily", () => {
+	it("returns the LATEST matching reset so a retry lands after real recovery", () => {
+		// Two overlapping records for the family: the account stays skipped
+		// until the last one expires, so the earliest reset would send a
+		// client straight back into a 503.
+		expect(
+			getAccountRecoveryTimeForFamily(
+				{ rateLimitResetTimes: { codex: 3_000, "codex:5h": 9_000 } },
+				1_000,
+				"codex",
+			),
+		).toBe(9_000);
+	});
+
+	it("ignores other families and expired records", () => {
+		expect(
+			getAccountRecoveryTimeForFamily(
+				{ rateLimitResetTimes: { "gpt-5.2": 9_000, codex: 500 } },
+				1_000,
+				"codex",
+			),
+		).toBeNull();
+	});
+
+	it("folds an active cooldown into the recovery moment", () => {
+		expect(
+			getAccountRecoveryTimeForFamily(
+				{ rateLimitResetTimes: { codex: 3_000 }, coolingDownUntil: 7_000 },
+				1_000,
+				"codex",
+			),
+		).toBe(7_000);
+		expect(
+			getAccountRecoveryTimeForFamily(
+				{ coolingDownUntil: 2_000 },
+				1_000,
+				"codex",
+			),
+		).toBe(2_000);
+	});
+
+	it("returns null when nothing bounds recovery", () => {
+		expect(getAccountRecoveryTimeForFamily({}, 1_000, "codex")).toBeNull();
+		expect(
+			getAccountRecoveryTimeForFamily(
+				{ coolingDownUntil: 900 },
+				1_000,
+				"codex",
+			),
+		).toBeNull();
 	});
 });

--- a/test/codex-manager-best-command.test.ts
+++ b/test/codex-manager-best-command.test.ts
@@ -168,12 +168,17 @@ describe("runBestCommand", () => {
 			})),
 		});
 
+		// No `--model` means no family: DEFAULT_LIVE_PROBE_MODEL is `gpt-5.6-sol`,
+		// whose prompt family is `gpt-5.2`. Threading it would let a bare `best`
+		// recommend an account that is rate-limited on the codex family, and the
+		// resulting pin would 503 on every Codex request.
 		await expect(runBestCommand(["--json"], deps)).resolves.toBe(0);
 		const defaulted = evaluateForecastAccounts.mock.calls.at(-1)?.[0] as
 			| Array<{ family?: string }>
 			| undefined;
-		expect(defaulted?.[0]?.family).toBe(
-			getModelProfile(DEFAULT_LIVE_PROBE_MODEL).promptFamily,
+		expect(defaulted?.[0]?.family).toBeUndefined();
+		expect(getModelProfile(DEFAULT_LIVE_PROBE_MODEL).promptFamily).not.toBe(
+			"codex",
 		);
 
 		const explicitDeps = createDeps({

--- a/test/codex-manager-best-command.test.ts
+++ b/test/codex-manager-best-command.test.ts
@@ -6,6 +6,8 @@ import {
 } from "../lib/codex-manager/commands/best.js";
 import { CodexUnavailableError } from "../lib/errors.js";
 import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../lib/quota-probe.js";
+import { DEFAULT_LIVE_PROBE_MODEL } from "../lib/codex-manager/quota-cache-helpers.js";
+import { getModelProfile } from "../lib/request/helpers/model-map.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 
 function createAccount(
@@ -135,6 +137,64 @@ describe("runBestCommand", () => {
 		expect(deps.logError).toHaveBeenCalledWith(
 			"--model requires --live for codex-multi-auth best",
 		);
+	});
+
+	it("threads the probe model's family into forecast evaluation", async () => {
+		const evaluateForecastAccounts = vi.fn((inputs) => {
+			void inputs;
+			return [
+				{
+					index: 0,
+					label: "1. best@example.com",
+					isCurrent: true,
+					availability: "ready",
+					riskScore: 0,
+					riskLevel: "low",
+					waitMs: 0,
+					reasons: [],
+				},
+			] as const;
+		});
+		const deps = createDeps({
+			evaluateForecastAccounts,
+			parseBestArgs: vi.fn(() => ({
+				ok: true as const,
+				options: {
+					live: false,
+					json: true,
+					model: DEFAULT_LIVE_PROBE_MODEL,
+					modelProvided: false,
+				} satisfies BestCliOptions,
+			})),
+		});
+
+		await expect(runBestCommand(["--json"], deps)).resolves.toBe(0);
+		const defaulted = evaluateForecastAccounts.mock.calls.at(-1)?.[0] as
+			| Array<{ family?: string }>
+			| undefined;
+		expect(defaulted?.[0]?.family).toBe(
+			getModelProfile(DEFAULT_LIVE_PROBE_MODEL).promptFamily,
+		);
+
+		const explicitDeps = createDeps({
+			evaluateForecastAccounts,
+			parseBestArgs: vi.fn(() => ({
+				ok: true as const,
+				options: {
+					live: true,
+					json: true,
+					model: "gpt-5.6-sol",
+					modelProvided: true,
+				} satisfies BestCliOptions,
+			})),
+		});
+		await expect(
+			runBestCommand(["--json", "--live", "--model", "gpt-5.6-sol"], explicitDeps),
+		).resolves.toBe(0);
+		const explicit = evaluateForecastAccounts.mock.calls.at(-1)?.[0] as
+			| Array<{ family?: string }>
+			| undefined;
+		expect(explicit?.[0]?.family).toBe(getModelProfile("gpt-5.6-sol").promptFamily);
 	});
 
 	it("emits json output when no accounts are configured", async () => {

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -198,13 +198,17 @@ describe("runForecastCommand", () => {
 			| undefined;
 		expect(explicit?.[0]?.family).toBe(getModelProfile("gpt-5.6-sol").promptFamily);
 
+		// No `--model` means no family: DEFAULT_PROBE_MODEL is `gpt-5.6-sol`,
+		// whose prompt family is `gpt-5.2`, so threading it here would move a bare
+		// `forecast` off the codex family that the wrapper actually routes and
+		// report a codex-rate-limited account as `ready`. Leaving it undefined
+		// keeps evaluateForecastAccount on its codex default.
 		await expect(runForecastCommand(["--json"], deps)).resolves.toBe(0);
 		const defaulted = evaluateForecastAccounts.mock.calls.at(-1)?.[0] as
 			| Array<{ family?: string }>
 			| undefined;
-		expect(defaulted?.[0]?.family).toBe(
-			getModelProfile(DEFAULT_PROBE_MODEL).promptFamily,
-		);
+		expect(defaulted?.[0]?.family).toBeUndefined();
+		expect(getModelProfile(DEFAULT_PROBE_MODEL).promptFamily).not.toBe("codex");
 	});
 
 	it("honors --no-runtime-overlay in json forecast output", async () => {

--- a/test/codex-manager-forecast-command.test.ts
+++ b/test/codex-manager-forecast-command.test.ts
@@ -5,7 +5,10 @@ import {
 } from "../lib/codex-manager/commands/forecast.js";
 import { CodexUnavailableError } from "../lib/errors.js";
 import { CODEX_UNAVAILABLE_PROBE_NOTE } from "../lib/quota-probe.js";
-import { DEFAULT_PROBE_MODEL } from "../lib/request/helpers/model-map.js";
+import {
+	DEFAULT_PROBE_MODEL,
+	getModelProfile,
+} from "../lib/request/helpers/model-map.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 
 function createStorage(): AccountStorageV3 {
@@ -166,6 +169,41 @@ describe("runForecastCommand", () => {
 		expect(result).toBe(0);
 		expect(deps.logInfo).toHaveBeenCalledWith(
 			expect.stringContaining('"command": "forecast"'),
+		);
+	});
+
+	it("threads the requested model's family into forecast evaluation", async () => {
+		const evaluateForecastAccounts = vi.fn((inputs) => {
+			void inputs;
+			return [
+				{
+					index: 0,
+					label: "1. forecast@example.com",
+					isCurrent: true,
+					availability: "ready",
+					riskScore: 0,
+					riskLevel: "low",
+					waitMs: 0,
+					reasons: [],
+				},
+			] as const;
+		});
+		const deps = createDeps({ evaluateForecastAccounts });
+
+		await expect(
+			runForecastCommand(["--json", "--model", "gpt-5.6-sol"], deps),
+		).resolves.toBe(0);
+		const explicit = evaluateForecastAccounts.mock.calls.at(-1)?.[0] as
+			| Array<{ family?: string }>
+			| undefined;
+		expect(explicit?.[0]?.family).toBe(getModelProfile("gpt-5.6-sol").promptFamily);
+
+		await expect(runForecastCommand(["--json"], deps)).resolves.toBe(0);
+		const defaulted = evaluateForecastAccounts.mock.calls.at(-1)?.[0] as
+			| Array<{ family?: string }>
+			| undefined;
+		expect(defaulted?.[0]?.family).toBe(
+			getModelProfile(DEFAULT_PROBE_MODEL).promptFamily,
 		);
 	});
 

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -144,6 +144,49 @@ describe("runReportCommand", () => {
 		expect(codex.accounts[0]?.availability).toBe("ready");
 	});
 
+	it("keeps the default (no --model) report on the codex family", async () => {
+		// DEFAULT_PROBE_MODEL is `gpt-5.6-sol`, whose prompt family is `gpt-5.2`.
+		// A bare `report` must NOT inherit that family: the wrapper routes
+		// codex-family traffic, so a codex record has to keep gating the default
+		// report and a gpt-5.2 record must not.
+		const readForecast = (
+			deps: ReportCommandDeps,
+		): { accounts: Array<{ availability: string }> } =>
+			(
+				JSON.parse(
+					String(
+						(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ??
+							"{}",
+					),
+				) as { forecast: { accounts: Array<{ availability: string }> } }
+			).forecast;
+		const withRecord = (
+			rateLimitResetTimes: Record<string, number>,
+		): ReportCommandDeps => {
+			const storage = createStorage([
+				{
+					email: "one@example.com",
+					refreshToken: "refresh-token-1",
+					accessToken: "access-token-1",
+					expiresAt: 10,
+					addedAt: 1,
+					lastUsed: 1,
+					enabled: true,
+					rateLimitResetTimes,
+				},
+			]);
+			return createDeps({ loadAccounts: vi.fn(async () => storage) });
+		};
+
+		const codexDeps = withRecord({ codex: 31_000 });
+		await expect(runReportCommand(["--json"], codexDeps)).resolves.toBe(0);
+		expect(readForecast(codexDeps).accounts[0]?.availability).toBe("delayed");
+
+		const generalDeps = withRecord({ "gpt-5.2": 31_000 });
+		await expect(runReportCommand(["--json"], generalDeps)).resolves.toBe(0);
+		expect(readForecast(generalDeps).accounts[0]?.availability).toBe("ready");
+	});
+
 	it("rejects a flag-like or whitespace-only --model value instead of consuming it", async () => {
 		// Split-arg form trims before validating, so "  -x" / "   " can't slip
 		// through and silently fall back to the default model.

--- a/test/codex-manager-report-command.test.ts
+++ b/test/codex-manager-report-command.test.ts
@@ -93,6 +93,57 @@ describe("runReportCommand", () => {
 		expect(deps.logError).toHaveBeenCalledWith("Unknown option: --bogus");
 	});
 
+	it("gates the forecast on the requested model's family record", async () => {
+		const storage = createStorage([
+			{
+				email: "one@example.com",
+				refreshToken: "refresh-token-1",
+				accessToken: "access-token-1",
+				expiresAt: 10,
+				addedAt: 1,
+				lastUsed: 1,
+				enabled: true,
+				rateLimitResetTimes: { "gpt-5.2": 31_000 },
+			},
+		]);
+		const deps = createDeps({ loadAccounts: vi.fn(async () => storage) });
+
+		const readForecast = (): {
+			accounts: Array<{ availability: string; reasons: string[] }>;
+		} =>
+			(
+				JSON.parse(
+					String(
+						(deps.logInfo as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ??
+							"{}",
+					),
+				) as {
+					forecast: {
+						accounts: Array<{ availability: string; reasons: string[] }>;
+					};
+				}
+			).forecast;
+
+		// The record is under the gpt-5.2 family, which gpt-5.6-sol belongs to.
+		await expect(
+			runReportCommand(["--json", "--model", "gpt-5.6-sol"], deps),
+		).resolves.toBe(0);
+		const general = readForecast();
+		expect(general.accounts[0]?.availability).toBe("delayed");
+		expect(
+			general.accounts[0]?.reasons.some((reason) =>
+				reason.startsWith("rate limit resets in"),
+			),
+		).toBe(true);
+
+		// A codex-family model is not gated by that record.
+		await expect(
+			runReportCommand(["--json", "--model", "gpt-5.3-codex"], deps),
+		).resolves.toBe(0);
+		const codex = readForecast();
+		expect(codex.accounts[0]?.availability).toBe("ready");
+	});
+
 	it("rejects a flag-like or whitespace-only --model value instead of consuming it", async () => {
 		// Split-arg form trims before validating, so "  -x" / "   " can't slip
 		// through and silently fall back to the default model.

--- a/test/forecast.test.ts
+++ b/test/forecast.test.ts
@@ -387,6 +387,84 @@ describe("forecast helpers", () => {
 		expect(result.reasons).toContain("runtime skip: rate-limited");
 	});
 
+	it("gates availability on the requested family's record, not the codex family", () => {
+		const now = 1_700_000_000_000;
+		const account = {
+			refreshToken: "refresh-1",
+			addedAt: now - 10_000,
+			lastUsed: now - 10_000,
+			rateLimitResetTimes: { "gpt-5.2": now + 30_000 },
+		};
+
+		const general = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			family: "gpt-5.2",
+		});
+		expect(general.availability).toBe("delayed");
+		expect(general.waitMs).toBe(30_000);
+		expect(
+			general.reasons.some((reason) => reason.startsWith("rate limit resets in")),
+		).toBe(true);
+
+		const codex = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account,
+			family: "codex",
+		});
+		expect(codex.availability).toBe("ready");
+	});
+
+	it("keeps a rate-limited overlay alive when the record matches the requested family", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				rateLimitResetTimes: { "gpt-5.2": now + 30_000 },
+			},
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "rate-limited" },
+			},
+			family: "gpt-5.2",
+		});
+
+		// Before family threading this overlay was cross-checked against the
+		// codex family, judged stale, and dropped - the account read "ready"
+		// while the runtime proxy refused every request for the family.
+		expect(result.availability).toBe("unavailable");
+		expect(result.reasons).toContain("runtime skip: rate-limited");
+	});
+
+	it("drops a rate-limited overlay backed only by another family's record", () => {
+		const now = 1_700_000_000_000;
+		const result = evaluateForecastAccount({
+			index: 0,
+			now,
+			isCurrent: false,
+			account: {
+				refreshToken: "refresh-1",
+				addedAt: now - 10_000,
+				lastUsed: now - 10_000,
+				rateLimitResetTimes: { "gpt-5.2": now + 30_000 },
+			},
+			runtimeOverlay: {
+				lastPoolExhaustionSkipReasons: { "0": "rate-limited" },
+			},
+			family: "codex",
+		});
+
+		expect(result.availability).toBe("ready");
+	});
+
 	it("ignores a stale cooling-down overlay when cooldown has elapsed on disk", () => {
 		const now = 1_700_000_000_000;
 		const result = evaluateForecastAccount({

--- a/test/rate-limit-decision.test.ts
+++ b/test/rate-limit-decision.test.ts
@@ -295,5 +295,39 @@ describe("buildPinnedUnavailableErrorBody", () => {
 		expect(body.message).not.toContain("Pinned account 1");
 		expect(body.message).not.toContain("(");
 		expect(body.account_skip_reasons).toEqual({});
+		expect(body.pin_source).toBeNull();
+		expect(body.reset_at).toBeNull();
+		expect(body.retry_after_ms).toBeNull();
+	});
+
+	it("tailors the remedy to a forced pin and threads the recorded reset", () => {
+		const resetAtMs = 1_700_000_030_000;
+		const body = buildPinnedUnavailableErrorBody(
+			0,
+			new Map([[0, "rate-limited"]]),
+			{ pinSource: "forced", resetAtMs, now: 1_700_000_000_000 },
+		);
+		expect(body.pin_source).toBe("forced");
+		expect(body.reset_at).toBe(new Date(resetAtMs).toISOString());
+		expect(body.retry_after_ms).toBe(30_000);
+		expect(body.message).toContain(
+			`the recorded limit resets at ${new Date(resetAtMs).toISOString()}`,
+		);
+		// A forced pin is not cleared by `unpin`; the remedy must not suggest it.
+		expect(body.message).toContain("set by this session's launcher");
+		expect(body.message).not.toContain("unpin");
+	});
+
+	it("keeps the unpin advice for manual pins and nulls an unknown reset", () => {
+		const body = buildPinnedUnavailableErrorBody(
+			1,
+			new Map([[1, "disabled"]]),
+			{ pinSource: "manual" },
+		);
+		expect(body.pin_source).toBe("manual");
+		expect(body.reset_at).toBeNull();
+		expect(body.retry_after_ms).toBeNull();
+		expect(body.message).toContain("codex-multi-auth unpin");
+		expect(body.message).not.toContain("resets at");
 	});
 });

--- a/test/rate-limit-decision.test.ts
+++ b/test/rate-limit-decision.test.ts
@@ -318,6 +318,21 @@ describe("buildPinnedUnavailableErrorBody", () => {
 		expect(body.message).not.toContain("unpin");
 	});
 
+	it("drops an out-of-range reset instead of throwing on toISOString", () => {
+		// A corrupted / hand-edited storage file can carry a `coolingDownUntil`
+		// or rate-limit reset past the ECMAScript time range. `new Date(x)
+		// .toISOString()` throws RangeError there, and this builder runs on the
+		// 503 path — a throw would replace the pin diagnostics with a generic 500.
+		const body = buildPinnedUnavailableErrorBody(
+			0,
+			new Map([[0, "rate-limited"]]),
+			{ pinSource: "manual", resetAtMs: 8.64e15 + 1, now: 1_700_000_000_000 },
+		);
+		expect(body.reset_at).toBeNull();
+		expect(body.retry_after_ms).toBeNull();
+		expect(body.message).not.toContain("resets at");
+	});
+
 	it("keeps the unpin advice for manual pins and nulls an unknown reset", () => {
 		const body = buildPinnedUnavailableErrorBody(
 			1,

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -892,14 +892,28 @@ describe("runtime rotation proxy", () => {
 		});
 		// Zero the network-error cooldown so every request reaches upstream
 		// and records a breaker failure; otherwise the cooldown absorbs the
-		// retries and the breaker never opens.
-		vi.stubEnv("CODEX_AUTH_NETWORK_ERROR_COOLDOWN_MS", "0");
-		const proxy = await startProxy({
-			accountManager,
-			fetchImpl,
-			options: { forcedAccountIndex: 0 },
-		});
-		vi.unstubAllEnvs();
+		// retries and the breaker never opens. The proxy reads the value once at
+		// startup, so restore the exact prior value right after — `unstubAllEnvs`
+		// would clear every other stub too, and an assertion failure before it ran
+		// would leak the override into every later test (this file's afterEach
+		// only clears CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX).
+		const previousCooldown =
+			process.env.CODEX_AUTH_NETWORK_ERROR_COOLDOWN_MS;
+		process.env.CODEX_AUTH_NETWORK_ERROR_COOLDOWN_MS = "0";
+		let proxy: Awaited<ReturnType<typeof startProxy>>;
+		try {
+			proxy = await startProxy({
+				accountManager,
+				fetchImpl,
+				options: { forcedAccountIndex: 0 },
+			});
+		} finally {
+			if (previousCooldown === undefined) {
+				delete process.env.CODEX_AUTH_NETWORK_ERROR_COOLDOWN_MS;
+			} else {
+				process.env.CODEX_AUTH_NETWORK_ERROR_COOLDOWN_MS = previousCooldown;
+			}
+		}
 		const body = {
 			model: "gpt-5-codex",
 			stream: true,

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -884,6 +884,57 @@ describe("runtime rotation proxy", () => {
 		expect(Date.parse(payload.error.reset_at ?? "")).toBeGreaterThan(now);
 	});
 
+	it("advertises the circuit deadline once repeated failures open the pinned account's breaker", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const { calls, fetchImpl } = createRecordingFetch(() => {
+			throw new TypeError("fetch failed");
+		});
+		// Zero the network-error cooldown so every request reaches upstream
+		// and records a breaker failure; otherwise the cooldown absorbs the
+		// retries and the breaker never opens.
+		vi.stubEnv("CODEX_AUTH_NETWORK_ERROR_COOLDOWN_MS", "0");
+		const proxy = await startProxy({
+			accountManager,
+			fetchImpl,
+			options: { forcedAccountIndex: 0 },
+		});
+		vi.unstubAllEnvs();
+		const body = {
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+		};
+
+		// Three failing requests trip the default breaker (threshold 3).
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			const failed = await postResponses(proxy, body);
+			expect(failed.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		}
+		expect(calls).toHaveLength(3);
+
+		const response = await postResponses(proxy, body);
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		// Circuit-open skips before any upstream attempt.
+		expect(calls).toHaveLength(3);
+		const payload = (await response.json()) as {
+			error: {
+				code: string;
+				pin_source: string | null;
+				reset_at: string | null;
+				retry_after_ms: number | null;
+			};
+		};
+		expect(payload.error.code).toBe("codex_pinned_account_unavailable");
+		expect(payload.error.pin_source).toBe("forced");
+		// The breaker's 30s reset outlives the short network-error cooldown
+		// that tripped it; the advertised recovery must be the circuit
+		// deadline, not the already-elapsed cooldown.
+		expect(payload.error.retry_after_ms).toBeGreaterThan(10_000);
+		expect(payload.error.retry_after_ms).toBeLessThanOrEqual(30_000);
+		expect(Date.parse(payload.error.reset_at ?? "")).toBeGreaterThan(now);
+	});
+
 	it("reads the forced account from CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX env when no option is passed (#623)", async () => {
 		// This is the exact mechanism the pin uses to cross the launcher -> detached
 		// app-helper process boundary: no option, env only.

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -799,6 +799,91 @@ describe("runtime rotation proxy", () => {
 		expect(calls).toHaveLength(0);
 	});
 
+	it("carries pin source and recovery metadata when the forced account 429s directly", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const { calls, fetchImpl } = createRecordingFetch(
+			() =>
+				new Response('{"error":{"message":"rate limited"}}', {
+					status: HTTP_STATUS.TOO_MANY_REQUESTS,
+					headers: {
+						"content-type": "application/json",
+						"retry-after": "120",
+					},
+				}),
+		);
+		const proxy = await startProxy({
+			accountManager,
+			fetchImpl,
+			options: { forcedAccountIndex: 0 },
+		});
+
+		const response = await postResponses(proxy, {
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+		});
+
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		// One direct attempt on the pin, then fail-hard — never a rotation.
+		expect(calls).toHaveLength(1);
+		const payload = (await response.json()) as {
+			error: {
+				code: string;
+				pin_source: string | null;
+				reason: string | null;
+				reset_at: string | null;
+				retry_after_ms: number | null;
+				message: string;
+			};
+		};
+		expect(payload.error.code).toBe("codex_pinned_account_unavailable");
+		expect(payload.error.pin_source).toBe("forced");
+		// The retry loop's selection verdict — recovery metadata must not
+		// depend on this string, only on the account's persisted state.
+		expect(payload.error.reason).toBe("already-attempted");
+		expect(payload.error.retry_after_ms).toBeGreaterThan(0);
+		expect(Date.parse(payload.error.reset_at ?? "")).toBeGreaterThan(now);
+		expect(payload.error.message).toContain("the recorded limit resets at");
+		expect(payload.error.message).toContain("launcher");
+		expect(payload.error.message).not.toContain("unpin");
+	});
+
+	it("carries cooldown recovery metadata when the forced account fails with a network error", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const { calls, fetchImpl } = createRecordingFetch(() => {
+			throw new TypeError("fetch failed");
+		});
+		const proxy = await startProxy({
+			accountManager,
+			fetchImpl,
+			options: { forcedAccountIndex: 0 },
+		});
+
+		const response = await postResponses(proxy, {
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+		});
+
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		expect(calls).toHaveLength(1);
+		const payload = (await response.json()) as {
+			error: {
+				code: string;
+				pin_source: string | null;
+				reset_at: string | null;
+				retry_after_ms: number | null;
+			};
+		};
+		expect(payload.error.code).toBe("codex_pinned_account_unavailable");
+		expect(payload.error.pin_source).toBe("forced");
+		// The network-error cooldown bounds recovery.
+		expect(payload.error.retry_after_ms).toBeGreaterThan(0);
+		expect(Date.parse(payload.error.reset_at ?? "")).toBeGreaterThan(now);
+	});
+
 	it("reads the forced account from CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX env when no option is passed (#623)", async () => {
 		// This is the exact mechanism the pin uses to cross the launcher -> detached
 		// app-helper process boundary: no option, env only.

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -935,6 +935,48 @@ describe("runtime rotation proxy", () => {
 		expect(Date.parse(payload.error.reset_at ?? "")).toBeGreaterThan(now);
 	});
 
+	it("suppresses timed recovery when a permanent blocker holds the pinned account", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const pinned = accountManager.getAccountByIndex(0);
+		if (!pinned) throw new Error("setup failed");
+		// Disabled outlives the record: after the rate limit expires the
+		// account is still unselectable, so no recovery time is honest.
+		pinned.enabled = false;
+		pinned.rateLimitResetTimes = { codex: now + 60_000 };
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			textEventStream("data: should-not-be-reached\n\n"),
+		);
+		const proxy = await startProxy({
+			accountManager,
+			fetchImpl,
+			options: { forcedAccountIndex: 0 },
+		});
+
+		const response = await postResponses(proxy, {
+			model: "gpt-5-codex",
+			stream: true,
+			input: [{ type: "message", role: "user", content: "hi" }],
+		});
+
+		expect(response.status).toBe(HTTP_STATUS.SERVICE_UNAVAILABLE);
+		expect(calls).toHaveLength(0);
+		const payload = (await response.json()) as {
+			error: {
+				code: string;
+				reason: string | null;
+				reset_at: string | null;
+				retry_after_ms: number | null;
+				message: string;
+			};
+		};
+		expect(payload.error.code).toBe("codex_pinned_account_unavailable");
+		expect(payload.error.reason).toBe("disabled");
+		expect(payload.error.reset_at).toBeNull();
+		expect(payload.error.retry_after_ms).toBeNull();
+		expect(payload.error.message).not.toContain("resets at");
+	});
+
 	it("reads the forced account from CODEX_MULTI_AUTH_FORCE_ACCOUNT_INDEX env when no option is passed (#623)", async () => {
 		// This is the exact mechanism the pin uses to cross the launcher -> detached
 		// app-helper process boundary: no option, env only.


### PR DESCRIPTION
## Summary

- Targets `fix/forecast-model-family` (#670), not `main`: the code it fixes only exists on that branch.
- #670 corrected the **family** axis of forecast availability but left the **model** axis wrong, so the surface it exists to make truthful still disagrees with the runtime proxy — in both directions.
- These are the forecast-side twins of two defects already fixed for the pinned-503 path in #671.
- Not a review-comment PR: every bot comment on #670 and #671 is already resolved and both are approved and mergeable. This is one defect found by reviewing the diffs themselves.

## What Changed

**The defect.** #670 made the forecast read the requested model's family instead of a hardwired `"codex"`. The record lookup underneath it did not follow:

```ts
// lib/runtime/account-status.ts - getRateLimitResetTimeForFamily
if (key !== family && !key.startsWith(`${family}:`)) continue;  // every model in the family
if (minReset === null || value < minReset) minReset = value;     // the EARLIEST of them
```

Selection does neither. `isRateLimitedForFamily` (`lib/accounts/rate-limits.ts:75`) consults exactly two keys — the family-wide key and `family:<model>` — and the account stays skipped while **either** is active. Two user-visible consequences:

1. **A sibling model's record reports a delay the proxy would not impose.** `markRateLimitedWithReason` keys token/concurrency limits under `family:<model>` (`lib/accounts.ts:1261`). A record on `gpt-5.2:gpt-5.6-terra` makes `forecast --model gpt-5.6-sol` read `delayed`, while the proxy serves that model because neither `gpt-5.2` nor `gpt-5.2:gpt-5.6-sol` is set. The same over-match keeps a stale `rate-limited` runtime overlay alive through the staleness cross-check, flipping the account to `unavailable`.
2. **The earliest reset understates the wait.** With `gpt-5.2` resetting in 5s and `gpt-5.2:gpt-5.6-sol` in 45s, the forecast advertises 5s; the account is not selectable for 45s.

Both mirror what Greptile already had fixed on the 503 path in #671 — [earliest reset misstating recovery](https://github.com/ndycode/codex-multi-auth/pull/671#discussion_r3790172331) and [an unrelated model's record inflating it](https://github.com/ndycode/codex-multi-auth/pull/671#discussion_r3790249983). Forecast never got the same treatment.

**The fix.**

- `getRateLimitResetTimeForModel` (`lib/runtime/account-status.ts`) resolves exactly the keys selection consults — via `getQuotaKey`, so the shape cannot drift from what `markRateLimitedWithReason` persists — and returns the **latest** active bound.
- `ForecastAccountInput` gains `model`; `forecast`, `best`, and `report` pass the normalized id each already resolves, and both injected evaluator contracts name it.
- Not a reuse of #671's `getAccountRecoveryTimeForFamily`: that one folds in `coolingDownUntil`, which forecast already scores separately. Folding it in here would attach a bogus `rate limit resets in` reason to a cooldown-only account and sustain a `rate-limited` overlay on cooldown evidence — exactly what the surrounding comment guards against.
- **Model-less callers are untouched.** `status` and `fix` pass no model and cannot single out a model key, so they keep the family-wide union through `getRateLimitResetTimeForFamily`, which also still serves the wait displays. #670's stated compatibility promise holds verbatim, and there is a test pinning it.

**Interaction with #671.** `git merge-tree pr671 <this branch>` is clean — #671 inserts its helper above `formatRateLimitEntry`, this one appends below it, and both add the same `getQuotaKey` import. Merge order does not matter.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 5447 passed. One pre-existing failure in `test/zz-stress-helper-lifecycle.test.ts` (`withDeadPids`, `test/helpers/owned-pids.ts:182`), unrelated to this change: it fails 3 of 4 runs on clean `main` at `524c397` and on `fix/pinned-503-remedy` too. A PID-reuse race in the test helper, not a product defect.
- [x] `npm test -- test/documentation.test.ts` — 32 passed
- [x] `npm run build`

New coverage — four behavioral cases, all of which **fail on `fix/forecast-model-family` as it stands**:

| Test | Without this PR |
|---|---|
| `test/forecast.test.ts` — sibling model's record ignored | `delayed`, expected `ready` |
| `test/forecast.test.ts` — later of two gating resets | `5000`, expected `45000` |
| `test/forecast.test.ts` — overlay dropped when only a sibling backs it | `unavailable`, expected `ready` |
| `test/codex-manager-report-command.test.ts` — same, end to end through the real evaluator | `delayed`, expected `ready` |

Plus a case pinning the model-less union so `status`/`fix` cannot regress, and command-level assertions that the **normalized** id reaches evaluation from `best` and `forecast` — extending the `family` assertions #670 added at CodeRabbit's request.

Suites: `test/forecast.test.ts`, `test/codex-manager-forecast-command.test.ts`, `test/codex-manager-best-command.test.ts`, `test/codex-manager-report-command.test.ts`.

## Docs and Governance Checklist

- [ ] README updated — not needed; no capability or flag surface changes, only the accuracy of `forecast`/`best`/`report` availability
- [ ] `docs/getting-started.md` updated — onboarding unchanged
- [ ] `docs/features.md` updated — capability surface unchanged
- [ ] relevant `docs/reference/*` pages updated — no commands, settings, or paths changed
- [ ] `docs/upgrade.md` updated — no migration behavior
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment — no impact

## Risk and Rollback

- **Risk level: low.** Behavior changes only for callers that pass a model, all of which #670 introduced and none of which have shipped. Model-less callers (`status`, `fix`) take a separate branch and are byte-identical, pinned by test. The new helper is additive; nothing existing changed signature or semantics.
- **Rollback plan:** revert this commit. `fix/forecast-model-family` returns to its current state with no other branch depending on `getRateLimitResetTimeForModel`.

## Additional Notes

- After both this and #671 land, `getRateLimitResetTimeForModel` and `getAccountRecoveryTimeForFamily` sit side by side with similar key selection. They differ deliberately — the latter folds in cooldown and circuit deadlines for the 503, the former is rate-limit-only for the forecast — but a follow-up could factor out the shared key-set resolution if the duplication starts to drift.
- `context.model` in the proxy is the raw body model, while forecast passes the normalized id. They agree for canonical ids, which is what both the CLI defaults and real codex traffic use; a client sending an alias could still key a record the forecast does not name. Pre-existing on `main`, out of scope here, noted so it is not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYnWb16vmd1XdS33GPtdxi

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds pinned-account recovery metadata and attempts to align forecast availability with the requested model family.

- adds pin-source, reset timestamp, and retry-delay fields to pinned 503 responses
- combines exact rate-limit, cooldown, and circuit deadlines for pinned recovery
- threads explicit model families through forecast, best, and report, but does not thread the model needed for exact runtime parity
- adds vitest coverage for family selection and pinned recovery, but misses sibling-model and overlapping-reset forecast cases

<h3>Confidence Score: 4/5</h3>

this pr should not merge until explicit-model forecasts use the same exact rate-limit keys and latest gating reset as runtime selection.

forecast, best, and report still aggregate sibling model records and choose the earliest family reset, so their availability and recommendations can disagree with the runtime proxy.

**Files Needing Attention:** lib/forecast.ts and the forecast input wiring in best.ts, forecast.ts, and report.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/forecast.ts | family-aware evaluation remains unable to distinguish sibling model records or compute the latest exact gating reset. |
| lib/runtime/account-status.ts | the new pinned-recovery helper correctly resolves exact family/model keys and cooldowns, but forecast does not use equivalent semantics. |
| lib/runtime-rotation-proxy.ts | pinned 503 responses now aggregate persisted and circuit recovery deadlines while suppressing them for permanent blockers; no concrete concurrency defect was established. |
| lib/request/rate-limit-decision.ts | pinned error bodies safely format bounded reset timestamps and distinguish forced from manual pin remedies without exposing tokens. |
| lib/codex-manager/commands/best.ts | explicit family threading is present, but omission of the normalized model leaves recommendations exposed to the forecast mismatch. |
| lib/codex-manager/commands/forecast.ts | explicit model families are resolved while the normalized model itself is not supplied to evaluation. |
| lib/codex-manager/commands/report.ts | report forwards the inspected family but not the model required for exact rate-limit key selection. |
| test/forecast.test.ts | vitest covers cross-family behavior but misses sibling-model isolation and latest-overlapping-reset behavior. |
| test/runtime-rotation-proxy.test.ts | vitest covers direct 429, cooldown, circuit, forced-pin, and permanent-blocker recovery responses. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[explicit model] --> B[forecast passes family only]
  B --> C[scan family and all sibling keys]
  C --> D[earliest reset and forecast result]
  A --> E[runtime passes family and model]
  E --> F[check family key and exact model key]
  F --> G[latest gating reset and selection]
  D -. mismatch .-> G
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Freview-670-671%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freview-670-671%22.%0A%0AGreploop%20ndycode%2Fcodex-multi-auth%20PR%20%23672%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=ndycode%2Fcodex-multi-auth&pr=672&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Freview-670-671%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freview-670-671%22.%0A%0A%23%23%23%20Issue%201%0Alib%2Fforecast.ts%3A252-256%0A**model-specific%20forecast%20gating%20is%20broken**%0A%0AWhen%20an%20explicit%20model%20has%20a%20sibling%20model%E2%80%99s%20rate-limit%20record%20or%20overlapping%20family%20and%20exact-model%20records%2C%20this%20family-wide%20helper%20scans%20every%20sibling%20key%20and%20selects%20the%20earliest%20reset%2C%20while%20runtime%20selection%20checks%20only%20the%20family%20and%20exact%20model%20keys%20until%20the%20latest%20gate%20expires.%20This%20makes%20%60forecast%60%2C%20%60best%60%2C%20and%20%60report%60%20report%20incorrect%20availability%20or%20wait%20times%2C%20and%20%60best%60%20can%20recommend%20the%20wrong%20account.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Fcodex-multi-auth&pr=672&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/forecast.ts:252-256
**model-specific forecast gating is broken**

When an explicit model has a sibling model’s rate-limit record or overlapping family and exact-model records, this family-wide helper scans every sibling key and selects the earliest reset, while runtime selection checks only the family and exact model keys until the latest gate expires. This makes `forecast`, `best`, and `report` report incorrect availability or wait times, and `best` can recommend the wrong account.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(forecast,runtime): keep the default ..."](https://github.com/ndycode/codex-multi-auth/commit/63c83bcc51548b350212fc39856c010943d489ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53750935)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Account rotation, selection, and routing mutex](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/account-rotation.md)
- Knowledge Base — [Quota, Usage, and Budget Tracking](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/quota-usage.md)
- Knowledge Base — [Request Pipeline](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/request-pipeline.md)
</details>

<!-- /greptile_comment -->