### PR TITLE
feat(cli): expose machine-readable quota limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ which would rebind the row to a different workspace.
 | Command | What it answers |
 | --- | --- |
 | `codex-multi-auth report --live --json` | How do I get the full machine-readable health report? |
+| `codex-multi-auth limits --json [--refresh]` | How do I read account quota windows without parsing internal cache files or terminal text? |
 | `codex-multi-auth fix --live --model gpt-5.5` | How do I run live repair probes with a chosen model? |
 | `codex-multi-auth why-selected --json` | Which account does the selector pick now, and why? |
 | `codex-multi-auth usage --since 24h --by project` | What local usage has been recorded recently? |

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,6 +25,7 @@ User-facing capability map for Codex CLI multi-account OAuth, account switching,
 | --- | --- | --- |
 | Readiness and risk forecast | Suggests the best next account | `codex-multi-auth forecast` |
 | Live quota probe mode | Uses live headers for stronger decisions (probe leads with `gpt-5.6-sol`) | `codex-multi-auth forecast --live` |
+| Machine-readable quota snapshot | Joins configured accounts to cached quota windows without exposing credentials; optional refresh retains the dashboard's five-minute freshness floor | `codex-multi-auth limits --json [--refresh]` |
 | Best-account helper | Shortcut for selection-oriented workflows | `codex-multi-auth best` |
 | JSON report output | Inspect account state in automation or support workflows | `codex-multi-auth report --live --json` |
 | Why-selected explanation | Explains current routing/selection context | `codex-multi-auth why-selected` |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -89,6 +89,8 @@ Prints a stable, machine-readable quota snapshot for local integrations:
 ```console
 codex-multi-auth limits --json
 codex-multi-auth limits --json --refresh
+codex-multi-auth auth limits --json          # supported namespaced alias
+codex-multi-auth auth limits --json --refresh
 ```
 
 The default command reads the local quota cache and performs no network
@@ -679,6 +681,11 @@ failure.
 
 ## Upgrade Notes
 
+- `codex-multi-auth limits` adds a machine-readable quota contract. It requires
+  `--json`, emits schema version 1, defaults to zero-network cached mode, and
+  accepts `--refresh` for the existing sequential five-minute age-gated refresh.
+  The namespaced `codex-multi-auth auth limits ...` form is an alias. No npm
+  scripts or storage migrations were added.
 - `codex-multi-auth login` remains browser-first by default.
 - `codex-multi-auth login --org <org_id>` binds the login to one ChatGPT workspace.
 - `codex-multi-auth login --device-auth` uses OpenAI Codex device-code login. It prints `https://auth.openai.com/codex/device` and a one-time code, then polls for completion without opening a browser or starting the local callback server.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -41,6 +41,7 @@ Compatibility forms are supported for migrations and wrapper-routed environments
 | `codex-multi-auth login` | Open interactive auth dashboard. Flags: `--device-auth`, `--manual`/`--no-browser`, `--org <org_id>`, `--preserve-selection`, `--account <index\|email\|account_id>` |
 | `codex-multi-auth status` | Print account pool, pin, runtime metrics, and storage summary (`list` is the same command) |
 | `codex-multi-auth check` | Live-probe account health against the Codex backend |
+| `codex-multi-auth limits --json` | Print configured accounts joined to their cached quota windows; add `--refresh` for an age-gated refresh |
 
 ---
 
@@ -78,6 +79,36 @@ Reset-time details:
   `forecast` keep their narrower percentage-only summaries.
 
 Turning `showQuotaDetails` off reduces the line to a bare `live session OK`.
+
+---
+
+## `codex-multi-auth limits`
+
+Prints a stable, machine-readable quota snapshot for local integrations:
+
+```console
+codex-multi-auth limits --json
+codex-multi-auth limits --json --refresh
+```
+
+The default command reads the local quota cache and performs no network
+requests. `--refresh` reuses the dashboard's sequential quota refresh and its
+five-minute freshness floor: only enabled accounts with usable credentials and
+missing or stale cache entries are probed. Countdown text should be calculated
+by the consumer from `resetAtMs`; the command emits numeric values rather than
+locale-formatted dates.
+
+The top-level object has `schemaVersion: 1`, a millisecond `generatedAt`, a
+`mode` of `cached` or `refresh` describing the requested command mode, and
+`accounts`. Each configured account includes
+`index`, `label`, `enabled`, `current`, and either a `quota` object or `null`.
+Quota objects contain `updatedAt`, HTTP `status`, `planType`, and `primary` /
+`secondary` windows with `usedPercent`, `windowMinutes`, and `resetAtMs`.
+Unavailable provider values are explicit JSON `null`; internal probe-model names,
+credentials, and orphan cache entries are not emitted.
+
+`--json` is required. `--help` / `-h` prints focused usage. Unknown flags fail
+with exit code 1 without reading account storage or quota cache.
 
 ---
 
@@ -149,7 +180,7 @@ Turning `showQuotaDetails` off reduces the line to a bare `live session OK`.
 | `--org <org_id>` | login | Bind this login to a specific ChatGPT workspace/org id (same seat can be registered as personal vs team/business) |
 | `--preserve-selection` | login | Add or refresh credentials without changing the active global/model-family selections or manual pin; performs one sign-in and exits |
 | `--account <index\|email\|account_id>` | login | Re-authenticate exactly one saved account. Implies `--preserve-selection`, refuses a different OAuth identity before writing, keeps a disabled account disabled, and cannot be combined with `--org` |
-| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle, history | Print machine-readable output |
+| `--json` | limits, verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle, history | Print machine-readable output |
 | `--csv` | usage | Print or write CSV bucket output |
 | `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |
 | `--live` | best, forecast, report, fix | Use live probe before decisions/output |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -110,11 +110,19 @@ Unavailable provider values are explicit JSON `null`; internal probe-model names
 credentials, and orphan cache entries are not emitted. Account emails are masked
 inside `label` the same way `forecast --json` masks them.
 
-`selection` reports how the routed account was chosen: `pinnedIndex` is the
-`switch` pin or `null`, `activeIndexByFamily` is the per-family active index,
-and `routedIndex` is the account the runtime proxy actually serves from
-(`pinnedIndex` when a pin is set, otherwise the `codex` active index). An
-account's `current` is true when its `index` equals `routedIndex`.
+`selection` reports the configured routing target: `pinnedIndex` is the `switch`
+pin or `null`, `activeIndexByFamily` is the per-family active index, and
+`routedIndex` is `pinnedIndex` when a pin is set and the `codex` active index
+otherwise (`null` for an empty pool). An account's `current` is true when its
+`index` equals `routedIndex`.
+
+`selection` describes configuration, not liveness. It is not a prediction of
+which account the next request lands on: the runtime proxy skips an account that
+is disabled, inside a rate-limit window, cooling down, or behind an open circuit
+breaker, and it applies session affinity and the ephemeral `--account` override,
+none of which are written to storage. Use `enabled` on each row for the cheap
+check, and `why-selected --json` when you need the live selection and its
+reasoning.
 
 `--json` (`-j`) is required. `--help` / `-h` prints focused usage. Unknown flags
 fail with exit code 1 without reading account storage or quota cache.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -101,16 +101,23 @@ by the consumer from `resetAtMs`; the command emits numeric values rather than
 locale-formatted dates.
 
 The top-level object has `schemaVersion: 1`, a millisecond `generatedAt`, a
-`mode` of `cached` or `refresh` describing the requested command mode, and
-`accounts`. Each configured account includes
+`mode` of `cached` or `refresh` describing the requested command mode,
+`selection`, and `accounts`. Each configured account includes
 `index`, `label`, `enabled`, `current`, and either a `quota` object or `null`.
 Quota objects contain `updatedAt`, HTTP `status`, `planType`, and `primary` /
 `secondary` windows with `usedPercent`, `windowMinutes`, and `resetAtMs`.
 Unavailable provider values are explicit JSON `null`; internal probe-model names,
-credentials, and orphan cache entries are not emitted.
+credentials, and orphan cache entries are not emitted. Account emails are masked
+inside `label` the same way `forecast --json` masks them.
 
-`--json` is required. `--help` / `-h` prints focused usage. Unknown flags fail
-with exit code 1 without reading account storage or quota cache.
+`selection` reports how the routed account was chosen: `pinnedIndex` is the
+`switch` pin or `null`, `activeIndexByFamily` is the per-family active index,
+and `routedIndex` is the account the runtime proxy actually serves from
+(`pinnedIndex` when a pin is set, otherwise the `codex` active index). An
+account's `current` is true when its `index` equals `routedIndex`.
+
+`--json` (`-j`) is required. `--help` / `-h` prints focused usage. Unknown flags
+fail with exit code 1 without reading account storage or quota cache.
 
 ---
 

--- a/lib/codex-manager.ts
+++ b/lib/codex-manager.ts
@@ -35,6 +35,7 @@ import { runBudgetCommand } from "./codex-manager/commands/budget.js";
 import { runBridgeCommand } from "./codex-manager/commands/bridge.js";
 import { runCheckCommand } from "./codex-manager/commands/check.js";
 import { runIntegrationsCommand } from "./codex-manager/commands/integrations.js";
+import { runLimitsCommand } from "./codex-manager/commands/limits.js";
 import { runModelsCommand } from "./codex-manager/commands/models.js";
 import { runMonitorCommand } from "./codex-manager/commands/monitor.js";
 import { runConfigExplainCommand } from "./codex-manager/commands/config-explain.js";
@@ -89,6 +90,7 @@ import { runHistoryCommand } from "./codex-manager/commands/history.js";
 import { runUnpinCommand } from "./codex-manager/commands/unpin.js";
 import { runWorkspaceCommand } from "./codex-manager/commands/workspace.js";
 import { runUsageCommand } from "./codex-manager/commands/usage.js";
+import { refreshQuotaCacheForMenu } from "./codex-manager/login-menu-data.js";
 import { printUsage } from "./codex-manager/help.js";
 import {
 	availabilityTone,
@@ -518,6 +520,17 @@ const CLI_COMMAND_HANDLERS: ReadonlyMap<string, CliCommandHandler> = new Map<
 	["login", (rest) => runAuthLogin(rest, { runForecast, createRepairCommandDeps })],
 	["list", runListOrStatusCommand],
 	["status", runListOrStatusCommand],
+	[
+		"limits",
+		(rest) =>
+			runLimitsCommand(rest, {
+				setStoragePath,
+				loadAccounts,
+				loadQuotaCache,
+				refreshQuotaCache: refreshQuotaCacheForMenu,
+				resolveActiveIndex,
+			}),
+	],
 	[
 		"switch",
 		(rest) =>

--- a/lib/codex-manager/account-manager-commands.ts
+++ b/lib/codex-manager/account-manager-commands.ts
@@ -14,6 +14,7 @@ export const ACCOUNT_MANAGER_COMMANDS = new Set([
 	"login",
 	"list",
 	"status",
+	"limits",
 	"switch",
 	"unpin",
 	"workspace",

--- a/lib/codex-manager/commands/limits.ts
+++ b/lib/codex-manager/commands/limits.ts
@@ -1,0 +1,148 @@
+import { formatAccountLabel } from "../../accounts.js";
+import { findQuotaCacheEntryForAccount } from "../../quota-readiness.js";
+import type { QuotaCacheData, QuotaCacheEntry } from "../../quota-cache.js";
+import type { AccountStorageV3 } from "../../storage.js";
+
+const LIMITS_SCHEMA_VERSION = 1;
+const LIMITS_REFRESH_MAX_AGE_MS = 5 * 60_000;
+const LIMITS_USAGE = "Usage: codex-multi-auth limits --json [--refresh]";
+
+export interface LimitsCommandDeps {
+	setStoragePath: (path: string | null) => void;
+	loadAccounts: () => Promise<AccountStorageV3 | null>;
+	loadQuotaCache: () => Promise<QuotaCacheData>;
+	refreshQuotaCache: (
+		storage: AccountStorageV3,
+		cache: QuotaCacheData,
+		maxAgeMs: number,
+	) => Promise<QuotaCacheData>;
+	resolveActiveIndex: (storage: AccountStorageV3, family?: "codex") => number;
+	getNow?: () => number;
+	logInfo?: (message: string) => void;
+	logError?: (message: string) => void;
+}
+
+interface ParsedLimitsOptions {
+	json: boolean;
+	refresh: boolean;
+	help: boolean;
+}
+
+function parseLimitsOptions(args: string[]):
+	| { ok: true; options: ParsedLimitsOptions }
+	| { ok: false; message: string } {
+	const options: ParsedLimitsOptions = { json: false, refresh: false, help: false };
+	for (const arg of args) {
+		if (arg === "--json" || arg === "-j") {
+			options.json = true;
+			continue;
+		}
+		if (arg === "--refresh") {
+			options.refresh = true;
+			continue;
+		}
+		if (arg === "--help" || arg === "-h") {
+			options.help = true;
+			continue;
+		}
+		return { ok: false, message: `Unknown limits option: ${arg}` };
+	}
+	if (!options.json && !options.help) {
+		return { ok: false, message: LIMITS_USAGE };
+	}
+	return { ok: true, options };
+}
+
+function publicWindow(window: QuotaCacheEntry["primary"]) {
+	return {
+		usedPercent: window.usedPercent ?? null,
+		windowMinutes: window.windowMinutes ?? null,
+		resetAtMs: window.resetAtMs ?? null,
+	};
+}
+
+function publicQuotaEntry(entry: QuotaCacheEntry) {
+	return {
+		updatedAt: entry.updatedAt,
+		status: entry.status,
+		planType: entry.planType ?? null,
+		primary: publicWindow(entry.primary),
+		secondary: publicWindow(entry.secondary),
+	};
+}
+
+export async function runLimitsCommand(
+	args: string[],
+	deps: LimitsCommandDeps,
+): Promise<number> {
+	const parsed = parseLimitsOptions(args);
+	const logInfo = deps.logInfo ?? console.log;
+	const logError = deps.logError ?? console.error;
+	if (!parsed.ok) {
+		logError(parsed.message);
+		return 1;
+	}
+	if (parsed.options.help) {
+		logInfo(LIMITS_USAGE);
+		return 0;
+	}
+
+	deps.setStoragePath(null);
+	const storage = await deps.loadAccounts();
+	if (!storage || storage.accounts.length === 0) {
+		const generatedAt = deps.getNow?.() ?? Date.now();
+		logInfo(
+			JSON.stringify(
+				{
+					schemaVersion: LIMITS_SCHEMA_VERSION,
+					generatedAt,
+					mode: parsed.options.refresh ? "refresh" : "cached",
+					accounts: [],
+				},
+				null,
+				2,
+			),
+		);
+		return 0;
+	}
+
+	let cache = await deps.loadQuotaCache();
+	if (parsed.options.refresh) {
+		cache = await deps.refreshQuotaCache(
+			storage,
+			cache,
+			LIMITS_REFRESH_MAX_AGE_MS,
+		);
+	}
+
+	const generatedAt = deps.getNow?.() ?? Date.now();
+	const activeIndex = deps.resolveActiveIndex(storage, "codex");
+	const accounts = storage.accounts.map((account, index) => {
+		const quota = findQuotaCacheEntryForAccount(
+			cache,
+			account,
+			storage.accounts,
+		);
+		return {
+			index,
+			label: formatAccountLabel(account, index),
+			enabled: account.enabled !== false,
+			current: index === activeIndex,
+			quota: quota ? publicQuotaEntry(quota) : null,
+		};
+	});
+
+	logInfo(
+		JSON.stringify(
+			{
+				schemaVersion: LIMITS_SCHEMA_VERSION,
+				generatedAt,
+				mode: parsed.options.refresh ? "refresh" : "cached",
+				accounts,
+			},
+			null,
+			2,
+		),
+	);
+	return 0;
+}

--- a/lib/codex-manager/commands/limits.ts
+++ b/lib/codex-manager/commands/limits.ts
@@ -28,6 +28,7 @@ interface ParsedLimitsOptions {
 	help: boolean;
 }
 
+/** Parse the intentionally small, JSON-only limits command surface. */
 function parseLimitsOptions(args: string[]):
 	| { ok: true; options: ParsedLimitsOptions }
 	| { ok: false; message: string } {
@@ -53,6 +54,7 @@ function parseLimitsOptions(args: string[]):
 	return { ok: true, options };
 }
 
+/** Convert a cached quota window to the explicit-null public JSON contract. */
 function publicWindow(window: QuotaCacheEntry["primary"]) {
 	return {
 		usedPercent: window.usedPercent ?? null,
@@ -61,6 +63,7 @@ function publicWindow(window: QuotaCacheEntry["primary"]) {
 	};
 }
 
+/** Remove internal probe metadata and stabilize optional quota fields. */
 function publicQuotaEntry(entry: QuotaCacheEntry) {
 	return {
 		updatedAt: entry.updatedAt,
@@ -71,6 +74,12 @@ function publicQuotaEntry(entry: QuotaCacheEntry) {
 	};
 }
 
+/**
+ * Emit configured accounts joined to safe cached quota records.
+ *
+ * Cached mode performs no provider requests. Refresh mode delegates to the
+ * existing sequential, age-gated refresh path before serializing the snapshot.
+ */
 export async function runLimitsCommand(
 	args: string[],
 	deps: LimitsCommandDeps,

--- a/lib/codex-manager/commands/limits.ts
+++ b/lib/codex-manager/commands/limits.ts
@@ -112,10 +112,12 @@ export async function runLimitsCommand(
 					generatedAt,
 					mode: parsed.options.refresh ? "refresh" : "cached",
 					// Keep the key set identical for an empty pool so a consumer
-					// never has to branch on its presence.
+					// never has to branch on its presence. There is no account to
+					// route to, so `routedIndex` is null rather than a positional 0
+					// that addresses nothing.
 					selection: {
 						pinnedIndex: null,
-						routedIndex: 0,
+						routedIndex: null,
 						activeIndexByFamily: {},
 					},
 					accounts: [],
@@ -173,24 +175,38 @@ export async function runLimitsCommand(
 }
 
 /**
- * Which account actually serves traffic, and the state that decides it.
+ * The CONFIGURED routing target, and the state that decides it.
  *
  * `current` cannot be `activeIndexByFamily.codex` alone. The runtime proxy
  * routes on `pinnedAccountIndex` whenever a `switch` pin is set, and flows that
  * move the active index without touching the pin (rotation saves, `unpin`, an
  * ephemeral `--account`) would otherwise leave `current: true` on a row that is
- * not serving anything. Both inputs are emitted so a consumer can tell which
- * one applied, and the per-family map is emitted because a pool can hold a
- * different active index per family.
+ * not the configured target. Both inputs are emitted so a consumer can tell
+ * which one applied, and the per-family map is emitted because a pool can hold
+ * a different active index per family.
+ *
+ * This is deliberately NOT a prediction of which account the next request
+ * lands on. The proxy skips an account that is disabled, inside a rate-limit
+ * window, cooling down, or behind an open circuit breaker, and it applies
+ * session affinity and an ephemeral `--account` override that never touch
+ * storage. Reproducing that here would mean a third copy of the selector
+ * (`why-selected` and `forecast` already own live selection), and a snapshot
+ * read from a cache cannot be authoritative about it in any case. Consumers
+ * that need liveness have `enabled` on every row and `why-selected --json`.
+ *
+ * `routedIndex` is null only for an empty pool, where no row is `current`.
  */
 function resolveSelection(
 	storage: AccountStorageV3,
 	resolveActiveIndex: LimitsCommandDeps["resolveActiveIndex"],
 ): {
 	pinnedIndex: number | null;
-	routedIndex: number;
+	routedIndex: number | null;
 	activeIndexByFamily: Partial<Record<ModelFamily, number>>;
 } {
+	if (storage.accounts.length === 0) {
+		return { pinnedIndex: null, routedIndex: null, activeIndexByFamily: {} };
+	}
 	const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
 	for (const family of MODEL_FAMILIES) {
 		activeIndexByFamily[family] = resolveActiveIndex(storage, family);

--- a/lib/codex-manager/commands/limits.ts
+++ b/lib/codex-manager/commands/limits.ts
@@ -1,6 +1,8 @@
 import { formatAccountLabel } from "../../accounts.js";
+import { MODEL_FAMILIES, type ModelFamily } from "../../prompts/codex.js";
 import { findQuotaCacheEntryForAccount } from "../../quota-readiness.js";
 import type { QuotaCacheData, QuotaCacheEntry } from "../../quota-cache.js";
+import { redactEmails } from "../../redaction.js";
 import type { AccountStorageV3 } from "../../storage.js";
 
 const LIMITS_SCHEMA_VERSION = 1;
@@ -16,7 +18,10 @@ export interface LimitsCommandDeps {
 		cache: QuotaCacheData,
 		maxAgeMs: number,
 	) => Promise<QuotaCacheData>;
-	resolveActiveIndex: (storage: AccountStorageV3, family?: "codex") => number;
+	resolveActiveIndex: (
+		storage: AccountStorageV3,
+		family?: ModelFamily,
+	) => number;
 	getNow?: () => number;
 	logInfo?: (message: string) => void;
 	logError?: (message: string) => void;
@@ -106,6 +111,13 @@ export async function runLimitsCommand(
 					schemaVersion: LIMITS_SCHEMA_VERSION,
 					generatedAt,
 					mode: parsed.options.refresh ? "refresh" : "cached",
+					// Keep the key set identical for an empty pool so a consumer
+					// never has to branch on its presence.
+					selection: {
+						pinnedIndex: null,
+						routedIndex: 0,
+						activeIndexByFamily: {},
+					},
 					accounts: [],
 				},
 				null,
@@ -125,7 +137,7 @@ export async function runLimitsCommand(
 	}
 
 	const generatedAt = deps.getNow?.() ?? Date.now();
-	const activeIndex = deps.resolveActiveIndex(storage, "codex");
+	const selection = resolveSelection(storage, deps.resolveActiveIndex);
 	const accounts = storage.accounts.map((account, index) => {
 		const quota = findQuotaCacheEntryForAccount(
 			cache,
@@ -134,9 +146,12 @@ export async function runLimitsCommand(
 		);
 		return {
 			index,
-			label: formatAccountLabel(account, index),
+			// Labels are built from the account email. Mask it, exactly as
+			// `forecast --json` already does, so a snapshot written to a log
+			// shipper or a ticket does not carry the address.
+			label: redactEmails(formatAccountLabel(account, index)),
 			enabled: account.enabled !== false,
-			current: index === activeIndex,
+			current: index === selection.routedIndex,
 			quota: quota ? publicQuotaEntry(quota) : null,
 		};
 	});
@@ -147,6 +162,7 @@ export async function runLimitsCommand(
 				schemaVersion: LIMITS_SCHEMA_VERSION,
 				generatedAt,
 				mode: parsed.options.refresh ? "refresh" : "cached",
+				selection,
 				accounts,
 			},
 			null,
@@ -154,4 +170,42 @@ export async function runLimitsCommand(
 		),
 	);
 	return 0;
+}
+
+/**
+ * Which account actually serves traffic, and the state that decides it.
+ *
+ * `current` cannot be `activeIndexByFamily.codex` alone. The runtime proxy
+ * routes on `pinnedAccountIndex` whenever a `switch` pin is set, and flows that
+ * move the active index without touching the pin (rotation saves, `unpin`, an
+ * ephemeral `--account`) would otherwise leave `current: true` on a row that is
+ * not serving anything. Both inputs are emitted so a consumer can tell which
+ * one applied, and the per-family map is emitted because a pool can hold a
+ * different active index per family.
+ */
+function resolveSelection(
+	storage: AccountStorageV3,
+	resolveActiveIndex: LimitsCommandDeps["resolveActiveIndex"],
+): {
+	pinnedIndex: number | null;
+	routedIndex: number;
+	activeIndexByFamily: Partial<Record<ModelFamily, number>>;
+} {
+	const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
+	for (const family of MODEL_FAMILIES) {
+		activeIndexByFamily[family] = resolveActiveIndex(storage, family);
+	}
+	const rawPin = storage.pinnedAccountIndex;
+	const pinnedIndex =
+		typeof rawPin === "number" &&
+		Number.isInteger(rawPin) &&
+		rawPin >= 0 &&
+		rawPin < storage.accounts.length
+			? rawPin
+			: null;
+	return {
+		pinnedIndex,
+		routedIndex: pinnedIndex ?? activeIndexByFamily.codex ?? 0,
+		activeIndexByFamily,
+	};
 }

--- a/lib/codex-manager/help.ts
+++ b/lib/codex-manager/help.ts
@@ -11,6 +11,7 @@ export function printUsage(): void {
 			"  codex-multi-auth login [--device-auth|--manual|--no-browser] [--org <org_id>] [--preserve-selection] [--account <index|email|account_id>]",
 			"  codex-multi-auth status [--json]   (list is the same command)",
 			"  codex-multi-auth check            (always live-probes)",
+			"  codex-multi-auth limits --json [--refresh]   (structured quota windows; refresh is age-gated)",
 			"",
 			"Daily use:",
 			"  codex-multi-auth list [--json]",

--- a/lib/forecast.ts
+++ b/lib/forecast.ts
@@ -10,6 +10,7 @@ import {
 	isQuotaCacheEntryExhausted,
 	quotaUsedPercentIsExhausted,
 } from "./quota-readiness.js";
+import { redactEmails } from "./redaction.js";
 import type { ModelFamily } from "./request/helpers/model-map.js";
 import {
 	getRateLimitResetTimeForFamily,
@@ -103,24 +104,6 @@ export interface ForecastSummary {
 function clampRisk(score: number): number {
 	if (!Number.isFinite(score)) return 100;
 	return Math.max(0, Math.min(100, Math.round(score)));
-}
-
-function maskEmail(value: string): string {
-	const atIndex = value.indexOf("@");
-	if (atIndex <= 0) return "***@***";
-	const local = value.slice(0, atIndex);
-	const domain = value.slice(atIndex + 1);
-	const domainParts = domain.split(".");
-	const tld = domainParts.pop() ?? "";
-	const prefix = local.slice(0, Math.min(2, local.length));
-	return `${prefix}***@***.${tld || "***"}`;
-}
-
-function redactEmails(value: string): string {
-	return value.replace(
-		/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
-		(match) => maskEmail(match),
-	);
 }
 
 function redactSensitiveReason(value: string): string {

--- a/lib/redaction.ts
+++ b/lib/redaction.ts
@@ -1,0 +1,32 @@
+/**
+ * Email redaction for machine-readable command output.
+ *
+ * Account labels are built from the operator-visible email, so any command that
+ * emits them as JSON hands that address to whatever consumes the output: log
+ * shippers, dashboards, ticket attachments. `forecast --json` has masked them
+ * since it was written; this module is that same masking, shared so other JSON
+ * surfaces do not each re-derive it.
+ */
+
+/**
+ * Mask one address, keeping just enough to tell two accounts apart: the first
+ * two characters of the local part and the TLD.
+ */
+export function maskEmail(value: string): string {
+	const atIndex = value.indexOf("@");
+	if (atIndex <= 0) return "***@***";
+	const local = value.slice(0, atIndex);
+	const domain = value.slice(atIndex + 1);
+	const domainParts = domain.split(".");
+	const tld = domainParts.pop() ?? "";
+	const prefix = local.slice(0, Math.min(2, local.length));
+	return `${prefix}***@***.${tld || "***"}`;
+}
+
+/** Mask every address embedded in a free-text string. */
+export function redactEmails(value: string): string {
+	return value.replace(
+		/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+		(match) => maskEmail(match),
+	);
+}

--- a/scripts/codex-routing.js
+++ b/scripts/codex-routing.js
@@ -2,6 +2,7 @@ const AUTH_SUBCOMMANDS = new Set([
 	"login",
 	"list",
 	"status",
+	"limits",
 	"switch",
 	"unpin",
 	"workspace",

--- a/test/codex-manager-cli.test.ts
+++ b/test/codex-manager-cli.test.ts
@@ -1486,6 +1486,57 @@ describe("codex manager cli commands", () => {
 		);
 	});
 
+	it("dispatches limits --json through the public manager CLI", async () => {
+		const now = Date.now();
+		storageMocks.loadAccounts.mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 0 },
+			accounts: [
+				{
+					accountId: "acct-limits",
+					email: "limits@example.com",
+					accessToken: "access-secret",
+					refreshToken: "refresh-secret",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		});
+		quotaCacheMocks.loadQuotaCache.mockResolvedValue({
+			byAccountId: {
+				"acct-limits": {
+					updatedAt: now,
+					status: 200,
+					model: "gpt-5.6-codex",
+					primary: { usedPercent: 25, windowMinutes: 300 },
+					secondary: { usedPercent: 50, windowMinutes: 10_080 },
+				},
+			},
+			byEmail: {},
+		});
+		const logSpy = silenceConsole("log");
+		const errorSpy = silenceConsole("error");
+		const { runCodexMultiAuthCli } = await import("../lib/codex-manager.js");
+
+		const exitCode = await runCodexMultiAuthCli(["limits", "--json"]);
+		const authExitCode = await runCodexMultiAuthCli(["auth", "limits", "--json"]);
+
+		expect(exitCode).toBe(0);
+		expect(authExitCode).toBe(0);
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(logSpy).toHaveBeenCalledTimes(2);
+		const serialized = String(logSpy.mock.calls[0]?.[0]);
+		const payload = JSON.parse(serialized) as {
+			schemaVersion: number;
+			accounts: Array<{ quota: { primary: { usedPercent: number } } | null }>;
+		};
+		expect(payload.schemaVersion).toBe(1);
+		expect(payload.accounts[0]?.quota?.primary.usedPercent).toBe(25);
+		expect(serialized).not.toContain("access-secret");
+		expect(serialized).not.toContain("refresh-secret");
+	});
+
 	it("runs forecast in json mode", async () => {
 		const now = Date.now();
 		storageMocks.loadAccounts.mockResolvedValueOnce({

--- a/test/codex-routing.test.ts
+++ b/test/codex-routing.test.ts
@@ -21,10 +21,10 @@ describe("codex routing helpers", () => {
 		expect(shouldHandleMultiAuthAuth(["status"])).toBe(false);
 	});
 
-	it("routes the newer auth subcommands (unpin, workspace, uninstall) locally", () => {
+	it("routes the newer auth subcommands (unpin, workspace, limits, uninstall) locally", () => {
 		// cli-manager-01/02: guard against accidental forwarding regressions for the
 		// subcommands added after the original wrapper list was written.
-		for (const subcommand of ["unpin", "workspace", "uninstall"]) {
+		for (const subcommand of ["unpin", "workspace", "limits", "uninstall"]) {
 			expect(AUTH_SUBCOMMANDS.has(subcommand), subcommand).toBe(true);
 			expect(shouldHandleMultiAuthAuth(["auth", subcommand]), subcommand).toBe(true);
 		}

--- a/test/documentation.test.ts
+++ b/test/documentation.test.ts
@@ -533,7 +533,7 @@ describe("Documentation Integrity", () => {
 			`codex-multi-auth fix --live --model ${DEFAULT_MODEL}`,
 		);
 		expect(commandRef).toContain(
-			"| `--json` | verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle, history |",
+			"| `--json` | limits, verify-flagged, verify, why-selected, best, forecast, report, usage, budget, models, monitor, integrations, fix, doctor, config explain, debug bundle, history |",
 		);
 		expect(commandRef).toContain(
 			"| `--explain` | forecast, report | Include reasoning details (forecast text/JSON, report text) |",

--- a/test/limits-command.test.ts
+++ b/test/limits-command.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from "vitest";
+import { runLimitsCommand } from "../lib/codex-manager/commands/limits.js";
+import type { QuotaCacheData } from "../lib/quota-cache.js";
+import {
+	accountStorageV3Fixture,
+	storageAccountFixture,
+} from "./helpers/cli-test-fixtures.js";
+
+const NOW = 1_790_000_000_000;
+
+function quotaCache(): QuotaCacheData {
+	return {
+		byAccountId: {
+			"acct-1": {
+				updatedAt: NOW - 60_000,
+				status: 200,
+				model: "gpt-5.6-codex",
+				planType: "plus",
+				primary: {
+					usedPercent: 12.5,
+					windowMinutes: 300,
+					resetAtMs: NOW + 3_600_000,
+				},
+				secondary: {
+					usedPercent: 63,
+					windowMinutes: 10_080,
+					resetAtMs: NOW + 86_400_000,
+				},
+			},
+			orphan: {
+				updatedAt: NOW,
+				status: 200,
+				model: "gpt-5.6-codex",
+				primary: {},
+				secondary: {},
+			},
+		},
+		byEmail: {},
+	};
+}
+
+function createDeps(cache = quotaCache()) {
+	const storage = accountStorageV3Fixture([
+		storageAccountFixture({
+			accountId: "acct-1",
+			email: "one@example.com",
+			accessToken: "secret-access-token",
+		}),
+		storageAccountFixture({
+			accountId: "acct-2",
+			email: "two@example.com",
+			accessToken: "second-secret-token",
+			enabled: false,
+		}),
+	]);
+	return {
+		setStoragePath: vi.fn(),
+		loadAccounts: vi.fn().mockResolvedValue(storage),
+		loadQuotaCache: vi.fn().mockResolvedValue(cache),
+		refreshQuotaCache: vi.fn().mockResolvedValue(cache),
+		resolveActiveIndex: vi.fn(() => 0),
+		getNow: vi.fn(() => NOW),
+		logInfo: vi.fn(),
+		logError: vi.fn(),
+	};
+}
+
+function emittedJson(deps: ReturnType<typeof createDeps>): Record<string, unknown> {
+	expect(deps.logInfo).toHaveBeenCalledTimes(1);
+	return JSON.parse(deps.logInfo.mock.calls[0]?.[0] as string) as Record<
+		string,
+		unknown
+	>;
+}
+
+describe("runLimitsCommand", () => {
+	it("emits configured accounts joined to cached quota and excludes secrets and orphan entries", async () => {
+		const deps = createDeps();
+
+		const exitCode = await runLimitsCommand(["--json"], deps);
+
+		expect(exitCode).toBe(0);
+		expect(deps.refreshQuotaCache).not.toHaveBeenCalled();
+		const payload = emittedJson(deps);
+		expect(payload).toMatchObject({
+			schemaVersion: 1,
+			generatedAt: NOW,
+			mode: "cached",
+		});
+		expect(payload).not.toHaveProperty("accountCount");
+		expect(payload).not.toHaveProperty("activeIndex");
+		expect(payload.accounts).toEqual([
+			{
+				index: 0,
+				label: expect.any(String),
+				enabled: true,
+				current: true,
+				quota: {
+					updatedAt: NOW - 60_000,
+					status: 200,
+					planType: "plus",
+					primary: {
+						usedPercent: 12.5,
+						windowMinutes: 300,
+						resetAtMs: NOW + 3_600_000,
+					},
+					secondary: {
+						usedPercent: 63,
+						windowMinutes: 10_080,
+						resetAtMs: NOW + 86_400_000,
+					},
+				},
+			},
+			{
+				index: 1,
+				label: expect.any(String),
+				enabled: false,
+				current: false,
+				quota: null,
+			},
+		]);
+		const serialized = JSON.stringify(payload);
+		expect(serialized).not.toContain("secret-access-token");
+		expect(serialized).not.toContain("second-secret-token");
+		expect(serialized).not.toContain("orphan");
+	});
+
+	it("emits explicit nulls for missing optional provider fields", async () => {
+		const cache = quotaCache();
+		cache.byAccountId["acct-1"] = {
+			updatedAt: NOW,
+			status: 200,
+			model: "gpt-5.6-codex",
+			primary: {},
+			secondary: {},
+		};
+		const deps = createDeps(cache);
+
+		expect(await runLimitsCommand(["-j"], deps)).toBe(0);
+
+		const accounts = emittedJson(deps).accounts as Array<Record<string, unknown>>;
+		expect(accounts[0]?.quota).toEqual({
+			updatedAt: NOW,
+			status: 200,
+			planType: null,
+			primary: { usedPercent: null, windowMinutes: null, resetAtMs: null },
+			secondary: { usedPercent: null, windowMinutes: null, resetAtMs: null },
+		});
+	});
+
+	it("uses a safe unique-email fallback without exposing orphan cache entries", async () => {
+		const cache = quotaCache();
+		cache.byAccountId = {};
+		cache.byEmail["one@example.com"] = {
+			updatedAt: NOW,
+			status: 200,
+			model: "gpt-5.6-codex",
+			primary: { usedPercent: 9 },
+			secondary: {},
+		};
+		const deps = createDeps(cache);
+
+		expect(await runLimitsCommand(["--json"], deps)).toBe(0);
+
+		const accounts = emittedJson(deps).accounts as Array<Record<string, unknown>>;
+		expect(accounts[0]?.quota).toMatchObject({ primary: { usedPercent: 9 } });
+	});
+
+	it("refuses an ambiguous same-email cache fallback", async () => {
+		const cache = quotaCache();
+		cache.byAccountId = {};
+		cache.byEmail["shared@example.com"] = {
+			updatedAt: NOW,
+			status: 200,
+			model: "gpt-5.6-codex",
+			primary: { usedPercent: 9 },
+			secondary: {},
+		};
+		const deps = createDeps(cache);
+		deps.loadAccounts.mockResolvedValueOnce(
+			accountStorageV3Fixture([
+				storageAccountFixture({ accountId: "acct-a", email: "shared@example.com" }),
+				storageAccountFixture({ accountId: "acct-b", email: "shared@example.com" }),
+			]),
+		);
+
+		expect(await runLimitsCommand(["--json"], deps)).toBe(0);
+
+		const accounts = emittedJson(deps).accounts as Array<Record<string, unknown>>;
+		expect(accounts.map((account) => account.quota)).toEqual([null, null]);
+	});
+
+	it("age-gates an explicit refresh before emitting the refreshed cache", async () => {
+		const deps = createDeps();
+		const refreshed = quotaCache();
+		refreshed.byAccountId["acct-1"] = {
+			...refreshed.byAccountId["acct-1"],
+			updatedAt: NOW,
+			primary: { usedPercent: 20, windowMinutes: 300 },
+		};
+		deps.refreshQuotaCache.mockResolvedValueOnce(refreshed);
+
+		const exitCode = await runLimitsCommand(["--refresh", "--json"], deps);
+
+		expect(exitCode).toBe(0);
+		expect(deps.refreshQuotaCache).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.any(Object),
+			300_000,
+		);
+		expect(deps.refreshQuotaCache.mock.invocationCallOrder[0]).toBeLessThan(
+			deps.getNow.mock.invocationCallOrder[0] ?? 0,
+		);
+		const payload = emittedJson(deps);
+		expect(payload.mode).toBe("refresh");
+		const accounts = payload.accounts as Array<Record<string, unknown>>;
+		expect(accounts[0]).toMatchObject({
+			quota: { updatedAt: NOW, primary: { usedPercent: 20 } },
+		});
+	});
+
+	it("emits a stable empty snapshot when no accounts are configured", async () => {
+		const deps = createDeps();
+		deps.loadAccounts.mockResolvedValueOnce(null);
+
+		const exitCode = await runLimitsCommand(["--json"], deps);
+
+		expect(exitCode).toBe(0);
+		expect(deps.loadQuotaCache).not.toHaveBeenCalled();
+		expect(deps.refreshQuotaCache).not.toHaveBeenCalled();
+		expect(emittedJson(deps)).toEqual({
+			schemaVersion: 1,
+			generatedAt: NOW,
+			mode: "cached",
+			accounts: [],
+		});
+	});
+
+	it("prints focused help without reading account storage", async () => {
+		const deps = createDeps();
+
+		const exitCode = await runLimitsCommand(["--help"], deps);
+
+		expect(exitCode).toBe(0);
+		expect(deps.logInfo).toHaveBeenCalledWith(
+			"Usage: codex-multi-auth limits --json [--refresh]",
+		);
+		expect(deps.loadAccounts).not.toHaveBeenCalled();
+	});
+
+	it("requires the explicit JSON output flag", async () => {
+		const deps = createDeps();
+
+		const exitCode = await runLimitsCommand([], deps);
+
+		expect(exitCode).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith(
+			"Usage: codex-multi-auth limits --json [--refresh]",
+		);
+		expect(deps.logInfo).not.toHaveBeenCalled();
+	});
+
+	it("rejects unsupported options without emitting a snapshot", async () => {
+		const deps = createDeps();
+
+		const exitCode = await runLimitsCommand(["--json", "--unknown"], deps);
+
+		expect(exitCode).toBe(1);
+		expect(deps.logError).toHaveBeenCalledWith(
+			"Unknown limits option: --unknown",
+		);
+		expect(deps.logInfo).not.toHaveBeenCalled();
+	});
+});

--- a/test/limits-command.test.ts
+++ b/test/limits-command.test.ts
@@ -232,8 +232,76 @@ describe("runLimitsCommand", () => {
 			schemaVersion: 1,
 			generatedAt: NOW,
 			mode: "cached",
+			selection: {
+				pinnedIndex: null,
+				routedIndex: 0,
+				activeIndexByFamily: {},
+			},
 			accounts: [],
 		});
+	});
+
+	it("marks the pinned account current, not the family active index", async () => {
+		// Regression: `current` was derived from the codex active index alone, so
+		// any flow that moves the active index without touching the `switch` pin
+		// (rotation saves, unpin, an ephemeral --account) reported `current: true`
+		// on a row the runtime proxy is not serving from.
+		const deps = createDeps();
+		const storage = accountStorageV3Fixture([
+			storageAccountFixture({ accountId: "acct-1", email: "one@example.com" }),
+			storageAccountFixture({ accountId: "acct-2", email: "two@example.com" }),
+		]);
+		storage.pinnedAccountIndex = 1;
+		deps.loadAccounts.mockResolvedValueOnce(storage);
+		deps.resolveActiveIndex.mockReturnValue(0);
+
+		expect(await runLimitsCommand(["--json"], deps)).toBe(0);
+
+		const payload = emittedJson(deps);
+		expect(payload.selection).toMatchObject({
+			pinnedIndex: 1,
+			routedIndex: 1,
+		});
+		const accounts = payload.accounts as Array<Record<string, unknown>>;
+		expect(accounts.map((account) => account.current)).toEqual([false, true]);
+	});
+
+	it("reports the per-family active index and ignores an out-of-range pin", async () => {
+		const deps = createDeps();
+		const storage = accountStorageV3Fixture([
+			storageAccountFixture({ accountId: "acct-1", email: "one@example.com" }),
+			storageAccountFixture({ accountId: "acct-2", email: "two@example.com" }),
+		]);
+		storage.pinnedAccountIndex = 9;
+		deps.loadAccounts.mockResolvedValueOnce(storage);
+		deps.resolveActiveIndex.mockImplementation((_storage, family) =>
+			family === "codex" ? 1 : 0,
+		);
+
+		expect(await runLimitsCommand(["--json"], deps)).toBe(0);
+
+		const selection = emittedJson(deps).selection as {
+			pinnedIndex: number | null;
+			routedIndex: number;
+			activeIndexByFamily: Record<string, number>;
+		};
+		expect(selection.pinnedIndex).toBeNull();
+		expect(selection.routedIndex).toBe(1);
+		expect(selection.activeIndexByFamily.codex).toBe(1);
+		expect(Object.keys(selection.activeIndexByFamily).length).toBeGreaterThan(1);
+	});
+
+	it("masks account emails in the emitted label", async () => {
+		// `limits --json` is meant to be piped into logs, dashboards and tickets,
+		// so it masks addresses the same way `forecast --json` does.
+		const deps = createDeps();
+
+		expect(await runLimitsCommand(["--json"], deps)).toBe(0);
+
+		const serialized = JSON.stringify(emittedJson(deps));
+		expect(serialized).not.toContain("one@example.com");
+		expect(serialized).not.toContain("two@example.com");
+		expect(serialized).toContain("on***@***.com");
 	});
 
 	it("prints focused help without reading account storage", async () => {

--- a/test/limits-command.test.ts
+++ b/test/limits-command.test.ts
@@ -234,11 +234,39 @@ describe("runLimitsCommand", () => {
 			mode: "cached",
 			selection: {
 				pinnedIndex: null,
-				routedIndex: 0,
+				routedIndex: null,
 				activeIndexByFamily: {},
 			},
 			accounts: [],
 		});
+	});
+
+	it("reports the configured target even when that account cannot serve", async () => {
+		// `selection` is configuration, not liveness. The proxy skips a disabled,
+		// rate-limited, cooling-down or circuit-broken account, and applies
+		// session affinity and --account, none of which touch storage. Predicting
+		// that here would be a third copy of the selector; `why-selected` owns it.
+		// The contract is pinned so the field is not mistaken for a live answer:
+		// `current` follows the configured pin, and `enabled` stays visible next
+		// to it so a consumer can see the account cannot serve.
+		const deps = createDeps();
+		const storage = accountStorageV3Fixture([
+			storageAccountFixture({ accountId: "acct-1", email: "one@example.com" }),
+			storageAccountFixture({
+				accountId: "acct-2",
+				email: "two@example.com",
+				enabled: false,
+			}),
+		]);
+		storage.pinnedAccountIndex = 1;
+		deps.loadAccounts.mockResolvedValueOnce(storage);
+
+		expect(await runLimitsCommand(["--json"], deps)).toBe(0);
+
+		const payload = emittedJson(deps);
+		expect(payload.selection).toMatchObject({ pinnedIndex: 1, routedIndex: 1 });
+		const accounts = payload.accounts as Array<Record<string, unknown>>;
+		expect(accounts[1]).toMatchObject({ current: true, enabled: false });
 	});
 
 	it("marks the pinned account current, not the family active index", async () => {


### PR DESCRIPTION
## Summary

- add a dedicated JSON-only `limits` command for stable quota integrations
- safely join configured accounts to cached quota windows while excluding credentials, probe models, and orphan or ambiguous cache rows
- support an optional sequential, five-minute age-gated refresh through the existing quota refresh path
- route the command through both bare and `auth` CLI forms and document the versioned contract

Refs #687

## Contract

```console
codex-multi-auth limits --json
codex-multi-auth limits --json --refresh
```

Cached mode performs no network requests. Output uses `schemaVersion: 1`, numeric timestamps, explicit `null` values for unavailable provider fields, and `mode: "cached" | "refresh"`.

## Verification

- `npm test -- test/limits-command.test.ts test/codex-manager-cli.test.ts test/codex-routing.test.ts test/documentation.test.ts test/codex-manager-login-menu-refresh.test.ts test/quota-readiness.test.ts test/quota-cache.test.ts` — 284 passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run typecheck:scripts` — passed
- `npm run pack:check` — passed
- built package/CLI smoke — passed
- cached invocation under `strace -e trace=network` — zero IPv4/IPv6 socket calls
- live local `--refresh` smoke — valid schema v1 snapshot for all configured accounts

The complete baseline suite currently reports 15 failures in Windows-path/installer tests. The same 15 tests fail unchanged on a detached `upstream/main` worktree, so they are not introduced by this diff. The repository's vendor-provenance and dependency-audit gates also fail unchanged on `upstream/main` due to current baseline metadata/advisories.

## Scope and follow-up

This PR intentionally does not change quota transport or cache format. The optional reset-credit count discussed in #687 requires switching the refresh transport to the undocumented read-only account usage endpoint plus an additive cache evolution. Keeping that separate makes this contract PR smaller and independently reversible; it can follow after the command shape is accepted.

## Security / privacy

- no access or refresh tokens in output
- no internal cache keys or orphan cache entries in output
- ambiguous duplicate identities fail closed to `quota: null`
- no account switching, credential refresh, or reset redemption
- argument errors emit no partial JSON








<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this revision resolves the prior routing-state concern by making the machine-readable contract explicitly configuration-oriented rather than claiming to predict live routing.
- empty pools now emit `routedIndex: null`.
- documentation distinguishes configured selection from runtime liveness and points consumers to `why-selected --json`.
- vitest coverage now includes disabled pinned accounts and empty-pool selection.
- account labels remain email-masked, and quota output excludes access tokens, refresh tokens, probe models, and orphan cache rows.
- no windows filesystem paths or cleanup behavior changed.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge; no outstanding blocking or non-blocking findings remain.

the previous email-exposure finding is fixed, the concurrency finding was conceded as a pre-existing shared-path issue, and the routing-state finding is resolved by changing and testing the public contract so it no longer claims to identify the live serving account.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/codex-manager/commands/limits.ts | emits the versioned quota snapshot and now clearly models configured selection, including a null route for empty pools. |
| docs/reference/commands.md | documents that selection is configuration state rather than a prediction of the next serving account. |
| test/limits-command.test.ts | adds focused vitest coverage for empty pools and disabled pinned accounts while retaining token-safety assertions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[configured accounts] --> D[limits command]
  B[quota cache] --> D
  C[optional age-gated refresh] --> B
  D --> E[email-redacted schema v1 json]
  E --> F[configured selection]
  E --> G[quota windows]
  H[why-selected --json] --> I[live routing explanation]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(cli): scope the limits selection blo..."](https://github.com/ndycode/codex-multi-auth/commit/c21e467fa185581f752694d8e42b292783352325) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60601544)</sub>

<!-- /greptile_comment -->