### PR TITLE
fix(accounts): revalidate pinned accounts on explicit switch

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -316,6 +316,7 @@ export class AccountManager {
 	private saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private pendingSave: Promise<void> | null = null;
 	private readonly storagePathState: StoragePathState;
+	private readonly selectionStoragePath = getStoragePath();
 	/**
 	 * Manual pin set by the `switch` CLI command, hydrated from disk at
 	 * construction time and refreshed from disk just before each
@@ -330,6 +331,12 @@ export class AccountManager {
 	 * as `pinnedAccountIndex`. See #474.
 	 */
 	private affinityGeneration: number;
+	// A 429 observed during an unreadable selection must survive the next
+	// reconciliation. Keep only those new markers, not the stale account map.
+	private readonly unsequencedRateLimits = new WeakMap<ManagedAccount, {
+		limits: RateLimitStateV3;
+		reason: RateLimitReason;
+	}>();
 	/**
 	 * PR-N / R4: feature-flagged routing mutex mode.
 	 * Defaults to `"legacy"` to preserve pre-PR-N behaviour for one release
@@ -744,7 +751,10 @@ export class AccountManager {
 		resetAllCircuitBreakers();
 	}
 
-	/** Apply each explicit selection once, without erasing a subsequent 429. */
+	/**
+	 * Apply each explicit selection once without erasing a subsequent 429.
+	 * @param meta Latest successfully read selection generation and pin.
+	 */
 	applyManualSelection(meta: {
 		pinnedAccountIndex?: number | null;
 		affinityGeneration: number;
@@ -756,7 +766,10 @@ export class AccountManager {
 			: null;
 		if (account) {
 			clearAllRateLimits(account);
-			account.lastRateLimitReason = undefined;
+			const pending = this.unsequencedRateLimits.get(account);
+			Object.assign(account.rateLimitResetTimes, pending?.limits);
+			account.lastRateLimitReason = pending?.reason;
+			this.unsequencedRateLimits.delete(account);
 		}
 		this.pinnedAccountIndex = account ? index ?? undefined : undefined;
 		this.affinityGeneration = meta.affinityGeneration;
@@ -1285,6 +1298,17 @@ export class AccountManager {
 		reason: RateLimitReason,
 		model?: string | null,
 	): void {
+		let selectionReadable = false;
+		try {
+			const meta = readPinAndGenFromDisk(this.selectionStoragePath, { strict: true });
+			// Observe a switch BEFORE recording this response, not at the later
+			// debounced save where it would erase a genuine post-switch 429.
+			this.applyManualSelection(meta);
+			selectionReadable = true;
+		} catch {
+			// Fail closed: retain this new limit if the selection cannot be read.
+			log.warn("Rate limit recorded while account selection metadata is unavailable");
+		}
 		// Clamp to MAX_RATE_LIMIT_DELAY_MS so a bogus upstream retry-after value
 		// cannot wedge this account unavailable for years (see stress audit H1).
 		const retryMs = Math.min(
@@ -1292,11 +1316,14 @@ export class AccountManager {
 			MAX_RATE_LIMIT_DELAY_MS,
 		);
 		const resetAt = nowMs() + retryMs;
+		const pending = this.unsequencedRateLimits.get(account);
+		const newLimits: RateLimitStateV3 = { ...pending?.limits };
 
 		const baseKey = getQuotaKey(family);
 		if (!model || reason === "quota" || reason === "unknown") {
 			const currentResetAt = account.rateLimitResetTimes[baseKey] ?? 0;
 			account.rateLimitResetTimes[baseKey] = Math.max(currentResetAt, resetAt);
+			newLimits[baseKey] = Math.max(newLimits[baseKey] ?? 0, resetAt);
 		}
 
 		if (
@@ -1306,9 +1333,15 @@ export class AccountManager {
 			const modelKey = getQuotaKey(family, model);
 			const currentResetAt = account.rateLimitResetTimes[modelKey] ?? 0;
 			account.rateLimitResetTimes[modelKey] = Math.max(currentResetAt, resetAt);
+			newLimits[modelKey] = Math.max(newLimits[modelKey] ?? 0, resetAt);
 		}
 
 		account.lastRateLimitReason = reason;
+		if (!selectionReadable) {
+			this.unsequencedRateLimits.set(account, { limits: newLimits, reason });
+		} else {
+			this.unsequencedRateLimits.delete(account);
+		}
 	}
 
 	markAccountCoolingDown(
@@ -1516,8 +1549,13 @@ export class AccountManager {
 		// See #474.
 		let effectivePinnedAccountIndex = this.pinnedAccountIndex;
 		let effectiveAffinityGeneration = this.affinityGeneration;
-		try {
-			const onDisk = readPinAndGenFromDisk(getStoragePath());
+		{
+			// Never replace a newer disk pin with stale memory after a failed
+			// read. Missing storage is only valid for a never-selected new pool.
+			const onDisk = readPinAndGenFromDisk(getStoragePath(), {
+				strict: true,
+				allowMissing: this.affinityGeneration === 0,
+			});
 			// A delayed save must not resurrect the markers the CLI just cleared.
 			this.applyManualSelection(onDisk);
 			if (onDisk.affinityGeneration > effectiveAffinityGeneration) {
@@ -1539,9 +1577,6 @@ export class AccountManager {
 			// freshest known state without re-reading every time.
 			this.pinnedAccountIndex = effectivePinnedAccountIndex;
 			this.affinityGeneration = effectiveAffinityGeneration;
-		} catch {
-			// Disk read failures fall back to in-memory values; better than
-			// dropping the snapshot save entirely.
 		}
 
 		const snapshot: AccountStorageV3 = {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -744,6 +744,24 @@ export class AccountManager {
 		resetAllCircuitBreakers();
 	}
 
+	/** Apply each explicit selection once, without erasing a subsequent 429. */
+	applyManualSelection(meta: {
+		pinnedAccountIndex?: number | null;
+		affinityGeneration: number;
+	}): void {
+		if (meta.affinityGeneration <= this.affinityGeneration) return;
+		const index = meta.pinnedAccountIndex;
+		const account = typeof index === "number"
+			? this.getAccountByIndex(index)
+			: null;
+		if (account) {
+			clearAllRateLimits(account);
+			account.lastRateLimitReason = undefined;
+		}
+		this.pinnedAccountIndex = account ? index ?? undefined : undefined;
+		this.affinityGeneration = meta.affinityGeneration;
+	}
+
 	/**
 	 * Wipe per-account transient state — active cooldowns and all rate-limit
 	 * reset windows — across every managed account, then schedule a debounced
@@ -1500,6 +1518,8 @@ export class AccountManager {
 		let effectiveAffinityGeneration = this.affinityGeneration;
 		try {
 			const onDisk = readPinAndGenFromDisk(getStoragePath());
+			// A delayed save must not resurrect the markers the CLI just cleared.
+			this.applyManualSelection(onDisk);
 			if (onDisk.affinityGeneration > effectiveAffinityGeneration) {
 				effectiveAffinityGeneration = onDisk.affinityGeneration;
 				// The pin is part of the same atomic write the CLI performs when

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -273,6 +273,29 @@ export type { Workspace } from "./storage/public-types.js";
 /** Stable operator-facing marker for an explicitly invalidated OAuth token. */
 export const AUTH_INVALIDATION_MARKER = "token-invalid — re-login needed";
 
+/**
+ * How long a 429 recorded while the selection metadata was unreadable stays
+ * eligible to be replayed over a `switch` that clears the account's markers.
+ *
+ * The window only has to cover the gap between the CLI's atomic storage write
+ * and this process observing it, which is a single filesystem read away and in
+ * practice sub-second. 30s is generous for a stalled Windows volume while still
+ * guaranteeing that a 429 from minutes or hours earlier can never be
+ * resurrected by a later, unrelated switch.
+ */
+export const UNSEQUENCED_RATE_LIMIT_TTL_MS = 30_000;
+
+/**
+ * How many times a debounced save re-arms itself after a failure before giving
+ * up. A save can fail because the selection metadata was momentarily
+ * unreadable, and dropping it loses every rate-limit window, cooldown and
+ * rotated refresh token accumulated since the last successful save.
+ */
+export const MAX_DEBOUNCED_SAVE_RETRIES = 5;
+
+/** Ceiling for the debounced-save retry backoff. */
+export const MAX_SAVE_RETRY_DELAY_MS = 8_000;
+
 export interface ManagedAccount {
 	index: number;
 	recordId?: string;
@@ -315,8 +338,9 @@ export class AccountManager {
 	private lastToastTime = 0;
 	private saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private pendingSave: Promise<void> | null = null;
+	/** Consecutive debounced-save failures; reset by the next success. */
+	private saveRetryCount = 0;
 	private readonly storagePathState: StoragePathState;
-	private readonly selectionStoragePath = getStoragePath();
 	/**
 	 * Manual pin set by the `switch` CLI command, hydrated from disk at
 	 * construction time and refreshed from disk just before each
@@ -331,11 +355,20 @@ export class AccountManager {
 	 * as `pinnedAccountIndex`. See #474.
 	 */
 	private affinityGeneration: number;
-	// A 429 observed during an unreadable selection must survive the next
-	// reconciliation. Keep only those new markers, not the stale account map.
+	// A 429 observed while the selection metadata was unreadable must survive
+	// the next reconciliation, because we cannot tell whether it landed before
+	// or after the `switch` that reconciliation is about to apply. Keep only
+	// those new markers, not the stale account map.
+	//
+	// `recordedAtMs` bounds that ambiguity. Only a 429 recorded within
+	// UNSEQUENCED_RATE_LIMIT_TTL_MS of the reconciliation could have raced the
+	// switch we are applying; an older entry provably predates it and must NOT
+	// be replayed, or an arbitrarily stale 429 would be resurrected by the very
+	// command meant to revalidate the account.
 	private readonly unsequencedRateLimits = new WeakMap<ManagedAccount, {
 		limits: RateLimitStateV3;
 		reason: RateLimitReason;
+		recordedAtMs: number;
 	}>();
 	/**
 	 * PR-N / R4: feature-flagged routing mutex mode.
@@ -753,6 +786,13 @@ export class AccountManager {
 
 	/**
 	 * Apply each explicit selection once without erasing a subsequent 429.
+	 *
+	 * A `switch` asks for a fresh upstream attempt, so the selected account's
+	 * rate-limit markers are cleared. The only markers that survive that clear
+	 * are ones recorded while the selection metadata was unreadable AND recent
+	 * enough to have raced this switch (see UNSEQUENCED_RATE_LIMIT_TTL_MS); an
+	 * older unsequenced entry provably predates the switch and is discarded.
+	 *
 	 * @param meta Latest successfully read selection generation and pin.
 	 */
 	applyManualSelection(meta: {
@@ -767,8 +807,13 @@ export class AccountManager {
 		if (account) {
 			clearAllRateLimits(account);
 			const pending = this.unsequencedRateLimits.get(account);
-			Object.assign(account.rateLimitResetTimes, pending?.limits);
-			account.lastRateLimitReason = pending?.reason;
+			const replayable =
+				pending !== undefined &&
+				nowMs() - pending.recordedAtMs <= UNSEQUENCED_RATE_LIMIT_TTL_MS
+					? pending
+					: undefined;
+			Object.assign(account.rateLimitResetTimes, replayable?.limits);
+			account.lastRateLimitReason = replayable?.reason;
 			this.unsequencedRateLimits.delete(account);
 		}
 		this.pinnedAccountIndex = account ? index ?? undefined : undefined;
@@ -1300,7 +1345,13 @@ export class AccountManager {
 	): void {
 		let selectionReadable = false;
 		try {
-			const meta = readPinAndGenFromDisk(this.selectionStoragePath, { strict: true });
+			// Deliberately a fresh strict read rather than the proxy's cached
+			// `readStorageMetaFromDisk`: that reader falls back to its last good
+			// snapshot on failure, so it cannot tell this call site the one thing
+			// it needs to know, namely whether the selection was observable at all.
+			const meta = readPinAndGenFromDisk(this.resolveSelectionStoragePath(), {
+				strict: true,
+			});
 			// Observe a switch BEFORE recording this response, not at the later
 			// debounced save where it would erase a genuine post-switch 429.
 			this.applyManualSelection(meta);
@@ -1315,9 +1366,18 @@ export class AccountManager {
 			Math.max(0, Math.floor(retryAfterMs)),
 			MAX_RATE_LIMIT_DELAY_MS,
 		);
-		const resetAt = nowMs() + retryMs;
+		const observedAtMs = nowMs();
+		const resetAt = observedAtMs + retryMs;
+		// Only carry forward an unsequenced entry that is still replayable.
+		// Merging an expired one would give it a fresh `recordedAtMs` below and
+		// keep resurrecting it indefinitely.
 		const pending = this.unsequencedRateLimits.get(account);
-		const newLimits: RateLimitStateV3 = { ...pending?.limits };
+		const carried =
+			pending !== undefined &&
+			observedAtMs - pending.recordedAtMs <= UNSEQUENCED_RATE_LIMIT_TTL_MS
+				? pending
+				: undefined;
+		const newLimits: RateLimitStateV3 = { ...carried?.limits };
 
 		const baseKey = getQuotaKey(family);
 		if (!model || reason === "quota" || reason === "unknown") {
@@ -1338,10 +1398,27 @@ export class AccountManager {
 
 		account.lastRateLimitReason = reason;
 		if (!selectionReadable) {
-			this.unsequencedRateLimits.set(account, { limits: newLimits, reason });
+			this.unsequencedRateLimits.set(account, {
+				limits: newLimits,
+				reason,
+				recordedAtMs: observedAtMs,
+			});
 		} else {
+			// The selection was observable, so this 429 is unambiguously ordered
+			// against the current generation and needs no replay backup.
 			this.unsequencedRateLimits.delete(account);
 		}
+	}
+
+	/**
+	 * Storage file this manager owns, resolved through the path state captured
+	 * at construction. Reading the ambient `getStoragePath()` instead would
+	 * point a project-scoped pool at whichever storage file happens to be
+	 * current on the calling async context. See `saveToDisk`, which wraps
+	 * `runWithStoragePathState(this.storagePathState, ...)` for the same reason.
+	 */
+	private resolveSelectionStoragePath(): string {
+		return this.storagePathState.currentStoragePath ?? getStoragePath();
 	}
 
 	markAccountCoolingDown(
@@ -1532,6 +1609,57 @@ export class AccountManager {
 		return snapshot;
 	}
 
+	/**
+	 * Re-read the on-disk selection and fold it into this manager's state.
+	 *
+	 * Race protection: a CLI `switch`/`unpin`/`best` may have written a NEW
+	 * pin/gen between proxy startup (or the last save) and now. If we persisted
+	 * our stale instance values, we'd silently clobber the CLI update on every
+	 * routine save (rate-limit, cooldown, near-quota refund, etc.). See #474.
+	 *
+	 * This MUTATES `pinnedAccountIndex`, `affinityGeneration` and, when the
+	 * generation advanced, the selected account's rate-limit markers, so it is a
+	 * separate step from the pure `buildStorageSnapshot` serializer below rather
+	 * than a hidden side effect of it. Callers must run it immediately before a
+	 * snapshot they intend to persist. Applying it twice is a no-op.
+	 *
+	 * @throws when the metadata exists but cannot be observed (see
+	 * `readPinAndGenFromDisk`), which is the one case where persisting would
+	 * risk overwriting a newer pin.
+	 */
+	private reconcileSelectionFromDisk(): void {
+		const onDisk = readPinAndGenFromDisk(this.resolveSelectionStoragePath(), {
+			strict: true,
+		});
+		// A delayed save must not resurrect the markers the CLI just cleared.
+		this.applyManualSelection(onDisk);
+		let effectivePinnedAccountIndex = this.pinnedAccountIndex;
+		let effectiveAffinityGeneration = this.affinityGeneration;
+		if (onDisk.affinityGeneration > effectiveAffinityGeneration) {
+			effectiveAffinityGeneration = onDisk.affinityGeneration;
+			// The pin is part of the same atomic write the CLI performs when it
+			// bumps the generation, so a strictly-greater on-disk gen is the
+			// signal that the disk pin is the authoritative one.
+			effectivePinnedAccountIndex = onDisk.pinnedAccountIndex;
+		}
+		// Validate the refreshed pin against the live account count.
+		if (
+			effectivePinnedAccountIndex !== undefined &&
+			(effectivePinnedAccountIndex < 0 ||
+				effectivePinnedAccountIndex >= this.accounts.length)
+		) {
+			effectivePinnedAccountIndex = undefined;
+		}
+		// Cache the refreshed values so subsequent saves start from the freshest
+		// known state without re-reading every time.
+		this.pinnedAccountIndex = effectivePinnedAccountIndex;
+		this.affinityGeneration = effectiveAffinityGeneration;
+	}
+
+	/**
+	 * Serialize the live pool. Pure: it reads no files and mutates no state.
+	 * Persisting callers must call `reconcileSelectionFromDisk()` first.
+	 */
 	private buildStorageSnapshot(): AccountStorageV3 {
 		const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
 		for (const family of MODEL_FAMILIES) {
@@ -1540,44 +1668,8 @@ export class AccountManager {
 		}
 
 		const activeIndex = clampNonNegativeInt(activeIndexByFamily.codex, 0);
-
-		// Race protection: a CLI `switch`/`unpin`/`best` may have written a NEW
-		// pin/gen between proxy startup (or the last save) and now. If we
-		// persisted our stale instance values, we'd silently clobber the CLI
-		// update on every routine save (rate-limit, cooldown, near-quota refund,
-		// etc.). Re-read just before snapshotting and prefer the fresher value.
-		// See #474.
-		let effectivePinnedAccountIndex = this.pinnedAccountIndex;
-		let effectiveAffinityGeneration = this.affinityGeneration;
-		{
-			// Never replace a newer disk pin with stale memory after a failed
-			// read. Missing storage is only valid for a never-selected new pool.
-			const onDisk = readPinAndGenFromDisk(getStoragePath(), {
-				strict: true,
-				allowMissing: this.affinityGeneration === 0,
-			});
-			// A delayed save must not resurrect the markers the CLI just cleared.
-			this.applyManualSelection(onDisk);
-			if (onDisk.affinityGeneration > effectiveAffinityGeneration) {
-				effectiveAffinityGeneration = onDisk.affinityGeneration;
-				// The pin is part of the same atomic write the CLI performs when
-				// it bumps the generation, so a strictly-greater on-disk gen is
-				// the signal that the disk pin is the authoritative one.
-				effectivePinnedAccountIndex = onDisk.pinnedAccountIndex;
-			}
-			// Validate the refreshed pin against the live account count.
-			if (
-				effectivePinnedAccountIndex !== undefined &&
-				(effectivePinnedAccountIndex < 0 ||
-					effectivePinnedAccountIndex >= this.accounts.length)
-			) {
-				effectivePinnedAccountIndex = undefined;
-			}
-			// Cache the refreshed values so subsequent saves start from the
-			// freshest known state without re-reading every time.
-			this.pinnedAccountIndex = effectivePinnedAccountIndex;
-			this.affinityGeneration = effectiveAffinityGeneration;
-		}
+		const effectivePinnedAccountIndex = this.pinnedAccountIndex;
+		const effectiveAffinityGeneration = this.affinityGeneration;
 
 		const snapshot: AccountStorageV3 = {
 			version: 3,
@@ -1637,7 +1729,11 @@ export class AccountManager {
 		try {
 			return await withAccountStorageTransaction(async (_current, persist) => {
 				// Snapshot the live in-memory pool under the storage lock so refresh
-				// persistence merges against the latest account state.
+				// persistence merges against the latest account state. Reconcile the
+				// selection first for the same reason `saveToDisk` does: this write
+				// carries `pinnedAccountIndex`/`affinityGeneration` too, so a stale
+				// pair here would clobber a `switch` that landed since the last save.
+				this.reconcileSelectionFromDisk();
 				const nextStorage = structuredClone(
 					this.buildStorageSnapshot(),
 				) as AccountStorageV3;
@@ -2053,7 +2149,8 @@ export class AccountManager {
 			await withAccountStorageTransaction(async (current, persist) => {
 				// Reconcile against the disk state loaded under the storage lock so a
 				// routine save does not clobber a token another process just rotated
-				// (stress audit H3).
+				// (stress audit H3) or a pin the CLI just wrote (#474).
+				this.reconcileSelectionFromDisk();
 				await persist(
 					this.reconcileTokensFromDisk(this.buildStorageSnapshot(), current),
 				);
@@ -2076,24 +2173,56 @@ export class AccountManager {
 						this.pendingSave = null;
 					});
 					await this.pendingSave;
+					this.saveRetryCount = 0;
 				} catch (error) {
 					log.warn("Debounced save failed", {
 						error: error instanceof Error ? error.message : String(error),
+						attempt: this.saveRetryCount + 1,
 					});
+					// The debounce timer has already fired and cleared itself, so
+					// without re-arming this save is simply lost, and with it every
+					// rate-limit window, cooldown and rotated refresh token recorded
+					// since the last successful write. Saves fail for transient
+					// reasons (a Windows AV scanner or indexer holding accounts.json,
+					// a torn read of a concurrent atomic rename), so back off and try
+					// again instead of dropping the state.
+					if (this.saveRetryCount < MAX_DEBOUNCED_SAVE_RETRIES) {
+						this.saveRetryCount += 1;
+						this.saveToDiskDebounced(
+							Math.min(delayMs * 2, MAX_SAVE_RETRY_DELAY_MS),
+						);
+					} else {
+						this.saveRetryCount = 0;
+						log.error(
+							"Dropping account state save after repeated failures; runtime state since the last successful save is lost",
+						);
+					}
 				}
 			};
 			void doSave();
 		}, delayMs);
 	}
 
+	/**
+	 * Flush any debounced save. Never rejects: this runs on the proxy shutdown
+	 * path (`RuntimeRotationProxy.close`), and a rejection there aborts the rest
+	 * of the teardown. A failure is logged at error level instead, because the
+	 * process is exiting and there is no later attempt to fall back to.
+	 */
 	async flushPendingSave(): Promise<void> {
-		if (this.saveDebounceTimer) {
-			clearTimeout(this.saveDebounceTimer);
-			this.saveDebounceTimer = null;
-			await this.saveToDisk();
-		}
-		if (this.pendingSave) {
-			await this.pendingSave;
+		try {
+			if (this.saveDebounceTimer) {
+				clearTimeout(this.saveDebounceTimer);
+				this.saveDebounceTimer = null;
+				await this.saveToDisk();
+			}
+			if (this.pendingSave) {
+				await this.pendingSave;
+			}
+		} catch (error) {
+			log.error("Failed to flush pending account state save", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 

--- a/lib/codex-manager/persist-selected-account.ts
+++ b/lib/codex-manager/persist-selected-account.ts
@@ -122,9 +122,19 @@ export async function persistAndSyncSelectedAccount({
 	if (setPin) {
 		storage.pinnedAccountIndex = targetIndex;
 		// A manual switch requests a fresh upstream attempt, including when
-		// reselecting the same account after an out-of-band quota reset.
-		// Real 429 responses will populate these markers again.
-		account.rateLimitResetTimes = {};
+		// reselecting the same account after an out-of-band quota reset. Real 429
+		// responses will populate these markers again.
+		//
+		// `setPin` is the right trigger because it is set only by `switch` (which
+		// the login dashboard's account picker also routes through), i.e. exactly
+		// the paths where a person picked this account. `best` passes `clearPin`
+		// and a backup restore passes neither, and neither of those is a request
+		// to revalidate a rate-limited account.
+		//
+		// Delete rather than assign `{}`: `AccountManager.buildStorageSnapshot`
+		// omits the field when the map is empty, so assigning would persist a
+		// second on-disk shape for the same state.
+		delete account.rateLimitResetTimes;
 	} else if (clearPin) {
 		delete storage.pinnedAccountIndex;
 	}

--- a/lib/codex-manager/persist-selected-account.ts
+++ b/lib/codex-manager/persist-selected-account.ts
@@ -121,6 +121,10 @@ export async function persistAndSyncSelectedAccount({
 	account.lastSwitchReason = switchReason;
 	if (setPin) {
 		storage.pinnedAccountIndex = targetIndex;
+		// A manual switch requests a fresh upstream attempt, including when
+		// reselecting the same account after an out-of-band quota reset.
+		// Real 429 responses will populate these markers again.
+		account.rateLimitResetTimes = {};
 	} else if (clearPin) {
 		delete storage.pinnedAccountIndex;
 	}

--- a/lib/preemptive-quota-scheduler.ts
+++ b/lib/preemptive-quota-scheduler.ts
@@ -338,6 +338,14 @@ export class PreemptiveQuotaScheduler {
 		return { defer: false, waitMs: 0 };
 	}
 
+	/** Forget cached quota observations for one caller-defined account prefix. */
+	clearByPrefix(prefix: string): void {
+		if (!prefix) return;
+		for (const key of this.snapshots.keys()) {
+			if (key.startsWith(prefix)) this.snapshots.delete(key);
+		}
+	}
+
 	prune(now = Date.now()): number {
 		let removed = 0;
 		for (const [key, snapshot] of this.snapshots.entries()) {

--- a/lib/preemptive-quota-scheduler.ts
+++ b/lib/preemptive-quota-scheduler.ts
@@ -338,7 +338,10 @@ export class PreemptiveQuotaScheduler {
 		return { defer: false, waitMs: 0 };
 	}
 
-	/** Forget cached quota observations for one caller-defined account prefix. */
+	/**
+	 * Forget cached quota observations for one account across its model keys.
+	 * @param prefix Account key including its trailing separator; empty is a no-op.
+	 */
 	clearByPrefix(prefix: string): void {
 		if (!prefix) return;
 		for (const key of this.snapshots.keys()) {

--- a/lib/preemptive-quota-scheduler.ts
+++ b/lib/preemptive-quota-scheduler.ts
@@ -340,13 +340,23 @@ export class PreemptiveQuotaScheduler {
 
 	/**
 	 * Forget cached quota observations for one account across its model keys.
-	 * @param prefix Account key including its trailing separator; empty is a no-op.
+	 *
+	 * @param prefix Account key INCLUDING its trailing separator, as produced by
+	 * `buildQuotaScheduleAccountPrefix`. Without that separator the prefix also
+	 * matches neighbouring identities (`account:email:foo` matches
+	 * `account:email:foobar:codex`). An empty prefix is a no-op rather than a
+	 * silent clear-all; use `clearAll()` when that is the intent.
 	 */
 	clearByPrefix(prefix: string): void {
 		if (!prefix) return;
 		for (const key of this.snapshots.keys()) {
 			if (key.startsWith(prefix)) this.snapshots.delete(key);
 		}
+	}
+
+	/** Forget every cached quota observation. */
+	clearAll(): void {
+		this.snapshots.clear();
 	}
 
 	prune(now = Date.now()): number {

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -193,14 +193,20 @@ const PINNED_PERMANENT_SKIP_REASONS: ReadonlySet<string> = new Set([
 const DEFAULT_QUOTA_REMAINING_THRESHOLD = 10;
 
 /** @internal Stable identity key for in-memory quota snapshots across reloads. */
-export function buildQuotaScheduleKey(
+/**
+ * Quota-scheduler key prefix identifying ONE account across every family and
+ * model key it owns.
+ *
+ * The trailing separator is part of the contract: without it the prefix
+ * `account:email:foo` also matches `account:email:foobar:codex`, so clearing
+ * one account's observations would silently clear a neighbour's.
+ */
+export function buildQuotaScheduleAccountPrefix(
 	account: Pick<ManagedAccount, "accountId" | "email" | "refreshToken"> & {
 		/** Stable per-record discriminator retained across token/account-id updates. */
 		addedAt?: number;
 		recordId?: string;
 	},
-	family: ModelFamily,
-	model?: string | null,
 ): string {
 	const emailKey = normalizeEmailKey(account.email);
 	const accountId = account.accountId?.trim();
@@ -219,7 +225,19 @@ export function buildQuotaScheduleKey(
 		: accountId
 			? `id:${accountId}${recordDiscriminator}`
 			: `refresh:${createHash("sha256").update(refreshToken).digest("hex")}${recordDiscriminator}`;
-	return `account:${accountIdentity}:${model ?? family}`;
+	return `account:${accountIdentity}:`;
+}
+
+export function buildQuotaScheduleKey(
+	account: Pick<ManagedAccount, "accountId" | "email" | "refreshToken"> & {
+		/** Stable per-record discriminator retained across token/account-id updates. */
+		addedAt?: number;
+		recordId?: string;
+	},
+	family: ModelFamily,
+	model?: string | null,
+): string {
+	return `${buildQuotaScheduleAccountPrefix(account)}${model ?? family}`;
 }
 
 const DEFAULT_MAX_RUNTIME_ACCOUNT_ATTEMPTS = 4;
@@ -1155,10 +1173,20 @@ async function handleRequestInner(
 					? null
 					: accountManager.getAccountByIndex(meta.pinnedAccountIndex);
 				if (switchedAccount) {
-					// The trailing separator isolates this account across all models.
 					state.preemptiveQuotaScheduler.clearByPrefix(
-						buildQuotaScheduleKey(switchedAccount, context.family, ""),
+						buildQuotaScheduleAccountPrefix(switchedAccount),
 					);
+				} else if (meta.pinnedAccountIndex !== null) {
+					// A pin we cannot resolve: this long-lived proxy re-reads only
+					// pin/gen, never the account list, so a `login` that appended an
+					// account before the `switch` leaves the new index out of range
+					// here. The generation only bumps on the NEXT user-initiated
+					// switch, so skipping the clear and advancing anyway would strand
+					// the pre-switch quota observation forever, which is the exact
+					// deferral this reconciliation exists to end. Drop every cached
+					// observation instead: it only costs a re-probe, and real 429
+					// windows live on the accounts themselves, not in this cache.
+					state.preemptiveQuotaScheduler.clearAll();
 				}
 				state.sessionAffinityStore?.clearAll();
 				state.lastObservedAffinityGeneration = meta.affinityGeneration;

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1144,13 +1144,28 @@ async function handleRequestInner(
 		// otherwise glue an in-flight chat thread to the previously selected
 		// account. The proxy itself never bumps the generation, so its own
 		// debounced disk writes do not clear affinity. See issue #474.
-		const storageMeta = readStorageMetaFromDisk();
-		// Also update managers retained by in-flight requests. Their later saves
-		// must not restore the pre-switch block. Generation guards make this a
-		// one-time retry per explicit switch, never a bypass on every request.
-		for (const manager of state.knownAccountManagers) {
-			manager.applyManualSelection(storageMeta);
-		}
+		/** Reconcile once before selection or recording a new upstream observation. */
+		const reconcileManualSelection = () => {
+			const meta = readStorageMetaFromDisk();
+			for (const manager of state.knownAccountManagers) {
+				manager.applyManualSelection(meta);
+			}
+			if (meta.affinityGeneration > state.lastObservedAffinityGeneration) {
+				const switchedAccount = meta.pinnedAccountIndex === null
+					? null
+					: accountManager.getAccountByIndex(meta.pinnedAccountIndex);
+				if (switchedAccount) {
+					// The trailing separator isolates this account across all models.
+					state.preemptiveQuotaScheduler.clearByPrefix(
+						buildQuotaScheduleKey(switchedAccount, context.family, ""),
+					);
+				}
+				state.sessionAffinityStore?.clearAll();
+				state.lastObservedAffinityGeneration = meta.affinityGeneration;
+			}
+			return meta;
+		};
+		const storageMeta = reconcileManualSelection();
 		// The ephemeral --account pin (issue #623) takes precedence over the
 		// persisted `switch` pin for this invocation, without ever mutating disk
 		// state. Use `??` (not `||`) so a forced index of 0 is honored. When set,
@@ -1188,20 +1203,6 @@ async function handleRequestInner(
 				1,
 				Math.min(state.maxRuntimeAccountAttempts, MAX_PINNED_TRANSIENT_ATTEMPTS),
 			);
-		}
-		if (storageMeta.affinityGeneration > state.lastObservedAffinityGeneration) {
-			const switchedAccount = storageMeta.pinnedAccountIndex === null
-				? null
-				: accountManager.getAccountByIndex(storageMeta.pinnedAccountIndex);
-			if (switchedAccount) {
-				// Include the trailing separator to exclude neighboring identities;
-				// clear all models for this account, not just the current request.
-				state.preemptiveQuotaScheduler.clearByPrefix(
-					buildQuotaScheduleKey(switchedAccount, context.family, ""),
-				);
-			}
-			state.sessionAffinityStore?.clearAll();
-			state.lastObservedAffinityGeneration = storageMeta.affinityGeneration;
 		}
 
 		let runtimeSelectionIterations = 0;
@@ -1515,6 +1516,7 @@ async function handleRequestInner(
 				noteRotation();
 				continue;
 			}
+			reconcileManualSelection();
 			const quotaSnapshot = readQuotaSchedulerSnapshot(
 				upstream.headers,
 				upstream.status,
@@ -1530,6 +1532,8 @@ async function handleRequestInner(
 					parseRetryAfterHeaderMs(upstream.headers, state.now()) ??
 					parseRetryAfterBodyMs(bodyText, state.now()) ??
 					60_000;
+				// Reading the body awaited I/O; a switch may have landed meanwhile.
+				reconcileManualSelection();
 				state.preemptiveQuotaScheduler.markRateLimited(
 					quotaScheduleKey,
 					retryAfterMs,

--- a/lib/runtime-rotation-proxy.ts
+++ b/lib/runtime-rotation-proxy.ts
@@ -1145,6 +1145,12 @@ async function handleRequestInner(
 		// account. The proxy itself never bumps the generation, so its own
 		// debounced disk writes do not clear affinity. See issue #474.
 		const storageMeta = readStorageMetaFromDisk();
+		// Also update managers retained by in-flight requests. Their later saves
+		// must not restore the pre-switch block. Generation guards make this a
+		// one-time retry per explicit switch, never a bypass on every request.
+		for (const manager of state.knownAccountManagers) {
+			manager.applyManualSelection(storageMeta);
+		}
 		// The ephemeral --account pin (issue #623) takes precedence over the
 		// persisted `switch` pin for this invocation, without ever mutating disk
 		// state. Use `??` (not `||`) so a forced index of 0 is honored. When set,
@@ -1184,6 +1190,16 @@ async function handleRequestInner(
 			);
 		}
 		if (storageMeta.affinityGeneration > state.lastObservedAffinityGeneration) {
+			const switchedAccount = storageMeta.pinnedAccountIndex === null
+				? null
+				: accountManager.getAccountByIndex(storageMeta.pinnedAccountIndex);
+			if (switchedAccount) {
+				// Include the trailing separator to exclude neighboring identities;
+				// clear all models for this account, not just the current request.
+				state.preemptiveQuotaScheduler.clearByPrefix(
+					buildQuotaScheduleKey(switchedAccount, context.family, ""),
+				);
+			}
 			state.sessionAffinityStore?.clearAll();
 			state.lastObservedAffinityGeneration = storageMeta.affinityGeneration;
 		}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1391,13 +1391,19 @@ export function bumpStorageAffinityGeneration(
  * persisting routine state (rate-limit hits, cooldowns, etc.) so a CLI
  * `switch`/`unpin` that landed between proxy startup and the save is not
  * clobbered. Returns `pinnedAccountIndex: undefined` and
- * `affinityGeneration: 0` on any failure. See issue #474.
+ * `affinityGeneration: 0` on any failure by default. Strict callers reject
+ * unreadable/invalid metadata so persistence cannot overwrite a newer pin.
+ * `allowMissing` permits initial storage creation, but not other read failures.
+ * See issue #474.
  */
-export function readPinAndGenFromDisk(path: string): {
+export function readPinAndGenFromDisk(path: string, options?: {
+	strict: boolean;
+	allowMissing?: boolean;
+}): {
 	pinnedAccountIndex: number | undefined;
 	affinityGeneration: number;
 } {
-	if (!existsSync(path)) {
+	if (!options?.strict && !existsSync(path)) {
 		return { pinnedAccountIndex: undefined, affinityGeneration: 0 };
 	}
 	try {
@@ -1407,6 +1413,14 @@ export function readPinAndGenFromDisk(path: string): {
 			affinityGeneration?: unknown;
 		};
 		const rawPin = parsed.pinnedAccountIndex;
+		if (options?.strict && (
+			!isRecord(parsed) ||
+			(rawPin !== undefined && (!Number.isSafeInteger(rawPin) || Number(rawPin) < 0)) ||
+			(parsed.affinityGeneration !== undefined &&
+				(!Number.isSafeInteger(parsed.affinityGeneration) || Number(parsed.affinityGeneration) < 0))
+		)) {
+			throw new Error("Invalid account selection metadata");
+		}
 		const pinnedAccountIndex =
 			typeof rawPin === "number" &&
 			Number.isFinite(rawPin) &&
@@ -1423,7 +1437,11 @@ export function readPinAndGenFromDisk(path: string): {
 				? rawGen
 				: 0;
 		return { pinnedAccountIndex, affinityGeneration };
-	} catch {
+	} catch (error) {
+		if (options?.strict && !(options.allowMissing &&
+			(error as NodeJS.ErrnoException).code === "ENOENT")) {
+			throw new Error("Unable to read account selection metadata");
+		}
 		return { pinnedAccountIndex: undefined, affinityGeneration: 0 };
 	}
 }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1391,59 +1391,74 @@ export function bumpStorageAffinityGeneration(
  * persisting routine state (rate-limit hits, cooldowns, etc.) so a CLI
  * `switch`/`unpin` that landed between proxy startup and the save is not
  * clobbered. Returns `pinnedAccountIndex: undefined` and
- * `affinityGeneration: 0` on any failure by default. Strict callers reject
- * unreadable/invalid metadata so persistence cannot overwrite a newer pin.
- * `allowMissing` permits initial storage creation, but not other read failures.
- * See issue #474.
+ * `affinityGeneration: 0` on any failure by default. See issue #474.
+ *
+ * `strict` callers additionally need to know when the metadata could not be
+ * OBSERVED AT ALL, because persisting a stale in-memory pin over a newer disk
+ * pin is exactly the #474 regression. Strict mode therefore throws for the two
+ * cases where a newer selection may be hiding behind the failure:
+ *   - the file exists but cannot be read (EBUSY/EPERM/EACCES: on Windows an AV
+ *     scanner or indexer can hold accounts.json open), and
+ *   - the bytes are not valid JSON (a torn read of a concurrent atomic write).
+ *
+ * A MISSING file and a successfully parsed file with INVALID field values are
+ * deliberately not failures, in either mode. Neither can be concealing a newer
+ * pin (there is no file, or we can see the whole file and the field is
+ * unusable), and both are self-repaired by the very write that follows. Making
+ * them throw would wedge persistence permanently, since recreating or repairing
+ * storage goes through the same save path, and it would take every rate-limit
+ * window, cooldown and rotated refresh token in memory down with it.
  */
-export function readPinAndGenFromDisk(path: string, options?: {
-	strict: boolean;
-	allowMissing?: boolean;
-}): {
+export function readPinAndGenFromDisk(
+	path: string,
+	options?: { strict?: boolean },
+): {
 	pinnedAccountIndex: number | undefined;
 	affinityGeneration: number;
 } {
-	if (!options?.strict && !existsSync(path)) {
-		return { pinnedAccountIndex: undefined, affinityGeneration: 0 };
+	const unselected = {
+		pinnedAccountIndex: undefined,
+		affinityGeneration: 0,
+	} as const;
+	if (!existsSync(path)) {
+		return { ...unselected };
 	}
+	let parsed: unknown;
 	try {
-		const bytes = readFileSync(path);
-		const parsed = JSON.parse(bytes.toString("utf8")) as {
-			pinnedAccountIndex?: unknown;
-			affinityGeneration?: unknown;
-		};
-		const rawPin = parsed.pinnedAccountIndex;
-		if (options?.strict && (
-			!isRecord(parsed) ||
-			(rawPin !== undefined && (!Number.isSafeInteger(rawPin) || Number(rawPin) < 0)) ||
-			(parsed.affinityGeneration !== undefined &&
-				(!Number.isSafeInteger(parsed.affinityGeneration) || Number(parsed.affinityGeneration) < 0))
-		)) {
-			throw new Error("Invalid account selection metadata");
-		}
-		const pinnedAccountIndex =
-			typeof rawPin === "number" &&
-			Number.isFinite(rawPin) &&
-			Number.isInteger(rawPin) &&
-			rawPin >= 0
-				? rawPin
-				: undefined;
-		const rawGen = parsed.affinityGeneration;
-		const affinityGeneration =
-			typeof rawGen === "number" &&
-			Number.isFinite(rawGen) &&
-			Number.isInteger(rawGen) &&
-			rawGen >= 0
-				? rawGen
-				: 0;
-		return { pinnedAccountIndex, affinityGeneration };
+		parsed = JSON.parse(readFileSync(path, "utf8"));
 	} catch (error) {
-		if (options?.strict && !(options.allowMissing &&
-			(error as NodeJS.ErrnoException).code === "ENOENT")) {
-			throw new Error("Unable to read account selection metadata");
+		// The file was deleted or renamed between existsSync and the read; same
+		// reasoning as the missing-file branch above.
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return { ...unselected };
 		}
-		return { pinnedAccountIndex: undefined, affinityGeneration: 0 };
+		if (options?.strict) {
+			throw new Error("Unable to read account selection metadata", {
+				cause: error,
+			});
+		}
+		return { ...unselected };
 	}
+	if (!isRecord(parsed)) {
+		return { ...unselected };
+	}
+	const rawPin = parsed.pinnedAccountIndex;
+	const pinnedAccountIndex =
+		typeof rawPin === "number" &&
+		Number.isFinite(rawPin) &&
+		Number.isInteger(rawPin) &&
+		rawPin >= 0
+			? rawPin
+			: undefined;
+	const rawGen = parsed.affinityGeneration;
+	const affinityGeneration =
+		typeof rawGen === "number" &&
+		Number.isFinite(rawGen) &&
+		Number.isInteger(rawGen) &&
+		rawGen >= 0
+			? rawGen
+			: 0;
+	return { pinnedAccountIndex, affinityGeneration };
 }
 
 /**

--- a/test/issue-474-pin-safety.test.ts
+++ b/test/issue-474-pin-safety.test.ts
@@ -444,13 +444,13 @@ describe("issue #474 — pin-honored review feedback", () => {
 	});
 
 	describe("readPinAndGenFromDisk transient FS error handling", () => {
-		// Belt-and-suspenders coverage for the disk read used inside
-		// AccountManager.buildStorageSnapshot. The outer guard in accounts.ts
-		// already makes the regression provably impossible (defaults of
-		// `{undefined, 0}` fail the `disk.affinityGeneration > effective` check
-		// so in-memory values are preserved), but explicit coverage here pins
-		// the contract so future refactors of `readPinAndGenFromDisk` can't
-		// silently throw.
+		// Coverage for the DEFAULT (non-strict) contract of the disk read used by
+		// AccountManager.reconcileSelectionFromDisk. Non-strict callers still get
+		// `{undefined, 0}` on any failure, which fails the
+		// `disk.affinityGeneration > effective` check and so preserves in-memory
+		// values. Strict callers instead throw when the metadata could not be
+		// observed at all; that contract is pinned in
+		// test/pr691-switch-revalidation.test.ts.
 
 		it("returns defaults for a missing file", () => {
 			const dir = mkdtempSync(join(tmpdir(), "issue-474-readpin-missing-"));

--- a/test/pr691-proxy-switch-invalidation.test.ts
+++ b/test/pr691-proxy-switch-invalidation.test.ts
@@ -1,0 +1,213 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AccountManager } from "../lib/accounts.js";
+import { PreemptiveQuotaScheduler } from "../lib/preemptive-quota-scheduler.js";
+import {
+	buildQuotaScheduleAccountPrefix,
+	resetPinCacheForTesting,
+	startRuntimeRotationProxy,
+	type RuntimeRotationProxyServer,
+} from "../lib/runtime-rotation-proxy.js";
+import { setStoragePathDirect, type AccountStorageV3 } from "../lib/storage.js";
+
+const { saveAccountsMock, withAccountStorageTransactionMock } = vi.hoisted(
+	() => ({
+		saveAccountsMock: vi.fn(),
+		withAccountStorageTransactionMock: vi.fn(),
+	}),
+);
+
+// The proxy's own debounced saves are irrelevant here and would race the
+// hand-written storage file this test uses as the CLI's output.
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		saveAccounts: saveAccountsMock,
+		withAccountStorageTransaction: withAccountStorageTransactionMock,
+	};
+});
+
+const CLIENT_API_KEY = "runtime-secret";
+const openServers: RuntimeRotationProxyServer[] = [];
+const tmpDirs: string[] = [];
+
+function createStorage(count: number): AccountStorageV3 {
+	const now = Date.now();
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { codex: 0 },
+		accounts: Array.from({ length: count }, (_, index) => ({
+			email: `account-${index + 1}@example.com`,
+			accountId: `acc_${index + 1}`,
+			refreshToken: `refresh-${index + 1}`,
+			accessToken: `access-${index + 1}`,
+			expiresAt: now + 3_600_000,
+			addedAt: now - 60_000 - index,
+			lastUsed: now - 60_000,
+			enabled: true,
+		})),
+	};
+}
+
+function writeStorage(path: string, storage: AccountStorageV3): void {
+	writeFileSync(path, JSON.stringify(storage), "utf8");
+	// The proxy caches metadata by content hash; drop it so the next request
+	// observes the file the "CLI" just wrote.
+	resetPinCacheForTesting();
+}
+
+function makeStoragePath(): string {
+	const dir = mkdtempSync(join(tmpdir(), "pr691-proxy-"));
+	tmpDirs.push(dir);
+	return join(dir, "openai-codex-accounts.json");
+}
+
+function streamingFetch(): typeof fetch {
+	return (async () =>
+		new Response("data: {}\n\n", {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		})) as unknown as typeof fetch;
+}
+
+async function postResponses(
+	proxy: RuntimeRotationProxyServer,
+): Promise<Response> {
+	return fetch(`${proxy.baseUrl}/responses`, {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${CLIENT_API_KEY}`,
+			"content-type": "application/json",
+		},
+		body: JSON.stringify({ model: "gpt-5.6", input: "hi" }),
+	});
+}
+
+beforeEach(() => {
+	resetPinCacheForTesting();
+	saveAccountsMock.mockReset();
+	saveAccountsMock.mockResolvedValue(undefined);
+	withAccountStorageTransactionMock.mockReset();
+	withAccountStorageTransactionMock.mockImplementation(async (handler) =>
+		handler(null, async () => undefined),
+	);
+});
+
+afterEach(async () => {
+	for (const proxy of openServers.splice(0, openServers.length)) {
+		await proxy.close();
+	}
+	resetPinCacheForTesting();
+	setStoragePathDirect(null);
+	vi.restoreAllMocks();
+	for (const dir of tmpDirs.splice(0, tmpDirs.length)) {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup
+		}
+	}
+});
+
+describe("runtime proxy quota invalidation on an observed switch", () => {
+	it("clears only the switched account's observations when the pin resolves", async () => {
+		const path = makeStoragePath();
+		const storage = createStorage(2);
+		writeStorage(path, storage);
+		setStoragePathDirect(path);
+
+		const accountManager = new AccountManager(undefined, storage);
+		const clearByPrefix = vi.spyOn(
+			PreemptiveQuotaScheduler.prototype,
+			"clearByPrefix",
+		);
+		const clearAll = vi.spyOn(PreemptiveQuotaScheduler.prototype, "clearAll");
+
+		const proxy = await startRuntimeRotationProxy({
+			accountManager,
+			fetchImpl: streamingFetch(),
+			upstreamBaseUrl: "https://example.test/backend-api",
+			clientApiKey: CLIENT_API_KEY,
+		});
+		openServers.push(proxy);
+
+		writeStorage(path, {
+			...storage,
+			pinnedAccountIndex: 1,
+			affinityGeneration: 1,
+		});
+		await postResponses(proxy);
+
+		const switched = accountManager.getAccountByIndex(1);
+		if (!switched) throw new Error("fixture account missing");
+		expect(clearByPrefix).toHaveBeenCalledWith(
+			buildQuotaScheduleAccountPrefix(switched),
+		);
+		expect(clearAll).not.toHaveBeenCalled();
+	});
+
+	it("clears every observation when the switched index is out of range", async () => {
+		// Regression: this long-lived proxy re-reads only pin/gen, never the
+		// account list, so a `login` that appended an account before the `switch`
+		// leaves the new index unresolvable here. The generation only bumps on the
+		// NEXT switch, so advancing the watermark without clearing anything
+		// stranded the pre-switch quota observation forever and the proxy kept
+		// deferring, which is the exact symptom this PR set out to fix.
+		const path = makeStoragePath();
+		const storage = createStorage(1);
+		writeStorage(path, storage);
+		setStoragePathDirect(path);
+
+		const accountManager = new AccountManager(undefined, storage);
+		const clearAll = vi.spyOn(PreemptiveQuotaScheduler.prototype, "clearAll");
+
+		const proxy = await startRuntimeRotationProxy({
+			accountManager,
+			fetchImpl: streamingFetch(),
+			upstreamBaseUrl: "https://example.test/backend-api",
+			clientApiKey: CLIENT_API_KEY,
+		});
+		openServers.push(proxy);
+
+		expect(accountManager.getAccountByIndex(1)).toBeNull();
+		writeStorage(path, {
+			...storage,
+			pinnedAccountIndex: 1,
+			affinityGeneration: 1,
+		});
+		await postResponses(proxy);
+
+		expect(clearAll).toHaveBeenCalled();
+	});
+
+	it("does not invalidate anything when the generation has not advanced", async () => {
+		const path = makeStoragePath();
+		const storage = createStorage(2);
+		writeStorage(path, storage);
+		setStoragePathDirect(path);
+
+		const accountManager = new AccountManager(undefined, storage);
+		const clearByPrefix = vi.spyOn(
+			PreemptiveQuotaScheduler.prototype,
+			"clearByPrefix",
+		);
+		const clearAll = vi.spyOn(PreemptiveQuotaScheduler.prototype, "clearAll");
+
+		const proxy = await startRuntimeRotationProxy({
+			accountManager,
+			fetchImpl: streamingFetch(),
+			upstreamBaseUrl: "https://example.test/backend-api",
+			clientApiKey: CLIENT_API_KEY,
+		});
+		openServers.push(proxy);
+
+		await postResponses(proxy);
+
+		expect(clearByPrefix).not.toHaveBeenCalled();
+		expect(clearAll).not.toHaveBeenCalled();
+	});
+});

--- a/test/pr691-switch-revalidation.test.ts
+++ b/test/pr691-switch-revalidation.test.ts
@@ -1,0 +1,446 @@
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AccountManager, type ManagedAccount } from "../lib/accounts.js";
+import { PreemptiveQuotaScheduler } from "../lib/preemptive-quota-scheduler.js";
+import {
+	buildQuotaScheduleAccountPrefix,
+	buildQuotaScheduleKey,
+	resetPinCacheForTesting,
+} from "../lib/runtime-rotation-proxy.js";
+import {
+	type AccountStorageV3,
+	readPinAndGenFromDisk,
+	setStoragePathDirect,
+} from "../lib/storage.js";
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(label: string): string {
+	const dir = mkdtempSync(join(tmpdir(), `pr691-${label}-`));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+function makeTmpStoragePath(): string {
+	return join(makeTmpDir("storage"), "openai-codex-accounts.json");
+}
+
+function createStorage(
+	count = 2,
+	overrides: Partial<AccountStorageV3> = {},
+): AccountStorageV3 {
+	const now = Date.now();
+	return {
+		version: 3,
+		activeIndex: 0,
+		activeIndexByFamily: { codex: 0 },
+		accounts: Array.from({ length: count }, (_, index) => ({
+			email: `account-${index + 1}@example.com`,
+			accountId: `acc_${index + 1}`,
+			refreshToken: `refresh-${index + 1}`,
+			accessToken: `access-${index + 1}`,
+			expiresAt: now + 3_600_000,
+			addedAt: now - 60_000,
+			lastUsed: now - 60_000,
+			enabled: true,
+		})),
+		...overrides,
+	};
+}
+
+function writeStorageFile(path: string, storage: AccountStorageV3): void {
+	writeFileSync(path, JSON.stringify(storage), "utf8");
+}
+
+/**
+ * Build a manager whose selection metadata reads always fail: the storage path
+ * points at a directory, so `existsSync` passes but `readFileSync` raises
+ * EISDIR/EPERM. That is the "selection unreadable" branch of
+ * `markRateLimitedWithReason`, without stubbing any module.
+ */
+function managerWithUnreadableSelection(): {
+	manager: AccountManager;
+	account: ManagedAccount;
+} {
+	setStoragePathDirect(makeTmpDir("unreadable"));
+	const manager = new AccountManager(undefined, createStorage(2));
+	const account = manager.getAccountByIndex(0);
+	if (!account) throw new Error("fixture account missing");
+	return { manager, account };
+}
+
+beforeEach(() => {
+	resetPinCacheForTesting();
+});
+
+afterEach(() => {
+	resetPinCacheForTesting();
+	setStoragePathDirect(null);
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+	for (const dir of tmpDirs.splice(0, tmpDirs.length)) {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup
+		}
+	}
+});
+
+describe("readPinAndGenFromDisk strict mode", () => {
+	it("throws when the file exists but cannot be read", () => {
+		// A newer pin may be hiding behind an EBUSY/EPERM, so persisting our
+		// possibly-stale in-memory pin would be the #474 clobber.
+		const dir = makeTmpDir("unreadable-strict");
+		expect(() => readPinAndGenFromDisk(dir, { strict: true })).toThrow(
+			/Unable to read account selection metadata/,
+		);
+	});
+
+	it("throws on malformed JSON, which can be a torn read of a newer write", () => {
+		const path = join(makeTmpDir("torn"), "accounts.json");
+		writeFileSync(path, '{"pinnedAccountIndex": 1, "affinityGen', "utf8");
+		expect(() => readPinAndGenFromDisk(path, { strict: true })).toThrow(
+			/Unable to read account selection metadata/,
+		);
+	});
+
+	it("falls back to defaults for the same failures when not strict", () => {
+		const dir = makeTmpDir("unreadable-lenient");
+		expect(readPinAndGenFromDisk(dir)).toEqual({
+			pinnedAccountIndex: undefined,
+			affinityGeneration: 0,
+		});
+	});
+
+	it("returns defaults for a missing file even in strict mode", () => {
+		// Nothing on disk can be clobbered by the write that follows, and
+		// throwing here would mean storage could never be recreated: the
+		// recreation goes through the same save path. See the regression at
+		// "recreates storage that was deleted after a switch" below.
+		const path = join(makeTmpDir("missing"), "accounts.json");
+		expect(readPinAndGenFromDisk(path, { strict: true })).toEqual({
+			pinnedAccountIndex: undefined,
+			affinityGeneration: 0,
+		});
+	});
+
+	it.each([
+		["null pin", { pinnedAccountIndex: null, affinityGeneration: 4 }, 4],
+		["negative pin", { pinnedAccountIndex: -1, affinityGeneration: 4 }, 4],
+		["fractional pin", { pinnedAccountIndex: 1.5, affinityGeneration: 4 }, 4],
+		["string pin", { pinnedAccountIndex: "1", affinityGeneration: 4 }, 4],
+		["negative generation", { pinnedAccountIndex: 1, affinityGeneration: -2 }, 0],
+	])(
+		"normalizes an invalid field rather than throwing: %s",
+		(_label, payload, expectedGeneration) => {
+			// The file parsed, so nothing is hidden from us and the value is
+			// simply unusable. Throwing would wedge every future save with no
+			// path to self-repair.
+			const path = join(makeTmpDir("invalid"), "accounts.json");
+			writeFileSync(path, JSON.stringify(payload), "utf8");
+			const meta = readPinAndGenFromDisk(path, { strict: true });
+			expect(meta.affinityGeneration).toBe(expectedGeneration);
+		},
+	);
+
+	it("returns defaults for a non-record top-level value without throwing", () => {
+		// `null` in particular used to be dereferenced before the isRecord guard.
+		for (const body of ["null", "[]", "42", '"pinned"']) {
+			const path = join(makeTmpDir("nonrecord"), "accounts.json");
+			writeFileSync(path, body, "utf8");
+			expect(readPinAndGenFromDisk(path, { strict: true })).toEqual({
+				pinnedAccountIndex: undefined,
+				affinityGeneration: 0,
+			});
+		}
+	});
+
+	it("round-trips a valid pin and generation", () => {
+		const path = join(makeTmpDir("valid"), "accounts.json");
+		writeFileSync(
+			path,
+			JSON.stringify({ pinnedAccountIndex: 2, affinityGeneration: 9 }),
+			"utf8",
+		);
+		expect(readPinAndGenFromDisk(path, { strict: true })).toEqual({
+			pinnedAccountIndex: 2,
+			affinityGeneration: 9,
+		});
+	});
+});
+
+describe("AccountManager.applyManualSelection", () => {
+	it("clears the switched account's rate-limit markers", () => {
+		setStoragePathDirect(makeTmpStoragePath());
+		const manager = new AccountManager(undefined, createStorage(2));
+		const account = manager.getAccountByIndex(0);
+		if (!account) throw new Error("fixture account missing");
+		account.rateLimitResetTimes = { codex: Date.now() + 600_000 };
+		account.lastRateLimitReason = "quota";
+
+		manager.applyManualSelection({
+			pinnedAccountIndex: 0,
+			affinityGeneration: 1,
+		});
+
+		expect(account.rateLimitResetTimes).toEqual({});
+		expect(account.lastRateLimitReason).toBeUndefined();
+	});
+
+	it("is a no-op when the on-disk generation is not newer", () => {
+		setStoragePathDirect(makeTmpStoragePath());
+		const manager = new AccountManager(
+			undefined,
+			createStorage(2, { affinityGeneration: 3 }),
+		);
+		const account = manager.getAccountByIndex(0);
+		if (!account) throw new Error("fixture account missing");
+		const resetAt = Date.now() + 600_000;
+		account.rateLimitResetTimes = { codex: resetAt };
+
+		manager.applyManualSelection({
+			pinnedAccountIndex: 0,
+			affinityGeneration: 3,
+		});
+
+		expect(account.rateLimitResetTimes).toEqual({ codex: resetAt });
+	});
+
+	it("replays a 429 that raced the switch it is applying", () => {
+		const { manager, account } = managerWithUnreadableSelection();
+		manager.markRateLimitedWithReason(account, 600_000, "codex", "quota");
+		expect(account.rateLimitResetTimes.codex).toBeGreaterThan(Date.now());
+
+		manager.applyManualSelection({
+			pinnedAccountIndex: 0,
+			affinityGeneration: 1,
+		});
+
+		// The 429 was recorded while the selection was unreadable, so we cannot
+		// prove it predates the switch. Keep it.
+		expect(account.rateLimitResetTimes.codex).toBeGreaterThan(Date.now());
+		expect(account.lastRateLimitReason).toBe("quota");
+	});
+
+	it("does NOT replay an unsequenced 429 that is older than the ambiguity window", () => {
+		// Regression: an unsequenced entry used to live until the next 429 or the
+		// next switch to that account, so an hours-old 429 was resurrected by the
+		// very `switch` meant to revalidate the account after a quota reset.
+		const { manager, account } = managerWithUnreadableSelection();
+		const base = Date.now();
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(base);
+
+		manager.markRateLimitedWithReason(account, 3_600_000, "codex", "quota");
+		expect(account.rateLimitResetTimes.codex).toBe(base + 3_600_000);
+
+		nowSpy.mockReturnValue(base + 3_600_000 - 1);
+		manager.applyManualSelection({
+			pinnedAccountIndex: 0,
+			affinityGeneration: 1,
+		});
+
+		expect(account.rateLimitResetTimes).toEqual({});
+		expect(account.lastRateLimitReason).toBeUndefined();
+	});
+
+	it("does not extend an expired unsequenced entry through a later 429", () => {
+		const { manager, account } = managerWithUnreadableSelection();
+		const base = Date.now();
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(base);
+		manager.markRateLimitedWithReason(account, 3_600_000, "codex", "quota");
+
+		// A second, much later 429 must not carry the stale entry's windows
+		// forward under a fresh timestamp.
+		nowSpy.mockReturnValue(base + 600_000);
+		manager.markRateLimitedWithReason(account, 1_000, "gpt", "tokens", "gpt-5");
+
+		nowSpy.mockReturnValue(base + 600_000 + 1);
+		manager.applyManualSelection({
+			pinnedAccountIndex: 0,
+			affinityGeneration: 1,
+		});
+
+		expect(account.rateLimitResetTimes.codex).toBeUndefined();
+	});
+
+	it("drops the pin when the switched index is out of range", () => {
+		setStoragePathDirect(makeTmpStoragePath());
+		const manager = new AccountManager(undefined, createStorage(2));
+		manager.applyManualSelection({
+			pinnedAccountIndex: 7,
+			affinityGeneration: 2,
+		});
+		expect(manager.getAccountByIndex(7)).toBeNull();
+	});
+});
+
+describe("AccountManager save resilience", () => {
+	it("recreates storage that was deleted after a switch", async () => {
+		// Regression: strict reads previously accepted a missing file only while
+		// affinityGeneration was 0, so any pool that had ever been switched could
+		// never recreate its storage; every later save threw ENOENT forever.
+		const path = makeTmpStoragePath();
+		const storage = createStorage(2, {
+			pinnedAccountIndex: 1,
+			affinityGeneration: 5,
+		});
+		writeStorageFile(path, storage);
+		setStoragePathDirect(path);
+		const manager = new AccountManager(undefined, storage);
+
+		rmSync(path, { force: true });
+		await manager.saveToDisk();
+
+		expect(existsSync(path)).toBe(true);
+		const onDisk = JSON.parse(readFileSync(path, "utf8")) as {
+			affinityGeneration?: unknown;
+			pinnedAccountIndex?: unknown;
+		};
+		expect(onDisk.affinityGeneration).toBe(5);
+		expect(onDisk.pinnedAccountIndex).toBe(1);
+	});
+
+	it("re-arms a debounced save that failed instead of dropping it", async () => {
+		// Regression: the debounce timer clears itself before the save runs, so a
+		// single transient failure silently discarded every rate-limit window,
+		// cooldown and rotated refresh token since the last successful write.
+		vi.useFakeTimers();
+		setStoragePathDirect(makeTmpStoragePath());
+		const manager = new AccountManager(undefined, createStorage(2));
+		const saveSpy = vi
+			.spyOn(manager, "saveToDisk")
+			.mockRejectedValueOnce(new Error("EBUSY: resource busy or locked"))
+			.mockResolvedValue();
+
+		manager.saveToDiskDebounced(10);
+		await vi.advanceTimersByTimeAsync(10);
+		expect(saveSpy).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(20);
+		expect(saveSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("gives up after a bounded number of retries", async () => {
+		vi.useFakeTimers();
+		setStoragePathDirect(makeTmpStoragePath());
+		const manager = new AccountManager(undefined, createStorage(2));
+		const saveSpy = vi
+			.spyOn(manager, "saveToDisk")
+			.mockRejectedValue(new Error("EBUSY: resource busy or locked"));
+
+		manager.saveToDiskDebounced(10);
+		// 1 initial attempt + MAX_DEBOUNCED_SAVE_RETRIES re-arms, with the delay
+		// doubling up to the 8s ceiling.
+		await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+		expect(saveSpy).toHaveBeenCalledTimes(6);
+
+		// The counter resets, so a later save is still attempted.
+		saveSpy.mockClear();
+		manager.saveToDiskDebounced(10);
+		await vi.advanceTimersByTimeAsync(10);
+		expect(saveSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not reject flushPendingSave when the save fails", async () => {
+		// `RuntimeRotationProxy.close` awaits this without a catch, so a
+		// rejection here aborts the rest of proxy teardown.
+		setStoragePathDirect(makeTmpStoragePath());
+		const manager = new AccountManager(undefined, createStorage(2));
+		vi.spyOn(manager, "saveToDisk").mockRejectedValue(
+			new Error("EPERM: operation not permitted"),
+		);
+
+		manager.saveToDiskDebounced(10_000);
+		await expect(manager.flushPendingSave()).resolves.toBeUndefined();
+	});
+});
+
+describe("quota scheduler account isolation", () => {
+	const account = {
+		email: "foo@example.com",
+		accountId: "acc_foo",
+		refreshToken: "refresh-foo",
+		addedAt: 1_700_000_000_000,
+	};
+	const neighbour = {
+		email: "foobar@example.com",
+		accountId: "acc_foobar",
+		refreshToken: "refresh-foobar",
+		addedAt: 1_700_000_000_000,
+	};
+
+	it("produces a prefix that every key for that account starts with", () => {
+		const prefix = buildQuotaScheduleAccountPrefix(account);
+		expect(prefix.endsWith(":")).toBe(true);
+		for (const key of [
+			buildQuotaScheduleKey(account, "codex"),
+			buildQuotaScheduleKey(account, "codex", "gpt-5.6"),
+			buildQuotaScheduleKey(account, "gpt", "gpt-5.6-codex"),
+		]) {
+			expect(key.startsWith(prefix)).toBe(true);
+		}
+	});
+
+	it("does not let one account's prefix match a neighbouring identity", () => {
+		const prefix = buildQuotaScheduleAccountPrefix(account);
+		expect(
+			buildQuotaScheduleKey(neighbour, "codex").startsWith(prefix),
+		).toBe(false);
+	});
+
+	it("clears every model key for one account and leaves the neighbour deferred", () => {
+		const scheduler = new PreemptiveQuotaScheduler();
+		const now = Date.now();
+		const mine = [
+			buildQuotaScheduleKey(account, "codex"),
+			buildQuotaScheduleKey(account, "codex", "gpt-5.6"),
+		];
+		const theirs = buildQuotaScheduleKey(neighbour, "codex");
+		for (const key of [...mine, theirs]) {
+			scheduler.markRateLimited(key, 600_000, now);
+		}
+
+		scheduler.clearByPrefix(buildQuotaScheduleAccountPrefix(account));
+
+		for (const key of mine) {
+			expect(scheduler.getDeferral(key, now).defer).toBe(false);
+		}
+		expect(scheduler.getDeferral(theirs, now).defer).toBe(true);
+	});
+
+	it("treats an empty prefix as a no-op rather than a clear-all", () => {
+		const scheduler = new PreemptiveQuotaScheduler();
+		const now = Date.now();
+		const key = buildQuotaScheduleKey(account, "codex");
+		scheduler.markRateLimited(key, 600_000, now);
+
+		scheduler.clearByPrefix("");
+
+		expect(scheduler.getDeferral(key, now).defer).toBe(true);
+	});
+
+	it("clearAll drops every observation", () => {
+		const scheduler = new PreemptiveQuotaScheduler();
+		const now = Date.now();
+		const keys = [
+			buildQuotaScheduleKey(account, "codex"),
+			buildQuotaScheduleKey(neighbour, "codex"),
+		];
+		for (const key of keys) scheduler.markRateLimited(key, 600_000, now);
+
+		scheduler.clearAll();
+
+		for (const key of keys) {
+			expect(scheduler.getDeferral(key, now).defer).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fix stale pinned-account rate-limit state after an out-of-band quota reset and an explicit `codex-multi-auth switch N`, including reselecting the same account.

Previously the proxy could keep returning a local `503 Pinned account N is currently unavailable (rate-limited)` even when a fresh quota check succeeded. Persisted markers, retained AccountManager instances and quota-scheduler observations could all retain the old deadline.

## What Changed

- An explicit switch clears the selected account's persisted rate-limit markers; the existing affinity generation reconciles retained managers once per selection.
- A manager observes the latest selection **before** recording a new rate-limit response. A delayed save therefore does not mistake a genuine post-switch 429 for pre-switch state.
- If selection metadata is unreadable when a 429 arrives, retain only the newly observed markers separately and conservatively merge them during the next reconciliation.
- Snapshot persistence uses an opt-in strict metadata read: unreadable, malformed or invalid metadata aborts the save instead of silently overwriting a newer pin with stale memory. Missing storage is allowed only for initializing a generation-zero pool. The default reader contract remains compatible.
- Reconcile quota-cache invalidation before recording upstream observations, including after awaiting a 429 body, so the next request does not erase the fresh scheduler observation.
- Prefix invalidation remains account-scoped across models, with a trailing separator protecting neighboring identities.

No quota is assumed available: the next normal upstream request revalidates it. A genuine new 429 is honored until expiration or another explicit switch. Pinning still disables automatic fallback; other accounts and unrelated cooldowns/circuit breakers are not cleared.

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test` — full suite not rerun for this revision
- [x] `npm test -- test/documentation.test.ts` — included in the targeted run
- [x] `npm run build`

Targeted Windows run: **551 passed, 1 existing skipped, 8 files**:
`pr-691-local`, `runtime-rotation-proxy`, `issue-474-pin-end-to-end`, `accounts`, `preemptive-quota-scheduler`, `storage`, `persist-selected-account`, and `documentation`.

Local regression scenarios include switch → in-flight 429 → delayed save → next request (no extra upstream attempt); another explicit switch allowing an attempt; EBUSY/EPERM/ENOENT and malformed metadata; a new 429 surviving unreadable metadata; other-account/cooldown preservation; and empty-prefix/all-model/neighboring-prefix isolation.

**The regression additions are local only, not committed in this production-only PR.** The existing pinned-503 test now passes without changing its fixture. Earlier full-suite Windows failures involving process launching and an occupied OAuth port were reproduced on pristine upstream; no claim of a fully green suite is made.

## Docs and Governance Checklist

- [ ] README updated — not included in this production-only patch
- [ ] `docs/getting-started.md` updated — onboarding unchanged
- [ ] `docs/features.md` updated — no new capability
- [ ] relevant `docs/reference/*` pages updated — not included; switch semantics explained above
- [ ] `docs/upgrade.md` updated — no schema migration
- [x] `SECURITY.md` and `CONTRIBUTING.md` reviewed for alignment

No new authentication flow or identity-bearing log output is introduced. The new diagnostics are fixed strings with no tokens or emails. Committed regression tests/docs remain intentionally outside the submitted scope, which differs from the contribution guideline preference.

## Risk and Rollback

- Risk level: moderate — concurrent selection changes, retained managers and filesystem failure handling.
- Unreadable metadata now postpones persistence instead of risking a stale pin overwrite. A 429 whose ordering cannot be established is retained conservatively; this favors respecting a real limit over immediate availability.
- This is not a redesign of cross-process account-list reconciliation or general last-writer-wins persistence.
- Rollback plan: revert the two PR commits and restart the proxy. No storage migration or package version change needs undoing.

## Additional Notes

Five production files only; no package versions, package metadata, documentation files or test files changed.

Review follow-up: the suggested pinned-request stale-reload path was not reproduced. The recovery guard requires `!isPinned`, while the selected-account cache clear requires a persisted pin; an unpinned selection has no switched account to clear. The local concurrent-response regression also asserts that pinned handling does not call `AccountManager.loadFromDisk`. Details are in the inline reply.



<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr revalidates explicitly switched accounts by reconciling selection generations, clearing account-scoped quota observations, and hardening persistence around concurrent filesystem changes.
- a 30-second ambiguity cutoff can still erase a genuine post-switch 429 after a prolonged windows metadata-read failure.
- strict reads and debounced retries improve pin and rotated-token persistence safety.
- new vitest coverage exercises switch invalidation, unreadable metadata, scheduler isolation, and save retries, but the full vitest suite was not run.
- the new test cleanup bypasses the repository’s windows retry helper.

<h3>Confidence Score: 4/5</h3>

this is not safe to merge until prolonged metadata-read failures preserve genuine post-switch 429s and the required windows-safe test cleanup is used.

the new reconciliation can discard a real rate limit when a concurrent switch is hidden by a windows filesystem failure for more than 30 seconds, causing premature upstream retries. the new vitest files also violate the repository’s mandatory windows cleanup rule. the previous 429-ordering finding is resolved by applying readable selection metadata before recording the response.

**Files Needing Attention:** lib/accounts.ts, test/pr691-switch-revalidation.test.ts, test/pr691-proxy-switch-invalidation.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds selection reconciliation, unsequenced 429 preservation, and bounded save retries; the time-based reconciliation cutoff has a concurrency defect. |
| lib/runtime-rotation-proxy.ts | invalidates account-scoped quota and affinity caches whenever a newer selection generation is observed. |
| lib/storage.ts | adds strict handling for unreadable or malformed selection metadata while permitting storage recreation. |
| lib/preemptive-quota-scheduler.ts | adds isolated prefix invalidation and explicit full-cache clearing. |
| lib/codex-manager/persist-selected-account.ts | clears persisted rate-limit markers on an explicit account switch. |
| test/pr691-switch-revalidation.test.ts | adds focused vitest coverage but uses non-retrying recursive cleanup on windows-sensitive temporary storage. |
| test/pr691-proxy-switch-invalidation.test.ts | covers proxy cache invalidation, with the same windows-unsafe cleanup pattern. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant cli as switch cli
  participant fs as accounts.json
  participant proxy as retained proxy
  participant upstream
  cli->>fs: write new pin and generation
  upstream-->>proxy: genuine 429
  proxy-xfs: strict metadata read fails
  proxy->>proxy: retain unsequenced 429
  Note over proxy,fs: more than 30 seconds elapse
  proxy->>fs: later metadata read succeeds
  proxy->>proxy: clear limits and discard aged 429
  proxy->>upstream: premature retry
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/accounts.ts:809-816
**aged 429 gets discarded**

if selection metadata remains unreadable for more than 30 seconds after a switch, a genuine 429 recorded during that windows filesystem failure ages out here. reconciliation clears the live rate limit and discards the pending observation, so concurrent requests can retry upstream before the genuine limit expires.

### Issue 2
test/pr691-switch-revalidation.test.ts:91-96
**windows cleanup skips retries**

this cleanup and the matching cleanup in `test/pr691-proxy-switch-invalidation.test.ts:109-114` use bare recursive `rmsync`. this violates the repository directive to use its windows-safe retry cleanup helper. locked files can leave temporary account directories behind and make vitest flaky on windows, so this requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(accounts): keep selection strictness..."](https://github.com/ndycode/codex-multi-auth/commit/4c7d209e743796e72aeddcfd12af7aa6c2a465fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61559114)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - test/AGENTS.md ([source](https://github.com/ndycode/codex-multi-auth/blob/main/test/AGENTS.md))

<!-- /greptile_comment -->