### PR TITLE
feat(auth): reauthenticate accounts without changing pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,11 @@ codex-multi-auth login --account <index|email|account_id> --preserve-selection
 ```
 
 Add `--device-auth` on a remote shell. The refreshed OAuth identity must match
-the requested saved account or nothing is written.
+the requested saved account or nothing is written. Refreshing the account Codex
+is currently using still publishes its new tokens to the native CLI; refreshing
+any other account leaves the active selection and the manual pin untouched. A
+disabled account stays disabled. `--account` cannot be combined with `--org`,
+which would rebind the row to a different workspace.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ codex-multi-auth forecast --live
 
 If browser launch is blocked, use the alternate login paths in [docs/getting-started.md](docs/getting-started.md#alternate-login-paths).
 For remote or headless shells, prefer `codex-multi-auth login --device-auth`.
+To refresh one saved account without changing the active selection or manual
+pin, run:
+
+```bash
+codex-multi-auth login --account <index|email|account_id> --preserve-selection
+```
+
+Add `--device-auth` on a remote shell. The refreshed OAuth identity must match
+the requested saved account or nothing is written.
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -38,7 +38,7 @@ Compatibility forms are supported for migrations and wrapper-routed environments
 
 | Command | Description |
 | --- | --- |
-| `codex-multi-auth login` | Open interactive auth dashboard. Flags: `--device-auth`, `--manual`/`--no-browser`, `login --org <org_id>` |
+| `codex-multi-auth login` | Open interactive auth dashboard. Flags: `--device-auth`, `--manual`/`--no-browser`, `--org <org_id>`, `--preserve-selection`, `--account <index\|email\|account_id>` |
 | `codex-multi-auth status` | Print account pool, pin, runtime metrics, and storage summary (`list` is the same command) |
 | `codex-multi-auth check` | Live-probe account health against the Codex backend |
 
@@ -147,6 +147,8 @@ Turning `showQuotaDetails` off reduces the line to a bare `live session OK`.
 | `--device-auth` | login | Use the OpenAI Codex device-code flow for remote/headless login (mutually exclusive with `--manual` / `--no-browser`) |
 | `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow (mutually exclusive with `--device-auth`) |
 | `--org <org_id>` | login | Bind this login to a specific ChatGPT workspace/org id (same seat can be registered as personal vs team/business) |
+| `--preserve-selection` | login | Add or refresh credentials without changing the active global/model-family selections or manual pin; performs one sign-in and exits |
+| `--account <index\|email\|account_id>` | login | Re-authenticate exactly one saved account. Implies `--preserve-selection` and refuses a different OAuth identity before writing |
 | `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle, history | Print machine-readable output |
 | `--csv` | usage | Print or write CSV bucket output |
 | `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |
@@ -637,7 +639,9 @@ failure.
 ## Upgrade Notes
 
 - `codex-multi-auth login` remains browser-first by default.
+- `codex-multi-auth login --org <org_id>` binds the login to one ChatGPT workspace.
 - `codex-multi-auth login --device-auth` uses OpenAI Codex device-code login. It prints `https://auth.openai.com/codex/device` and a one-time code, then polls for completion without opening a browser or starting the local callback server.
+- `codex-multi-auth login --account <identity> --preserve-selection` refreshes a saved account transactionally without changing the account used by Codex. If the provider returns a different account id/email, the write is refused and the previous credentials remain intact. Combine it with `--device-auth` for remote shells.
 - `codex-multi-auth login --manual` and `codex-multi-auth login --no-browser` force the manual callback flow instead of launching a browser.
 - `CODEX_AUTH_NO_BROWSER=1` suppresses browser launch for automation/headless sessions. False-like values such as `0` and `false` do not disable browser launch by themselves.
 - In non-TTY/manual shells, pass the full redirect URL on stdin, for example: `echo "http://127.0.0.1:1455/auth/callback?code=..." | codex-multi-auth login --manual`.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -148,7 +148,7 @@ Turning `showQuotaDetails` off reduces the line to a bare `live session OK`.
 | `--manual`, `--no-browser` | login | Skip browser launch and use manual callback flow (mutually exclusive with `--device-auth`) |
 | `--org <org_id>` | login | Bind this login to a specific ChatGPT workspace/org id (same seat can be registered as personal vs team/business) |
 | `--preserve-selection` | login | Add or refresh credentials without changing the active global/model-family selections or manual pin; performs one sign-in and exits |
-| `--account <index\|email\|account_id>` | login | Re-authenticate exactly one saved account. Implies `--preserve-selection` and refuses a different OAuth identity before writing |
+| `--account <index\|email\|account_id>` | login | Re-authenticate exactly one saved account. Implies `--preserve-selection`, refuses a different OAuth identity before writing, keeps a disabled account disabled, and cannot be combined with `--org` |
 | `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle, history | Print machine-readable output |
 | `--csv` | usage | Print or write CSV bucket output |
 | `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |
@@ -641,7 +641,7 @@ failure.
 - `codex-multi-auth login` remains browser-first by default.
 - `codex-multi-auth login --org <org_id>` binds the login to one ChatGPT workspace.
 - `codex-multi-auth login --device-auth` uses OpenAI Codex device-code login. It prints `https://auth.openai.com/codex/device` and a one-time code, then polls for completion without opening a browser or starting the local callback server.
-- `codex-multi-auth login --account <identity> --preserve-selection` refreshes a saved account transactionally without changing the account used by Codex. If the provider returns a different account id/email, the write is refused and the previous credentials remain intact. Combine it with `--device-auth` for remote shells.
+- `codex-multi-auth login --account <identity> --preserve-selection` refreshes a saved account transactionally without changing which account is selected. If the provider returns a different account id/email, the write is refused and the previous credentials remain intact. Refreshing the account that is currently active still writes its new tokens to the native `~/.codex/auth.json`, so plain `codex` keeps working; refreshing any other account leaves that file alone. A manual `switch <n>` pin survives the refresh, and an account you disabled stays disabled. `--account` cannot be combined with `--org` — re-authenticate the saved row on its own workspace, or register the other workspace with `--org` on its own. Combine it with `--device-auth` for remote shells.
 - `codex-multi-auth login --manual` and `codex-multi-auth login --no-browser` force the manual callback flow instead of launching a browser.
 - `CODEX_AUTH_NO_BROWSER=1` suppresses browser launch for automation/headless sessions. False-like values such as `0` and `false` do not disable browser launch by themselves.
 - In non-TTY/manual shells, pass the full redirect URL on stdin, for example: `echo "http://127.0.0.1:1455/auth/callback?code=..." | codex-multi-auth login --manual`.

--- a/lib/codex-manager/account-pool-write.ts
+++ b/lib/codex-manager/account-pool-write.ts
@@ -32,6 +32,14 @@ export interface ResolvedAccountWrite {
 	accessToken?: string;
 	expiresAt?: number;
 	workspaces?: Workspace[];
+	/**
+	 * Keep the saved row's `enabled` flag instead of re-enabling it. A targeted
+	 * re-authentication only tops up credentials for a row the user named, so it
+	 * must not pull a deliberately disabled account back into rotation behind
+	 * their back. A plain login still re-enables: signing in is the user asking
+	 * for that account to be usable again.
+	 */
+	preserveEnabledState?: boolean;
 	now: number;
 }
 
@@ -192,7 +200,7 @@ export function buildUpdatedAccount(
 			refreshToken: write.refreshToken,
 			accessToken: write.accessToken,
 			expiresAt: write.expiresAt,
-			enabled: true,
+			enabled: write.preserveEnabledState ? existing.enabled : true,
 			authInvalidatedAt: undefined,
 			authInvalidationErrorCode: undefined,
 			lastUsed: write.now,

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -161,6 +161,18 @@ export function parseAuthLoginArgs(args: string[]): ParsedAuthLoginArgs {
 		};
 	}
 
+	// --org rebinds a login to a different workspace, which is exactly the
+	// identity change a targeted re-auth is built to refuse. Rejecting the pair
+	// up front beats failing after the user has already completed a sign-in.
+	if (options.account && options.org) {
+		return {
+			ok: false,
+			reason: "error",
+			message:
+				"Cannot combine --account with --org. Re-authenticate the saved account on its own workspace, or register the other workspace with --org on its own.",
+		};
+	}
+
 	return { ok: true, options };
 }
 

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -8,7 +8,7 @@ export function printUsage(): void {
 			"Codex Multi-Auth CLI",
 			"",
 			"Start here:",
-			"  codex-multi-auth login [--device-auth|--manual|--no-browser] [--org <org_id>]",
+			"  codex-multi-auth login [--device-auth|--manual|--no-browser] [--org <org_id>] [--preserve-selection] [--account <index|email|account_id>]",
 			"  codex-multi-auth status [--json]   (list is the same command)",
 			"  codex-multi-auth check            (always live-probes)",
 			"",
@@ -61,7 +61,9 @@ export function printUsage(): void {
 export type AuthLoginOptions = {
 	manual: boolean;
 	deviceAuth: boolean;
+	preserveSelection?: boolean;
 	org?: string;
+	account?: string;
 };
 
 export type ParsedAuthLoginArgs =
@@ -87,6 +89,33 @@ export function parseAuthLoginArgs(args: string[]): ParsedAuthLoginArgs {
 		}
 		if (arg === "--device-auth") {
 			options.deviceAuth = true;
+			continue;
+		}
+		if (arg === "--preserve-selection") {
+			options.preserveSelection = true;
+			continue;
+		}
+		if (arg === "--account" || arg?.startsWith("--account=")) {
+			let value: string | undefined;
+			if (arg === "--account") {
+				value = args[i + 1];
+				i += 1;
+			} else {
+				value = arg.slice("--account=".length);
+			}
+			const trimmed = value?.trim();
+			if (!trimmed || trimmed.startsWith("--")) {
+				return {
+					ok: false,
+					reason: "error",
+					message:
+						"Missing value for --account. Usage: codex-multi-auth login --account <index|email|account_id>",
+				};
+			}
+			options.account = trimmed;
+			// A targeted re-auth must never select the refreshed account as a
+			// side effect, even if the caller omits the redundant safety flag.
+			options.preserveSelection = true;
 			continue;
 		}
 		if (arg === "--org" || arg?.startsWith("--org=")) {

--- a/lib/codex-manager/login-flow.ts
+++ b/lib/codex-manager/login-flow.ts
@@ -1,4 +1,5 @@
-﻿import { isBrowserLaunchSuppressed } from "../auth/browser.js";
+﻿import { sanitizeEmail } from "../accounts.js";
+import { isBrowserLaunchSuppressed } from "../auth/browser.js";
 import { promptAddAnotherAccount, promptLoginMode } from "../cli.js";
 import { ACCOUNT_LIMITS } from "../constants.js";
 import { loadDashboardDisplaySettings } from "../dashboard-settings.js";
@@ -6,6 +7,8 @@ import { createLogger } from "../logger.js";
 import { loadQuotaCache } from "../quota-cache.js";
 import { resolveActiveIndex } from "../runtime/account-status.js";
 import {
+	type AccountMetadataV3,
+	type AccountStorageV3,
 	clearAccounts,
 	formatStorageErrorHint,
 	getNamedBackups,
@@ -16,6 +19,7 @@ import {
 	setStoragePath,
 	StorageError,
 } from "../storage.js";
+import { CodexValidationError } from "../errors.js";
 import { UI_COPY } from "../ui/ui-copy.js";
 import { confirm } from "../ui/confirm.js";
 import { stylePromptText } from "./formatters/index.js";
@@ -104,6 +108,30 @@ const log = createLogger("codex-manager");
 
 async function clearAccountsAndReset(): Promise<void> {
 	await clearAccounts();
+}
+
+/** @internal */
+export function resolveLoginAccountTarget(
+	storage: AccountStorageV3,
+	identifier: string,
+): AccountMetadataV3 | null {
+	if (/^[1-9]\d*$/.test(identifier)) {
+		const byIndex = storage.accounts[Number(identifier) - 1];
+		return byIndex ?? null;
+	}
+
+	const byAccountId = storage.accounts.filter(
+		(account) => account.accountId === identifier,
+	);
+	if (byAccountId.length === 1) return byAccountId[0] ?? null;
+	if (byAccountId.length > 1) return null;
+
+	const email = sanitizeEmail(identifier);
+	if (!email) return null;
+	const byEmail = storage.accounts.filter(
+		(account) => sanitizeEmail(account.email) === email,
+	);
+	return byEmail.length === 1 ? (byEmail[0] ?? null) : null;
 }
 
 /** @internal */
@@ -341,7 +369,11 @@ async function runAuthLoginFlow(
 	// (--device-auth, --manual, --no-browser), they want to add a new account
 	// directly. Skipping the dashboard menu keeps `login --device-auth`
 	// usable from scripts and matches the documented behavior of the help text.
-	const explicitSignInMode = loginOptions.deviceAuth || loginOptions.manual;
+	const explicitSignInMode =
+		loginOptions.deviceAuth ||
+		loginOptions.manual ||
+		loginOptions.preserveSelection ||
+		Boolean(loginOptions.account);
 	loginFlow: while (true) {
 		const existingStorage = await loadAccounts();
 		if (
@@ -357,7 +389,18 @@ async function runAuthLoginFlow(
 
 		const refreshedStorage = await loadAccounts();
 		let existingCount = refreshedStorage?.accounts.length ?? 0;
-		let forceNewLogin = existingCount > 0;
+		const expectedAccount = loginOptions.account
+			? refreshedStorage
+				? resolveLoginAccountTarget(refreshedStorage, loginOptions.account)
+				: null
+			: undefined;
+		if (loginOptions.account && !expectedAccount) {
+			console.error(
+				"The requested Codex account is missing or ambiguous. No login was started.",
+			);
+			return 1;
+		}
+		let forceNewLogin = existingCount > 0 || Boolean(expectedAccount);
 		let onboardingBackupDiscoveryWarning: string | null = null;
 		const loadNamedBackupsForOnboarding = async (): Promise<
 			NamedBackupSummary[]
@@ -533,9 +576,30 @@ async function runAuthLoginFlow(
 				return 1;
 			}
 
-			const resolved = resolveAccountSelection(tokenResult, loginOptions.org);
-			const persistOutcome = await persistAccountPool([resolved], false);
-			await syncSelectionToCodex(resolved);
+			const resolved = resolveAccountSelection(
+				tokenResult,
+				loginOptions.org,
+				expectedAccount?.accountId,
+			);
+			let persistOutcome: Awaited<ReturnType<typeof persistAccountPool>>;
+			try {
+				persistOutcome =
+					loginOptions.preserveSelection || expectedAccount
+						? await persistAccountPool([resolved], false, {
+								preserveSelection: loginOptions.preserveSelection,
+								expectedAccount: expectedAccount ?? undefined,
+							})
+						: await persistAccountPool([resolved], false);
+			} catch (error) {
+				if (error instanceof CodexValidationError) {
+					console.error(`Re-authentication failed: ${error.message}`);
+					return 1;
+				}
+				throw error;
+			}
+			if (!loginOptions.preserveSelection || existingCount === 0) {
+				await syncSelectionToCodex(resolved);
+			}
 
 			const latestStorage = await loadAccounts();
 			const count = latestStorage?.accounts.length ?? 1;
@@ -560,6 +624,9 @@ async function runAuthLoginFlow(
 			console.log(
 				"  codex-multi-auth list    Review saved accounts before switching.",
 			);
+			if (loginOptions.preserveSelection) {
+				return 0;
+			}
 			if (count >= ACCOUNT_LIMITS.MAX_ACCOUNTS) {
 				console.log(
 					`Reached maximum account limit (${ACCOUNT_LIMITS.MAX_ACCOUNTS}).`,

--- a/lib/codex-manager/login-flow.ts
+++ b/lib/codex-manager/login-flow.ts
@@ -400,7 +400,16 @@ async function runAuthLoginFlow(
 			);
 			return 1;
 		}
-		let forceNewLogin = existingCount > 0 || Boolean(expectedAccount);
+		// Positional hint for the write, re-verified (never trusted) inside the
+		// storage transaction. resolveLoginAccountTarget hands back a row out of
+		// this very array, so indexOf is an exact identity lookup.
+		const expectedAccountIndex =
+			expectedAccount && refreshedStorage
+				? refreshedStorage.accounts.indexOf(expectedAccount)
+				: -1;
+		// A non-empty pool already forces a fresh sign-in, and a resolved target
+		// implies the pool was non-empty, so it adds no condition of its own.
+		let forceNewLogin = existingCount > 0;
 		let onboardingBackupDiscoveryWarning: string | null = null;
 		const loadNamedBackupsForOnboarding = async (): Promise<
 			NamedBackupSummary[]
@@ -581,15 +590,14 @@ async function runAuthLoginFlow(
 				loginOptions.org,
 				expectedAccount?.accountId,
 			);
-			let persistOutcome: Awaited<ReturnType<typeof persistAccountPool>>;
+			let persistResult: Awaited<ReturnType<typeof persistAccountPool>>;
 			try {
-				persistOutcome =
-					loginOptions.preserveSelection || expectedAccount
-						? await persistAccountPool([resolved], false, {
-								preserveSelection: loginOptions.preserveSelection,
-								expectedAccount: expectedAccount ?? undefined,
-							})
-						: await persistAccountPool([resolved], false);
+				persistResult = await persistAccountPool([resolved], false, {
+					preserveSelection: loginOptions.preserveSelection,
+					expectedAccount: expectedAccount ?? undefined,
+					expectedAccountIndex:
+						expectedAccountIndex >= 0 ? expectedAccountIndex : undefined,
+				});
 			} catch (error) {
 				if (error instanceof CodexValidationError) {
 					console.error(`Re-authentication failed: ${error.message}`);
@@ -597,7 +605,13 @@ async function runAuthLoginFlow(
 				}
 				throw error;
 			}
-			if (!loginOptions.preserveSelection || existingCount === 0) {
+			// Publish to ~/.codex/auth.json exactly when this write owns the
+			// selection. Skipping the sync whenever --preserve-selection was passed
+			// stranded the native CLI on the expired tokens of the very account the
+			// user had just refreshed, and nothing downstream repaired it: the
+			// drift check compares identity, not tokens, so a same-identity refresh
+			// never looks like drift.
+			if (!persistResult || persistResult.isActiveAccount) {
 				await syncSelectionToCodex(resolved);
 			}
 
@@ -610,12 +624,17 @@ async function runAuthLoginFlow(
 			// same-email login that maps onto an existing entry updates or
 			// rebinds it instead of growing the pool (issue #512).
 			const outcomeMessage =
-				persistOutcome === "rebound"
+				persistResult?.outcome === "rebound"
 					? `Rebound workspace for existing account. Total: ${count}`
-					: persistOutcome === "updated"
+					: persistResult?.outcome === "updated"
 						? `Updated existing account. Total: ${count}`
 						: `Added account. Total: ${count}`;
 			console.log(outcomeMessage);
+			if (persistResult && !persistResult.accountEnabled) {
+				console.log(
+					`Account ${persistResult.accountIndex + 1} is still disabled and stays out of rotation. Re-enable it from the manage menu in "codex-multi-auth login".`,
+				);
+			}
 			console.log("Next steps:");
 			console.log("  codex-multi-auth status  Check that the wrapper is active.");
 			console.log(

--- a/lib/codex-manager/login-menu-actions.ts
+++ b/lib/codex-manager/login-menu-actions.ts
@@ -26,7 +26,6 @@ import {
 	persistAccountPool,
 	resolveAccountSelection,
 	runOAuthFlow,
-	syncSelectionToCodex,
 } from "./login-oauth.js";
 import { persistAndSyncSelectedAccount } from "./persist-selected-account.js";
 
@@ -428,9 +427,15 @@ export async function handleManageAction(
 			return;
 		}
 
-		const resolved = resolveAccountSelection(tokenResult);
-		await persistAccountPool([resolved], false);
-		await syncSelectionToCodex(resolved);
+		const resolved = resolveAccountSelection(
+			tokenResult,
+			undefined,
+			existing.accountId,
+		);
+		await persistAccountPool([resolved], false, {
+			preserveSelection: true,
+			expectedAccount: existing,
+		});
 		console.log(`Refreshed account ${idx + 1}.`);
 	}
 }

--- a/lib/codex-manager/login-menu-actions.ts
+++ b/lib/codex-manager/login-menu-actions.ts
@@ -1,6 +1,7 @@
 ﻿import { stdin as input, stdout as output } from "node:process";
 import { sanitizeEmail } from "../accounts.js";
 import type { promptLoginMode } from "../cli.js";
+import { CodexValidationError } from "../errors.js";
 import { MODEL_FAMILIES } from "../prompts/codex.js";
 import {
 	type AccountMetadataV3,
@@ -26,6 +27,7 @@ import {
 	persistAccountPool,
 	resolveAccountSelection,
 	runOAuthFlow,
+	syncSelectionToCodex,
 } from "./login-oauth.js";
 import { persistAndSyncSelectedAccount } from "./persist-selected-account.js";
 
@@ -432,10 +434,38 @@ export async function handleManageAction(
 			undefined,
 			existing.accountId,
 		);
-		await persistAccountPool([resolved], false, {
-			preserveSelection: true,
-			expectedAccount: existing,
-		});
-		console.log(`Refreshed account ${idx + 1}.`);
+		let persistResult: Awaited<ReturnType<typeof persistAccountPool>>;
+		try {
+			persistResult = await persistAccountPool([resolved], false, {
+				preserveSelection: true,
+				expectedAccount: existing,
+				expectedAccountIndex: idx,
+			});
+		} catch (error) {
+			// A mismatched sign-in (the user picked a different ChatGPT account in
+			// the browser) is a refusal, not a crash. Nothing between here and the
+			// process entrypoint catches this, so an uncaught throw would take the
+			// whole interactive dashboard down with a raw stack trace.
+			if (error instanceof CodexValidationError) {
+				console.error(`Refresh failed: ${error.message}`);
+				return;
+			}
+			throw error;
+		}
+		// Refreshing the account Codex is currently using must publish its new
+		// tokens; refreshing any other row must leave the selection alone.
+		if (!persistResult || persistResult.isActiveAccount) {
+			await syncSelectionToCodex(resolved);
+		}
+		// Report the row that was actually written. The pool can shift between the
+		// dashboard render and this transaction, so the menu index may name a
+		// different account by now.
+		const refreshedIndex = persistResult?.accountIndex ?? idx;
+		console.log(`Refreshed account ${refreshedIndex + 1}.`);
+		if (persistResult && !persistResult.accountEnabled) {
+			console.log(
+				`Account ${refreshedIndex + 1} is still disabled and stays out of rotation. Toggle it from this menu to bring it back.`,
+			);
+		}
 	}
 }

--- a/lib/codex-manager/login-oauth.ts
+++ b/lib/codex-manager/login-oauth.ts
@@ -28,10 +28,10 @@ import { createLogger } from "../logger.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import {
 	type AccountMetadataV3,
-	type AccountStorageV3,
 	findMatchingAccountIndex,
 	withAccountStorageTransaction,
 } from "../storage.js";
+import { cloneAccountStorageForPersistence } from "../storage/account-persistence.js";
 import { CodexValidationError } from "../errors.js";
 import type { AccountIdSource, TokenResult } from "../types.js";
 import { UI_COPY } from "../ui/ui-copy.js";
@@ -113,33 +113,54 @@ export function resolveAccountSelection(
 				}))
 			: undefined;
 
-	const override = resolveOrgOverride(orgOverride);
-	if (override) {
-		// Prefer the token candidate's human label for the chosen org so the
-		// saved row is identifiable, falling back to a bare manual binding.
-		const matched = candidates.find(
-			(candidate) => candidate.accountId === override,
+	// A targeted re-authentication names one saved row, which is a stricter and
+	// more specific instruction than the ambient CODEX_AUTH_ACCOUNT_ID env var
+	// that resolveOrgOverride also honours. Consulting the override first let an
+	// unrelated exported org id hijack `login --account <n>` and then fail the
+	// identity guard with a misleading "does not match" message. An explicit
+	// `--org` cannot reach here alongside a target: parseAuthLoginArgs rejects
+	// that combination outright.
+	if (targetAccountId) {
+		const targetedCandidate = candidates.find(
+			(candidate) => candidate.accountId === targetAccountId,
 		);
-		return {
-			...tokens,
-			accountIdOverride: override,
-			accountIdSource: "manual",
-			accountLabel: matched?.label,
-			workspaces,
-		};
-	}
-
-	const targetedCandidate = targetAccountId
-		? candidates.find((candidate) => candidate.accountId === targetAccountId)
-		: undefined;
-	if (targetedCandidate) {
-		return {
-			...tokens,
-			accountIdOverride: targetedCandidate.accountId,
-			accountIdSource: targetedCandidate.source,
-			accountLabel: targetedCandidate.label,
-			workspaces,
-		};
+		if (targetedCandidate) {
+			return {
+				...tokens,
+				accountIdOverride: targetedCandidate.accountId,
+				// `id_token` candidates auto-follow the access token inside
+				// resolveRequestAccountId, which would rewrite this binding back to
+				// the access-token account and make the caller's own identity guard
+				// reject the write. Pin those as an explicit selection; a `token`
+				// candidate already IS the access-token account, and an `org`
+				// candidate never auto-follows, so both keep their source.
+				accountIdSource:
+					targetedCandidate.source === "id_token"
+						? "manual"
+						: targetedCandidate.source,
+				accountLabel: targetedCandidate.label,
+				workspaces,
+			};
+		}
+		// The user signed in as somebody else. Fall through to the generic
+		// selection so persistAccountPool refuses the write with the precise
+		// identity-mismatch message instead of a confusing override error.
+	} else {
+		const override = resolveOrgOverride(orgOverride);
+		if (override) {
+			// Prefer the token candidate's human label for the chosen org so the
+			// saved row is identifiable, falling back to a bare manual binding.
+			const matched = candidates.find(
+				(candidate) => candidate.accountId === override,
+			);
+			return {
+				...tokens,
+				accountIdOverride: override,
+				accountIdSource: "manual",
+				accountLabel: matched?.label,
+				workspaces,
+			};
+		}
 	}
 
 	if (candidates.length === 0) {
@@ -446,55 +467,133 @@ export async function runSignInFlow(
 export type PersistAccountPoolOutcome = AccountPoolWriteOutcome;
 
 /** @internal */
+export interface PersistAccountPoolResult {
+	/** How the pool absorbed this login (appended, refreshed, or rebound). */
+	outcome: PersistAccountPoolOutcome;
+	/** Index of the row the login actually wrote. */
+	accountIndex: number;
+	/** Global selection index after the write. */
+	activeIndex: number;
+	/**
+	 * Whether the written row is the one plain `codex` will use. Callers gate the
+	 * ~/.codex/auth.json sync on this: refreshing the active account must publish
+	 * its new tokens, and refreshing any other row must not steal the selection.
+	 */
+	isActiveAccount: boolean;
+	/** Whether the written row is enabled for rotation after the write. */
+	accountEnabled: boolean;
+}
+
+/** @internal */
+export type ExpectedLoginAccount = Pick<
+	AccountMetadataV3,
+	"recordId" | "accountId" | "email" | "refreshToken"
+>;
+
+/** @internal */
 export interface PersistAccountPoolOptions {
 	/** Keep every global/model-family selection on its pre-login identity. */
 	preserveSelection?: boolean;
 	/** Refuse the write unless the OAuth result is this saved account. */
-	expectedAccount?: Pick<
-		AccountMetadataV3,
-		"recordId" | "accountId" | "email" | "refreshToken"
-	>;
+	expectedAccount?: ExpectedLoginAccount;
+	/**
+	 * Position {@link expectedAccount} occupied when the caller resolved it.
+	 * Treated as a hint that is verified against the row actually sitting there,
+	 * never trusted: the pool can change between the caller's read and this
+	 * transaction. It exists so an unambiguous positional request such as
+	 * `login --account 2` stays deterministic when several saved rows share an
+	 * identity, which identity matching alone cannot tell apart.
+	 */
+	expectedAccountIndex?: number;
 }
 
 function sameExpectedLoginIdentity(
 	write: ResolvedAccountWrite,
-	expected: NonNullable<PersistAccountPoolOptions["expectedAccount"]>,
+	expected: ExpectedLoginAccount,
 ): boolean {
 	const expectedAccountId = expected.accountId?.trim();
 	const incomingAccountId = write.accountId?.trim();
 	const expectedEmail = sanitizeEmail(expected.email);
 	const incomingEmail = sanitizeEmail(write.email);
 
-	// When either side carries the provider identity, both must carry and match
-	// it. The provider id is authoritative when the user changes their email;
-	// falling back to a shared email across different workspaces would let a
-	// targeted re-auth overwrite the wrong saved account.
-	if (expectedAccountId || incomingAccountId) {
-		return Boolean(
-			expectedAccountId &&
-				incomingAccountId &&
-				expectedAccountId === incomingAccountId,
-		);
+	// When the saved row already carries the provider identity it is
+	// authoritative and the incoming login must match it: the id survives an
+	// email change, and falling back to a shared email across workspaces would
+	// let a targeted re-auth overwrite the wrong saved account.
+	if (expectedAccountId) {
+		return incomingAccountId === expectedAccountId;
 	}
+	// A pre-#491 row saved before workspace tracking carries no account id at
+	// all. Fresh tokens essentially always carry one, so demanding the id on both
+	// sides made every legacy row permanently un-refreshable through --account.
+	// Email is the only identity such a row has, and the caller already resolved
+	// it to a single unambiguous row before starting the sign-in.
 	return Boolean(expectedEmail && incomingEmail === expectedEmail);
 }
 
+function matchesExpectedAccount(
+	account: AccountMetadataV3 | undefined,
+	expected: ExpectedLoginAccount,
+): boolean {
+	if (!account) return false;
+	if (expected.recordId && account.recordId) {
+		return account.recordId === expected.recordId;
+	}
+	const expectedAccountId = expected.accountId?.trim();
+	const candidateAccountId = account.accountId?.trim();
+	if (expectedAccountId || candidateAccountId) {
+		return Boolean(
+			expectedAccountId &&
+				candidateAccountId &&
+				expectedAccountId === candidateAccountId,
+		);
+	}
+	const expectedEmail = sanitizeEmail(expected.email);
+	const candidateEmail = sanitizeEmail(account.email);
+	if (expectedEmail || candidateEmail) {
+		return Boolean(expectedEmail && candidateEmail === expectedEmail);
+	}
+	return account.refreshToken === expected.refreshToken;
+}
+
+/**
+ * Locate the saved row a targeted re-authentication must write.
+ *
+ * Resolution is deliberately identity-first and refresh-token-last. The runtime
+ * rotation proxy rewrites a stored refreshToken whenever it refreshes an account
+ * (AccountManager.commitRefreshedAuth), so a sign-in that overlaps a live codex
+ * session would otherwise "lose" its own target and throw away a completed
+ * OAuth. `recordId` is exact when both sides have one, the caller's position is
+ * honoured only while the row sitting there is still the same identity, and
+ * findMatchingAccountIndex supplies the same composite/email/refresh-token
+ * ladder the rest of the pool already resolves identities with.
+ */
 function resolveExpectedAccountIndex(
 	accounts: readonly AccountMetadataV3[],
-	expected: NonNullable<PersistAccountPoolOptions["expectedAccount"]>,
+	expected: ExpectedLoginAccount,
+	hintedIndex: number | undefined,
 ): number | undefined {
-	const matches: number[] = [];
-	for (let index = 0; index < accounts.length; index += 1) {
-		const account = accounts[index];
-		if (!account) continue;
-		if (expected.recordId) {
-			if (account.recordId !== expected.recordId) continue;
-		} else if (account.refreshToken !== expected.refreshToken) {
-			continue;
-		}
-		matches.push(index);
+	if (expected.recordId) {
+		const byRecordId = accounts.findIndex(
+			(account) => account?.recordId === expected.recordId,
+		);
+		if (byRecordId >= 0) return byRecordId;
 	}
-	return matches.length === 1 ? matches[0] : undefined;
+	if (
+		validSelectionIndex(hintedIndex, accounts) &&
+		matchesExpectedAccount(accounts[hintedIndex], expected)
+	) {
+		return hintedIndex;
+	}
+	return findMatchingAccountIndex(
+		accounts,
+		{
+			accountId: expected.accountId,
+			email: expected.email,
+			refreshToken: expected.refreshToken,
+		},
+		{ allowUniqueAccountIdFallbackWithoutEmail: true },
+	);
 }
 
 function validSelectionIndex(
@@ -514,7 +613,7 @@ export async function persistAccountPool(
 	results: TokenSuccessWithAccount[],
 	replaceAll: boolean,
 	options: PersistAccountPoolOptions = {},
-): Promise<PersistAccountPoolOutcome | null> {
+): Promise<PersistAccountPoolResult | null> {
 	if (results.length === 0) return null;
 
 	return await withAccountStorageTransaction(async (loadedStorage, persist) => {
@@ -544,6 +643,9 @@ export async function persistAccountPool(
 				accessToken: result.access,
 				expiresAt: result.expires,
 				workspaces: result.workspaces,
+				// A targeted re-auth only tops up credentials for the row the user
+				// named; it must not silently re-enable an account they disabled.
+				preserveEnabledState: Boolean(options.expectedAccount),
 				now,
 			};
 		});
@@ -555,7 +657,11 @@ export async function persistAccountPool(
 		}
 		const expectedAccountIndex =
 			options.expectedAccount && stored
-				? resolveExpectedAccountIndex(stored.accounts, options.expectedAccount)
+				? resolveExpectedAccountIndex(
+						stored.accounts,
+						options.expectedAccount,
+						options.expectedAccountIndex,
+					)
 				: undefined;
 		if (options.expectedAccount && expectedAccountIndex === undefined) {
 			throw new CodexValidationError(
@@ -599,23 +705,45 @@ export async function persistAccountPool(
 					: nextActiveIndex;
 		}
 
-		const nextStorage: AccountStorageV3 = {
-			version: 3,
-			accounts,
-			activeIndex: nextActiveIndex,
-			activeIndexByFamily,
-			affinityGeneration: stored?.affinityGeneration,
-		};
-		// Login only updates a row in place or appends one; it never reorders or
-		// removes the pool. Preserve the raw pin position so even duplicate
-		// identities keep pointing at the exact row the user selected.
-		if (validSelectionIndex(stored?.pinnedAccountIndex, accounts)) {
-			nextStorage.pinnedAccountIndex = stored.pinnedAccountIndex;
+		// Reuse the shared persistence clone so the pin/affinity carry-over rule
+		// (issue #474) keeps living in exactly one place instead of being
+		// re-derived at every write site with a slightly different validity check.
+		const nextStorage = cloneAccountStorageForPersistence(stored);
+		nextStorage.accounts = accounts;
+		nextStorage.activeIndex = nextActiveIndex;
+		nextStorage.activeIndexByFamily = activeIndexByFamily;
+		// A selection-preserving login leaves the pool exactly where it was, so a
+		// manual `switch <n>` pin survives it: login only updates a row in place
+		// or appends one and never reorders, so the raw position still points at
+		// the row the user pinned even when two rows share an identity.
+		//
+		// A plain login is the opposite. It moves activeIndex onto the account
+		// just signed in and publishes that account to ~/.codex/auth.json.
+		// Carrying an old pin through it would leave storage claiming one account
+		// is active while the runtime proxy routes every request to another
+		// (runtime-rotation-proxy resolves pinnedAccountIndex first) -- the
+		// contradiction `status` reports as "runtime using N but pin requests M".
+		if (
+			!options.preserveSelection ||
+			!validSelectionIndex(nextStorage.pinnedAccountIndex, accounts)
+		) {
+			delete nextStorage.pinnedAccountIndex;
 		}
 
 		await persist(nextStorage);
 
-		return outcome;
+		if (outcome === null) return null;
+		return {
+			outcome,
+			accountIndex: activeIndex,
+			activeIndex: nextActiveIndex,
+			// The Codex CLI reads the `codex` family selection, so that -- not the
+			// bare global index -- decides whether this write owns the native
+			// ~/.codex/auth.json credentials.
+			isActiveAccount:
+				activeIndex === (activeIndexByFamily.codex ?? nextActiveIndex),
+			accountEnabled: accounts[activeIndex]?.enabled !== false,
+		};
 	});
 }
 

--- a/lib/codex-manager/login-oauth.ts
+++ b/lib/codex-manager/login-oauth.ts
@@ -27,9 +27,12 @@ import { setCodexCliActiveSelection } from "../codex-cli/writer.js";
 import { createLogger } from "../logger.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import {
+	type AccountMetadataV3,
+	type AccountStorageV3,
 	findMatchingAccountIndex,
 	withAccountStorageTransaction,
 } from "../storage.js";
+import { CodexValidationError } from "../errors.js";
 import type { AccountIdSource, TokenResult } from "../types.js";
 import { UI_COPY } from "../ui/ui-copy.js";
 import {
@@ -91,6 +94,7 @@ export function isAbortError(error: unknown): boolean {
 export function resolveAccountSelection(
 	tokens: TokenSuccess,
 	orgOverride?: string,
+	targetAccountId?: string,
 ): TokenSuccessWithAccount {
 	const candidates = getAccountIdCandidates(tokens.access, tokens.idToken);
 
@@ -121,6 +125,19 @@ export function resolveAccountSelection(
 			accountIdOverride: override,
 			accountIdSource: "manual",
 			accountLabel: matched?.label,
+			workspaces,
+		};
+	}
+
+	const targetedCandidate = targetAccountId
+		? candidates.find((candidate) => candidate.accountId === targetAccountId)
+		: undefined;
+	if (targetedCandidate) {
+		return {
+			...tokens,
+			accountIdOverride: targetedCandidate.accountId,
+			accountIdSource: targetedCandidate.source,
+			accountLabel: targetedCandidate.label,
 			workspaces,
 		};
 	}
@@ -429,9 +446,74 @@ export async function runSignInFlow(
 export type PersistAccountPoolOutcome = AccountPoolWriteOutcome;
 
 /** @internal */
+export interface PersistAccountPoolOptions {
+	/** Keep every global/model-family selection on its pre-login identity. */
+	preserveSelection?: boolean;
+	/** Refuse the write unless the OAuth result is this saved account. */
+	expectedAccount?: Pick<
+		AccountMetadataV3,
+		"recordId" | "accountId" | "email" | "refreshToken"
+	>;
+}
+
+function sameExpectedLoginIdentity(
+	write: ResolvedAccountWrite,
+	expected: NonNullable<PersistAccountPoolOptions["expectedAccount"]>,
+): boolean {
+	const expectedAccountId = expected.accountId?.trim();
+	const incomingAccountId = write.accountId?.trim();
+	const expectedEmail = sanitizeEmail(expected.email);
+	const incomingEmail = sanitizeEmail(write.email);
+
+	// When either side carries the provider identity, both must carry and match
+	// it. The provider id is authoritative when the user changes their email;
+	// falling back to a shared email across different workspaces would let a
+	// targeted re-auth overwrite the wrong saved account.
+	if (expectedAccountId || incomingAccountId) {
+		return Boolean(
+			expectedAccountId &&
+				incomingAccountId &&
+				expectedAccountId === incomingAccountId,
+		);
+	}
+	return Boolean(expectedEmail && incomingEmail === expectedEmail);
+}
+
+function resolveExpectedAccountIndex(
+	accounts: readonly AccountMetadataV3[],
+	expected: NonNullable<PersistAccountPoolOptions["expectedAccount"]>,
+): number | undefined {
+	const matches: number[] = [];
+	for (let index = 0; index < accounts.length; index += 1) {
+		const account = accounts[index];
+		if (!account) continue;
+		if (expected.recordId) {
+			if (account.recordId !== expected.recordId) continue;
+		} else if (account.refreshToken !== expected.refreshToken) {
+			continue;
+		}
+		matches.push(index);
+	}
+	return matches.length === 1 ? matches[0] : undefined;
+}
+
+function validSelectionIndex(
+	index: number | undefined,
+	accounts: readonly AccountMetadataV3[],
+): index is number {
+	return (
+		typeof index === "number" &&
+		Number.isInteger(index) &&
+		index >= 0 &&
+		index < accounts.length
+	);
+}
+
+/** @internal */
 export async function persistAccountPool(
 	results: TokenSuccessWithAccount[],
 	replaceAll: boolean,
+	options: PersistAccountPoolOptions = {},
 ): Promise<PersistAccountPoolOutcome | null> {
 	if (results.length === 0) return null;
 
@@ -466,24 +548,72 @@ export async function persistAccountPool(
 			};
 		});
 
+		if (options.expectedAccount && writes.length !== 1) {
+			throw new CodexValidationError(
+				"Targeted re-authentication accepts exactly one OAuth result. No saved credentials were changed.",
+			);
+		}
+		const expectedAccountIndex =
+			options.expectedAccount && stored
+				? resolveExpectedAccountIndex(stored.accounts, options.expectedAccount)
+				: undefined;
+		if (options.expectedAccount && expectedAccountIndex === undefined) {
+			throw new CodexValidationError(
+				"The requested Codex account is no longer present. No saved credentials were changed.",
+			);
+		}
+
+		const expectedAccount = options.expectedAccount;
+		if (
+			expectedAccount &&
+			writes.some((write) => !sameExpectedLoginIdentity(write, expectedAccount))
+		) {
+			throw new CodexValidationError(
+				"The authenticated Codex identity does not match the account requested for re-authentication. No saved credentials were changed.",
+			);
+		}
+
 		const { accounts, activeIndex, outcome } = applyAccountPoolResults({
 			existing,
 			writes,
 			priorActiveIndex: stored?.activeIndex,
-			findMatchingAccountIndex,
+			findMatchingAccountIndex:
+				expectedAccountIndex === undefined
+					? findMatchingAccountIndex
+					: () => expectedAccountIndex,
 		});
 
+		const nextActiveIndex =
+			options.preserveSelection &&
+			validSelectionIndex(stored?.activeIndex, accounts)
+				? stored.activeIndex
+				: activeIndex;
 		const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
 		for (const family of MODEL_FAMILIES) {
-			activeIndexByFamily[family] = activeIndex;
+			const priorFamilyIndex =
+				stored?.activeIndexByFamily?.[family] ?? stored?.activeIndex;
+			activeIndexByFamily[family] =
+				options.preserveSelection &&
+				validSelectionIndex(priorFamilyIndex, accounts)
+					? priorFamilyIndex
+					: nextActiveIndex;
 		}
 
-		await persist({
+		const nextStorage: AccountStorageV3 = {
 			version: 3,
 			accounts,
-			activeIndex,
+			activeIndex: nextActiveIndex,
 			activeIndexByFamily,
-		});
+			affinityGeneration: stored?.affinityGeneration,
+		};
+		// Login only updates a row in place or appends one; it never reorders or
+		// removes the pool. Preserve the raw pin position so even duplicate
+		// identities keep pointing at the exact row the user selected.
+		if (validSelectionIndex(stored?.pinnedAccountIndex, accounts)) {
+			nextStorage.pinnedAccountIndex = stored.pinnedAccountIndex;
+		}
+
+		await persist(nextStorage);
 
 		return outcome;
 	});

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -6329,6 +6329,11 @@ describe("codex manager cli commands", () => {
 		uiMocks.select.mockResolvedValueOnce("manual");
 
 		const authModule = await import("../lib/auth/auth.js");
+		const accountsModule = await import("../lib/accounts.js");
+		vi.mocked(accountsModule.extractAccountId).mockReturnValueOnce("acc_refresh");
+		vi.mocked(accountsModule.extractAccountEmail).mockReturnValueOnce(
+			"refresh@example.com",
+		);
 		vi.mocked(authModule.createAuthorizationFlow).mockResolvedValueOnce({
 			pkce: { challenge: "pkce-challenge", verifier: "pkce-verifier" },
 			state: "oauth-state",

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -38,6 +38,20 @@ describe("codex-manager help parsers", () => {
 		});
 	});
 
+	it("rejects --account combined with --org", () => {
+		// --org rebinds the login to a different workspace, which is exactly the
+		// identity change a targeted re-auth refuses to write.
+		const result = parseAuthLoginArgs([
+			"--account",
+			"2",
+			"--org",
+			"org_team",
+		]);
+		expect(result.ok).toBe(false);
+		expect(result.ok === false && result.reason === "error" && result.message)
+			.toContain("Cannot combine --account with --org");
+	});
+
 	it("rejects --account without an identity", () => {
 		expect(parseAuthLoginArgs(["--account"])).toEqual({
 			ok: false,

--- a/test/codex-manager-help.test.ts
+++ b/test/codex-manager-help.test.ts
@@ -7,6 +7,46 @@ import {
 import { DEFAULT_PROBE_MODEL } from "../lib/request/helpers/model-map.js";
 
 describe("codex-manager help parsers", () => {
+	it("parses selection-preserving and targeted re-auth options", () => {
+		expect(
+			parseAuthLoginArgs([
+				"--device-auth",
+				"--preserve-selection",
+				"--account",
+				"acc_target",
+			]),
+		).toEqual({
+			ok: true,
+			options: {
+				manual: false,
+				deviceAuth: true,
+				preserveSelection: true,
+				account: "acc_target",
+			},
+		});
+	});
+
+	it("makes a targeted re-auth preserve selection even without the flag", () => {
+		expect(parseAuthLoginArgs(["--account=a@example.com"])).toEqual({
+			ok: true,
+			options: {
+				manual: false,
+				deviceAuth: false,
+				preserveSelection: true,
+				account: "a@example.com",
+			},
+		});
+	});
+
+	it("rejects --account without an identity", () => {
+		expect(parseAuthLoginArgs(["--account"])).toEqual({
+			ok: false,
+			reason: "error",
+			message:
+				"Missing value for --account. Usage: codex-multi-auth login --account <index|email|account_id>",
+		});
+	});
+
 	it("parses login flags without printing usage", () => {
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
 

--- a/test/login-flow.test.ts
+++ b/test/login-flow.test.ts
@@ -99,6 +99,36 @@ function deps() {
 	};
 }
 
+type PersistOutcome = "inserted" | "updated" | "rebound";
+
+// persistAccountPool reports which row it wrote and whether that row owns the
+// native ~/.codex/auth.json selection; the flow gates its sync on that.
+function persistResult(
+	overrides: Partial<{
+		outcome: PersistOutcome;
+		accountIndex: number;
+		activeIndex: number;
+		isActiveAccount: boolean;
+		accountEnabled: boolean;
+	}> = {},
+) {
+	return {
+		outcome: "inserted" as PersistOutcome,
+		accountIndex: 0,
+		activeIndex: 0,
+		isActiveAccount: true,
+		accountEnabled: true,
+		...overrides,
+	};
+}
+
+// A plain login opts into none of the targeted-re-auth behaviour.
+const PLAIN_PERSIST_OPTIONS = {
+	preserveSelection: undefined,
+	expectedAccount: undefined,
+	expectedAccountIndex: undefined,
+};
+
 const CANCELLED = { type: "failed" as const, message: "User cancelled login" };
 const TOKEN_SUCCESS = { type: "success" as const };
 const RESOLVED = { type: "success" as const, accountIdOverride: "acc_x" };
@@ -127,7 +157,10 @@ beforeEach(() => {
 	// "rebound"/"updated" semantics override this with a non-growing impl.
 	persistAccountPoolMock.mockImplementation(async () => {
 		accountsOnDisk = storageWith((accountsOnDisk?.accounts.length ?? 0) + 1);
-		return "inserted";
+		return persistResult({
+			accountIndex: (accountsOnDisk?.accounts.length ?? 1) - 1,
+			activeIndex: (accountsOnDisk?.accounts.length ?? 1) - 1,
+		});
 	});
 	syncSelectionToCodexMock.mockResolvedValue(undefined);
 	promptAddAnotherAccountMock.mockResolvedValue(false);
@@ -178,9 +211,17 @@ describe("runAuthLogin argument handling", () => {
 });
 
 describe("runAuthLogin explicit transports", () => {
-	it("targeted re-auth preserves selection and does not sync Codex auth", async () => {
+	it("targeted re-auth of a non-active row preserves selection and skips the Codex sync", async () => {
 		accountsOnDisk = storageWith(2);
 		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+		persistAccountPoolMock.mockResolvedValue(
+			persistResult({
+				outcome: "updated",
+				accountIndex: 1,
+				activeIndex: 0,
+				isActiveAccount: false,
+			}),
+		);
 
 		expect(
 			await runAuthLogin(
@@ -197,10 +238,76 @@ describe("runAuthLogin explicit transports", () => {
 			{
 				preserveSelection: true,
 				expectedAccount: expect.objectContaining({ accountId: "acc_a1" }),
+				// The position the target occupied when the flow resolved it, so
+				// the transaction can stay deterministic across duplicate rows.
+				expectedAccountIndex: 1,
 			},
 		);
 		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
 		expect(promptAddAnotherAccountMock).not.toHaveBeenCalled();
+	});
+
+	it("syncs Codex auth when the refreshed row is the active account", async () => {
+		// Regression: gating the sync on --preserve-selection alone stranded the
+		// native CLI on the expired tokens of the account just refreshed, and the
+		// drift check never repaired it (it compares identity, not tokens).
+		accountsOnDisk = storageWith(2);
+		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+		persistAccountPoolMock.mockResolvedValue(
+			persistResult({
+				outcome: "updated",
+				accountIndex: 0,
+				activeIndex: 0,
+				isActiveAccount: true,
+			}),
+		);
+
+		expect(
+			await runAuthLogin(["--account", "1", "--preserve-selection"], deps()),
+		).toBe(0);
+
+		expect(persistAccountPoolMock).toHaveBeenCalledExactlyOnceWith(
+			[RESOLVED],
+			false,
+			{
+				preserveSelection: true,
+				expectedAccount: expect.objectContaining({ accountId: "acc_a0" }),
+				expectedAccountIndex: 0,
+			},
+		);
+		expect(syncSelectionToCodexMock).toHaveBeenCalledExactlyOnceWith(RESOLVED);
+	});
+
+	it("tells the user a refreshed account is still disabled", async () => {
+		accountsOnDisk = storageWith(2);
+		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+		persistAccountPoolMock.mockResolvedValue(
+			persistResult({
+				outcome: "updated",
+				accountIndex: 1,
+				activeIndex: 0,
+				isActiveAccount: false,
+				accountEnabled: false,
+			}),
+		);
+
+		expect(await runAuthLogin(["--account", "2"], deps())).toBe(0);
+
+		expect(loggedLines(logSpy).join("\n")).toContain(
+			"Account 2 is still disabled",
+		);
+	});
+
+	it("rejects --account combined with --org before starting a login", async () => {
+		expect(
+			await runAuthLogin(["--account", "2", "--org", "org_team"], deps()),
+		).toBe(1);
+
+		expect(loadAccountsMock).not.toHaveBeenCalled();
+		expect(runSignInFlowMock).not.toHaveBeenCalled();
+		expect(loggedLines(errorSpy).join("\n")).toContain(
+			"Cannot combine --account with --org",
+		);
 	});
 
 	it("refuses a missing targeted account before starting OAuth", async () => {
@@ -274,6 +381,7 @@ describe("runAuthLogin explicit transports", () => {
 		expect(persistAccountPoolMock).toHaveBeenCalledExactlyOnceWith(
 			[RESOLVED],
 			false,
+			PLAIN_PERSIST_OPTIONS,
 		);
 		expect(syncSelectionToCodexMock).toHaveBeenCalledExactlyOnceWith(RESOLVED);
 		// Empty pool at start: this was not a forced re-login.
@@ -292,7 +400,7 @@ describe("runAuthLogin explicit transports", () => {
 			runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
 			persistAccountPoolMock.mockImplementation(async () => {
 				accountsOnDisk = storageWith(1);
-				return outcome;
+				return persistResult({ outcome });
 			});
 
 			expect(await runAuthLogin(["--manual"], deps())).toBe(0);
@@ -304,7 +412,7 @@ describe("runAuthLogin explicit transports", () => {
 		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
 		persistAccountPoolMock.mockImplementation(async () => {
 			accountsOnDisk = storageWith(ACCOUNT_LIMITS.MAX_ACCOUNTS);
-			return "inserted";
+			return persistResult();
 		});
 
 		expect(await runAuthLogin(["--manual"], deps())).toBe(0);

--- a/test/login-flow.test.ts
+++ b/test/login-flow.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ACCOUNT_LIMITS } from "../lib/constants.js";
+import { CodexValidationError } from "../lib/errors.js";
 import type { AccountMetadataV3, AccountStorageV3 } from "../lib/storage.js";
 
 const {
@@ -177,6 +178,56 @@ describe("runAuthLogin argument handling", () => {
 });
 
 describe("runAuthLogin explicit transports", () => {
+	it("targeted re-auth preserves selection and does not sync Codex auth", async () => {
+		accountsOnDisk = storageWith(2);
+		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+
+		expect(
+			await runAuthLogin(
+				["--account", "acc_a1", "--preserve-selection"],
+				deps(),
+			),
+		).toBe(0);
+
+		expect(promptLoginModeMock).not.toHaveBeenCalled();
+		expect(runSignInFlowMock).toHaveBeenCalledExactlyOnceWith(true, "browser");
+		expect(persistAccountPoolMock).toHaveBeenCalledExactlyOnceWith(
+			[RESOLVED],
+			false,
+			{
+				preserveSelection: true,
+				expectedAccount: expect.objectContaining({ accountId: "acc_a1" }),
+			},
+		);
+		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
+		expect(promptAddAnotherAccountMock).not.toHaveBeenCalled();
+	});
+
+	it("refuses a missing targeted account before starting OAuth", async () => {
+		accountsOnDisk = storageWith(1);
+
+		expect(await runAuthLogin(["--account", "acc_missing"], deps())).toBe(1);
+
+		expect(runSignInFlowMock).not.toHaveBeenCalled();
+		expect(persistAccountPoolMock).not.toHaveBeenCalled();
+		expect(loggedLines(errorSpy).join("\n")).toContain("missing or ambiguous");
+	});
+
+	it("reports a targeted identity mismatch without syncing selection", async () => {
+		accountsOnDisk = storageWith(1);
+		runSignInFlowMock.mockResolvedValue(TOKEN_SUCCESS);
+		persistAccountPoolMock.mockRejectedValue(
+			new CodexValidationError("authenticated identity does not match"),
+		);
+
+		expect(await runAuthLogin(["--account", "acc_a0"], deps())).toBe(1);
+
+		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
+		expect(loggedLines(errorSpy).join("\n")).toContain(
+			"Re-authentication failed",
+		);
+	});
+
 	it("bypasses the dashboard with --device-auth and exits cleanly on cancel", async () => {
 		// With saved accounts a plain `login` would open the dashboard; an
 		// explicit transport must skip it, and cancelling must NOT fall back to
@@ -218,6 +269,7 @@ describe("runAuthLogin explicit transports", () => {
 		expect(resolveAccountSelectionMock).toHaveBeenCalledExactlyOnceWith(
 			TOKEN_SUCCESS,
 			"org_team",
+			undefined,
 		);
 		expect(persistAccountPoolMock).toHaveBeenCalledExactlyOnceWith(
 			[RESOLVED],

--- a/test/login-menu-actions.test.ts
+++ b/test/login-menu-actions.test.ts
@@ -413,9 +413,16 @@ describe("handleManageAction refresh", () => {
 
 		// Non-TTY sign-in mode resolves to "browser" without prompting.
 		expect(runOAuthFlowMock).toHaveBeenCalledWith(true, "browser");
-		expect(resolveAccountSelectionMock).toHaveBeenCalledWith(tokenResult);
-		expect(persistAccountPoolMock).toHaveBeenCalledWith([resolved], false);
-		expect(syncSelectionToCodexMock).toHaveBeenCalledWith(resolved);
+		expect(resolveAccountSelectionMock).toHaveBeenCalledWith(
+			tokenResult,
+			undefined,
+			"acc_a",
+		);
+		expect(persistAccountPoolMock).toHaveBeenCalledWith([resolved], false, {
+			preserveSelection: true,
+			expectedAccount: storage.accounts[0],
+		});
+		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
 		expect(logSpy).toHaveBeenCalledWith("Refreshed account 1.");
 	});
 
@@ -481,7 +488,7 @@ describe("handleManageAction refresh", () => {
 		} satisfies MenuResult);
 
 		expect(runOAuthFlowMock).toHaveBeenCalledWith(true, "manual");
-		expect(syncSelectionToCodexMock).toHaveBeenCalledWith(resolved);
+		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
 	});
 
 	it("bails out silently on a non-transport prompt selection", async () => {

--- a/test/login-menu-actions.test.ts
+++ b/test/login-menu-actions.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { promptLoginMode } from "../lib/cli.js";
+import { CodexValidationError } from "../lib/errors.js";
 import { UI_COPY } from "../lib/ui/ui-copy.js";
 import type {
 	AccountMetadataV3,
@@ -396,6 +397,27 @@ describe("handleManageAction toggle", () => {
 	});
 });
 
+// persistAccountPool reports the row it wrote and whether that row owns the
+// native ~/.codex/auth.json selection.
+function refreshResult(
+	overrides: Partial<{
+		outcome: "inserted" | "updated" | "rebound";
+		accountIndex: number;
+		activeIndex: number;
+		isActiveAccount: boolean;
+		accountEnabled: boolean;
+	}> = {},
+) {
+	return {
+		outcome: "updated" as const,
+		accountIndex: 0,
+		activeIndex: 0,
+		isActiveAccount: true,
+		accountEnabled: true,
+		...overrides,
+	};
+}
+
 describe("handleManageAction refresh", () => {
 	it("runs the OAuth flow and persists the resolved selection on success", async () => {
 		const storage = storageWith([account("a")]);
@@ -403,7 +425,7 @@ describe("handleManageAction refresh", () => {
 		const resolved = { type: "success" as const, accountIdOverride: "acc_a" };
 		runOAuthFlowMock.mockResolvedValue(tokenResult);
 		resolveAccountSelectionMock.mockReturnValue(resolved);
-		persistAccountPoolMock.mockResolvedValue(undefined);
+		persistAccountPoolMock.mockResolvedValue(refreshResult());
 		syncSelectionToCodexMock.mockResolvedValue(undefined);
 
 		await handleManageAction(storage, {
@@ -421,9 +443,90 @@ describe("handleManageAction refresh", () => {
 		expect(persistAccountPoolMock).toHaveBeenCalledWith([resolved], false, {
 			preserveSelection: true,
 			expectedAccount: storage.accounts[0],
+			expectedAccountIndex: 0,
 		});
-		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
+		// Account 1 is the active row, so its fresh tokens must reach the native
+		// Codex CLI; dropping this sync left `codex` on the expired credentials.
+		expect(syncSelectionToCodexMock).toHaveBeenCalledWith(resolved);
 		expect(logSpy).toHaveBeenCalledWith("Refreshed account 1.");
+	});
+
+	it("leaves the Codex selection alone when refreshing a non-active row", async () => {
+		const storage = storageWith([account("a"), account("b")]);
+		const resolved = { type: "success" as const, accountIdOverride: "acc_b" };
+		runOAuthFlowMock.mockResolvedValue({ type: "success" });
+		resolveAccountSelectionMock.mockReturnValue(resolved);
+		persistAccountPoolMock.mockResolvedValue(
+			refreshResult({ accountIndex: 1, isActiveAccount: false }),
+		);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 1,
+		} satisfies MenuResult);
+
+		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
+		expect(logSpy).toHaveBeenCalledWith("Refreshed account 2.");
+	});
+
+	it("refuses a mismatched sign-in without crashing the dashboard", async () => {
+		// Nothing between here and the process entrypoint catches this, so an
+		// uncaught throw would take the whole interactive session down.
+		const storage = storageWith([account("a")]);
+		runOAuthFlowMock.mockResolvedValue({ type: "success" });
+		resolveAccountSelectionMock.mockReturnValue({ type: "success" });
+		persistAccountPoolMock.mockRejectedValue(
+			new CodexValidationError(
+				"The authenticated Codex identity does not match the account requested for re-authentication.",
+			),
+		);
+
+		await expect(
+			handleManageAction(storage, {
+				mode: "manage",
+				refreshAccountIndex: 0,
+			} satisfies MenuResult),
+		).resolves.toBeUndefined();
+
+		expect(errorSpy.mock.calls.map(String).join("\n")).toContain(
+			"Refresh failed: The authenticated Codex identity does not match",
+		);
+		expect(syncSelectionToCodexMock).not.toHaveBeenCalled();
+	});
+
+	it("names the row that was actually written, not the stale menu index", async () => {
+		// The pool can shift between the dashboard render and the transaction.
+		const storage = storageWith([account("a"), account("b")]);
+		runOAuthFlowMock.mockResolvedValue({ type: "success" });
+		resolveAccountSelectionMock.mockReturnValue({ type: "success" });
+		persistAccountPoolMock.mockResolvedValue(
+			refreshResult({ accountIndex: 0, isActiveAccount: true }),
+		);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 1,
+		} satisfies MenuResult);
+
+		expect(logSpy).toHaveBeenCalledWith("Refreshed account 1.");
+	});
+
+	it("reports that a refreshed account is still disabled", async () => {
+		const storage = storageWith([account("a")]);
+		runOAuthFlowMock.mockResolvedValue({ type: "success" });
+		resolveAccountSelectionMock.mockReturnValue({ type: "success" });
+		persistAccountPoolMock.mockResolvedValue(
+			refreshResult({ accountEnabled: false }),
+		);
+
+		await handleManageAction(storage, {
+			mode: "manage",
+			refreshAccountIndex: 0,
+		} satisfies MenuResult);
+
+		expect(logSpy.mock.calls.map(String).join("\n")).toContain(
+			"Account 1 is still disabled",
+		);
 	});
 
 	it("reports a failed OAuth flow without persisting anything", async () => {
@@ -479,7 +582,9 @@ describe("handleManageAction refresh", () => {
 		const resolved = { type: "success" as const, accountIdOverride: "acc_a" };
 		runOAuthFlowMock.mockResolvedValue({ type: "success" });
 		resolveAccountSelectionMock.mockReturnValue(resolved);
-		persistAccountPoolMock.mockResolvedValue(undefined);
+		persistAccountPoolMock.mockResolvedValue(
+			refreshResult({ isActiveAccount: false }),
+		);
 		syncSelectionToCodexMock.mockResolvedValue(undefined);
 
 		await handleManageAction(storage, {

--- a/test/login-oauth-selection.test.ts
+++ b/test/login-oauth-selection.test.ts
@@ -156,6 +156,49 @@ describe("resolveAccountSelection", () => {
 		expect(result.accountLabel).toContain("Target");
 	});
 
+	it("prefers an explicit --account target over an ambient env override", () => {
+		// CODEX_AUTH_ACCOUNT_ID is ambient config; `--account` names one saved row
+		// for this call. Letting the env win hijacked the targeted re-auth and
+		// then failed the identity guard with a misleading mismatch error.
+		process.env.CODEX_AUTH_ACCOUNT_ID = "org_env";
+		jwtPayloads.set("access-token", {
+			[JWT_CLAIM_PATH]: { chatgpt_account_id: "acc_personal" },
+			organizations: [
+				{ id: "org_env", name: "Env" },
+				{ id: "org_target", name: "Target" },
+			],
+		});
+
+		const result = resolveAccountSelection(
+			BASE_TOKENS,
+			undefined,
+			"org_target",
+		);
+
+		expect(result.accountIdOverride).toBe("org_target");
+	});
+
+	it("pins an id_token-sourced target so the access token cannot overwrite it", () => {
+		// `id_token` auto-follows the access token in resolveRequestAccountId,
+		// which would rewrite the binding back to the access-token account and
+		// make persistAccountPool reject our own write.
+		jwtPayloads.set("access-token", {
+			[JWT_CLAIM_PATH]: { chatgpt_account_id: "acc_access" },
+		});
+		jwtPayloads.set("id-token", {
+			[JWT_CLAIM_PATH]: { chatgpt_account_id: "acc_id_only" },
+		});
+
+		const result = resolveAccountSelection(
+			{ ...BASE_TOKENS, idToken: "id-token" },
+			undefined,
+			"acc_id_only",
+		);
+
+		expect(result.accountIdOverride).toBe("acc_id_only");
+		expect(result.accountIdSource).toBe("manual");
+	});
+
 	it("binds an explicit --org override as manual and reuses the candidate label", () => {
 		jwtPayloads.set("access-token", {
 			organizations: [
@@ -304,7 +347,12 @@ describe("persistAccountPool selection-preserving re-auth", () => {
 		expect(persisted?.accounts[1]?.refreshToken).toBe("new-refresh-b");
 	});
 
-	it("preserves a pin even for a normal add that selects the new login", async () => {
+	it("drops a stale pin on a normal add that selects the new login", async () => {
+		// A plain login moves activeIndex onto the account just signed in and
+		// publishes it to ~/.codex/auth.json. Carrying the old pin through would
+		// leave storage claiming one account is active while the runtime proxy
+		// (which resolves pinnedAccountIndex first) routes every request to
+		// another -- what `status` surfaces as "runtime using N, pin requests M".
 		const a = savedAccount("a");
 		const b = savedAccount("b");
 		installTransaction({
@@ -318,7 +366,146 @@ describe("persistAccountPool selection-preserving re-auth", () => {
 		await persistAccountPool([incoming("b")], false);
 
 		expect(persisted?.activeIndex).toBe(1);
-		expect(persisted?.pinnedAccountIndex).toBe(0);
+		expect(persisted?.pinnedAccountIndex).toBeUndefined();
+	});
+
+	it("finds the target after the runtime rotated its refresh token", async () => {
+		// AccountManager.commitRefreshedAuth rewrites a stored refreshToken
+		// whenever a live codex session refreshes the account. Matching the target
+		// by refresh token alone threw away a completed OAuth as "no longer
+		// present" whenever a sign-in overlapped an active session.
+		const expected = savedAccount("rot");
+		installTransaction({
+			version: 3,
+			accounts: [{ ...expected, refreshToken: "runtime-rotated-refresh" }],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		});
+
+		await persistAccountPool([incoming("rot")], false, {
+			preserveSelection: true,
+			expectedAccount: expected,
+		});
+
+		expect(persisted?.accounts[0]?.refreshToken).toBe("new-refresh-rot");
+	});
+
+	it("re-authenticates a legacy row that carries no account id", async () => {
+		// Rows saved before workspace tracking (#491) have no accountId, while
+		// fresh tokens essentially always carry one. Demanding the id on both
+		// sides made every such row permanently un-refreshable via --account.
+		const legacy: AccountMetadataV3 = {
+			...savedAccount("legacy"),
+			accountId: undefined,
+		};
+		installTransaction({
+			version: 3,
+			accounts: [legacy],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		});
+
+		await persistAccountPool([incoming("legacy")], false, {
+			preserveSelection: true,
+			expectedAccount: legacy,
+		});
+
+		expect(persisted?.accounts[0]?.refreshToken).toBe("new-refresh-legacy");
+		expect(persisted?.accounts[0]?.accountId).toBe("acc_legacy");
+	});
+
+	it("keeps a deliberately disabled account out of rotation", async () => {
+		const disabled: AccountMetadataV3 = {
+			...savedAccount("off"),
+			enabled: false,
+		};
+		installTransaction({
+			version: 3,
+			accounts: [disabled],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		});
+
+		const result = await persistAccountPool([incoming("off")], false, {
+			preserveSelection: true,
+			expectedAccount: disabled,
+		});
+
+		expect(persisted?.accounts[0]?.refreshToken).toBe("new-refresh-off");
+		expect(persisted?.accounts[0]?.enabled).toBe(false);
+		expect(result?.accountEnabled).toBe(false);
+	});
+
+	it("re-enables an account on a plain login", async () => {
+		// Signing in without a target IS the user asking for that account back.
+		const disabled: AccountMetadataV3 = {
+			...savedAccount("off"),
+			enabled: false,
+		};
+		installTransaction({
+			version: 3,
+			accounts: [disabled],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		});
+
+		const result = await persistAccountPool([incoming("off")], false);
+
+		expect(persisted?.accounts[0]?.enabled).toBe(true);
+		expect(result?.accountEnabled).toBe(true);
+	});
+
+	it("ignores an index hint that no longer holds the expected identity", async () => {
+		const a = savedAccount("a");
+		const b = savedAccount("b");
+		installTransaction({
+			version: 3,
+			accounts: [a, b],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		});
+
+		// The caller saw `b` at index 0; a concurrent write reordered the pool.
+		await persistAccountPool([incoming("b")], false, {
+			preserveSelection: true,
+			expectedAccount: b,
+			expectedAccountIndex: 0,
+		});
+
+		expect(persisted?.accounts[0]?.refreshToken).toBe("old-refresh-a");
+		expect(persisted?.accounts[1]?.refreshToken).toBe("new-refresh-b");
+	});
+
+	it("reports which row it wrote and whether that row owns the Codex selection", async () => {
+		const a = savedAccount("a");
+		const b = savedAccount("b");
+		installTransaction({
+			version: 3,
+			accounts: [a, b],
+			activeIndex: 1,
+			activeIndexByFamily: { codex: 1 },
+		});
+
+		const refreshedActive = await persistAccountPool([incoming("b")], false, {
+			preserveSelection: true,
+			expectedAccount: b,
+		});
+		expect(refreshedActive).toMatchObject({
+			outcome: "updated",
+			accountIndex: 1,
+			activeIndex: 1,
+			isActiveAccount: true,
+		});
+
+		const refreshedOther = await persistAccountPool([incoming("a")], false, {
+			preserveSelection: true,
+			expectedAccount: a,
+		});
+		expect(refreshedOther).toMatchObject({
+			accountIndex: 0,
+			activeIndex: 1,
+			isActiveAccount: false,
+		});
 	});
 
 	it("rejects a different OAuth identity before persistence", async () => {
@@ -356,9 +543,13 @@ describe("persistAccountPool selection-preserving re-auth", () => {
 			pinnedAccountIndex: 1,
 		});
 
+		// Identity matching alone cannot separate these rows, and its newest-wins
+		// tie-break actively points at the other one (lastUsed 99 vs 1). The
+		// caller's verified position is what keeps `--account 1` deterministic.
 		await persistAccountPool([incoming("dup")], false, {
 			preserveSelection: true,
 			expectedAccount: target,
+			expectedAccountIndex: 0,
 		});
 
 		expect(persisted?.accounts[0]?.refreshToken).toBe("new-refresh-dup");

--- a/test/login-oauth-selection.test.ts
+++ b/test/login-oauth-selection.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { JWT_CLAIM_PATH } from "../lib/constants.js";
+import type { AccountMetadataV3, AccountStorageV3 } from "../lib/storage.js";
 
 // Maps fake token strings to decoded JWT payloads so the real candidate
 // extraction in lib/auth/token-utils.ts runs against controlled claims.
-const { jwtPayloads } = vi.hoisted(() => ({
+const { jwtPayloads, withAccountStorageTransactionMock } = vi.hoisted(() => ({
 	jwtPayloads: new Map<string, unknown>(),
+	withAccountStorageTransactionMock: vi.fn(),
 }));
 
 vi.mock("../lib/auth/auth.js", async (importOriginal) => {
@@ -15,8 +17,20 @@ vi.mock("../lib/auth/auth.js", async (importOriginal) => {
 	};
 });
 
-const { isAbortError, isOAuthCancellation, resolveAccountSelection } =
-	await import("../lib/codex-manager/login-oauth.js");
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		withAccountStorageTransaction: withAccountStorageTransactionMock,
+	};
+});
+
+const {
+	isAbortError,
+	isOAuthCancellation,
+	persistAccountPool,
+	resolveAccountSelection,
+} = await import("../lib/codex-manager/login-oauth.js");
 
 const BASE_TOKENS = {
 	type: "success" as const,
@@ -30,6 +44,7 @@ const originalEnvOverride = process.env.CODEX_AUTH_ACCOUNT_ID;
 
 beforeEach(() => {
 	jwtPayloads.clear();
+	withAccountStorageTransactionMock.mockReset();
 	delete process.env.CODEX_AUTH_ACCOUNT_ID;
 });
 
@@ -121,6 +136,26 @@ describe("resolveAccountSelection", () => {
 		]);
 	});
 
+	it("selects the targeted saved workspace instead of the default candidate", () => {
+		jwtPayloads.set("access-token", {
+			[JWT_CLAIM_PATH]: { chatgpt_account_id: "acc_personal" },
+			organizations: [
+				{ id: "org_default", name: "Default", is_default: true },
+				{ id: "org_target", name: "Target" },
+			],
+		});
+
+		const result = resolveAccountSelection(
+			BASE_TOKENS,
+			undefined,
+			"org_target",
+		);
+
+		expect(result.accountIdOverride).toBe("org_target");
+		expect(result.accountIdSource).toBe("org");
+		expect(result.accountLabel).toContain("Target");
+	});
+
 	it("binds an explicit --org override as manual and reuses the candidate label", () => {
 		jwtPayloads.set("access-token", {
 			organizations: [
@@ -191,5 +226,197 @@ describe("resolveAccountSelection", () => {
 		const result = resolveAccountSelection(BASE_TOKENS, "   ");
 
 		expect(result.accountIdOverride).toBe("org_env");
+	});
+});
+
+function savedAccount(id: string): AccountMetadataV3 {
+	return {
+		accountId: `acc_${id}`,
+		email: `${id}@example.com`,
+		refreshToken: `old-refresh-${id}`,
+		accessToken: `old-access-${id}`,
+		expiresAt: 10,
+		enabled: true,
+		addedAt: 1,
+		lastUsed: 1,
+	};
+}
+
+function incoming(id: string) {
+	const access = `access-${id}`;
+	const idToken = `id-${id}`;
+	jwtPayloads.set(access, {
+		email: `${id}@example.com`,
+		[JWT_CLAIM_PATH]: { chatgpt_account_id: `acc_${id}` },
+	});
+	jwtPayloads.set(idToken, { email: `${id}@example.com` });
+	return {
+		type: "success" as const,
+		access,
+		refresh: `new-refresh-${id}`,
+		expires: 20,
+		idToken,
+		accountIdOverride: `acc_${id}`,
+		accountIdSource: "token" as const,
+	};
+}
+
+describe("persistAccountPool selection-preserving re-auth", () => {
+	let persisted: AccountStorageV3 | null;
+
+	beforeEach(() => {
+		persisted = null;
+	});
+
+	function installTransaction(storage: AccountStorageV3): void {
+		withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+			handler(storage, async (next: AccountStorageV3) => {
+				persisted = next;
+			}),
+		);
+	}
+
+	it("refreshes the target while preserving global, family, pin, and affinity state", async () => {
+		const a = savedAccount("a");
+		const b = savedAccount("b");
+		installTransaction({
+			version: 3,
+			accounts: [a, b],
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0, "codex-max": 1 },
+			pinnedAccountIndex: 0,
+			affinityGeneration: 7,
+		});
+
+		await persistAccountPool([incoming("b")], false, {
+			preserveSelection: true,
+			expectedAccount: b,
+		});
+
+		expect(persisted).toMatchObject({
+			activeIndex: 0,
+			pinnedAccountIndex: 0,
+			affinityGeneration: 7,
+		});
+		expect(persisted?.activeIndexByFamily?.codex).toBe(0);
+		expect(persisted?.activeIndexByFamily?.["codex-max"]).toBe(1);
+		expect(persisted?.accounts).toHaveLength(2);
+		expect(persisted?.accounts[1]?.refreshToken).toBe("new-refresh-b");
+	});
+
+	it("preserves a pin even for a normal add that selects the new login", async () => {
+		const a = savedAccount("a");
+		const b = savedAccount("b");
+		installTransaction({
+			version: 3,
+			accounts: [a, b],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+			pinnedAccountIndex: 0,
+		});
+
+		await persistAccountPool([incoming("b")], false);
+
+		expect(persisted?.activeIndex).toBe(1);
+		expect(persisted?.pinnedAccountIndex).toBe(0);
+	});
+
+	it("rejects a different OAuth identity before persistence", async () => {
+		const a = savedAccount("a");
+		const b = savedAccount("b");
+		installTransaction({
+			version: 3,
+			accounts: [a, b],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+			pinnedAccountIndex: 0,
+		});
+
+		await expect(
+			persistAccountPool([incoming("a")], false, {
+				preserveSelection: true,
+				expectedAccount: b,
+			}),
+		).rejects.toThrow("does not match");
+		expect(persisted).toBeNull();
+	});
+
+	it("updates the exact targeted row when saved identities are duplicated", async () => {
+		const target = savedAccount("dup");
+		const other = {
+			...savedAccount("dup"),
+			refreshToken: "old-refresh-other-row",
+			lastUsed: 99,
+		};
+		installTransaction({
+			version: 3,
+			accounts: [target, other],
+			activeIndex: 1,
+			activeIndexByFamily: { codex: 1 },
+			pinnedAccountIndex: 1,
+		});
+
+		await persistAccountPool([incoming("dup")], false, {
+			preserveSelection: true,
+			expectedAccount: target,
+		});
+
+		expect(persisted?.accounts[0]?.refreshToken).toBe("new-refresh-dup");
+		expect(persisted?.accounts[1]?.refreshToken).toBe(
+			"old-refresh-other-row",
+		);
+		expect(persisted?.activeIndex).toBe(1);
+		expect(persisted?.activeIndexByFamily?.codex).toBe(1);
+		expect(persisted?.pinnedAccountIndex).toBe(1);
+	});
+
+	it("accepts an email change when the provider account id is unchanged", async () => {
+		const target = savedAccount("renamed");
+		installTransaction({
+			version: 3,
+			accounts: [target],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+			pinnedAccountIndex: 0,
+		});
+		const result = incoming("renamed");
+		jwtPayloads.set(result.access, {
+			email: "new-address@example.com",
+			[JWT_CLAIM_PATH]: { chatgpt_account_id: "acc_renamed" },
+		});
+		jwtPayloads.set(result.idToken, { email: "new-address@example.com" });
+
+		await persistAccountPool([result], false, {
+			preserveSelection: true,
+			expectedAccount: target,
+		});
+
+		expect(persisted?.accounts[0]?.email).toBe("new-address@example.com");
+		expect(persisted?.pinnedAccountIndex).toBe(0);
+	});
+
+	it("tracks the exact record across a concurrent refresh-token rotation", async () => {
+		const expected = { ...savedAccount("stable"), recordId: "record-stable" };
+		installTransaction({
+			version: 3,
+			accounts: [
+				{
+					...expected,
+					refreshToken: "runtime-rotated-refresh",
+				},
+			],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+			pinnedAccountIndex: 0,
+		});
+
+		await persistAccountPool([incoming("stable")], false, {
+			preserveSelection: true,
+			expectedAccount: expected,
+		});
+
+		expect(persisted?.accounts[0]?.recordId).toBe("record-stable");
+		expect(persisted?.accounts[0]?.refreshToken).toBe("new-refresh-stable");
+		expect(persisted?.pinnedAccountIndex).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

- add `login --preserve-selection` for a one-shot login that does not change global, model-family, or pinned selection
- add `login --account <index|email|account_id>` for exact targeted re-authentication
- resolve the exact stored row by stable `recordId`, with a refresh-token fallback for legacy rows
- validate provider account identity before persistence and select the requested workspace instead of the default candidate
- keep affinity generation and every selection index stable while refreshing credentials

## What Changed

- extended login parsing, help, and reference documentation
- made dashboard refresh selection-preserving
- made new-account login duplicate-safe through the existing real-identity merge path
- added coverage for duplicate rows, email changes, workspace selection, concurrent token rotation, and mismatch rollback

## Testing

- `npm run lint`
- `npm run typecheck`
- focused and documentation tests
- `npm run build`
- `npm run clean:repo:check`
- full suite through pull-request CI

## Risk and Rollback

Risk is limited to OAuth persistence for targeted and dashboard refreshes. Reverting this commit restores the previous login behavior. Identity validation runs inside the existing storage transaction before persistence, so rejected re-authentication performs no write.
