### PR TITLE
fix: repair five latent runtime defects (inert budget caps on both paths, stale session affinity, policy key collision, stream backpressure)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -141,6 +141,15 @@ import {
 	type RuntimeUsageRecorder,
 	type RuntimeUsageRecordInput,
 } from "./lib/policy/runtime-policy.js";
+import { createStreamUsageDeferral } from "./lib/usage/stream-usage-deferral.js";
+
+/**
+ * How long a streaming request's usage-ledger row may wait for the upstream
+ * `usage` event before it is written without token counts. Long enough not to
+ * truncate a genuinely slow completion; the timer is unref'd so it never holds
+ * the process open. See createStreamUsageDeferral.
+ */
+const USAGE_STREAM_RECORD_FALLBACK_MS = 15 * 60_000;
 import {
 	getModelFamily,
 	MODEL_FAMILIES,
@@ -943,6 +952,20 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 						): Promise<Response> {
 							let usageRecorder: RuntimeUsageRecorder | null = null;
 							let usageCompletion: RuntimeUsageRecordInput | null = null;
+							// A non-streaming response reports its token counts while
+							// handleSuccessResponse is still assembling the body, so they
+							// are folded straight into usageCompletion below. A streaming
+							// one reports them only as the client drains the body, long
+							// after the `finally` that writes the row — so that row is
+							// handed to the deferral instead of written empty.
+							const usageDeferral = createStreamUsageDeferral<RuntimeUsageRecordInput>(
+								{
+									record: (completion) => {
+										void usageRecorder?.record(completion);
+									},
+									fallbackMs: USAGE_STREAM_RECORD_FALLBACK_MS,
+								},
+							);
 							try {
 								if (
 									cachedAccountManager &&
@@ -2740,6 +2763,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 														);
 														storedResponseIdForSuccess = true;
 													},
+													onUsage: usageDeferral.onUsage,
 													streamStallTimeoutMs,
 												},
 											);
@@ -2887,7 +2911,20 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 														successAccountForResponse.accountId ?? null,
 													email: successAccountForResponse.email ?? null,
 												},
+												// Already known for a non-streaming response, which
+												// reported its usage while the body was being
+												// assembled above.
+												...(usageDeferral.captured() ?? {}),
 											};
+											if (isStreaming && !usageDeferral.captured()) {
+												// Writing the row in the `finally` below would stamp
+												// zero tokens — the client has not read a byte yet —
+												// and the ledger is append-only, so the real counts
+												// could never correct it. Zero tokens is exactly what
+												// left maxTokens / maxCostUsd unenforceable here.
+												usageDeferral.defer(usageCompletion);
+												usageCompletion = null;
+											}
 											if (
 												lastCodexCliActiveSyncIndex !==
 												successAccountForResponse.index

--- a/lib/account-policy.ts
+++ b/lib/account-policy.ts
@@ -107,13 +107,28 @@ export function getAccountPolicyPath(): string {
 }
 
 export function getAccountPolicyKey(
-	account: Pick<AccountMetadataV3, "accountId" | "email">,
+	account: Pick<AccountMetadataV3, "accountId" | "email"> & {
+		refreshToken?: string | null;
+	},
 	_index?: number,
 ): string {
+	// The key must be stable across processes and independent of the account's
+	// slot (policy state is persisted and survives reordering), so it is derived
+	// from identity, never from `_index`.
+	//
+	// An account whose accountId AND email are both missing — freshly imported,
+	// or not yet hydrated from its token — used to hash the literal "unknown",
+	// which gave EVERY such account the same key: pausing, draining or tagging
+	// one silently applied to all of them. Fall back to the refresh token
+	// instead, which every account has and no two accounts share. It is
+	// namespaced before hashing so a token value can never collide with an
+	// email or accountId of the same text, and only its digest is persisted.
+	// Mirrors getAccountIdentityKey's `allowRefreshFallback`.
+	const refreshFallback = account.refreshToken?.trim();
 	const identity =
 		account.accountId?.trim() ||
 		account.email?.trim().toLowerCase() ||
-		"unknown";
+		(refreshFallback ? `refresh:${refreshFallback}` : "unknown");
 	return `sha256:${createHash("sha256").update(identity).digest("hex")}`;
 }
 

--- a/lib/codex-manager/login-flow.ts
+++ b/lib/codex-manager/login-flow.ts
@@ -460,6 +460,13 @@ async function runAuthLoginFlow(
 								parsed: targetIndex + 1,
 								switchReason: "restore",
 								preserveActiveIndexByFamily: true,
+								// A restore replaces the whole account list, so every
+								// index moves. Session affinity remembers accounts BY
+								// INDEX, so without this a live proxy keeps routing
+								// in-flight sessions to whatever now occupies the old
+								// slot. `switch`/`best` already bump for a single
+								// move; a restore moves everything. See issue #474.
+								bumpAffinityGeneration: true,
 							});
 							console.log(
 								UI_COPY.oauth.restoreBackupLoaded(

--- a/lib/codex-manager/login-menu-actions.ts
+++ b/lib/codex-manager/login-menu-actions.ts
@@ -5,6 +5,7 @@ import { MODEL_FAMILIES } from "../prompts/codex.js";
 import {
 	type AccountMetadataV3,
 	type AccountStorageV3,
+	bumpStorageAffinityGeneration,
 	findMatchingAccountIndex,
 	loadAccounts,
 	reconcilePinnedAccountIndex,
@@ -350,6 +351,12 @@ export async function handleManageAction(
 					pinnedAccount,
 					nextStorage.accounts,
 				);
+				// The splice shifts every index above the removed slot, and session
+				// affinity remembers accounts BY INDEX. Without a generation bump a
+				// live proxy keeps routing in-flight sessions to the account that
+				// slid into the old slot. Reconciling the pin is not enough — the
+				// affinity map is separate state. See issue #474.
+				bumpStorageAffinityGeneration(nextStorage);
 				await persist(nextStorage);
 				replaceManageActionStorage(storage, nextStorage);
 				deleted = true;

--- a/lib/policy/runtime-policy.ts
+++ b/lib/policy/runtime-policy.ts
@@ -30,6 +30,13 @@ export interface RuntimePolicyAccount {
 	index: number;
 	accountId?: string | null;
 	email?: string | null;
+	/**
+	 * Only used to key account policy for an account with no accountId and no
+	 * email. Without it the runtime would key such an account as "unknown"
+	 * while the CLI keys it by refresh-token digest, and pause/drain/tag state
+	 * written by one would be invisible to the other.
+	 */
+	refreshToken?: string | null;
 }
 
 export interface RuntimePolicyDecision {
@@ -184,6 +191,7 @@ export async function evaluateRuntimePolicy(input: {
 			{
 				accountId: account.accountId ?? undefined,
 				email: account.email ?? undefined,
+				refreshToken: account.refreshToken ?? undefined,
 			},
 			account.index,
 		);

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -17,6 +17,7 @@ import {
 	ensureContentType,
 } from "./response-handler.js";
 import type { UserConfig, RequestBody } from "../types.js";
+import type { UsageTokenCounts } from "../usage/types.js";
 import { isRecord } from "../utils.js";
 import {
 	HTTP_STATUS,
@@ -285,6 +286,12 @@ export async function handleSuccessResponse(
     isStreaming: boolean,
     options?: {
 		onResponseId?: (responseId: string) => void;
+		/**
+		 * Reports the upstream token counts once they are known, for the usage
+		 * ledger. Fires from the SSE tee on the streaming path and from the
+		 * assembled response on the non-streaming path.
+		 */
+		onUsage?: (usage: UsageTokenCounts) => void;
 		streamStallTimeoutMs?: number;
 	},
 ): Promise<Response> {
@@ -299,7 +306,12 @@ export async function handleSuccessResponse(
 	}
 
 	// For streaming requests (streamText), return stream as-is
-	return attachResponseIdCapture(response, responseHeaders, options?.onResponseId);
+	return attachResponseIdCapture(
+		response,
+		responseHeaders,
+		options?.onResponseId,
+		options?.onUsage,
+	);
 }
 
 async function safeReadBody(response: Response): Promise<string> {

--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -1,9 +1,10 @@
 import { createLogger, logRequest, LOGGING_ENABLED } from "../logger.js";
 import { HTTP_STATUS, PLUGIN_NAME } from "../constants.js";
 import { isRecord } from "../utils.js";
+import { extractResponsesUsage } from "../usage/usage-extraction.js";
+import type { UsageTokenCounts } from "../usage/types.js";
 
 import type { SSEEventData } from "../types.js";
-
 const log = createLogger("response-handler");
 
 const MAX_SSE_SIZE = 10 * 1024 * 1024; // 10MB limit to prevent memory exhaustion
@@ -785,6 +786,7 @@ export async function convertSseToJson(
 	headers: Headers,
 	options?: {
 		onResponseId?: (responseId: string) => void;
+		onUsage?: (usage: UsageTokenCounts) => void;
 		streamStallTimeoutMs?: number;
 	},
 ): Promise<Response> {
@@ -887,9 +889,16 @@ export async function convertSseToJson(
 				headers: headers,
 			});
 		}
-
 		logStreamDiagnostics(finalResponse);
 
+		if (options?.onUsage) {
+			// The non-streaming branch already holds the assembled response, so
+			// the token counts come straight off it. Reported even though the
+			// caller sees JSON rather than SSE: the usage ledger (and therefore
+			// the maxTokens / maxCostUsd budget caps) needs both shapes.
+			const usage = extractResponsesUsage(finalResponse);
+			if (usage) options.onUsage(usage);
+		}
 		// Return as plain JSON (not SSE)
 		const jsonHeaders = new Headers(headers);
 		jsonHeaders.set("content-type", "application/json; charset=utf-8");
@@ -914,7 +923,8 @@ export async function convertSseToJson(
 
 function createResponseIdCapturingStream(
 	body: ReadableStream<Uint8Array>,
-	onResponseId: (responseId: string) => void,
+	onResponseId?: (responseId: string) => void,
+	onUsage?: (usage: UsageTokenCounts) => void,
 ): ReadableStream<Uint8Array> {
 	const decoder = new TextDecoder();
 	let bufferedText = "";
@@ -937,7 +947,17 @@ function createResponseIdCapturingStream(
 			if (!payload || payload === "[DONE]") continue;
 			try {
 				const data = JSON.parse(payload) as SSEEventData;
-				maybeCaptureResponseEvent(state, data, onResponseId);
+				if (onResponseId) {
+					maybeCaptureResponseEvent(state, data, onResponseId);
+				}
+				if (onUsage) {
+					// Reuse the JSON this loop already parsed rather than scanning
+					// the stream twice. Without these counts every usage-ledger row
+					// lands with zero tokens and zero cost, which silently disables
+					// the maxTokens / maxCostUsd budget caps.
+					const usage = extractResponsesUsage(data);
+					if (usage) onUsage(usage);
+				}
 				if (state.encounteredError) break;
 			} catch (error) {
 				// AUDIT-H9 / H-03: stream passthrough. The raw bytes still
@@ -1067,8 +1087,9 @@ export function attachResponseIdCapture(
 	response: Response,
 	headers: Headers,
 	onResponseId?: (responseId: string) => void,
+	onUsage?: (usage: UsageTokenCounts) => void,
 ): Response {
-	if (!response.body || !onResponseId) {
+	if (!response.body || (!onResponseId && !onUsage)) {
 		return new Response(response.body, {
 			status: response.status,
 			statusText: response.statusText,
@@ -1077,7 +1098,7 @@ export function attachResponseIdCapture(
 	}
 
 	return new Response(
-		createResponseIdCapturingStream(response.body, onResponseId),
+		createResponseIdCapturingStream(response.body, onResponseId, onUsage),
 		{
 			status: response.status,
 			statusText: response.statusText,

--- a/lib/request/stream-failover-runtime.ts
+++ b/lib/request/stream-failover-runtime.ts
@@ -146,6 +146,13 @@ export async function forwardStreamingResponse(
 	status: RuntimeRotationProxyStatus,
 	onStreamError: () => void,
 	streamStallTimeoutMs: number,
+	/**
+	 * Observe each forwarded chunk. Used to recover the upstream `usage` totals
+	 * for the usage ledger without buffering the body; it must not mutate the
+	 * chunk and is called before the write, so a slow observer delays the
+	 * forward. Implementations are expected to swallow their own errors.
+	 */
+	onChunk?: (chunk: Uint8Array) => void,
 ): Promise<boolean> {
 	status.streamsStarted += 1;
 	res.writeHead(
@@ -175,6 +182,7 @@ export async function forwardStreamingResponse(
 			);
 			if (done) break;
 			if (value && value.byteLength > 0) {
+				onChunk?.(value);
 				// If the response is already finished (clean end by a concurrent
 				// close-then-reader-cancel path), stop writing. Do NOT guard on
 				// res.destroyed here: a socket-error-during-backpressure scenario sets

--- a/lib/request/stream-failover.ts
+++ b/lib/request/stream-failover.ts
@@ -144,6 +144,34 @@ export function withStreamingFailover(
 
 	let closed = false;
 	let releaseCurrentReaderForCancel: (() => Promise<void>) | null = null;
+	// Backpressure. `pump()` runs from `start()` as a free-running loop, so
+	// without a demand signal it enqueues every chunk upstream delivers as fast
+	// as it arrives and the whole stream buffers in memory for a slow consumer.
+	// `pull()` (and cancellation) release the loop; the sibling forwarder in
+	// stream-failover-runtime.ts gets the same guarantee from waitForDrain.
+	let demandWaiter: (() => void) | null = null;
+	let demandPending = false;
+	const signalDemand = (): void => {
+		if (demandWaiter) {
+			demandWaiter();
+			return;
+		}
+		// `pull()` can fire before the loop parks. Latch it, or the next
+		// awaitDemand() would block on a signal that already happened.
+		demandPending = true;
+	};
+	const awaitDemand = (): Promise<void> => {
+		if (demandPending || closed) {
+			demandPending = false;
+			return Promise.resolve();
+		}
+		return new Promise<void>((resolve) => {
+			demandWaiter = () => {
+				demandWaiter = null;
+				resolve();
+			};
+		});
+	};
 	const body = new ReadableStream<Uint8Array>({
 		start(controller) {
 			let currentReader = initialResponse.body?.getReader() ?? null;
@@ -205,6 +233,15 @@ export function withStreamingFailover(
 						if (result.value && result.value.byteLength > 0) {
 							emittedBytes += result.value.byteLength;
 							controller.enqueue(result.value);
+							// Park until the consumer asks for more. desiredSize is
+							// null once the controller is errored or closed, and the
+							// loop's own `closed` checks cover that case.
+							if (
+								typeof controller.desiredSize === "number" &&
+								controller.desiredSize <= 0
+							) {
+								await awaitDemand();
+							}
 						}
 					} catch (error) {
 						let switched = false;
@@ -235,8 +272,14 @@ export function withStreamingFailover(
 				}
 			});
 		},
+		pull() {
+			signalDemand();
+		},
 		cancel() {
 			closed = true;
+			// Release a parked pump so it observes `closed` and unwinds instead
+			// of holding the upstream reader open for a demand that never comes.
+			signalDemand();
 			if (releaseCurrentReaderForCancel) {
 				void releaseCurrentReaderForCancel();
 			}

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -49,6 +49,7 @@ import {
 	loadRuntimePolicyState,
 	type RuntimePolicyDecision,
 } from "./policy/runtime-policy.js";
+import { createUsageStreamScanner } from "./usage/usage-extraction.js";
 import { isWorkspaceDisabledError } from "./request/fetch-helpers.js";
 import {
 	PreemptiveQuotaScheduler,
@@ -1564,6 +1565,14 @@ async function handleRequestInner(
 				state.schedulingStrategy,
 			);
 
+			// Recover the upstream token counts as the body streams past. Without
+			// them every ledger row lands with all-zero tokens and a zero cost, so
+			// evaluateBudgetGuard compares `0 >= limit` for maxTokens/maxCostUsd
+			// and those caps never fire — `budget set --cost 50` would allow
+			// unlimited spend, with only --requests actually enforced.
+			const usageScanner = createUsageStreamScanner({
+				contentType: upstream.headers.get("content-type"),
+			});
 			const forwarded = await forwardStreamingResponse(
 				upstream,
 				res,
@@ -1589,12 +1598,17 @@ async function handleRequestInner(
 					accountManager.saveToDiskDebounced();
 				},
 				state.streamStallTimeoutMs,
+				usageScanner.push,
 			);
+			// A stream that broke mid-flight still bills for whatever the upstream
+			// reported before the break, so record the counts on both outcomes.
+			const usageTokens = usageScanner.result();
 			await usageRecorder.record({
 				outcome: forwarded ? "success" : "failure",
 				statusCode: upstream.status,
 				errorCode: forwarded ? null : "stream_forward_failed",
 				account: refreshed.account,
+				...(usageTokens ?? {}),
 			});
 			return;
 		}

--- a/lib/runtime/account-check.ts
+++ b/lib/runtime/account-check.ts
@@ -4,6 +4,7 @@ import { isCodexUnavailableError } from "../errors.js";
 import type { ModelFamily } from "../prompts/codex.js";
 import {
 	type AccountStorageV3,
+	bumpStorageAffinityGeneration,
 	type FlaggedAccountMetadataV1,
 	reconcilePinnedAccountIndex,
 } from "../storage.js";
@@ -339,6 +340,13 @@ export async function runRuntimeAccountCheck(
 			pinnedAccount,
 			workingStorage.accounts,
 		);
+		// The filter can drop several accounts at once, shifting every index
+		// after each hole. Session affinity remembers accounts BY INDEX, so
+		// without a generation bump a live proxy keeps routing in-flight
+		// sessions to whatever now occupies the old slot — and this path is
+		// AUTOMATIC (revoked-token accounts are removed without a prompt), so
+		// nothing else invalidates the affinity map. See issue #474.
+		bumpStorageAffinityGeneration(workingStorage);
 		state.storageChanged = true;
 	}
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1351,6 +1351,40 @@ export function readAffinityGenerationFromDisk(path: string): number {
 }
 
 /**
+ * Advance the session-affinity generation so a running runtime proxy drops its
+ * sticky session→account bindings on the next request.
+ *
+ * Session affinity remembers an account by ITS INDEX, so any mutation that
+ * reshuffles the pool (removing an account, restoring a backup) silently
+ * re-points every live session at a different account until the generation
+ * changes. `switch`/`best`/`unpin` already bump it; the reshuffling paths are
+ * the ones that need it most, because they move every index at once.
+ *
+ * Re-reads the on-disk generation first so concurrent CLI processes do not lose
+ * increments via lost-update on the load+mutate pair. `Math.max` keeps the
+ * counter monotonic: an extra bump only costs one additional affinity
+ * invalidation, while a missed bump lets the proxy cling to the wrong account.
+ * See issue #474.
+ */
+export function bumpStorageAffinityGeneration(
+	storage: { affinityGeneration?: number },
+	storagePath?: string | null,
+): number {
+	let diskGeneration = 0;
+	try {
+		const path = storagePath ?? getStoragePath();
+		if (path) diskGeneration = readAffinityGenerationFromDisk(path);
+	} catch {
+		// No resolvable storage path (never configured). The in-memory counter
+		// is still bumped below; only the lost-update guard is unavailable.
+	}
+	const inMemoryGeneration = storage.affinityGeneration ?? 0;
+	const next = Math.max(inMemoryGeneration, diskGeneration) + 1;
+	storage.affinityGeneration = next;
+	return next;
+}
+
+/**
  * Synchronously reads both the top-level `pinnedAccountIndex` and
  * `affinityGeneration` fields from the accounts storage file. Used by
  * `AccountManager.buildStorageSnapshot` to refresh from disk just before

--- a/lib/usage/index.ts
+++ b/lib/usage/index.ts
@@ -2,4 +2,4 @@ export * from "./types.js";
 export * from "./pricing.js";
 export * from "./redaction.js";
 export * from "./ledger.js";
-
+export * from "./usage-extraction.js";

--- a/lib/usage/index.ts
+++ b/lib/usage/index.ts
@@ -3,3 +3,4 @@ export * from "./pricing.js";
 export * from "./redaction.js";
 export * from "./ledger.js";
 export * from "./usage-extraction.js";
+export * from "./stream-usage-deferral.js";

--- a/lib/usage/stream-usage-deferral.ts
+++ b/lib/usage/stream-usage-deferral.ts
@@ -1,0 +1,75 @@
+import type { UsageTokenCounts } from "./types.js";
+
+export interface StreamUsageDeferral<TRow> {
+	/** Latest counts reported by upstream, or null if none have arrived. */
+	captured: () => UsageTokenCounts | null;
+	/** Feed upstream-reported counts. Writes a deferred row immediately. */
+	onUsage: (usage: UsageTokenCounts) => void;
+	/**
+	 * Hand over a row to be written once upstream reports its counts, or after
+	 * `fallbackMs` without them. Only the first pending row is held.
+	 */
+	defer: (completion: TRow) => void;
+}
+
+/**
+ * Holds a usage-ledger row open until a streaming response reports its tokens.
+ *
+ * A streaming request's row would otherwise be written when the request handler
+ * returns its Response — before the client has read a byte, and therefore
+ * before the upstream `usage` event exists. The ledger is append-only, so that
+ * row could never be corrected: it would stand at zero tokens and zero cost
+ * forever, which is what silently disables the `maxTokens` and `maxCostUsd`
+ * budget caps (`evaluateBudgetGuard` compares `0 >= limit`).
+ *
+ * The fallback timer is not optional bookkeeping. A client that disconnects
+ * mid-stream, or an upstream that never emits a terminal usage event, must
+ * still cost one row, because `maxRequests` counts rows — losing it would
+ * weaken a cap that currently works.
+ *
+ * Generic over the row type so this stays inside `lib/usage` rather than
+ * importing the policy layer that imports it back.
+ */
+export function createStreamUsageDeferral<TRow extends object>(options: {
+	record: (completion: TRow & Partial<UsageTokenCounts>) => void;
+	fallbackMs: number;
+	/** Injectable for tests; defaults to an unref'd setTimeout. */
+	schedule?: (run: () => void, ms: number) => { cancel: () => void };
+}): StreamUsageDeferral<TRow> {
+	const schedule =
+		options.schedule ??
+		((run, ms) => {
+			const timer = setTimeout(run, ms);
+			// Never hold the process open for a row that is only a fallback.
+			timer.unref?.();
+			return { cancel: () => clearTimeout(timer) };
+		});
+
+	let captured: UsageTokenCounts | null = null;
+	let pending: TRow | null = null;
+	let timer: { cancel: () => void } | null = null;
+
+	const flush = (usage: UsageTokenCounts | null): void => {
+		const completion = pending;
+		pending = null;
+		timer?.cancel();
+		timer = null;
+		if (!completion) return;
+		options.record(usage ? { ...completion, ...usage } : completion);
+	};
+
+	return {
+		captured: () => captured,
+		onUsage: (usage) => {
+			captured = usage;
+			flush(usage);
+		},
+		defer: (completion) => {
+			// A second defer would orphan the first row's timer, so keep the row
+			// already in flight and let it settle on its own terms.
+			if (pending) return;
+			pending = completion;
+			timer = schedule(() => flush(null), options.fallbackMs);
+		},
+	};
+}

--- a/lib/usage/usage-extraction.ts
+++ b/lib/usage/usage-extraction.ts
@@ -1,0 +1,192 @@
+import type { UsageTokenCounts } from "./types.js";
+
+/**
+ * Extracting token counts from upstream Responses API traffic.
+ *
+ * Without this the usage ledger records every request with all-zero tokens and
+ * a zero cost, which silently disables the `maxTokens` / `maxCostUsd` budget
+ * caps: `evaluateBudgetGuard` compares `0 >= limit`, which never fires, so
+ * `codex-multi-auth budget set --cost 50` allows unlimited spend and only
+ * `--requests` actually enforces anything.
+ */
+
+/** Cap on retained bytes so a hostile or unterminated body cannot grow forever. */
+const MAX_BUFFERED_BYTES = 1_048_576;
+/** Terminal Responses stream events that carry the final `usage` object. */
+const TERMINAL_EVENT_TYPES = new Set([
+	"response.completed",
+	"response.incomplete",
+	"response.failed",
+	"response.done",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonNegativeInteger(value: unknown): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+	return Math.max(0, Math.trunc(value));
+}
+
+/**
+ * Read an OpenAI Responses `usage` object into the ledger's token shape.
+ *
+ * Two containment rules drive the mapping, and getting either backwards
+ * mis-prices every row:
+ *
+ * - `input_tokens_details.cached_tokens` is a SUBSET of `input_tokens`, and
+ *   `estimateUsageCostUsd` already subtracts it (`billableInputTokens`), so
+ *   both are passed through raw.
+ * - `output_tokens_details.reasoning_tokens` is likewise a SUBSET of
+ *   `output_tokens`, but `estimateUsageCostUsd` prices `outputTokens` and
+ *   `reasoningTokens` as DISJOINT buckets and sums them. Passing the raw
+ *   `output_tokens` alongside the reasoning count would bill reasoning twice,
+ *   so the reasoning share is subtracted out here.
+ */
+export function extractUsageTokenCounts(
+	usage: unknown,
+): UsageTokenCounts | null {
+	if (!isRecord(usage)) return null;
+	const hasAnyCount =
+		typeof usage.input_tokens === "number" ||
+		typeof usage.output_tokens === "number" ||
+		typeof usage.total_tokens === "number";
+	if (!hasAnyCount) return null;
+
+	const inputTokens = nonNegativeInteger(usage.input_tokens);
+	const rawOutputTokens = nonNegativeInteger(usage.output_tokens);
+	const cachedInputTokens = isRecord(usage.input_tokens_details)
+		? Math.min(inputTokens, nonNegativeInteger(usage.input_tokens_details.cached_tokens))
+		: 0;
+	const reasoningTokens = isRecord(usage.output_tokens_details)
+		? Math.min(
+				rawOutputTokens,
+				nonNegativeInteger(usage.output_tokens_details.reasoning_tokens),
+			)
+		: 0;
+	const providedTotal =
+		typeof usage.total_tokens === "number" && Number.isFinite(usage.total_tokens)
+			? Math.max(0, Math.trunc(usage.total_tokens))
+			: inputTokens + rawOutputTokens;
+
+	return {
+		inputTokens,
+		outputTokens: rawOutputTokens - reasoningTokens,
+		cachedInputTokens,
+		reasoningTokens,
+		totalTokens: providedTotal,
+	};
+}
+
+/**
+ * Pull the `usage` object out of a Responses payload, whether it arrived as a
+ * bare response object (non-streaming) or wrapped in a stream event envelope.
+ */
+export function extractResponsesUsage(payload: unknown): UsageTokenCounts | null {
+	if (!isRecord(payload)) return null;
+	const direct = extractUsageTokenCounts(payload.usage);
+	if (direct) return direct;
+	if (isRecord(payload.response)) {
+		return extractUsageTokenCounts(payload.response.usage);
+	}
+	return null;
+}
+
+export interface UsageStreamScanner {
+	/** Feed one forwarded chunk. Never throws. */
+	push: (chunk: Uint8Array) => void;
+	/** Flush any trailing partial data and return the final counts, if any. */
+	result: () => UsageTokenCounts | null;
+}
+
+/**
+ * Observe a forwarded response body and recover its token counts.
+ *
+ * SSE bodies are scanned line by line so only the current partial line is
+ * retained; a full response can be gigabytes of deltas and must never be
+ * buffered. Non-SSE JSON bodies have no incremental structure to exploit, so
+ * they are accumulated up to `MAX_BUFFERED_BYTES` and parsed at the end —
+ * beyond that cap the scanner gives up on usage rather than grow without
+ * bound.
+ */
+export function createUsageStreamScanner(options: {
+	contentType?: string | null;
+}): UsageStreamScanner {
+	const sse = (options.contentType ?? "").toLowerCase().includes("text/event-stream");
+	const decoder = new TextDecoder("utf-8");
+	let pending = "";
+	let bufferedBytes = 0;
+	let overflowed = false;
+	let latest: UsageTokenCounts | null = null;
+
+	const consumeLine = (line: string): void => {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith("data:")) return;
+		const payload = trimmed.slice("data:".length).trim();
+		if (payload.length === 0 || payload === "[DONE]") return;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(payload);
+		} catch {
+			return;
+		}
+		// Prefer terminal events, which carry the authoritative totals, but fall
+		// back to any event that reports usage so a stream that ends on a
+		// non-standard terminal type still records something.
+		const type = isRecord(parsed) ? parsed.type : undefined;
+		const isTerminal = typeof type === "string" && TERMINAL_EVENT_TYPES.has(type);
+		const counts = extractResponsesUsage(parsed);
+		if (counts && (isTerminal || latest === null)) {
+			latest = counts;
+		}
+	};
+
+	return {
+		push: (chunk) => {
+			try {
+				if (overflowed || chunk.byteLength === 0) return;
+				bufferedBytes += chunk.byteLength;
+				pending += decoder.decode(chunk, { stream: true });
+				if (!sse) {
+					if (bufferedBytes > MAX_BUFFERED_BYTES) {
+						overflowed = true;
+						pending = "";
+					}
+					return;
+				}
+				let newlineAt = pending.indexOf("\n");
+				while (newlineAt !== -1) {
+					consumeLine(pending.slice(0, newlineAt));
+					pending = pending.slice(newlineAt + 1);
+					newlineAt = pending.indexOf("\n");
+				}
+				// A single unterminated line this long is not SSE any more; stop
+				// retaining it rather than growing the buffer for the whole body.
+				if (pending.length > MAX_BUFFERED_BYTES) {
+					overflowed = true;
+					pending = "";
+				}
+			} catch {
+				// Usage accounting must never break the forwarded response.
+			}
+		},
+		result: () => {
+			try {
+				if (overflowed) return latest;
+				pending += decoder.decode();
+				if (sse) {
+					if (pending.length > 0) consumeLine(pending);
+					pending = "";
+					return latest;
+				}
+				if (pending.trim().length === 0) return latest;
+				const parsed: unknown = JSON.parse(pending);
+				pending = "";
+				return extractResponsesUsage(parsed) ?? latest;
+			} catch {
+				return latest;
+			}
+		},
+	};
+}

--- a/test/account-policy.test.ts
+++ b/test/account-policy.test.ts
@@ -81,5 +81,47 @@ describe("account policy store", () => {
 			getAccountPolicyKey(unidentified, 4),
 		);
 	});
+
+	it("separates two accounts that have neither an accountId nor an email", async () => {
+		const { getAccountPolicyKey } = await import("../lib/account-policy.js");
+
+		// Both used to hash the literal "unknown" and share one policy entry, so
+		// pausing, draining or tagging either one silently applied to both.
+		expect(
+			getAccountPolicyKey({ refreshToken: "refresh-a" }, 0),
+		).not.toBe(getAccountPolicyKey({ refreshToken: "refresh-b" }, 1));
+	});
+
+	it("keeps the refresh-token fallback key stable across slots", async () => {
+		const { getAccountPolicyKey } = await import("../lib/account-policy.js");
+		const account = { refreshToken: "refresh-a" };
+
+		// Policy state is persisted and survives reordering, so the key must not
+		// move when the account does.
+		expect(getAccountPolicyKey(account, 0)).toBe(getAccountPolicyKey(account, 6));
+	});
+
+	it("prefers a real identity over the refresh-token fallback", async () => {
+		const { getAccountPolicyKey } = await import("../lib/account-policy.js");
+		const withId = { accountId: "acc_1", refreshToken: "refresh-a" };
+		const withEmail = { email: "user@example.com", refreshToken: "refresh-a" };
+
+		// Hydrating an account's identity must not orphan its existing policy.
+		expect(getAccountPolicyKey(withId)).toBe(
+			getAccountPolicyKey({ accountId: "acc_1", refreshToken: "refresh-z" }),
+		);
+		expect(getAccountPolicyKey(withEmail)).toBe(
+			getAccountPolicyKey({ email: "USER@example.com", refreshToken: "refresh-z" }),
+		);
+		expect(getAccountPolicyKey(withId)).not.toBe(getAccountPolicyKey(withEmail));
+	});
+
+	it("namespaces the refresh token so it cannot collide with an email", async () => {
+		const { getAccountPolicyKey } = await import("../lib/account-policy.js");
+
+		expect(getAccountPolicyKey({ refreshToken: "user@example.com" })).not.toBe(
+			getAccountPolicyKey({ email: "user@example.com", refreshToken: "refresh-a" }),
+		);
+	});
 });
 

--- a/test/affinity-generation.test.ts
+++ b/test/affinity-generation.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { bumpStorageAffinityGeneration } from "../lib/storage.js";
+
+function tempStoragePath(): string {
+	return join(mkdtempSync(join(tmpdir(), "cma-affinity-")), "accounts.json");
+}
+
+describe("bumpStorageAffinityGeneration", () => {
+	it("increments the in-memory counter when nothing is on disk yet", () => {
+		const storage = { affinityGeneration: 4 };
+
+		expect(bumpStorageAffinityGeneration(storage, tempStoragePath())).toBe(5);
+		expect(storage.affinityGeneration).toBe(5);
+	});
+
+	it("starts at 1 when the counter was never set", () => {
+		const storage: { affinityGeneration?: number } = {};
+
+		expect(bumpStorageAffinityGeneration(storage, tempStoragePath())).toBe(1);
+	});
+
+	it("takes the max of the in-memory and on-disk counters", () => {
+		const path = tempStoragePath();
+		// Another CLI process advanced the counter after this one loaded storage.
+		// Incrementing the stale in-memory value would hand back 5 and silently
+		// undo that process's invalidation, so a live proxy would keep its
+		// stale session→index bindings.
+		writeFileSync(path, JSON.stringify({ affinityGeneration: 9 }));
+		const storage = { affinityGeneration: 4 };
+
+		expect(bumpStorageAffinityGeneration(storage, path)).toBe(10);
+	});
+
+	it("still bumps when the on-disk counter is unreadable", () => {
+		const path = tempStoragePath();
+		writeFileSync(path, "not json at all");
+		const storage = { affinityGeneration: 2 };
+
+		expect(bumpStorageAffinityGeneration(storage, path)).toBe(3);
+	});
+
+	it("never moves the counter backwards for a lower on-disk value", () => {
+		const path = tempStoragePath();
+		writeFileSync(path, JSON.stringify({ affinityGeneration: 1 }));
+		const storage = { affinityGeneration: 7 };
+
+		expect(bumpStorageAffinityGeneration(storage, path)).toBe(8);
+	});
+});

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -1060,6 +1060,73 @@ describe('createEntitlementErrorResponse', () => {
 			expect(text).toBe('stream body');
 		});
 
+		it('reports streaming usage only once the body is consumed', async () => {
+			const onUsage = vi.fn();
+			const response = new Response(
+				[
+					'data: {"type":"response.output_text.delta","delta":"hi"}',
+					'',
+					'data: {"type":"response.completed","response":{"usage":{"input_tokens":1000,"input_tokens_details":{"cached_tokens":400},"output_tokens":500,"output_tokens_details":{"reasoning_tokens":200},"total_tokens":1500}}}',
+					'',
+				].join('\n'),
+				{ status: 200, headers: new Headers({ 'content-type': 'text/event-stream' }) },
+			);
+
+			const result = await handleSuccessResponse(response, true, { onUsage });
+
+			// The tee only sees bytes the client pulls, so nothing is known yet.
+			// This is why the plugin host defers its usage-ledger row instead of
+			// writing it when the handler returns.
+			expect(onUsage).not.toHaveBeenCalled();
+
+			const text = await result.text();
+
+			// The stream is passed through untouched.
+			expect(text).toContain('response.output_text.delta');
+			expect(onUsage).toHaveBeenCalledTimes(1);
+			expect(onUsage).toHaveBeenCalledWith({
+				inputTokens: 1000,
+				// reasoning_tokens is a SUBSET of output_tokens upstream, but
+				// estimateUsageCostUsd prices the two buckets as disjoint, so it is
+				// subtracted out or every reasoning request is billed twice.
+				outputTokens: 300,
+				cachedInputTokens: 400,
+				reasoningTokens: 200,
+				totalTokens: 1500,
+			});
+		});
+
+		it('reports non-streaming usage before returning, from the assembled response', async () => {
+			const onUsage = vi.fn();
+			const response = new Response(
+				[
+					'data: {"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":10,"output_tokens":4,"total_tokens":14}}}',
+					'',
+				].join('\n'),
+				{ status: 200, headers: new Headers({ 'content-type': 'text/event-stream' }) },
+			);
+
+			await handleSuccessResponse(response, false, { onUsage });
+
+			// The non-streaming branch already holds the whole response, so the
+			// caller can fold the counts straight into its ledger row.
+			expect(onUsage).toHaveBeenCalledWith(
+				expect.objectContaining({ inputTokens: 10, outputTokens: 4, totalTokens: 14 }),
+			);
+		});
+
+		it('leaves the stream untouched when no usage callback is supplied', async () => {
+			const body = 'data: {"type":"response.completed","response":{"usage":{"input_tokens":1}}}\n\n';
+			const response = new Response(body, {
+				status: 200,
+				headers: new Headers({ 'content-type': 'text/event-stream' }),
+			});
+
+			const result = await handleSuccessResponse(response, true);
+
+			expect(await result.text()).toBe(body);
+		});
+
 		it('captures response ids from streaming semantic SSE without rewriting the stream', async () => {
 			const onResponseId = vi.fn();
 			const response = new Response(

--- a/test/login-menu-actions.test.ts
+++ b/test/login-menu-actions.test.ts
@@ -307,6 +307,24 @@ describe("handleManageAction delete", () => {
 		expect(saved.pinnedAccountIndex).toBeUndefined();
 		expect(storage.pinnedAccountIndex).toBeUndefined();
 	});
+
+	it("bumps the affinity generation so a live proxy drops stale session bindings", async () => {
+		const storage = storageWith([account("a"), account("b"), account("c")]);
+		storage.affinityGeneration = 4;
+		loadedStorage = structuredClone(storage);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			deleteAccountIndex: 0,
+		} satisfies MenuResult);
+
+		const saved = persisted[0];
+		// Session affinity is keyed by account INDEX, and the splice shifts every
+		// index above the removed slot. Reconciling the pin is not enough: without
+		// a generation bump the proxy keeps gluing in-flight sessions to whatever
+		// slid into the old slot. See issue #474.
+		expect(saved.affinityGeneration).toBeGreaterThan(4);
+	});
 });
 
 describe("handleManageAction toggle", () => {

--- a/test/runtime-account-check.test.ts
+++ b/test/runtime-account-check.test.ts
@@ -498,13 +498,17 @@ describe("runRuntimeAccountCheck", () => {
 			now: () => now,
 			showLine: vi.fn(),
 		});
-
 		const saved = saveAccounts.mock.calls[0]?.[0];
 		expect(saved.accounts.map((entry) => entry.refreshToken)).toEqual([
 			"r1",
 			"r2",
 		]);
 		expect(saved.pinnedAccountIndex).toBe(1);
+		// The pin is not the only index-keyed state the removal invalidates:
+		// session affinity maps a session to an account INDEX, and this removal
+		// path is AUTOMATIC. Without a generation bump a live proxy keeps routing
+		// in-flight sessions to whatever slid into the removed slot (#474).
+		expect(saved.affinityGeneration).toBeGreaterThan(0);
 	});
 
 	it("clears a manual pin when the pinned account itself is auto-removed on deep probe", async () => {

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -3562,4 +3562,43 @@ describe("chooseAccount sequential mode (issue #509)", () => {
 
 		expect(selected).toBeNull();
 	});
+
+	it("records upstream token usage so the cost and token budget caps can fire", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 1));
+		const recorded: Record<string, unknown>[] = [];
+		vi.spyOn(runtimePolicy, "createRuntimeUsageRecorder").mockImplementation(
+			() => ({
+				hasRecorded: () => recorded.length > 0,
+				record: async (input) => {
+					recorded.push(input as unknown as Record<string, unknown>);
+				},
+			}),
+		);
+		const { fetchImpl } = createRecordingFetch(() =>
+			textEventStream(
+				'data: {"type":"response.output_text.delta","delta":"hi"}\n\n' +
+					'data: {"type":"response.completed","response":{"usage":{"input_tokens":1000,"input_tokens_details":{"cached_tokens":400},"output_tokens":500,"output_tokens_details":{"reasoning_tokens":200},"total_tokens":1500}}}\n\n',
+			),
+		);
+		const proxy = await startProxy({ accountManager, fetchImpl });
+
+		const response = await postResponses(proxy, { model: "gpt-5-codex", stream: true });
+		expect(response.status).toBe(HTTP_STATUS.OK);
+		await response.text();
+
+		// Every ledger row used to land with all-zero tokens, so
+		// evaluateBudgetGuard compared `0 >= limit` for maxTokens/maxCostUsd and
+		// those caps never fired — only --requests was enforced.
+		expect(recorded.at(-1)).toMatchObject({
+			outcome: "success",
+			inputTokens: 1000,
+			// reasoning_tokens is a SUBSET of output_tokens upstream, but pricing
+			// treats the two buckets as disjoint, so it is subtracted out here.
+			outputTokens: 300,
+			cachedInputTokens: 400,
+			reasoningTokens: 200,
+			totalTokens: 1500,
+		});
+	});
 });

--- a/test/stream-failover.test.ts
+++ b/test/stream-failover.test.ts
@@ -304,4 +304,47 @@ describe("stream failover", () => {
 			process.off("unhandledRejection", onUnhandled);
 		}
 	});
+
+	it("stops pulling from upstream while the consumer is not reading", async () => {
+		const TOTAL_CHUNKS = 50;
+		let produced = 0;
+		const source = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				if (produced >= TOTAL_CHUNKS) {
+					controller.close();
+					return;
+				}
+				produced += 1;
+				controller.enqueue(encoder.encode(`data: chunk-${produced}\n\n`));
+			},
+		});
+		const response = withStreamingFailover(
+			new Response(source, { headers: { "content-type": "text/event-stream" } }),
+			async () => null,
+			{ maxFailovers: 1, stallTimeoutMs: 10_000 },
+		);
+
+		const reader = response.body?.getReader();
+		expect(reader).toBeDefined();
+		const first = await reader?.read();
+		expect(new TextDecoder().decode(first?.value)).toBe("data: chunk-1\n\n");
+
+		// Let every pending microtask and timer turn settle without reading
+		// again. A pump that ignores controller.desiredSize drains the whole
+		// upstream into the controller queue here, buffering it in memory for a
+		// consumer that asked for exactly one chunk.
+		for (let tick = 0; tick < 5; tick += 1) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		expect(produced).toBeLessThan(TOTAL_CHUNKS);
+		// A small constant of read-ahead is expected (the source stream and the
+		// wrapper each hold one queued chunk); the point is that it is bounded and
+		// does not grow with the length of the stream.
+		expect(produced).toBeLessThanOrEqual(6);
+
+		// Demand resumes the pump rather than wedging it.
+		const second = await reader?.read();
+		expect(new TextDecoder().decode(second?.value)).toBe("data: chunk-2\n\n");
+		await reader?.cancel();
+	});
 });

--- a/test/stream-usage-deferral.test.ts
+++ b/test/stream-usage-deferral.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { createStreamUsageDeferral } from "../lib/usage/stream-usage-deferral.js";
+import type { UsageTokenCounts } from "../lib/usage/types.js";
+
+interface Row {
+	outcome: "success";
+	statusCode: number;
+}
+
+const ROW: Row = { outcome: "success", statusCode: 200 };
+
+const USAGE: UsageTokenCounts = {
+	inputTokens: 1_000,
+	outputTokens: 300,
+	cachedInputTokens: 400,
+	reasoningTokens: 200,
+	totalTokens: 1_500,
+};
+
+function harness() {
+	const record = vi.fn();
+	let fire: (() => void) | null = null;
+	const cancel = vi.fn(() => {
+		fire = null;
+	});
+	const schedule = vi.fn((run: () => void) => {
+		fire = run;
+		return { cancel };
+	});
+	const deferral = createStreamUsageDeferral<Row>({
+		record,
+		fallbackMs: 900_000,
+		schedule,
+	});
+	return {
+		deferral,
+		record,
+		cancel,
+		schedule,
+		fireFallback: () => {
+			const run = fire;
+			if (!run) throw new Error("no fallback armed");
+			run();
+		},
+	};
+}
+
+describe("createStreamUsageDeferral", () => {
+	it("writes the deferred row with token counts once usage arrives", () => {
+		const { deferral, record, cancel } = harness();
+
+		deferral.defer(ROW);
+		expect(record).not.toHaveBeenCalled();
+
+		deferral.onUsage(USAGE);
+
+		expect(record).toHaveBeenCalledTimes(1);
+		expect(record).toHaveBeenCalledWith({ ...ROW, ...USAGE });
+		// The armed fallback must be cancelled, or it would try to write a
+		// second row for the same request.
+		expect(cancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("writes the row without counts when the fallback fires first", () => {
+		const { deferral, record, fireFallback } = harness();
+
+		// A client that disconnects mid-stream never pulls the terminal usage
+		// event. The row must still be written, because maxRequests counts rows.
+		deferral.defer(ROW);
+		fireFallback();
+
+		expect(record).toHaveBeenCalledTimes(1);
+		expect(record).toHaveBeenCalledWith(ROW);
+	});
+
+	it("writes exactly one row when usage arrives after the fallback", () => {
+		const { deferral, record, fireFallback } = harness();
+
+		deferral.defer(ROW);
+		fireFallback();
+		deferral.onUsage(USAGE);
+
+		expect(record).toHaveBeenCalledTimes(1);
+		expect(record).toHaveBeenCalledWith(ROW);
+	});
+
+	it("does nothing when usage arrives with no row deferred", () => {
+		const { deferral, record, schedule } = harness();
+
+		// The non-streaming path folds captured() into its row itself and never
+		// defers, so the callback must stay inert there.
+		deferral.onUsage(USAGE);
+
+		expect(record).not.toHaveBeenCalled();
+		expect(schedule).not.toHaveBeenCalled();
+		expect(deferral.captured()).toEqual(USAGE);
+	});
+
+	it("exposes the counts for a caller that folds them in itself", () => {
+		const { deferral } = harness();
+
+		expect(deferral.captured()).toBeNull();
+		deferral.onUsage(USAGE);
+		expect(deferral.captured()).toEqual(USAGE);
+	});
+
+	it("keeps the first deferred row rather than orphaning its timer", () => {
+		const { deferral, record, schedule } = harness();
+		const second: Row = { outcome: "success", statusCode: 201 };
+
+		deferral.defer(ROW);
+		deferral.defer(second);
+		deferral.onUsage(USAGE);
+
+		expect(schedule).toHaveBeenCalledTimes(1);
+		expect(record).toHaveBeenCalledTimes(1);
+		expect(record).toHaveBeenCalledWith({ ...ROW, ...USAGE });
+	});
+});

--- a/test/usage-extraction.test.ts
+++ b/test/usage-extraction.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+	createUsageStreamScanner,
+	extractResponsesUsage,
+	extractUsageTokenCounts,
+} from "../lib/usage/usage-extraction.js";
+import { estimateUsageCostUsd } from "../lib/usage/pricing.js";
+
+const encoder = new TextEncoder();
+
+function sseEvent(type: string, payload: Record<string, unknown>): string {
+	return `event: ${type}\ndata: ${JSON.stringify({ type, ...payload })}\n\n`;
+}
+
+const COMPLETED_USAGE = {
+	input_tokens: 1_000,
+	input_tokens_details: { cached_tokens: 400 },
+	output_tokens: 500,
+	output_tokens_details: { reasoning_tokens: 200 },
+	total_tokens: 1_500,
+};
+
+describe("extractUsageTokenCounts", () => {
+	it("subtracts reasoning tokens out of the output bucket", () => {
+		const counts = extractUsageTokenCounts(COMPLETED_USAGE);
+
+		// OpenAI reports output_tokens INCLUSIVE of reasoning_tokens, but
+		// estimateUsageCostUsd prices the two as disjoint buckets and sums them.
+		// Passing output_tokens through raw would bill the 200 reasoning tokens
+		// twice.
+		expect(counts).toEqual({
+			inputTokens: 1_000,
+			outputTokens: 300,
+			cachedInputTokens: 400,
+			reasoningTokens: 200,
+			totalTokens: 1_500,
+		});
+	});
+
+	it("prices the split buckets back to the upstream output total", () => {
+		const counts = extractUsageTokenCounts(COMPLETED_USAGE);
+		if (!counts) throw new Error("expected counts");
+		const split = estimateUsageCostUsd("gpt-5-codex", counts);
+		const doubleCounted = estimateUsageCostUsd("gpt-5-codex", {
+			...counts,
+			outputTokens: 500,
+		});
+
+		expect(split).not.toBeNull();
+		// The regression this guards: the naive mapping is strictly more
+		// expensive, so a cost cap would trip early on every reasoning request.
+		expect(doubleCounted).toBeGreaterThan(split as number);
+	});
+
+	it("keeps cached tokens inside the input bucket", () => {
+		// estimateUsageCostUsd computes billableInput = input - cached, so a
+		// cached count larger than input would make the input bucket negative.
+		const counts = extractUsageTokenCounts({
+			input_tokens: 10,
+			input_tokens_details: { cached_tokens: 99 },
+			output_tokens: 0,
+		});
+
+		expect(counts?.inputTokens).toBe(10);
+		expect(counts?.cachedInputTokens).toBe(10);
+	});
+
+	it("derives a missing total from input plus the full output", () => {
+		const counts = extractUsageTokenCounts({
+			input_tokens: 7,
+			output_tokens: 5,
+			output_tokens_details: { reasoning_tokens: 2 },
+		});
+
+		expect(counts?.totalTokens).toBe(12);
+	});
+
+	it("returns null for payloads that carry no counts at all", () => {
+		expect(extractUsageTokenCounts(null)).toBeNull();
+		expect(extractUsageTokenCounts({})).toBeNull();
+		expect(extractUsageTokenCounts({ input_tokens: "12" })).toBeNull();
+	});
+
+	it("reads usage from either a bare response or a stream envelope", () => {
+		expect(extractResponsesUsage({ usage: { input_tokens: 3 } })?.inputTokens).toBe(3);
+		expect(
+			extractResponsesUsage({ response: { usage: { input_tokens: 4 } } })?.inputTokens,
+		).toBe(4);
+		expect(extractResponsesUsage({ response: {} })).toBeNull();
+	});
+});
+
+describe("createUsageStreamScanner", () => {
+	it("recovers the terminal usage from an SSE body", () => {
+		const scanner = createUsageStreamScanner({
+			contentType: "text/event-stream; charset=utf-8",
+		});
+		scanner.push(encoder.encode(sseEvent("response.output_text.delta", { delta: "hi" })));
+		scanner.push(
+			encoder.encode(
+				sseEvent("response.completed", { response: { usage: COMPLETED_USAGE } }),
+			),
+		);
+
+		expect(scanner.result()).toMatchObject({ inputTokens: 1_000, outputTokens: 300 });
+	});
+
+	it("survives an event split across chunk boundaries", () => {
+		const raw = sseEvent("response.completed", {
+			response: { usage: COMPLETED_USAGE },
+		});
+		const bytes = encoder.encode(raw);
+		const scanner = createUsageStreamScanner({ contentType: "text/event-stream" });
+		// Feed one byte at a time: the scanner must not lose the event to a
+		// mid-line or mid-UTF-8-sequence split.
+		for (const byte of bytes) {
+			scanner.push(Uint8Array.of(byte));
+		}
+
+		expect(scanner.result()).toMatchObject({ totalTokens: 1_500 });
+	});
+
+	it("prefers the terminal event over an earlier partial usage report", () => {
+		const scanner = createUsageStreamScanner({ contentType: "text/event-stream" });
+		scanner.push(
+			encoder.encode(
+				sseEvent("response.in_progress", {
+					response: { usage: { input_tokens: 1, output_tokens: 1 } },
+				}),
+			),
+		);
+		scanner.push(
+			encoder.encode(
+				sseEvent("response.completed", { response: { usage: COMPLETED_USAGE } }),
+			),
+		);
+
+		expect(scanner.result()?.totalTokens).toBe(1_500);
+	});
+
+	it("ignores the [DONE] sentinel and unparseable data lines", () => {
+		const scanner = createUsageStreamScanner({ contentType: "text/event-stream" });
+		scanner.push(encoder.encode("data: {not json\n\ndata: [DONE]\n\n"));
+
+		expect(scanner.result()).toBeNull();
+	});
+
+	it("parses a non-streaming JSON body at the end", () => {
+		const scanner = createUsageStreamScanner({ contentType: "application/json" });
+		const body = JSON.stringify({ id: "resp_1", usage: COMPLETED_USAGE });
+		scanner.push(encoder.encode(body.slice(0, 20)));
+		scanner.push(encoder.encode(body.slice(20)));
+
+		expect(scanner.result()).toMatchObject({ reasoningTokens: 200 });
+	});
+
+	it("gives up rather than buffer an oversized non-streaming body", () => {
+		const scanner = createUsageStreamScanner({ contentType: "application/json" });
+		// 2 MiB of payload, over the 1 MiB retention cap.
+		const chunk = new Uint8Array(512 * 1024);
+		chunk.fill(0x20);
+		for (let i = 0; i < 4; i += 1) scanner.push(chunk);
+
+		expect(scanner.result()).toBeNull();
+	});
+
+	it("never throws out of push, whatever the bytes are", () => {
+		const scanner = createUsageStreamScanner({ contentType: null });
+		expect(() => scanner.push(Uint8Array.of(0xff, 0xfe, 0x00))).not.toThrow();
+		expect(() => scanner.result()).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

Five latent defects found in a whole-repo sweep, on top of `main` with #677 merged. Each was re-verified against current code before being touched, and each ships with a regression test that fails when its fix is reverted.

## 1. Token and cost budget caps were inert (HIGH)

Nothing ever wrote token counts into the usage ledger. Every `usageRecorder.record()` call omitted them, so `summarizeUsageLedger` totalled zero and `evaluateBudgetGuard` compared `0 >= limit` for both `maxTokens` and `maxCostUsd`. Those caps could never fire: `codex-multi-auth budget set --cost 50` allowed unlimited spend, and only `--requests` enforced anything.

New `lib/usage/usage-extraction.ts` scans the forwarded body for the upstream `usage` object — line by line for SSE, so only the current partial line is retained and a multi-gigabyte stream is never buffered, and a capped accumulate-then-parse for JSON bodies. `forwardStreamingResponse` gained an optional chunk observer to feed it.

The mapping is deliberately not a straight copy. `estimateUsageCostUsd` prices `outputTokens` and `reasoningTokens` as **disjoint** buckets and sums them, while OpenAI reports `output_tokens` **inclusive** of `output_tokens_details.reasoning_tokens`. Passing the raw value through would bill reasoning twice on every reasoning request, so the reasoning share is subtracted out first. `input_tokens_details.cached_tokens` is passed raw, because `estimateUsageCostUsd` already subtracts it from the input bucket.

## 2. The plugin-host path recorded zeros even after (1) (HIGH)

Fixing the rotation proxy left `index.ts` still writing every row empty. The obstacle was ordering, not plumbing: `usageCompletion` is written in a `finally` that runs when the handler returns its Response — for a streaming request, before the client has read a byte and therefore before the upstream `usage` event exists. The ledger is append-only, so a row written there could never be corrected.

An `onUsage` callback now threads through `handleSuccessResponse`. On the streaming path it rides the SSE tee `createResponseIdCapturingStream` already runs for response-id capture, so the counts come off JSON that loop had parsed anyway — no second scan, no buffering. On the non-streaming path `convertSseToJson` already holds the assembled response and reports synchronously, so those counts fold straight into the row.

Streaming rows are handed to `createStreamUsageDeferral`, which writes them when the counts arrive. Its fallback timer is load-bearing, not padding: a client that disconnects mid-stream, or an upstream that never emits a terminal usage event, would otherwise cost the ledger a whole row — and `maxRequests` counts rows, so losing them would weaken a cap that already worked. The deferral is a separate unit precisely so that ordering is testable without mounting the plugin host.

## 3. Session affinity survived account removal and backup restore (MED)

Session affinity maps a session to an account **index**, and `affinityGeneration` is what invalidates it. Only `switch`, `best` and `unpin` bumped it. Three paths that reshuffle indexes did not:

- deleting an account from the login menu,
- the **automatic** removal of revoked-token accounts in the runtime account check,
- restoring a backup, which replaces the entire account list.

A live proxy therefore kept gluing in-flight sessions to whatever slid into the old slot. Same failure class as the pin-by-position bug fixed in #638 — reconciling the pin was never sufficient, because the affinity map is separate state.

Adds `bumpStorageAffinityGeneration`, which takes the max of the in-memory and on-disk counters so a concurrent CLI process's increment is not lost, and calls it from all three paths.

## 4. Two identity-less accounts shared one account-policy entry (MED)

`getAccountPolicyKey` hashed the literal `"unknown"` when an account had neither an `accountId` nor an `email`, collapsing every such account onto one key — pausing, draining or tagging one silently applied to all of them.

Falls back to the refresh token, namespaced before hashing so it cannot collide with an email or accountId of the same text, mirroring `getAccountIdentityKey`'s `allowRefreshFallback`. Only the digest is persisted, and the key stays index-independent (the existing test asserting that still passes). `RuntimePolicyAccount` gains `refreshToken` so the runtime derives the same key the CLI writes; both call sites already pass full account objects, so nothing else changes.

## 5. `withStreamingFailover` ignored consumer backpressure (MED)

`pump()` runs as a free-running loop from `start()` and enqueued every chunk as fast as upstream delivered it, never consulting `controller.desiredSize` — so a slow client buffered the whole response in memory. Verified: a 50-chunk source was drained completely for a consumer that had read exactly one chunk.

The loop now parks on a demand signal released by `pull()`, and cancellation releases it so a parked pump unwinds instead of holding the upstream reader open. The sibling forwarder in `stream-failover-runtime.ts` already had this via `waitForDrain`.

## Validation

- [x] Full suite: **5524 passed**. The 2 failures in `test/codex-bin-wrapper.test.ts` (native `codex` discovery on PATH) are pre-existing and environment-dependent — they reproduce with these changes stashed.
- [x] `tsc --noEmit` clean; ESLint clean on every changed file.
- [x] Mutation-checked: reverting the backpressure fix makes the new test report all 50 chunks drained; removing the usage-scanner wiring makes the proxy test's token assertions fail.

## Found but deliberately not fixed here

`MODEL_PRICING` holds 9 model ids, and the lookup is an exact lowercase match. The routed catalog is much larger — `gpt-5.1-codex-max`, `gpt-5.2-codex`, `gpt-5.3-codex-spark`, `gpt-5.4-pro`, and the mini/nano/pro variants all miss it. Those rows price at `null`, count as `0` in the summary, and leave `maxCostUsd` under-enforcing for exactly those models. This mattered less while every row was zero; now that token counts are real, it is the remaining hole in cost enforcement. Filling the table needs real per-model rates, which is a data decision rather than a code one, so it is reported rather than guessed at.

## Docs and Governance Checklist

- [x] No documented contract changes. Budget caps now behave as the docs already describe; the other fixes restore intended behavior.
- [x] No generated files, credentials, or local task metadata included.

## Risk and Rollback

Item 4 changes a **persisted** policy key for accounts that currently have no identity: their existing policy entries become orphaned. That state was already wrong — it was shared across every identity-less account — so orphaning it is the correction rather than a regression. The other four add behavior without changing any stored format. Roll back the commits to restore previous behavior.


<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr repairs usage accounting, account-affinity invalidation, anonymous-account policy separation, and stream backpressure.

- extracts upstream token usage for budget enforcement while retaining only bounded stream data
- invalidates session affinity after account removal and backup restoration
- separates identity-less policy entries using a namespaced, digest-only token fallback
- bounds stream read-ahead for slow consumers

<h3>Confidence Score: 3/5</h3>

this pr is not yet safe to merge because policy controls can be orphaned and concurrent account reshuffles can leave stale session affinity active.

the anonymous-account policy key still changes after token rotation or identity hydration, while the affinity counter remains a non-atomic cross-process read-modify-write; both leave current routing state incorrect despite the attempted fixes.

**Files Needing Attention:** lib/account-policy.ts, lib/storage.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/account-policy.ts | separates anonymous accounts, but the persisted key still rotates with refresh-token replacement or identity hydration. |
| lib/storage.ts | adds generation advancement, but concurrent processes can still compute and persist the same next value. |
| lib/usage/usage-extraction.ts | adds bounded token extraction for json and sse responses, including disjoint reasoning-token pricing. |
| lib/usage/stream-usage-deferral.ts | defers streaming ledger writes until usage arrives, with a request-count-preserving fallback. |
| lib/request/stream-failover.ts | adds demand-driven stream forwarding and cancellation release with focused vitest coverage. |
| index.ts | wires deferred streaming usage into the plugin-host ledger path. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  client[client request] --> runtime[runtime or plugin host]
  runtime --> upstream[upstream response stream]
  upstream --> usage[bounded usage extraction]
  usage --> ledger[usage ledger and budget guard]
  upstream --> backpressure[backpressure-aware forwarding]
  storage[account mutations] --> generation[affinity generation]
  generation --> affinity[session affinity invalidation]
  policy[account identity or token digest] --> routing[account policy lookup]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(usage): record token counts on the p..."](https://github.com/ndycode/codex-multi-auth/commit/39858a831032fe8fc9d2c04cd85f18505320f6c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56644350)</sub>

<!-- /greptile_comment -->