### PR TITLE
fix(models): strip `max` and `ultra` effort suffixes, without mangling Codex Max

### DIFF
--- a/lib/capability-policy.ts
+++ b/lib/capability-policy.ts
@@ -2,6 +2,7 @@ import {
 	getNormalizedModel,
 	resolveNormalizedModel,
 } from "./request/helpers/model-map.js";
+import { stripModelEffortSuffix } from "./constants.js";
 
 export interface CapabilityPolicySnapshot {
 	successes: number;
@@ -61,7 +62,7 @@ function normalizeModel(model: string | undefined): string | null {
 			: withoutProvider);
 	const trimmed = mapped.trim().toLowerCase();
 	if (!trimmed) return null;
-	return trimmed.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
+	return stripModelEffortSuffix(trimmed);
 }
 
 /**

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -2,6 +2,7 @@ import { existsSync, promises as fs, readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { parseBooleanEnv } from "./env-parsing.js";
+import { stripModelEffortSuffix } from "./constants.js";
 import { withRetry, withRetrySync } from "./fs-retry.js";
 import { logWarn } from "./logger.js";
 import { StorageError } from "./errors.js";
@@ -1256,7 +1257,7 @@ export function getUnsupportedCodexFallbackChain(
 		const stripped = trimmed.includes("/")
 			? (trimmed.split("/").pop() ?? trimmed)
 			: trimmed;
-		return stripped.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
+		return stripModelEffortSuffix(stripped);
 	};
 
 	// Null-prototype: the keys come from user config, so a `__proto__` entry on a

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -133,3 +133,37 @@ export type ModelReasoningEffort = (typeof REASONING_EFFORTS)[number];
 
 /** Effort levels the Responses API actually accepts. */
 export type WireReasoningEffort = Exclude<ModelReasoningEffort, "ultra">;
+
+/**
+ * Model ids whose final segment is an effort word but is part of the NAME.
+ *
+ * `codex-max` and `gpt-5.1-codex-max` are models. Stripping their trailing
+ * `-max` as if it were an effort suffix renames them to `codex` and
+ * `gpt-5.1-codex`, which silently retargets the unsupported-model fallback
+ * chain and splits their cache keys. This is the reason the strippers below
+ * omitted `max` and `ultra` for so long; naming the exception is what lets them
+ * be added.
+ */
+const EFFORT_SUFFIX_EXEMPT_PATTERN = /codex-max$/i;
+
+/**
+ * Trailing `-<effort>` on a model id, derived from REASONING_EFFORTS so a new
+ * tier cannot be added to the union and missed here.
+ */
+const EFFORT_SUFFIX_PATTERN = new RegExp(
+	`-(${REASONING_EFFORTS.join("|")})$`,
+	"i",
+);
+
+/**
+ * Strip a trailing reasoning-effort suffix from a model id.
+ *
+ * Callers use this to collapse `gpt-5.6-sol-max` and `gpt-6-astra-ultra` onto
+ * the model they actually route to, so cache keys, policy keys and fallback
+ * chain lookups all agree on one id per model. Ids exempted above are returned
+ * untouched.
+ */
+export function stripModelEffortSuffix(modelId: string): string {
+	if (EFFORT_SUFFIX_EXEMPT_PATTERN.test(modelId)) return modelId;
+	return modelId.replace(EFFORT_SUFFIX_PATTERN, "");
+}

--- a/lib/entitlement-cache.ts
+++ b/lib/entitlement-cache.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "./logger.js";
+import { stripModelEffortSuffix } from "./constants.js";
 
 const log = createLogger("entitlement-cache");
 
@@ -37,7 +38,7 @@ function normalizeModel(model: string | undefined): string | null {
 	const trimmed = model.trim().toLowerCase();
 	if (!trimmed) return null;
 	const stripped = trimmed.includes("/") ? (trimmed.split("/").pop() ?? trimmed) : trimmed;
-	return stripped.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
+	return stripModelEffortSuffix(stripped);
 }
 
 function normalizeEntitlementEmail(email: string | undefined): string | undefined {

--- a/lib/request/error-classification.ts
+++ b/lib/request/error-classification.ts
@@ -5,7 +5,7 @@
  */
 
 import { isRecord } from "../utils.js";
-import { HTTP_STATUS } from "../constants.js";
+import { HTTP_STATUS, stripModelEffortSuffix } from "../constants.js";
 
 export interface EntitlementError {
         isEntitlement: true;
@@ -99,7 +99,7 @@ function canonicalizeModelName(model: string | undefined): string | undefined {
 	const stripped = trimmed.includes("/")
 		? (trimmed.split("/").pop() ?? trimmed)
 		: trimmed;
-	return stripped.replace(/-(none|minimal|low|medium|high|xhigh)$/i, "");
+	return stripModelEffortSuffix(stripped);
 }
 
 function normalizeFallbackChain(

--- a/test/effort-suffix-stripping.test.ts
+++ b/test/effort-suffix-stripping.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { REASONING_EFFORTS, stripModelEffortSuffix } from "../lib/constants.js";
+import { CapabilityPolicyStore } from "../lib/capability-policy.js";
+import { resolveUnsupportedCodexFallbackModel } from "../lib/request/error-classification.js";
+import { getUnsupportedCodexFallbackChain } from "../lib/config.js";
+
+/**
+ * Four call sites used to strip only `none|minimal|low|medium|high|xhigh`,
+ * omitting `max` and `ultra`. That predates GPT-5.6, which introduced both, so
+ * `gpt-5.6-sol-max` and `gpt-6-astra-ultra` kept their suffix and keyed
+ * separately from the model they route to: a split entitlement cache, a policy
+ * key no request reads, and a fallback chain lookup that finds no row.
+ *
+ * The reason the suffix set was never widened is that `codex-max` and
+ * `gpt-5.1-codex-max` are model NAMES whose last segment is `max`. Stripping
+ * theirs renames them. The shared helper names that exception, which is what
+ * makes adding `max` and `ultra` safe.
+ */
+describe("stripModelEffortSuffix", () => {
+	it("strips every effort in the union, including max and ultra", () => {
+		for (const effort of REASONING_EFFORTS) {
+			expect(
+				stripModelEffortSuffix(`gpt-6-astra-${effort}`),
+				effort,
+			).toBe("gpt-6-astra");
+		}
+		// Non-vacuous: the union has to actually contain the two that were missing.
+		expect(REASONING_EFFORTS).toContain("max");
+		expect(REASONING_EFFORTS).toContain("ultra");
+	});
+
+	it("leaves a model whose name ends in `-max` alone", () => {
+		expect(stripModelEffortSuffix("codex-max")).toBe("codex-max");
+		expect(stripModelEffortSuffix("gpt-5.1-codex-max")).toBe("gpt-5.1-codex-max");
+	});
+
+	it("leaves ids with no effort suffix untouched", () => {
+		for (const id of [
+			"gpt-6-astra",
+			"gpt-6-astra-aeon",
+			"gpt-5.3-codex",
+			"gpt-daybreak-red-latest",
+			"codex-mini-latest",
+			"gpt-5.3-codex-spark",
+			"",
+		]) {
+			expect(stripModelEffortSuffix(id), id).toBe(id);
+		}
+	});
+});
+
+describe("the four call sites agree on one key per model", () => {
+	it("capability policy shares a key across effort suffixes", () => {
+		const store = new CapabilityPolicyStore();
+		store.recordSuccess("id:acc", "gpt-6-astra-max", 1_000);
+		expect(store.getBoost("id:acc", "gpt-6-astra", 1_500)).toBeGreaterThan(0);
+		expect(store.getBoost("id:acc", "gpt-6-astra-ultra", 1_500)).toBeGreaterThan(0);
+	});
+
+	it("capability policy still separates Codex Max from Codex", () => {
+		// If `-max` were stripped here, these two would collapse onto one key.
+		const store = new CapabilityPolicyStore();
+		store.recordSuccess("id:acc2", "codex-max", 1_000);
+		const codexMax = store.getBoost("id:acc2", "codex-max", 1_500);
+		expect(codexMax).toBeGreaterThan(0);
+	});
+
+	it("the fallback chain resolves from an effort-suffixed model", () => {
+		const body = {
+			error: {
+				message:
+					"model is not supported when using codex with a chatgpt account",
+			},
+		};
+		// Before the fix `gpt-6-astra-max` found no row and returned undefined.
+		expect(
+			resolveUnsupportedCodexFallbackModel({
+				requestedModel: "gpt-6-astra-max",
+				errorBody: body,
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			}),
+		).toBe("gpt-5.6-sol");
+		expect(
+			resolveUnsupportedCodexFallbackModel({
+				requestedModel: "gpt-5.6-sol-ultra",
+				errorBody: body,
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			}),
+		).toBe("gpt-5.5");
+	});
+
+	it("the fallback chain keeps Codex Max on its own row", () => {
+		const body = {
+			error: {
+				message:
+					"model is not supported when using codex with a chatgpt account",
+			},
+		};
+		// `codex-max` has its own chain row. Stripping its `-max` would look up
+		// `codex`, which has no row, and the fallback would vanish.
+		expect(
+			resolveUnsupportedCodexFallbackModel({
+				requestedModel: "codex-max",
+				errorBody: body,
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			}),
+		).toBe("gpt-5.3-codex");
+	});
+
+	it("a config chain override keyed with an effort suffix still applies", () => {
+		const chain = getUnsupportedCodexFallbackChain({
+			unsupportedCodexFallbackChain: {
+				"gpt-6-astra-max": ["gpt-5.4"],
+			},
+		} as never);
+		expect(chain["gpt-6-astra"]).toEqual(["gpt-5.4"]);
+	});
+});

--- a/test/effort-suffix-stripping.test.ts
+++ b/test/effort-suffix-stripping.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { REASONING_EFFORTS, stripModelEffortSuffix } from "../lib/constants.js";
 import { CapabilityPolicyStore } from "../lib/capability-policy.js";
+import { EntitlementCache } from "../lib/entitlement-cache.js";
 import { resolveUnsupportedCodexFallbackModel } from "../lib/request/error-classification.js";
 import { getUnsupportedCodexFallbackChain } from "../lib/config.js";
 
@@ -50,6 +51,28 @@ describe("stripModelEffortSuffix", () => {
 });
 
 describe("the four call sites agree on one key per model", () => {
+	it("the entitlement cache shares one block across effort suffixes", () => {
+		// This is the fourth call site the suite name claims and did not cover.
+		// Before the fix a block written for `gpt-6-astra-max` was invisible to a
+		// lookup for `gpt-6-astra`, so the same account/model pair was probed and
+		// blocked twice under two keys.
+		const cache = new EntitlementCache();
+		cache.markBlocked("acc:1", "gpt-6-astra-max", "unsupported-model", 60_000, 1_000);
+
+		expect(cache.isBlocked("acc:1", "gpt-6-astra", 1_500).blocked).toBe(true);
+		expect(cache.isBlocked("acc:1", "gpt-6-astra-ultra", 1_500).blocked).toBe(true);
+		expect(cache.isBlocked("acc:1", "gpt-6-astra-max", 1_500).blocked).toBe(true);
+	});
+
+	it("the entitlement cache still keeps Codex Max separate from Codex", () => {
+		// If `-max` were stripped here, blocking Codex Max would also block the
+		// plain codex model, taking a working model out of rotation.
+		const cache = new EntitlementCache();
+		cache.markBlocked("acc:2", "codex-max", "unsupported-model", 60_000, 1_000);
+		expect(cache.isBlocked("acc:2", "codex-max", 1_500).blocked).toBe(true);
+		expect(cache.isBlocked("acc:2", "codex", 1_500).blocked).toBe(false);
+	});
+
 	it("capability policy shares a key across effort suffixes", () => {
 		const store = new CapabilityPolicyStore();
 		store.recordSuccess("id:acc", "gpt-6-astra-max", 1_000);


### PR DESCRIPTION
fix(models): strip `max` and `ultra` effort suffixes, without mangling Codex Max

Four call sites stripped only `none|minimal|low|medium|high|xhigh` from a model
id. That set predates GPT-5.6, which introduced `max` and `ultra`, so
`gpt-5.6-sol-max` and `gpt-6-astra-ultra` kept their suffix and keyed separately
from the model they actually route to:

- `lib/entitlement-cache.ts` cached an entitlement block under a key no
  canonical lookup reads, so the same account/model pair was probed twice.
- `lib/capability-policy.ts` recorded success and failure under a key the
  matrix does not read back.
- `lib/request/error-classification.ts` looked up a fallback chain row that does
  not exist, so `--model gpt-6-astra-max` on an unentitled account found no
  fallback at all while `gpt-6-astra` did.
- `lib/config.ts` normalised a user's `unsupportedCodexFallbackChain` override
  key to something the resolver never asks for.

The reason the set was never widened is real, not an oversight: `codex-max` and
`gpt-5.1-codex-max` are model NAMES whose final segment is `max`. Stripping
theirs renames them to `codex` and `gpt-5.1-codex`, which retargets the fallback
chain (`codex-max` has its own row) and splits their cache keys. So this adds
`stripModelEffortSuffix` to `lib/constants.ts`, which names that exception
explicitly and derives the suffix set from `REASONING_EFFORTS` rather than
hardcoding a fifth copy of the list. A tier added to the union can no longer be
missed here.

`lib/constants.ts` was chosen because it has zero imports, so every one of the
four consumers can depend on it without a cycle.

`test/effort-suffix-stripping.test.ts` covers both directions: every effort in
the union strips, `codex-max` and `gpt-5.1-codex-max` do not, and the chain
still resolves `codex-max` to `gpt-5.3-codex` rather than losing its row. The
union membership of `max` and `ultra` is asserted directly so the first test
cannot pass vacuously if the union changes.

Verified: 5737 passed, 19 skipped, 5758 total. No existing test changed
behaviour, which is the check that Codex Max handling survived. The 2 failures
are the standing `codex-bin-wrapper` native-spawn cases this machine always
shows. `tsc --noEmit` and `npm run lint` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ajbw5bo5Wmd1KC81eAKYzg




<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr centralizes reasoning-effort suffix stripping and applies it consistently to entitlement, capability, configuration, and fallback-chain keys.
- strips all efforts declared in `reasoning_efforts`, including `max` and `ultra`
- preserves model names ending in `codex-max`
- adds vitest coverage across the four consumers, with one incomplete capability-key separation assertion
- no relevant windows filesystem, token safety, or concurrency regression is introduced

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge; the only issue is non-blocking missing vitest coverage for capability-key separation.

the shared helper preserves codex-max while canonicalizing effort suffixes consistently. no functional, windows filesystem, token safety, or concurrency issue remains; one regression test can pass without proving the separation stated in its name.

**Files Needing Attention:** test/effort-suffix-stripping.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/constants.ts | adds a shared effort-suffix normalizer with an explicit codex-max exemption. |
| lib/capability-policy.ts | uses shared normalization for capability history keys. |
| lib/entitlement-cache.ts | uses shared normalization for entitlement block keys. |
| lib/request/error-classification.ts | normalizes effort-suffixed models before fallback-chain lookup. |
| lib/config.ts | normalizes configured fallback-chain override keys consistently. |
| test/effort-suffix-stripping.test.ts | covers suffix normalization and consumers, but does not directly assert capability separation from plain codex. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Feffort-suffix-strippers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Feffort-suffix-strippers%22.%0A%0AGreploop%20ndycode%2Fcodex-multi-auth%20PR%20%23685%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=ndycode%2Fcodex-multi-auth&pr=685&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Fcodex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Feffort-suffix-strippers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Feffort-suffix-strippers%22.%0A%0A%23%23%23%20Issue%201%0Atest%2Feffort-suffix-stripping.test.ts%3A83-89%0A**assert%20capability%20key%20separation**%0A%0Athis%20vitest%20claims%20to%20verify%20that%20capability%20policy%20keeps%20%60codex-max%60%20separate%20from%20%60codex%60%2C%20but%20it%20only%20reads%20%60codex-max%60.%20if%20normalization%20collapses%20both%20names%20to%20%60codex%60%2C%20the%20assertion%20still%20passes%2C%20leaving%20this%20cache-key%20regression%20uncovered.%20also%20assert%20that%20the%20boost%20for%20plain%20%60codex%60%20remains%20zero.%0A%0A%60%60%60suggestion%0A%09it%28%22capability%20policy%20still%20separates%20Codex%20Max%20from%20Codex%22%2C%20%28%29%20%3D%3E%20%7B%0A%09%09%2F%2F%20If%20%60-max%60%20were%20stripped%20here%2C%20these%20two%20would%20collapse%20onto%20one%20key.%0A%09%09const%20store%20%3D%20new%20CapabilityPolicyStore%28%29%3B%0A%09%09store.recordSuccess%28%22id%3Aacc2%22%2C%20%22codex-max%22%2C%201_000%29%3B%0A%09%09const%20codexMax%20%3D%20store.getBoost%28%22id%3Aacc2%22%2C%20%22codex-max%22%2C%201_500%29%3B%0A%09%09expect%28codexMax%29.toBeGreaterThan%280%29%3B%0A%09%09expect%28store.getBoost%28%22id%3Aacc2%22%2C%20%22codex%22%2C%201_500%29%29.toBe%280%29%3B%0A%09%7D%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Fcodex-multi-auth&pr=685&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/effort-suffix-stripping.test.ts:83-89
**assert capability key separation**

this vitest claims to verify that capability policy keeps `codex-max` separate from `codex`, but it only reads `codex-max`. if normalization collapses both names to `codex`, the assertion still passes, leaving this cache-key regression uncovered. also assert that the boost for plain `codex` remains zero.

```suggestion
	it("capability policy still separates Codex Max from Codex", () => {
		// If `-max` were stripped here, these two would collapse onto one key.
		const store = new CapabilityPolicyStore();
		store.recordSuccess("id:acc2", "codex-max", 1_000);
		const codexMax = store.getBoost("id:acc2", "codex-max", 1_500);
		expect(codexMax).toBeGreaterThan(0);
		expect(store.getBoost("id:acc2", "codex", 1_500)).toBe(0);
	});
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(entitlement-cache): cover the fourt..."](https://github.com/ndycode/codex-multi-auth/commit/40d3ab07e89100ff6af51043740d8a2f41231405) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60205585)</sub>

**Context used:**

- Knowledge Base — [Account eligibility and capability policy](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/account-eligibility-policy.md)
- Knowledge Base — [Request transformation and resilience](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/codex-multi-auth/-/docs/request-processing.md)

<!-- /greptile_comment -->