### PR TITLE
fix(runtime): bypass the pool token bucket for pinned requests

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1086,22 +1086,45 @@ export class AccountManager {
 		model?: string | null,
 		options: { bypassTokenBucket?: boolean } = {},
 	): boolean {
+		return this.consumeTokenWithReason(account, family, model, options).ok;
+	}
+
+	/**
+	 * `consumeToken`, but it says which admission gate rejected the request.
+	 *
+	 * There are two gates and they are not interchangeable to a caller writing
+	 * `account_skip_reasons`: the pool-scoring token bucket, and the circuit
+	 * breaker's race-safe admission slot. Re-deriving the answer afterwards
+	 * with `getManagedAccountRuntimeSkipReason` gets it wrong in both
+	 * directions -- that helper reports the FIRST blocker it finds (so a live
+	 * cooldown masks a drained bucket), and its `isAvailable()` check answers
+	 * true for a half-open breaker whose single probe `canExecute()` just
+	 * handed to a concurrent request. Reporting the gate that actually
+	 * rejected removes the race and the mis-attribution, and avoids a second
+	 * state-mutating evaluation (`clearExpiredRateLimits`) on the hot path.
+	 */
+	consumeTokenWithReason(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+		options: { bypassTokenBucket?: boolean } = {},
+	): { ok: true } | { ok: false; reason: "token-exhausted" | "circuit-open" } {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
 		const trackerKey = getRuntimeTrackerKey(account);
 		const shouldConsumeToken = options.bypassTokenBucket !== true;
 		if (shouldConsumeToken && !tokenTracker.tryConsume(trackerKey, quotaKey)) {
-			return false;
+			return { ok: false, reason: "token-exhausted" };
 		}
 
 		try {
 			getCircuitBreaker(getAccountCircuitKey(account)).canExecute();
-			return true;
+			return { ok: true };
 		} catch {
 			if (shouldConsumeToken) {
 				tokenTracker.refundToken(trackerKey, quotaKey);
 			}
-			return false;
+			return { ok: false, reason: "circuit-open" };
 		}
 	}
 

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1084,11 +1084,13 @@ export class AccountManager {
 		account: ManagedAccount,
 		family: ModelFamily,
 		model?: string | null,
+		options: { bypassTokenBucket?: boolean } = {},
 	): boolean {
 		const quotaKey = model ? `${family}:${model}` : family;
 		const tokenTracker = getTokenTracker();
 		const trackerKey = getRuntimeTrackerKey(account);
-		if (!tokenTracker.tryConsume(trackerKey, quotaKey)) {
+		const shouldConsumeToken = options.bypassTokenBucket !== true;
+		if (shouldConsumeToken && !tokenTracker.tryConsume(trackerKey, quotaKey)) {
 			return false;
 		}
 
@@ -1096,7 +1098,9 @@ export class AccountManager {
 			getCircuitBreaker(getAccountCircuitKey(account)).canExecute();
 			return true;
 		} catch {
-			tokenTracker.refundToken(trackerKey, quotaKey);
+			if (shouldConsumeToken) {
+				tokenTracker.refundToken(trackerKey, quotaKey);
+			}
 			return false;
 		}
 	}

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1013,6 +1013,16 @@ async function handleRequestInner(
 		// applies unchanged because it all keys off `pinnedIndex` / `isPinned`.
 		const pinnedIndex = state.forcedAccountIndex ?? storageMeta.pinnedAccountIndex;
 		const isPinned = typeof pinnedIndex === "number";
+		// The token bucket spreads load across a selectable pool. A pin has no
+		// alternative account, so exhausting that local heuristic can only reject a
+		// request that the pinned account could serve. Keep circuit-breaker admission
+		// inside consumeToken, but do not debit the pool-scoring bucket for a pin.
+		const bypassPoolTokenBucket = isPinned;
+		const refundConsumedPoolToken = (account: ManagedAccount): void => {
+			if (!bypassPoolTokenBucket) {
+				accountManager.refundToken(account, context.family, context.model);
+			}
+		};
 		if (storageMeta.affinityGeneration > state.lastObservedAffinityGeneration) {
 			state.sessionAffinityStore?.clearAll();
 			state.lastObservedAffinityGeneration = storageMeta.affinityGeneration;
@@ -1150,8 +1160,22 @@ async function handleRequestInner(
 				continue;
 			}
 
-			if (!accountManager.consumeToken(selected, context.family, context.model)) {
-				accountSkipReasons.set(selected.index, "token-exhausted");
+			if (
+				!accountManager.consumeToken(selected, context.family, context.model, {
+					bypassTokenBucket: bypassPoolTokenBucket,
+				})
+			) {
+				// consumeToken also takes the race-safe circuit admission slot. If the
+				// circuit changed after selection, report that live blocker; otherwise
+				// this is the unpinned pool bucket running dry.
+				accountSkipReasons.set(
+					selected.index,
+					accountManager.getManagedAccountRuntimeSkipReason(
+						selected,
+						context.family,
+						context.model,
+					) ?? "token-exhausted",
+				);
 				exhaustionReason = "rate-limit";
 				continue;
 			}
@@ -1166,7 +1190,7 @@ async function handleRequestInner(
 				tokenInvalidationCooldownMs: state.tokenInvalidationCooldownMs,
 			});
 			if (!refreshed.ok) {
-				accountManager.refundToken(selected, context.family, context.model);
+				refundConsumedPoolToken(selected);
 				exhaustionReason = "auth-failure";
 				if (refreshed.invalidated) {
 					// Refresh endpoint explicitly revoked the token. Stop cascade:
@@ -1195,7 +1219,7 @@ async function handleRequestInner(
 
 			const accountId = resolveAccountId(refreshed.account, refreshed.accessToken);
 			if (!accountId) {
-				accountManager.refundToken(refreshed.account, context.family, context.model);
+				refundConsumedPoolToken(refreshed.account);
 				accountManager.recordFailure(refreshed.account, context.family, context.model);
 				accountManager.markAccountCoolingDown(
 					refreshed.account,
@@ -1260,7 +1284,7 @@ async function handleRequestInner(
 					code: "codex_runtime_rotation_transport_error",
 					error: transportError,
 				});
-				accountManager.refundToken(refreshed.account, context.family, context.model);
+				refundConsumedPoolToken(refreshed.account);
 				// A pre-header transport exception is a property of the network path,
 				// not of this account's credentials or quota, so it must NOT feed the
 				// account's circuit breaker / health tracker: that is what would
@@ -1333,11 +1357,7 @@ async function handleRequestInner(
 					const accountWasEnabled =
 						accountManager.getAccountByIndex(refreshed.account.index)?.enabled !==
 						false;
-					accountManager.refundToken(
-						refreshed.account,
-						context.family,
-						context.model,
-					);
+					refundConsumedPoolToken(refreshed.account);
 					if (accountWasEnabled) {
 						accountManager.recordFailure(
 							refreshed.account,
@@ -1425,7 +1445,7 @@ async function handleRequestInner(
 
 			if (upstream.status === HTTP_STATUS.UNAUTHORIZED) {
 				const bodyText = await readErrorBody(upstream, state.streamStallTimeoutMs);
-				accountManager.refundToken(refreshed.account, context.family, context.model);
+				refundConsumedPoolToken(refreshed.account);
 				accountManager.recordFailure(refreshed.account, context.family, context.model);
 				if (isTokenInvalidationError(bodyText)) {
 					// The upstream explicitly revoked this OAuth token. Applying a long
@@ -1478,7 +1498,7 @@ async function handleRequestInner(
 
 			if (upstream.status >= 500) {
 				await readErrorBody(upstream, state.streamStallTimeoutMs);
-				accountManager.refundToken(refreshed.account, context.family, context.model);
+				refundConsumedPoolToken(refreshed.account);
 				accountManager.recordFailure(refreshed.account, context.family, context.model);
 				accountManager.markAccountCoolingDown(
 					refreshed.account,

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1160,22 +1160,19 @@ async function handleRequestInner(
 				continue;
 			}
 
-			if (
-				!accountManager.consumeToken(selected, context.family, context.model, {
-					bypassTokenBucket: bypassPoolTokenBucket,
-				})
-			) {
-				// consumeToken also takes the race-safe circuit admission slot. If the
-				// circuit changed after selection, report that live blocker; otherwise
-				// this is the unpinned pool bucket running dry.
-				accountSkipReasons.set(
-					selected.index,
-					accountManager.getManagedAccountRuntimeSkipReason(
-						selected,
-						context.family,
-						context.model,
-					) ?? "token-exhausted",
-				);
+			// consumeToken also takes the race-safe circuit admission slot, so it
+			// can reject for either gate. Take the reason from the call that
+			// rejected rather than re-deriving it: a second evaluation reports the
+			// first blocker it finds (a live cooldown would mask a drained bucket)
+			// and cannot see a half-open probe slot that was just claimed.
+			const admission = accountManager.consumeTokenWithReason(
+				selected,
+				context.family,
+				context.model,
+				{ bypassTokenBucket: bypassPoolTokenBucket },
+			);
+			if (!admission.ok) {
+				accountSkipReasons.set(selected.index, admission.reason);
 				exhaustionReason = "rate-limit";
 				continue;
 			}

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -4227,6 +4227,61 @@ describe("AccountManager", () => {
 			expect(result).toBe(true);
 		});
 
+		it("can bypass an exhausted pool bucket without bypassing circuit admission", () => {
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						email: "pinned@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const tokenTracker = getTokenTracker();
+			const trackerKey = getRuntimeTrackerKey(account);
+			const quotaKey = "codex:gpt-5.1";
+			tokenTracker.drain(
+				trackerKey,
+				quotaKey,
+				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens,
+			);
+
+			expect(manager.consumeToken(account, "codex", "gpt-5.1")).toBe(false);
+			const tryConsumeSpy = vi.spyOn(tokenTracker, "tryConsume");
+			const refundTokenSpy = vi.spyOn(tokenTracker, "refundToken");
+			try {
+				expect(
+					manager.consumeToken(account, "codex", "gpt-5.1", {
+						bypassTokenBucket: true,
+					}),
+				).toBe(true);
+				expect(tryConsumeSpy).not.toHaveBeenCalled();
+				expect(tokenTracker.getTokens(trackerKey, quotaKey)).toBeLessThan(1);
+
+				manager.recordFailure(account, "codex", "gpt-5.1");
+				manager.recordFailure(account, "codex", "gpt-5.1");
+				manager.recordFailure(account, "codex", "gpt-5.1");
+				expect(
+					manager.consumeToken(account, "codex", "gpt-5.1", {
+						bypassTokenBucket: true,
+					}),
+				).toBe(false);
+				// A rejected bypass must not refund another request's bucket token.
+				expect(tryConsumeSpy).not.toHaveBeenCalled();
+				expect(refundTokenSpy).not.toHaveBeenCalled();
+				expect(tokenTracker.getTokens(trackerKey, quotaKey)).toBeLessThan(1);
+			} finally {
+				tryConsumeSpy.mockRestore();
+				refundTokenSpy.mockRestore();
+			}
+		});
+
 		it("consumeToken returns false and refunds the token when the circuit is open", () => {
 			const now = Date.now();
 			const stored = {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -4282,6 +4282,72 @@ describe("AccountManager", () => {
 			}
 		});
 
+		it("names the admission gate that actually rejected the request", () => {
+			// `account_skip_reasons` is written from this verdict. Re-deriving it
+			// afterwards with getManagedAccountRuntimeSkipReason reports the FIRST
+			// blocker on the account instead of the gate that rejected, so a drained
+			// bucket on a cooling-down account came back as the cooldown.
+			const now = Date.now();
+			const stored = {
+				version: 3 as const,
+				activeIndex: 0,
+				accounts: [
+					{
+						refreshToken: "token-1",
+						email: "gates@example.com",
+						addedAt: now,
+						lastUsed: now,
+					},
+				],
+			};
+			const manager = new AccountManager(undefined, stored);
+			const account = manager.getCurrentAccount()!;
+			const tokenTracker = getTokenTracker();
+			const trackerKey = getRuntimeTrackerKey(account);
+			const quotaKey = "codex:gpt-5.1";
+
+			expect(manager.consumeTokenWithReason(account, "codex", "gpt-5.1")).toEqual({
+				ok: true,
+			});
+
+			tokenTracker.drain(
+				trackerKey,
+				quotaKey,
+				DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens,
+			);
+			// A cooldown on the same account must not be reported in place of the
+			// bucket: the bucket is what rejected.
+			manager.markAccountCoolingDown(account, 60_000, "server-error");
+			expect(manager.consumeTokenWithReason(account, "codex", "gpt-5.1")).toEqual({
+				ok: false,
+				reason: "token-exhausted",
+			});
+			// Contrast: re-deriving the reason from account state answers with the
+			// cooldown, which is NOT what rejected this call. That substitution is
+			// exactly the mis-attribution consumeTokenWithReason exists to avoid.
+			expect(
+				manager.getManagedAccountRuntimeSkipReason(account, "codex", "gpt-5.1"),
+			).toBe("cooling-down:server-error");
+
+			// With the bucket bypassed the only gate left is circuit admission, so a
+			// rejection there is reported as such and never as an exhausted bucket.
+			manager.recordFailure(account, "codex", "gpt-5.1");
+			manager.recordFailure(account, "codex", "gpt-5.1");
+			manager.recordFailure(account, "codex", "gpt-5.1");
+			expect(
+				manager.consumeTokenWithReason(account, "codex", "gpt-5.1", {
+					bypassTokenBucket: true,
+				}),
+			).toEqual({ ok: false, reason: "circuit-open" });
+
+			// consumeToken stays the boolean face of the same evaluation.
+			expect(
+				manager.consumeToken(account, "codex", "gpt-5.1", {
+					bypassTokenBucket: true,
+				}),
+			).toBe(false);
+		});
+
 		it("consumeToken returns false and refunds the token when the circuit is open", () => {
 			const now = Date.now();
 			const stored = {

--- a/test/runtime-rotation-proxy.test.ts
+++ b/test/runtime-rotation-proxy.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { request } from "node:http";
-import { AccountManager } from "../lib/accounts.js";
+import { AccountManager, getRuntimeTrackerKey } from "../lib/accounts.js";
 import { CodexValidationError } from "../lib/errors.js";
 import { HTTP_STATUS, OPENAI_HEADERS } from "../lib/constants.js";
 import {
@@ -21,7 +21,11 @@ import {
 } from "../lib/routing-mutex.js";
 import * as runtimePolicy from "../lib/policy/runtime-policy.js";
 import { resetRefreshQueue } from "../lib/refresh-queue.js";
-import { resetTrackers } from "../lib/rotation.js";
+import {
+	DEFAULT_TOKEN_BUCKET_CONFIG,
+	getTokenTracker,
+	resetTrackers,
+} from "../lib/rotation.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 
 const {
@@ -772,6 +776,48 @@ describe("runtime rotation proxy", () => {
 			lastAccountIndex: 2,
 			lastAccountId: "acc_3",
 		});
+	});
+
+	it("does not let the pool token bucket starve a forced pin", async () => {
+		const now = Date.now();
+		const accountManager = new AccountManager(undefined, createStorage(now, 2));
+		const pinnedAccount = accountManager.getAccountByIndex(0);
+		if (!pinnedAccount) throw new Error("expected pinned account");
+		const tokenTracker = getTokenTracker();
+		const trackerKey = getRuntimeTrackerKey(pinnedAccount);
+		const quotaKey = "codex:gpt-5-codex";
+		tokenTracker.drain(
+			trackerKey,
+			quotaKey,
+			DEFAULT_TOKEN_BUCKET_CONFIG.maxTokens,
+		);
+		const tryConsumeSpy = vi.spyOn(tokenTracker, "tryConsume");
+		const { calls, fetchImpl } = createRecordingFetch(() =>
+			textEventStream("data: pinned\n\n"),
+		);
+		const proxy = await startProxy({
+			accountManager,
+			fetchImpl,
+			options: { forcedAccountIndex: 0 },
+		});
+
+		try {
+			const response = await postResponses(proxy, {
+				model: "gpt-5-codex",
+				stream: true,
+				input: [{ type: "message", role: "user", content: "hi" }],
+			});
+
+			expect(response.status).toBe(HTTP_STATUS.OK);
+			expect(await response.text()).toBe("data: pinned\n\n");
+			expect(calls).toHaveLength(1);
+			expect(calls[0]?.headers.get(OPENAI_HEADERS.ACCOUNT_ID)).toBe("acc_1");
+			// A pinned request neither consumes nor refills the pool-scoring bucket.
+			expect(tryConsumeSpy).not.toHaveBeenCalled();
+			expect(tokenTracker.getTokens(trackerKey, quotaKey)).toBeLessThan(1);
+		} finally {
+			tryConsumeSpy.mockRestore();
+		}
 	});
 
 	it("fails hard (503, no upstream call) when the forced account is unavailable (#623)", async () => {


### PR DESCRIPTION
## Problem

The runtime token bucket is a pool-selection heuristic: it spreads requests across accounts by debiting each `(account, model)` bucket. A pinned request has no alternative pool member, so an exhausted local bucket can only reject a request that the pinned account may still be able to serve.

That rejection happens before any upstream call and becomes a fatal `codex_pinned_account_unavailable` 503. In the affected sustained pinned workload, one helper recorded 12,643 total requests but only 5,359 upstream requests; the last 3,000 ledger rows contained 1,620 pinned-unavailable failures and no upstream 429, 5xx, network, or authentication failure. The burst/refill timeline matched the stock 50-token burst and 6-token-per-minute refill.

## Fix

- Let `AccountManager.consumeToken` bypass only the pool token debit when explicitly requested.
- Use that bypass for both forced and persisted/manual pins, since both converge on the same `isPinned` gate.
- Keep circuit-breaker admission inside `consumeToken`; an open circuit still rejects the pinned account.
- Do not refund a token that a pinned request never consumed.
- Leave unpinned selection and refund behavior unchanged. A pin still cannot rotate to another account.

This does **not** change `maxTokens`, `tokensPerMinute`, hybrid scoring, or rotation stickiness.

## Tests

- The account-manager regression drains the bucket, proves an explicit bypass succeeds, then opens the circuit and proves admission still fails without consuming or refunding a token.
- The proxy regression drains the pinned account/model bucket and proves the request reaches the pinned account exactly once without touching the pool bucket.

## Validation

- [x] `npx vitest run test/accounts.test.ts test/runtime-rotation-proxy.test.ts --maxWorkers=1` — 290/290
- [x] `npx vitest run test/documentation.test.ts --maxWorkers=1` — 32/32
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] `npm test` — attempted twice on the combined integration branch; the local host killed Vitest with exit 137 near completion. All changed-scope tests passed, and the remaining observed failures were untouched Windows-path/wrapper fixtures.

## Docs and Governance Checklist

- [x] No command, setting, path, migration, or error-schema change
- [x] Token-bucket defaults remain stock (`maxTokens: 50`, `tokensPerMinute: 6`)
- [x] Runtime responses and logs expose no account email or token

## Risk and Rollback

- **Risk level: low-medium.** Pinned requests no longer receive pool-load throttling, but they still pass live health checks, policy checks, rate-limit/cooldown checks, and circuit admission. Unpinned requests are byte-for-byte on the prior token path.
- **Rollback:** revert this commit; no persisted format or migration is involved.

## Additional Notes

The separate bounded pinned-retry change is intentionally independent so this pool-token fix can be reviewed and landed on its own.




<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this change bypasses the pool token debit for forced and persisted pinned requests while preserving circuit-breaker admission and token safety by suppressing refunds for tokens that were never consumed.
- adds gate-specific admission results to distinguish token exhaustion from an open circuit
- keeps unpinned consumption and refund behavior unchanged
- adds focused account-manager and forced-pin proxy coverage

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge because no blocking failure remains within the eligible follow-up scope.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds a reason-bearing admission api while preserving the existing boolean interface and conditional token refunds. |
| lib/runtime-rotation-proxy.ts | bypasses token-bucket debit and refund operations for pinned requests while retaining circuit admission. |
| test/accounts.test.ts | covers exhausted-bucket bypass, circuit rejection, reason attribution, and token safety. |
| test/runtime-rotation-proxy.test.ts | verifies the forced-pin path reaches upstream without touching the pool bucket. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as client
    participant P as runtime proxy
    participant A as account manager
    participant B as token bucket
    participant CB as circuit breaker
    participant U as upstream
    C->>P: pinned request
    P->>A: "consumeTokenWithReason(bypassTokenBucket=true)"
    Note over A,B: pool token is neither consumed nor refunded
    A->>CB: canExecute()
    alt circuit admits
        CB-->>A: admitted
        A-->>P: ok
        P->>U: forward request
        U-->>C: response
    else circuit rejects
        CB-->>A: circuit-open
        A-->>P: rejected
        P-->>C: pinned-account-unavailable 503
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): report the admission gate ..."](https://github.com/ndycode/codex-multi-auth/commit/c6de5df3ca0639a40f9efe311f12e16e7adf04c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58492889)</sub>

<!-- /greptile_comment -->