### PR TITLE
fix(ci): build dist before script typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Typecheck scripts
         run: npm run typecheck:scripts
 
@@ -119,6 +122,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Build
+        run: npm run build
 
       - name: Typecheck scripts
         run: npm run typecheck:scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
-
       - name: Typecheck scripts
         run: npm run typecheck:scripts
 
@@ -122,9 +119,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Build
-        run: npm run build
 
       - name: Typecheck scripts
         run: npm run typecheck:scripts
@@ -188,9 +182,6 @@ jobs:
         # tests-ci-05: run coverage on PRs so the 80% threshold gates the PR,
         # not only the post-merge push-to-main run of the test matrix.
         run: npm run coverage
-
-      - name: Build
-        run: npm run build
 
       - name: Typecheck scripts
         run: npm run typecheck:scripts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ If a proposal conflicts with OpenAI policy boundaries, it will be declined.
 ```bash
 npm ci
 npm run typecheck
+npm run typecheck:scripts
 npm run lint
 npm test
 npm run build
@@ -99,6 +100,7 @@ Set `HUSKY=0` in environments where the hook install is undesirable.
 2. Keep commits atomic and reviewable.
 3. Run the full local gate:
    - `npm run typecheck`
+   - `npm run typecheck:scripts`
    - `npm run lint`
    - `npm test`
    - `npm run build`

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"build": "tsc && node scripts/copy-oauth-success.js",
 		"generate:schema": "npm run build && node scripts/generate-config-schema.mjs",
 		"typecheck": "tsc --noEmit",
-		"typecheck:scripts": "tsc -p tsconfig.scripts.json",
+		"typecheck:scripts": "npm run build && tsc -p tsconfig.scripts.json",
 		"lint": "npm run lint:ts && npm run lint:scripts",
 		"lint:ts": "eslint . --ext .ts",
 		"lint:scripts": "eslint scripts --ext .js,.mjs",

--- a/test/ci-workflows.test.ts
+++ b/test/ci-workflows.test.ts
@@ -4,26 +4,104 @@ import { describe, expect, it } from "vitest";
 
 const projectRoot = resolve(process.cwd());
 
+/** A ci.yml step reduced to what the ordering guards need to reason about. */
+interface WorkflowStep {
+	run: string;
+	conditional: boolean;
+}
+
 function readWorkflow(name: string): string {
 	// Normalize CRLF -> LF so the job-boundary matching in extractJobBlock works
 	// on Windows checkouts (autocrlf), where the raw file uses `\r\n` and the
 	// `:\n` boundary regex would otherwise never match, over-capturing to EOF.
-	return readFileSync(join(projectRoot, ".github", "workflows", name), "utf-8").replace(
-		/\r\n/g,
-		"\n",
-	);
+	return readFileSync(
+		join(projectRoot, ".github", "workflows", name),
+		"utf-8",
+	).replace(/\r\n/g, "\n");
+}
+
+function readPackageScripts(): Record<string, string> {
+	const raw = readFileSync(join(projectRoot, "package.json"), "utf-8");
+	const parsed = JSON.parse(raw) as { scripts?: Record<string, string> };
+	return parsed.scripts ?? {};
+}
+
+// A top-level job key: exactly two spaces of indent, then a bare `name:` with
+// nothing after it but an optional comment. Underscores and uppercase are legal
+// in GitHub job ids, so the character class must accept them — a narrower class
+// silently runs past the boundary and makes every extracted block over-capture
+// into the following jobs.
+const JOB_KEY_PATTERN = /\n {2}([A-Za-z0-9_][\w-]*):[ \t]*(?:#[^\n]*)?\n/;
+
+function listJobs(workflow: string): string[] {
+	const jobsAt = workflow.indexOf("\njobs:\n");
+	const body = jobsAt === -1 ? workflow : workflow.slice(jobsAt);
+	const scanner = new RegExp(JOB_KEY_PATTERN.source, "g");
+	const names: string[] = [];
+	let match = scanner.exec(body);
+	while (match !== null) {
+		const name = match[1];
+		if (name !== undefined) {
+			names.push(name);
+		}
+		// Rewind over the trailing newline the match consumed, so two job keys
+		// on consecutive lines are both found.
+		scanner.lastIndex = Math.max(scanner.lastIndex - 1, match.index + 1);
+		match = scanner.exec(body);
+	}
+	return names;
 }
 
 function extractJobBlock(workflow: string, jobName: string): string {
-	const start = workflow.indexOf(`  ${jobName}:`);
+	const start = workflow.indexOf(`\n  ${jobName}:`);
 	if (start === -1) {
 		throw new Error(`Missing workflow job: ${jobName}`);
 	}
-	const nextMatch = workflow
-		.slice(start + 1)
-		.match(/\n  [a-z0-9][a-z0-9-]*:\n/);
-	const end = nextMatch ? start + 1 + nextMatch.index + 1 : workflow.length;
-	return workflow.slice(start, end);
+	const rest = workflow.slice(start + 1);
+	const nextAt = rest.search(JOB_KEY_PATTERN);
+	return nextAt === -1 ? rest : rest.slice(0, nextAt + 1);
+}
+
+/**
+ * Pull the `run:` payload out of a single step, covering both the inline form
+ * (`run: npm run build`) and the block-scalar form (`run: |` plus indented
+ * lines). Anchoring on the YAML key position is what makes this immune to
+ * commented-out steps and to command text that merely appears inside another
+ * step's heredoc — a plain substring search treats both as a real build.
+ */
+function extractRun(step: string): string {
+	const block = step.match(
+		/^(?: {6}- | {8})run: [|>][-+]?[ \t]*\n((?: {10}[^\n]*(?:\n|$))*)/m,
+	);
+	if (block) {
+		return block[1] ?? "";
+	}
+	const inline = step.match(/^(?: {6}- | {8})run:[ \t]+([^\n]*)$/m);
+	return inline?.[1] ?? "";
+}
+
+function extractSteps(jobBlock: string): WorkflowStep[] {
+	const stepsAt = jobBlock.search(/\n {4}steps:[ \t]*\n/);
+	if (stepsAt === -1) {
+		return [];
+	}
+	return jobBlock
+		.slice(stepsAt)
+		.split(/\n {6}- /)
+		.slice(1)
+		.map((chunk) => {
+			const step = `      - ${chunk}`;
+			return {
+				run: extractRun(step),
+				// A step guarded by `if:` may be skipped at runtime, so it cannot
+				// be counted on to have produced dist for a later step.
+				conditional: /^ {8}if:/m.test(step),
+			};
+		});
+}
+
+function buildsGeneratedDist(command: string): boolean {
+	return /(?:^|&&|\|\||;)\s*npm run build\b/.test(command);
 }
 
 describe("CI workflow parity", () => {
@@ -33,9 +111,9 @@ describe("CI workflow parity", () => {
 	it("is the single consolidated workflow (pr-ci.yml removed) covering push and PR", () => {
 		const ci = readWorkflow("ci.yml");
 
-		expect(existsSync(join(projectRoot, ".github", "workflows", "pr-ci.yml"))).toBe(
-			false,
-		);
+		expect(
+			existsSync(join(projectRoot, ".github", "workflows", "pr-ci.yml")),
+		).toBe(false);
 		expect(ci).toContain("push:");
 		expect(ci).toContain("pull_request:");
 	});
@@ -86,19 +164,63 @@ describe("CI workflow parity", () => {
 		expect(windowsJob).not.toContain("github.event_name");
 	});
 
-	it("builds generated dist before script typechecking", () => {
-		const ci = readWorkflow("ci.yml");
-		for (const jobName of ["release-harness", "scripts-windows"]) {
-			const job = extractJobBlock(ci, jobName);
-			const buildIndex = job.indexOf("run: npm run build");
-			const scriptTypecheckIndex = job.indexOf("run: npm run typecheck:scripts");
+	// scripts/codex-multi-auth.js dynamically imports ../dist/lib/codex-manager.js
+	// and tsconfig.scripts.json typechecks it with checkJs, so `typecheck:scripts`
+	// fails with TS2307 whenever dist has not been generated. The build belongs in
+	// the script itself rather than in individual CI steps: that covers CI jobs,
+	// clean local checkouts and git hooks in one place, and it matches every other
+	// dist-dependent script here (pack:check, coverage, bench:runtime-path,
+	// generate:schema all start with `npm run build &&`).
+	it("builds generated dist inside the typecheck:scripts script", () => {
+		const scripts = readPackageScripts();
+		const typecheckScripts = scripts["typecheck:scripts"] ?? "";
 
-			expect(buildIndex, `${jobName} must build before script typechecking`).toBeGreaterThanOrEqual(0);
-			expect(scriptTypecheckIndex, `${jobName} must run script typechecking`).toBeGreaterThanOrEqual(0);
-			expect(buildIndex, `${jobName} build must precede script typechecking`).toBeLessThan(
-				scriptTypecheckIndex,
+		expect(typecheckScripts).toContain("tsc -p tsconfig.scripts.json");
+		expect(
+			buildsGeneratedDist(typecheckScripts),
+			"typecheck:scripts must build generated dist before running tsc",
+		).toBe(true);
+	});
+
+	// Backstop for the guard above, derived over every job rather than a fixed
+	// list, so a new job (or a reordered `validate`) is covered automatically.
+	// While typecheck:scripts self-builds this holds trivially; it becomes the
+	// load-bearing check the moment that build is removed from the script.
+	it("guarantees generated dist at every ci.yml script typecheck call site", () => {
+		const ci = readWorkflow("ci.yml");
+		const selfBuilds = buildsGeneratedDist(
+			readPackageScripts()["typecheck:scripts"] ?? "",
+		);
+
+		let callSites = 0;
+		for (const jobName of listJobs(ci)) {
+			const steps = extractSteps(extractJobBlock(ci, jobName));
+			const typecheckAt = steps.findIndex((step) =>
+				step.run.includes("npm run typecheck:scripts"),
 			);
+			if (typecheckAt === -1) {
+				continue;
+			}
+			callSites += 1;
+			if (selfBuilds) {
+				continue;
+			}
+			const builtEarlier = steps
+				.slice(0, typecheckAt)
+				.some((step) => !step.conditional && buildsGeneratedDist(step.run));
+			expect(
+				builtEarlier,
+				`${jobName}: typecheck:scripts runs without a preceding unconditional build`,
+			).toBe(true);
 		}
+
+		// Proves the parser actually reached the call sites: release-harness,
+		// scripts-windows and validate. Without this, a boundary or step-parsing
+		// regression would make the loop above silently vacuous.
+		expect(
+			callSites,
+			"expected at least three typecheck:scripts call sites in ci.yml",
+		).toBeGreaterThanOrEqual(3);
 	});
 
 	// Issue #523: validate the engines floor (node >=18) with a runtime smoke

--- a/test/ci-workflows.test.ts
+++ b/test/ci-workflows.test.ts
@@ -86,6 +86,21 @@ describe("CI workflow parity", () => {
 		expect(windowsJob).not.toContain("github.event_name");
 	});
 
+	it("builds generated dist before script typechecking", () => {
+		const ci = readWorkflow("ci.yml");
+		for (const jobName of ["release-harness", "scripts-windows"]) {
+			const job = extractJobBlock(ci, jobName);
+			const buildIndex = job.indexOf("run: npm run build");
+			const scriptTypecheckIndex = job.indexOf("run: npm run typecheck:scripts");
+
+			expect(buildIndex, `${jobName} must build before script typechecking`).toBeGreaterThanOrEqual(0);
+			expect(scriptTypecheckIndex, `${jobName} must run script typechecking`).toBeGreaterThanOrEqual(0);
+			expect(buildIndex, `${jobName} build must precede script typechecking`).toBeLessThan(
+				scriptTypecheckIndex,
+			);
+		}
+	});
+
 	// Issue #523: validate the engines floor (node >=18) with a runtime smoke
 	// job that installs the packed tarball on Node 18 without devDependencies.
 	it("smoke-tests the packed CLI on the Node 18 engines floor", () => {


### PR DESCRIPTION
## Summary

The release-harness and Windows script-typecheck jobs ran `npm run typecheck:scripts` before generating `dist/`. This caused clean checkouts to fail with a missing `dist/lib/codex-manager.js` module.

Build `dist/` before script typechecking in both jobs and add a workflow regression test that enforces the ordering.

## Validation

- `npm run test -- test/ci-workflows.test.ts` (7 passed)
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:scripts`
- `git diff --check`





<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr makes script typechecking build its required dist output first and removes a redundant ci build step.

- adds workflow regression coverage for clean-checkout ordering.
- documents script typechecking in the local contribution gate.
- handles windows checkout line endings in the vitest workflow parser.
- introduces no token safety or concurrency changes.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | typecheck:scripts now generates dist before checking scripts that import generated modules. |
| .github/workflows/ci.yml | removes the redundant validate-job build because the script now owns its prerequisite. |
| test/ci-workflows.test.ts | adds vitest coverage for script-level builds and current ci call sites, including windows crlf normalization. |
| CONTRIBUTING.md | adds script typechecking to both documented local validation sequences. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[clean checkout] --> B[npm run typecheck scripts]
  B --> C[npm run build]
  C --> D[generate dist]
  D --> E[tsc scripts]
  E --> F[script typecheck succeeds]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): build generated dist inside typ..."](https://github.com/ndycode/codex-multi-auth/commit/514639a43630c661cc031fa83999d5a4918b8258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58170181)</sub>

<!-- /greptile_comment -->